### PR TITLE
Fix media links

### DIFF
--- a/src/page/Centralized_Logging.rst
+++ b/src/page/Centralized_Logging.rst
@@ -154,16 +154,16 @@ Current the proof of concept project contains:
 Dashboards
 ^^^^^^^^^^
 
--  `User Logins <Media:Rek-user-logins.png>`__: User login attempts and
+-  `User Logins <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Rek-user-logins.png>`__: User login attempts and
    their results across FreeIPA domain, most-logged-to hosts
 -  `IPA Server
-   Administration <Media:Rek-ipa-server-administration.png>`__:
+   Administration <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Rek-ipa-server-administration.png>`__:
    Administrative API usage on the FreeIPA servers
--  `IPA Server Utilization <Media:Rek-ipa-server-utilization.png>`__:
+-  `IPA Server Utilization <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Rek-ipa-server-utilization.png>`__:
    Kerberos/LDAP protocol utilization across FreeIPA servers
--  `IPA Server Health <Media:Rek-ipa-server-health.png>`__: Replication
+-  `IPA Server Health <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Rek-ipa-server-health.png>`__: Replication
    errors, server SSSD errors
--  `SSSD <Media:Rek-sssd.png>`__: selected client SSSD errors (dashboard
+-  `SSSD <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Rek-sssd.png>`__: selected client SSSD errors (dashboard
    still in progress)
 
 

--- a/src/page/Client.rst
+++ b/src/page/Client.rst
@@ -66,14 +66,14 @@ server. The services mostly use SSSD so that they can also benefit from
    ``ipa-client-automount`` which can be run after
    ``ipa-client-install``.
 -  **SSH**: server can keep SSH public keys (`training
-   material <Media:Freeipa30_SSH_Public_Keys.odp>`__) that are than used
+   material <https://github.com/freeipa/freeipa.github.io/raw/main/src/page/Freeipa30_SSH_Public_Keys.odp>`__) that are than used
    by both ``sshd`` and ``ssh``. The integration is configured
    automatically with ``ipa-client-install``, unless limited with
    ``--no-ssh``/``--no-sshd``. DNS SSHFP records for the host are
    automatically created by ``ipa-client-install``, unless run with
    ``--no-dns-sshfp``.
 -  **SUDO**: server can provide centralized *sudoers* to all clients
-   (`training material <Media:Freeipa30_SSSD_SUDO_Integration.pdf>`__.
+   (`training material <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSSD_SUDO_Integration.pdf>`__.
    The feature needs to be configured manually in FreeIPA clients older
    than 4.0 (`related
    ticket <https://fedorahosted.org/freeipa/ticket/3358>`__). Since
@@ -82,5 +82,5 @@ server. The services mostly use SSSD so that they can also benefit from
 -  **SELinux user map**: server can keep policies to assign different
    SELinux user roles to users, based on their group or host group (see
    `SELinux user mapping <SELinux_user_mapping>`__ article or `training
-   material <Media:Freeipa30_SELinuxUserMap.pdf>`__). The feature is
+   material <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SELinuxUserMap.pdf>`__). The feature is
    configure automatically with ``ipa-client-install``

--- a/src/page/Documentation.rst
+++ b/src/page/Documentation.rst
@@ -175,8 +175,8 @@ FreeIPA Training Series
 FreeIPA 4.5
 -----------
 
--  `FreeIPA CA <Media:freeipa-ca-component.pdf>`__
--  `Introduction to LDAP <Media:freeipa-introduction-to-ldap.pdf>`__
+-  `FreeIPA CA <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa-ca-component.pdf>`__
+-  `Introduction to LDAP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa-introduction-to-ldap.pdf>`__
 
 
 
@@ -188,14 +188,14 @@ FreeIPA 3.3 & SSSD 1.11
 FreeIPA server presentations
 ----------------------------------------------------------------------------------------------
 
--  `FreeIPA 3.3 Trust features <Media:FreeIPA33-trust.pdf>`__
+-  `FreeIPA 3.3 Trust features <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-trust.pdf>`__
 -  `Blending FreeIPA in a Certificate
-   Infrastructure <Media:FreeIPA33-blending-in-a-certificate-infrastructure.pdf>`__
+   Infrastructure <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-blending-in-a-certificate-infrastructure.pdf>`__
 -  `Extending the FreeIPA
-   Server <Media:FreeIPA33-extending-freeipa.pdf>`__
--  `AD Trust for Legacy Clients <Media:FreeIPA33-legacy-clients.pdf>`__
+   Server <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-extending-freeipa.pdf>`__
+-  `AD Trust for Legacy Clients <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-legacy-clients.pdf>`__
 -  `FreeIPA Client and Server Improvements in
-   3.3 <Media:FreeIPA33-server-and-client.pdf>`__
+   3.3 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-server-and-client.pdf>`__
 
 
 
@@ -203,11 +203,11 @@ SSSD client presentations
 ----------------------------------------------------------------------------------------------
 
 -  `SSSD Active Directory Improvements in
-   1.11 <Media:FreeIPA33-sssd-1-11-ad-improvements.pdf>`__
+   1.11 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-sssd-1-11-ad-improvements.pdf>`__
 -  `SSSD AD Provider: Access
-   Control <Media:FreeIPA33-sssd-access-control.pdf>`__
+   Control <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-sssd-access-control.pdf>`__
 -  `SSSD DNS Improvements in AD
-   Environment <Media:FreeIPA33-sssd-dns-ad.pdf>`__
+   Environment <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA33-sssd-dns-ad.pdf>`__
 
 
 
@@ -219,40 +219,40 @@ FreeIPA 3.0 & SSSD 1.9.2
 FreeIPA server presentations
 ----------------------------------------------------------------------------------------------
 
--  `FreeIPA Trust Basics <Media:Freeipa30_Trust_Basics.pdf>`__
-   (`ODP <Media:Freeipa30_Trust_Basics.odp>`__)
+-  `FreeIPA Trust Basics <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_Trust_Basics.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/raw/main/src/page/Freeipa30_Trust_Basics.odp>`__)
 -  `FreeIPA Server/Client Core
-   Changes <Media:Freeipa30_client_server.pdf>`__
-   (`ODP <Media:Freeipa30_client_server.odp>`__)
--  `SSH Public Keys Feature <Media:Freeipa30_SSH_Public_Keys.pdf>`__
-   (`ODP <Media:Freeipa30_SSH_Public_Keys.odp>`__)
--  `SELinux User Maps Feature <Media:Freeipa30_SELinuxUserMap.pdf>`__
-   (`ODP <Media:Freeipa30_SELinuxUserMap.odp>`__)
+   Changes <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_client_server.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_client_server.odp>`__)
+-  `SSH Public Keys Feature <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSH_Public_Keys.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSH_Public_Keys.odp>`__)
+-  `SELinux User Maps Feature <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SELinuxUserMap.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SELinuxUserMap.odp>`__)
 -  `DNS Persistent Search
-   Feature <Media:Freeipa30_DNS_persistent_search.pdf>`__
-   (`ODP <Media:Freeipa30_DNS_persistent_search.odp>`__)
--  `DNS Zone Transfers <Media:Freeipa30_DNS_zone_transfers.pdf>`__
-   (`ODP <Media:Freeipa30_DNS_zone_transfers.odp>`__)
+   Feature <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_DNS_persistent_search.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_DNS_persistent_search.odp>`__)
+-  `DNS Zone Transfers <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_DNS_zone_transfers.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_DNS_zone_transfers.odp>`__)
 
 
 
 SSSD client presentations
 ----------------------------------------------------------------------------------------------
 
--  `SSSD AD Provider Feature <Media:Freeipa30_sssd-ad-provider.pdf>`__
-   (`ODP <Media:Freeipa30_sssd-ad-provider.odp>`__)
+-  `SSSD AD Provider Feature <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-ad-provider.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-ad-provider.odp>`__)
 -  `SSSD AutoFS
-   Integration <Media:Freeipa30_sssd-autofs-integration.pdf>`__
-   (`ODP <Media:Freeipa30_sssd-autofs-integration.odp>`__)
+   Integration <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-autofs-integration.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-autofs-integration.odp>`__)
 -  `SSSD OpenSSH
-   Integration <Media:Freeipa30_SSSD_OpenSSH_integration.pdf>`__
-   (`ODP <Media:Freeipa30_SSSD_OpenSSH_integration.odp>`__)
+   Integration <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSSD_OpenSSH_integration.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSSD_OpenSSH_integration.odp>`__)
 -  `SSSD Pre-Seeding Users for First
-   Boot <Media:Freeipa30_sssd-preseed-users.pdf>`__
-   (`ODP <Media:Freeipa30_sssd-preseed-users.odp>`__)
+   Boot <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-preseed-users.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_sssd-preseed-users.odp>`__)
 -  `SSSD SUDO Integration
-   Feature <Media:Freeipa30_SSSD_SUDO_Integration.pdf>`__
-   (`ODP <Media:Freeipa30_SSSD_SUDO_Integration.odp>`__)
+   Feature <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSSD_SUDO_Integration.pdf>`__
+   (`ODP <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Freeipa30_SSSD_SUDO_Integration.odp>`__)
 
 
 
@@ -267,29 +267,29 @@ presented on various public conferences.
    (talk on youtube)
 -  `SnowCamp.io <http://snowcamp.io/fr/previous-editions/>`__:
    `Authentication using One-Time Password Token and Smart
-   Card <media:snowcampio_2FA.pdf>`__
+   Card <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/snowcampio_2FA.pdf>`__
 -  FreeIPA presentation at `NYLUG's
    meetup <http://www.meetup.com/nylug-meetings/events/218903375/>`__ in
    January 2014:
-   `PDF <media:Identity_And_Directories_with_FreeIPA.pdf>`__
+   `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Identity_And_Directories_with_FreeIPA.pdf>`__
 -  `Devconf 2013 <http://www.devconf.cz>`__: `Integrating Linux systems
    into Active Directory
-   Environment <media:Devconf2013-linux-ad-integration-options.pdf>`__
+   Environment <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Devconf2013-linux-ad-integration-options.pdf>`__
    (`talk on youtube <http://www.youtube.com/watch?v=cS6EJ1L7fRI>`__)
 -  `FOSDEM 2013 <https://fosdem.org/2013/>`__ Idm Presentation slides in
-   `PDF <media:FOSDEM-Building-IDM.pdf>`__ format
+   `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FOSDEM-Building-IDM.pdf>`__ format
 -  `DjangoCon Europe 2013 - Django + Kerberos
    authentication <http://www.roguelynn.com/circus/>`__ with
    `slides <https://speakerdeck.com/roguelynn/introduce-django-to-your-old-friends>`__
    and `video <http://www.youtube.com/watch?v=oerxTvMn-uM>`__ available.
 -  `LinuxAlt 2012 <http://www.linuxalt.cz>`__: `Introducing
-   FreeIPA <Media:Mkosek-linuxalt2012.pdf>`__
+   FreeIPA <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Mkosek-linuxalt2012.pdf>`__
 -  `LinuxCon
    2012 <http://events.linuxfoundation.org/events/linuxcon-europe>`__:
    `FreeIPA hands-on workshop
-   session <Media:Linuxcon-ipa-hands-on.pdf>`__
+   session <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Linuxcon-ipa-hands-on.pdf>`__
 -  `Red Hat Summit 2011 <http://www.redhat.com/summit/2011>`__: `FreeIPA
    presentation <http://www.redhat.com/summit/2011/presentations/summit/whats_next/friday/pal_crittenden_f_1100_ipa_overview_rev3.pdf>`__
 -  `FOSDEM 2009 <https://archive.fosdem.org/2009/>`__: FreeIPA
-   presentation - `PDF <media:FreeIPA-FOSDEM.pdf>`__, `OO.org
+   presentation - `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/FreeIPA-FOSDEM.pdf>`__, `OO.org
    3.0.1 <http://simo.fedorapeople.org/freeipa/FreeIPA-FOSDEM.odp>`__

--- a/src/page/Samba_4_Replication.rst
+++ b/src/page/Samba_4_Replication.rst
@@ -116,7 +116,7 @@ agreements.
 
    % yum install perl-LDAP
 
-Download `mmr.pl <Media:mmr.txt>`__ script to configure MMR:
+Download `mmr.pl <https://wiki.samba.org/images/f/f4/Mmr.txt>`__ script to configure MMR:
 
 ::
 

--- a/src/page/Trusts.rst
+++ b/src/page/Trusts.rst
@@ -22,7 +22,7 @@ instead of directly talking to AD.
 
 It dives into various options how to integrate classic POSIX and Active
 Directory worlds together
-(`slides <media:Devconf2013-linux-ad-integration-options.pdf>`__),
+(`slides <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Devconf2013-linux-ad-integration-options.pdf>`__),
 compares them and explains advantages and disadvantages of each:
 
 {{#ev:youtube|cS6EJ1L7fRI}}

--- a/src/page/V1_Documentation.rst
+++ b/src/page/V1_Documentation.rst
@@ -26,7 +26,7 @@ v1.2.1
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/Release_Notes/en-US/html/>`__
 
-:\*\ `PDF <Media:Release_Notes.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Release_Notes.pdf>`__
 
 Guides
 ======
@@ -41,7 +41,7 @@ Installation and Deployment Guide
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/Installation_Deployment_Guide/en-US/html>`__
 
-:\*\ `PDF <Media:Installation_and_Deployment_Guide.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Installation_and_Deployment_Guide.pdf>`__
 
 
 
@@ -54,7 +54,7 @@ Client Configuration Guide
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/Client_Setup_Guide/en-US/html/>`__
 
-:\*\ `PDF <Media:Client_Configuration_Guide.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Client_Configuration_Guide.pdf>`__
 
 
 
@@ -66,7 +66,7 @@ Administration Guide
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/Administration_Guide/en-US/html/>`__
 
-:\*\ `PDF <Media:Administration_Guide.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Administration_Guide.pdf>`__
 
 
 
@@ -78,7 +78,7 @@ User Guide
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/User_Guide/en-US/html/>`__
 
-:\*\ `PDF <Media:User_Guide.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/User_Guide.pdf>`__
 
 References
 ==========
@@ -95,7 +95,7 @@ Administrator's Reference
 
 :\*\ `HTML <http://freeipa.org/docs/1.2/Administrators_Reference/en-US/html/>`__
 
-:\*\ `PDF <Media:Administration_Reference.pdf>`__
+:\*\ `PDF <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Administration_Reference.pdf>`__
 
 
 

--- a/src/page/V2/Language_usage.rst
+++ b/src/page/V2/Language_usage.rst
@@ -28,7 +28,7 @@ In particular - it is important the the term referring the "containing
 others" and the term referring to "contained by others" be
 linguistically different from each other. The terms "Member" and
 "Membership", for instance, are too similar to provide much
-disambiguation. In the `July 7 <Media:July_7.pdf>`__ set of skeletons, I
+disambiguation. In the `July 7 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/July_7.pdf>`__ set of skeletons, I
 introduced a consistent terminology in which these terms were
 linguistically different. Dmitry pointed out to me yet another cause of
 confusion that my terms added. After some discussion, we came up with a
@@ -54,7 +54,7 @@ Objects:
 -  To delete an object, use \*Delete\*
 
 These terms form the basis of the grammar I used in the `July
-7 <Media:July_7.pdf>`__ skeletons, and commands, help strings, labels,
+7 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/July_7.pdf>`__ skeletons, and commands, help strings, labels,
 and titles are derived from these.
 
 There are several other clues that are designed in as well:

--- a/src/page/V2/Second_Round_Of_UI_design.rst
+++ b/src/page/V2/Second_Round_Of_UI_design.rst
@@ -13,14 +13,14 @@ Skeletons
 
 PDF files of the skeletons and site map:
 
--  `July 16, 2010 <Media:IPA_July_16.pdf>`__
--  `July 7, 2010 <Media:July_7.pdf>`__
--  `July 1, 2010 <Media:July_1_IPA_skeletons.pdf>`__
+-  `July 16, 2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/IPA_July_16.pdf>`__
+-  `July 7, 2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/July_7.pdf>`__
+-  `July 1, 2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/July_1_IPA_skeletons.pdf>`__
 -  `IPA HBAC skeletons from October 14,
-   2010 <Media:IPA_HBAC_skeletons.pdf>`__
+   2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/IPA_HBAC_skeletons.pdf>`__
 -  `IPA HBAC and ACI skeletons from Nov 10,
-   2010 <Media:Action_and_HBAC_and_ACI_3.pdf>`__
--  `IPA Autmount skeletons from Dec, 2010 <Media:IPA_Automount.pdf>`__
+   2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/Action_and_HBAC_and_ACI_3.pdf>`__
+-  `IPA Autmount skeletons from Dec, 2010 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/IPA_Automount.pdf>`__
 
 http://freeipa.org/page/Image:IPA_HBAC_skeletons.pdf
 
@@ -29,8 +29,8 @@ http://freeipa.org/page/Image:IPA_HBAC_skeletons.pdf
 Screen Comps
 ------------
 
--  `Screen 110 <Media:110-16-July.png>`__, July 16, 2010
--  `Screen 112 <Media:112-16-July.png>`__, July 16, 2010
+-  `Screen 110 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/110-16-July.png>`__, July 16, 2010
+-  `Screen 112 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/112-16-July.png>`__, July 16, 2010
 
 Behaviors
 ---------

--- a/src/page/WebUI-2-1.rst
+++ b/src/page/WebUI-2-1.rst
@@ -19,7 +19,7 @@ and integrated support on the top.
 
 The search box will be available from anywhere within the entity
 
-`Navigation Enhancements for 2.1 <Media:2.1_Enhancements_v2.pdf>`__
+`Navigation Enhancements for 2.1 <https://github.com/freeipa/freeipa.github.io/blob/main/src/page/2.1_Enhancements_v2.pdf>`__
 
 
 


### PR DESCRIPTION
Fix links using mediawiki's 'Media:' format to point to our GitHub repo.