### PR TITLE
Fix logo not loading on some pages

### DIFF
--- a/src/_templates/custom_nav.html
+++ b/src/_templates/custom_nav.html
@@ -1,5 +1,5 @@
 <a class="navbar-brand logo" href="/">
-    <img src="_static/freeipa-logo-small.png" class="logo__image" alt="Logo image" />
+    <img src="https://raw.githubusercontent.com/freeipa/freeipa.github.io/main/src/_static/freeipa-logo-small.png" class="logo__image" alt="Logo image" />
 </a>
 <div class="sidebar-primary-item">
     <nav class="bd-links" id="bd-docs-nav" aria-label="Main">


### PR DESCRIPTION
Use absolute URL for logo, as it's hosted in GitHub already.