### PR TITLE
fix: Recreate CNAME on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: _build/html/
+        cname: www.freeipa.org


### PR DESCRIPTION
Deploy using actions-gh-pages action was causing CNAME file to be deleted on deploy, making the website unavailable in custom domain.