### PR TITLE
Update the URL to Debian packaging

### DIFF
--- a/src/Downloads.rst
+++ b/src/Downloads.rst
@@ -22,7 +22,7 @@ FreeIPA versions:
 -  `CentOS <https://www.centos.org/>`__ - `get
    started <https://access.redhat.com/products/identity-management#getstarted>`__
 -  `Debian <https://www.debian.org/>`__ - `FreeIPA
-   package <https://packages.debian.org/sid/net/freeipa-server>`__
+   package <https://tracker.debian.org/pkg/freeipa>`__
 
 Releases in Container
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The old link doesn't work, as sid/unstable doesn't have freeipa-server at the moment. It's best to point to the packaging page instead, and it also has more useful information.