### PR TITLE
Add search bar to navigation bar

### DIFF
--- a/src/_templates/custom_nav.html
+++ b/src/_templates/custom_nav.html
@@ -1,6 +1,3 @@
-<a class="navbar-brand logo" href="/">
-    <img src="https://raw.githubusercontent.com/freeipa/freeipa.github.io/main/src/_static/freeipa-logo-small.png" class="logo__image" alt="Logo image" />
-</a>
 <div class="sidebar-primary-item">
     <nav class="bd-links" id="bd-docs-nav" aria-label="Main">
         <div class="bd-toc-item navbar-nav active">

--- a/src/_templates/logo.html
+++ b/src/_templates/logo.html
@@ -1,0 +1,3 @@
+<a class="navbar-brand logo" href="/">
+    <img src="https://raw.githubusercontent.com/freeipa/freeipa.github.io/main/src/_static/freeipa-logo-small.png" class="logo__image" alt="Logo image" />
+</a>

--- a/src/conf.py
+++ b/src/conf.py
@@ -49,7 +49,7 @@ html_theme = "sphinx_book_theme"
 # html_theme_path = ["themes"]
 
 html_sidebars = {
-    "**": ["custom_nav.html"]
+    "**": ["logo.html", "search-button-field.html", "custom_nav.html"]
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Add search bar to navigation bar. This required to split our navigation bar into two separate templates in order to fit the bar between the logo and the links.