### PR TITLE
Removed 'config_file_version' option from 'sssd.conf' examples

### DIFF
--- a/src/page/Web_App_Authentication/Example_setup.rst
+++ b/src/page/Web_App_Authentication/Example_setup.rst
@@ -571,7 +571,6 @@ and enable and configure its **ifp** subsystem:
     [sssd]
    -services = nss, pam, ssh
    +services = nss, pam, ssh, ifp
-    config_file_version = 2
 
     domains = example.com
    @@ -28,3 +30,7 @@

--- a/src/page/Web_App_Authentication/Namespace_separation.rst
+++ b/src/page/Web_App_Authentication/Namespace_separation.rst
@@ -193,7 +193,6 @@ The next part to configure is sssd, in **/etc/sssd/sssd.conf**:
    # in [sssd] section, append EXAMPLE.COM to domains
    [sssd]
    services = nss, pam, ssh, ifp
-   config_file_version = 2
    domains = company.net, EXAMPLE.COM
    # add new section [domain/EXAMPLE.COM]
    [domain/EXAMPLE.COM]


### PR DESCRIPTION
This option is obsolete / doesn't have meaning quite some time already. It wasn't required as well.
Starting sssd-2.10 it's removed altogether.