### PR TITLE
Add proper HBAC documentation

### DIFF
--- a/src/page/ConfiguringAixClients.rst
+++ b/src/page/ConfiguringAixClients.rst
@@ -228,7 +228,7 @@ Create :file:`/etc/security/ldap/ldap.cfg`, **note that you don't want to allow 
     krbkeypath:/etc/krb5/krb5.keytab
     krbprincipal:host/aix73.example.com@EXAMPLE.COM
     defaultentrylocation:local
-    userbasedn:cn=users,cn=accounts,dc=example,dc=com??(!(nsaccountlocked=TRUE))
+    userbasedn:cn=users,cn=accounts,dc=example,dc=com??(!(nsaccountlock=TRUE))
     groupbasedn:cn=groups,cn=accounts,dc=example,dc=com
     netgroupbasedn:cn=ng,cn=compat,dc=example,dc=com
     userclasses:posixaccount
@@ -276,7 +276,7 @@ And add the following to :file:`/etc/pam.cfg`:
 ::
 
     (...)
-    userbasedn:cn=users,cn=accounts,dc=example,dc=com??(&(!(nsaccountlocked=TRUE))(memberOf=ipaUniqeID=12345678-1234-1234-1234567890ab,cn=hbac,dc=example,dc=com))
+    userbasedn:cn=users,cn=accounts,dc=example,dc=com??(&(!(nsaccountlock=TRUE))(memberOf=ipaUniqeID=12345678-1234-1234-1234567890ab,cn=hbac,dc=example,dc=com))
     (...)
 
 Or... **if you don't want to use HBAC, or prevent locked users from logging in**, your `userbasedn` parameter may be specified without any additional filters, like:

--- a/src/page/ConfiguringAixClients.rst
+++ b/src/page/ConfiguringAixClients.rst
@@ -271,7 +271,7 @@ And add the following to `/etc/pam.cfg`:
     userbasedn:cn=users,cn=accounts,dc=example,dc=com??(&(!(nsaccountlocked=TRUE))(memberOf=ipaUniqeID=12345678-1234-1234-1234567890ab,cn=hbac,dc=example,dc=com))
     (...)
 
-If you don't want to use HBAC, or prevent locked users from logging in, your `userbasedn` parameter may be specified without any additional filters, like:
+Or... **if you don't want to use HBAC, or prevent locked users from logging in**, your `userbasedn` parameter may be specified without any additional filters, like:
 
 ::
 

--- a/src/page/ConfiguringAixClients.rst
+++ b/src/page/ConfiguringAixClients.rst
@@ -247,16 +247,18 @@ The password to the GSKit certificate store (`ldapsslkeypwd`) can be encrypted u
 HBAC (Host-based access control)
 --------------------------------
 
-You can have **true** :abbr:`HBAC (Host-based access control)` using `pam_ipahbac <https://github.com/rseabra/pam_ipahbac/>`, after installation you place a `/etc/ipahbac.conf` file with the pam module's configuration:
+You can have **true** :abbr:`HBAC (Host-based access control)` using `pam_ipahbac <https://github.com/rseabra/pam_ipahbac/>`__.
+
+After installation, place a :file:`/etc/ipahbac.conf` file with the pam module's configuration:
 
 ::
 
-    -u YourSysAccount
-    -b dc=your,dc=domain
+    -u uid=aix.bind.account,cn=users,cn=accounts,dc=example,dc=com
+    -b dc=example,dc=com
     -P /etc/ldap.secret
-    -l ldaps://ldap1/,ldaps://ldap2/..
+    -l ldaps://ipaserver1.example.com/,ldaps://ipaserver2.example.com/
 
-And add the following to `/etc/pam.cfg`:
+And add the following to :file:`/etc/pam.cfg`:
 
 ::
 

--- a/src/page/ConfiguringAixClients.rst
+++ b/src/page/ConfiguringAixClients.rst
@@ -253,16 +253,22 @@ After installation, place a :file:`/etc/ipahbac.conf` file with the pam module's
 
 ::
 
-    -u uid=aix.bind.account,cn=users,cn=accounts,dc=example,dc=com
+    -k /etc/security/ldap/ldap.kdb
+    -U bind.aix.user
     -b dc=example,dc=com
     -P /etc/ldap.secret
-    -l ldaps://ipaserver1.example.com/,ldaps://ipaserver2.example.com/
+    -l ipaserver1.example.com,ipaserver2.example.com
+    -D example.com
 
 And add the following to :file:`/etc/pam.cfg`:
 
 ::
 
-    sshd account    required     pam_ipahbac.so /etc/ipahbac.conf
+    (...)
+    sshd    account    requisite       pam_ipahbac.so /etc/ipahbac.conf
+    (...)
+    ipahbac_test    account    requisite     pam_ipahbac.so /etc/ipahbac.conf
+
 
 
 **Alternatively**, if you don't mind using a limited version of HBAC support, you can change your *userbasedn* field in **ldap.cfg** to check the user properties for being a member of a particular HBAC rule:


### PR DESCRIPTION
Hi,

I wrote a simple PAM module to allow HBAC integration for systems without sssd or environments where adding sssd would be too complex.

With that AIX can have proper HBAC checks, which is what this PR mostly shows.

Br,
Rui