### PR TITLE
Replace Pagure links with new repo at Codeberg

### DIFF
--- a/src/Contribute.rst
+++ b/src/Contribute.rst
@@ -21,7 +21,7 @@ Security Bugs and Flaws
 Tracking
 ^^^^^^^^
 
--  We use `Pagure <https://pagure.io/freeipa/issues>`__ for the upstream
+-  We use `Codeberg <https://codeberg.org/freeipa/freeipa>`__ for the upstream
    development, so all RFEs or bug reports should go primarily there.
 -  Bugs against released Fedora versions can be logged using the
    following `Bugzilla
@@ -76,8 +76,8 @@ free to ask!
 How To Start
 ~~~~~~~~~~~~
 
-The FreeIPA project uses the `Pagure ticketing
-system <https://pagure.io/freeipa/>`__ to keep track of work being done.
+The FreeIPA project uses the `Codeberg ticketing
+system <https://codeberg.org/freeipa/freeipa>`__ to keep track of work being done.
 If you want to contribute check out if there are interesting tickets in
 the pipeline (or file your own).
 

--- a/src/Downloads.rst
+++ b/src/Downloads.rst
@@ -46,9 +46,9 @@ Sources
 ~~~~~~~
 
 If you want to `build <https://www.freeipa.org/page/Build>`__ FreeIPA
-yourself, you can check the sources stored on the project Pagure:
+yourself, you can check the sources stored on the project Codeberg:
 
--  `Latest Released Sources <https://releases.pagure.org/freeipa/>`__
+-  `Latest Released Sources <https://codeberg.org/freeipa/freeipa/releases>`__
 -  `Steps on verifying the
    release <https://www.freeipa.org/page/Verify_Release_Signature>`__
 

--- a/src/index.rst
+++ b/src/index.rst
@@ -34,9 +34,9 @@ Main features
    (Fedora), `389 Directory
    Server <http://directory.fedoraproject.org/>`__, `MIT
    Kerberos <http://k5wiki.kerberos.org/wiki/Main_Page>`__, NTP,
-   `DNS <https://pagure.io/bind-dyndb-ldap>`__, `Dogtag certificate
+   `DNS <https://codeberg.org/freeipa/bind-dyndb-ldap>`__, `Dogtag certificate
    system <http://pki.fedoraproject.org>`__,
-   `SSSD <https://pagure.io/SSSD/sssd>`__ and others.
+   `SSSD <https://sssd.io/>`__ and others.
 -  Built on top of well known Open Source components and standard
    protocols
 -  Strong focus on ease of management and automation of installation and

--- a/src/page/Build.rst
+++ b/src/page/Build.rst
@@ -44,7 +44,7 @@ In order to get more familiar with git submodule concepts, you can read
 You can clone the FreeIPA repository and its submodules using the following
 command:
 
-``$ git clone --recurse-submodules https://pagure.io/freeipa.git``
+``$ git clone --recurse-submodules https://codeberg.org/freeipa/freeipa.git``
 
 Next, we will install all packages needed to build FreeIPA as they do
 not have to be installed on your system. You can install them easily by

--- a/src/page/Contribute/Code.rst
+++ b/src/page/Contribute/Code.rst
@@ -4,7 +4,7 @@ Code
 This article should serve both as a reference article for already
 seasoned FreeIPA developers, but also as a guide for new people who
 would like to contribute. You can fix an open bug described in chosen
-`Pagure ticket <https://pagure.io/freeipa/issues>`__ or implement a
+`Codeberg ticket <https://codeberg.org/freeipa/freeipa>`__ or implement a
 whole new feature! The steps below should help get you started.
 
 If you need to learn more about FreeIPA itself, visit the `main
@@ -27,8 +27,8 @@ Find something to start with
 
 If you want to start with something (relatively) easy please take a look
 at `list of "easyfix"
-tickets <https://pagure.io/freeipa/issues?status=Open&tags=easyfix>`__
-in our Pagure. It is always better to start with something simple :-)
+tickets <https://codeberg.org/freeipa/freeipa>`__
+in our Codeberg. It is always better to start with something simple :-)
 
 Do not hesitate to `contact us <Contribute#Communication>`__ with any
 question or idea!
@@ -84,12 +84,12 @@ in git. Retrieve it and its submodules with:
 
 ::
 
-    git clone --recurse-submodules https://pagure.io/freeipa.git
+    git clone --recurse-submodules https://codeberg.org/freeipa/freeipa.git
 
 The code can also be browsed online
-`here <https://pagure.io/freeipa/commits>`__
+`here <https://codeberg.org/freeipa/freeipa>`__
 
-Note: to avoid pushing by mistake to pagure.io, you can replace the (push) url
+Note: to avoid pushing by mistake to Codeberg, you can replace the (push) url
 with the following command:
 
 ::
@@ -136,15 +136,15 @@ Then, you just need to run:
 
 
 
-Update Pagure ticket
+Update Codeberg ticket
 ----------------------------------------------------------------------------------------------
 
-We use Pagure for work coordination. Please be so kind and assign the
+We use Codeberg for work coordination. Please be so kind and assign the
 ticket you are working on to yourself. It is just a few clicks and it
 prevents people from working on the same thing at the same time without
 knowing about each other.
 
--  `Find a ticket <https://pagure.io/freeipa/issues>`__ related to your
+-  `Find a ticket <https://codeberg.org/freeipa/freeipa>`__ related to your
    work.
 
    -  Maybe the ticket does not exist. If you consider the code change
@@ -155,10 +155,7 @@ knowing about each other.
       different approaches etc.
 
 -  In the particular ticket, assign the ticket to yourself by clicking
-   on the "Take" button (note: you must be logged in
-   `pagure.io <https://pagure.io/login/?next=https://pagure.io/freeipa/>`__,
-   see `Login to pagure or create your
-   account <https://docs.pagure.org/pagure/usage/first_steps.html#login-to-pagure-or-create-your-account>`__)
+   on the "Assign to me" option.
 
 
 
@@ -265,9 +262,9 @@ present in the source tree (.git-commit-template):
 
   Explanation
 
-  Fixes: https://pagure.io/freeipa/issue/XXXX
+  Fixes: https://codeberg.org/freeipa/freeipa/issues//XXXX
   or
-  Related: https://pagure.io/freeipa/issue/XXXX
+  Related: https://codeberg.org/freeipa/freeipa/issues/XXXX
   Signed-off-by: Full Name <email@yourmail.com>
 
 
@@ -286,7 +283,7 @@ present in the source tree (.git-commit-template):
    way, but does not resolve it/them.
 -  *Signed-off-by:* contains your email, will be credited in the Contributors and Release Notes
 
-When a pull request is created, please update Pagure ticket with link to
+When a pull request is created, please update Codeberg ticket with link to
 the pull request (in the ticket, click on "Edit Metadata" and update the
 field "on_review" with the link to your PR, for instance
 https://github.com/freeipa/freeipa/pull/1234).
@@ -355,7 +352,7 @@ to keep track of the process.
 When the reviewer pass a feedback, patch should be then updated to clear
 all concerns and thus be ready to be merged. See `Pull request on
 Github <https://www.freeipa.org/page/Pull_request_on_Github>`__ for advice how to update a pull
-request. No changes in Pagure are needed when a reviewer rejects the
+request. No changes in Codeberg are needed when a reviewer rejects the
 patch or submitter sends a new version of the patch.
 
 

--- a/src/page/Contribute/Repository.rst
+++ b/src/page/Contribute/Repository.rst
@@ -14,8 +14,7 @@ FreeIPA project has 1 active repository:
 -  **Main code repository**: FreeIPA project code and tests
 
    -  Link:
-      ```https://pagure.io/freeipa.git`` <https://pagure.io/freeipa.git>`__
-   -  `Code browser <https://pagure.io/freeipa/commits/master>`__
+      ```https://codeberg.org/freeipa/freeipa.git`` <https://codeberg.org/freeipa/freeipa.git>`__
    -  `Contribution howto <Contribute/Code>`__
 
 
@@ -33,7 +32,7 @@ Write access
 ============
 
 Write access is allowed only to a limited list of upstream core
-developers (`member list <https://pagure.io/group/freeipa>`__) who are
+developers (`member list <https://codeberg.org/org/freeipa/members>`__) who are
 contributing to the project success, keep the code base clean and
 functional. The list is kept short to make sure that all committers know
 what should be pushed, when, to which branch(es) and with appropriate

--- a/src/page/Contribute/Tests.rst
+++ b/src/page/Contribute/Tests.rst
@@ -141,14 +141,14 @@ Committing (doesn’t apply for the temp commit)
 #. Follow the commit message guidelines listed in `Commit message
    requirements <Contribute/Code#Commit_message_requirements>`__
 #. Signoff and sign your commit
-#. All commits must include Pagure link
+#. All commits must include Codeberg ticket link
 #. Include separate temp commit (see below)
 
 ::
 
     (lowercase) ipatests : short summary within 80 chars (no dot)
     This is the particular reason for a change and or addition of a new test. Be as specific as possible. Use imperative language (fix bug, not fixed bug nor fixes bug) and present time.
-    Fixes (or Related): Pagure ticket link
+    Fixes (or Related): Codeberg ticket link
     Signed off by: (use –signoff and -S when committing)
 
 Note: “Fixes” is used when providing a fix for the raised issue.

--- a/src/page/Pull_request_on_Github.rst
+++ b/src/page/Pull_request_on_Github.rst
@@ -10,7 +10,7 @@ repository (cloned from fedorahosted)
 
 ::
 
-    $ git clone --recurse-submodules https://pagure.io/freeipa.git
+    $ git clone --recurse-submodules https://codeberg.org/freeipa/freeipa.git
     $ cd freeipa/
     $ git remote add myfork git@github.com:/freeipa.git
 
@@ -61,4 +61,4 @@ enough, but it is also possible to develop Modern WebUI separately using:
 The other processes are similar.
 
 Do note, that all of the development for Modern WebUI is done on
-`GitHub <https://github.com/freeipa/freeipa-webui>`__, not on Pagure.
+`GitHub <https://github.com/freeipa/freeipa-webui>`__, not on Codeberg.

--- a/src/page/Release.md
+++ b/src/page/Release.md
@@ -207,7 +207,7 @@ Building the sources
 If doing a pre release pull a fresh tree to do the builds into a separate directory:
 
 ```
-$ git clone --recurse-submodules [https://pagure.io/freeipa.git](https://pagure.io/freeipa.git) freeipa-x-y-z
+$ git clone --recurse-submodules [https://codeberg.org/freeipa/freeipa.git](https://codeberg.org/freeipa/freeipa.git) freeipa-x-y-z
 $ cd freeipa-x-y-z
 ```
 
@@ -263,7 +263,7 @@ $ gpg2 --default-key <IPA MASTER KEYID> --armor --detach-sign freeipa-x.y.z.tar.
 $ gpg2 --verify freeipa-x.y.z.tar.gz.asc
 ```
 
-Upload tarball and signature to pagure.io: [https://pagure.io/freeipa/releases](https://pagure.io/freeipa/releases)
+Upload tarball and signature to Codeberg: [https://codeberg.org/freeipa/freeipa/releases](https://codeberg.org/freeipa/freeipa/releases)
 
 If you signing key is not in the [Verify Release Signature](/web/20221001164305/https://freeipa.org/page/Verify_Release_Signature "Verify Release Signature") guide, append it to the list and gpg verify command.
 
@@ -383,13 +383,3 @@ When doing a major release, consider following extra steps:
 *   [Roadmap](/web/20221001164305/https://freeipa.org/page/Roadmap "Roadmap") - consider updating information about planned or new releases
 *   [Documentation](/web/20221001164305/https://freeipa.org/page/Documentation "Documentation") - update links and version numbers
 *   [Build](/web/20221001164305/https://freeipa.org/page/Build "Build") - update COPR repositories if new ones are introduced or old abandoned
-
-Tickets administravia
----------------------
-
-FixMe: is this being done for 4.9.x?
-
-*   [Create a milestone](https://fedorahosted.org/freeipa/milestone?action=new) for next FreeIPA version in form FreeIPA x.y.z.
-*   Create a new milestone in [Pagure project settings](https://pagure.io/freeipa/settings) (if doesn't exist).
-*   Move all [opened tickets](https://pagure.io/freeipa/roadmap?status=Open&milestone=FreeIPA+4.5.1&all_stones=True&no_stones=) from the released version milestone to the new milestone. (Following script can be used, use [move-milestone.py --help](https://raw.githubusercontent.com/freeipa/freeipa-tools/master/release/move-milestone.py) to see usage)
-*   Close the old milestone in the [Roadmap](https://fedorahosted.org/freeipa/roadmap).

--- a/src/page/Releases/4.10.0.rst
+++ b/src/page/Releases/4.10.0.rst
@@ -77,29 +77,29 @@ Rob Crittenden (9)
 ----------------------------------------------------------------------------------------------
 
 -  Fix test_secure_ajp_connector.py failing with Python 3.6.8
-   `commit <https://pagure.io/freeipa/c/9a97f9b40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a97f9b40>`__
 -  Add tests for Random Serial Number v3 support
-   `commit <https://pagure.io/freeipa/c/d241d7405>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d241d7405>`__
    `#2016 <https://pagure.io/freeipa/issue/2016>`__
 -  Add support for Random Serial Numbers v3
-   `commit <https://pagure.io/freeipa/c/beaa0562d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/beaa0562d>`__
    `#2016 <https://pagure.io/freeipa/issue/2016>`__
 -  Add a new parameter type, SerialNumber, as a subclass of Str
-   `commit <https://pagure.io/freeipa/c/83be923ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83be923ac>`__
    `#2016 <https://pagure.io/freeipa/issue/2016>`__
 -  doc/designs: add Random Serial Numbers v3 support
-   `commit <https://pagure.io/freeipa/c/d3481449e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3481449e>`__
    `#2016 <https://pagure.io/freeipa/issue/2016>`__
 -  Design for IPA-to-IPA migration
-   `commit <https://pagure.io/freeipa/c/d4859db4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4859db4e>`__
 -  Re-work the quiet option in ipa-join to not suppress errors
-   `commit <https://pagure.io/freeipa/c/61650c577>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61650c577>`__
    `#9105 <https://pagure.io/freeipa/issue/9105>`__
 -  Improve sudooption docs, make the option multi-value
-   `commit <https://pagure.io/freeipa/c/47fbe05f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47fbe05f7>`__
    `#2278 <https://pagure.io/freeipa/issue/2278>`__
 -  Design doc to allow LDAP bind using the RADIUS auth type
-   `commit <https://pagure.io/freeipa/c/16ab690bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16ab690bf>`__
 
 
 
@@ -107,7 +107,7 @@ Matthew Davis (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add missing parameter to Suse modify_nsswitch_pam_stack
-   `commit <https://pagure.io/freeipa/c/6d6b135ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d6b135ff>`__
 
 
 
@@ -115,11 +115,11 @@ Anuja More (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fix install_master for test_idp.py
-   `commit <https://pagure.io/freeipa/c/ef091c99f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef091c99f>`__
 -  Add end to end integration tests for external IdP
-   `commit <https://pagure.io/freeipa/c/bd57ff356>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd57ff356>`__
 -  ipatests: update prci definitions for test_idp.py
-   `commit <https://pagure.io/freeipa/c/a80a98194>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a80a98194>`__
 
 
 
@@ -127,9 +127,9 @@ Timo Aaltonen (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform/debian: Drop the path for ldap.so
-   `commit <https://pagure.io/freeipa/c/808ac46ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/808ac46ba>`__
 -  ipaplatform/debian: Use multiarch path for libsofthsm2.so
-   `commit <https://pagure.io/freeipa/c/92d718dbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92d718dbf>`__
 
 
 
@@ -137,16 +137,16 @@ Michal Polovka (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Healthcheck use subject base from IPA not REALM
-   `commit <https://pagure.io/freeipa/c/d3c11f762>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3c11f762>`__
 -  ipatests: Increase expect timeout for interactive mode
-   `commit <https://pagure.io/freeipa/c/40b3c11bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b3c11bd>`__
 -  ipatests: Healthcheck should ignore pki errors when CA is not
-   configured `commit <https://pagure.io/freeipa/c/b2bbf8165>`__
+   configured `commit <https://codeberg.org/freeipa/freeipa/commit/b2bbf8165>`__
 -  test_webui: test_hostgroup: Wait for modal dialog to appear
-   `commit <https://pagure.io/freeipa/c/d0269f236>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0269f236>`__
    `#8684 <https://pagure.io/freeipa/issue/8684>`__
 -  WebUI: Test if links are opened in new tab correctly
-   `commit <https://pagure.io/freeipa/c/89c846a1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89c846a1f>`__
 
 
 
@@ -154,24 +154,24 @@ Florence Blanc-Renaud (9)
 ----------------------------------------------------------------------------------------------
 
 -  xmlrpc tests: updated expected output for preserved user
-   `commit <https://pagure.io/freeipa/c/3732349bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3732349bc>`__
 -  Preserve user: fix the confusing summary
-   `commit <https://pagure.io/freeipa/c/cbc18ff8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbc18ff8c>`__
 -  ipatests: update packages in rawhide test test_installation_client.py
-   `commit <https://pagure.io/freeipa/c/4c61b9266>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c61b9266>`__
    `#9035 <https://pagure.io/freeipa/issue/9035>`__
 -  ipatests: revert wrong commit on gating definition
-   `commit <https://pagure.io/freeipa/c/4b665ccf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b665ccf2>`__
 -  Design: Integrate SID configuration into base IPA installers
-   `commit <https://pagure.io/freeipa/c/bacddb828>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bacddb828>`__
 -  Doc: add a design template
-   `commit <https://pagure.io/freeipa/c/5edf144a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5edf144a7>`__
 -  ipatests: add test_acme.py in nightly previous
-   `commit <https://pagure.io/freeipa/c/96a297f3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96a297f3b>`__
 -  ipatests: fix incomplete nightly def in nightly_previous
-   `commit <https://pagure.io/freeipa/c/296f27dce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/296f27dce>`__
 -  ipatests: fix discrepancies in nightly defs
-   `commit <https://pagure.io/freeipa/c/9b2c05aff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b2c05aff>`__
 
 
 
@@ -179,21 +179,21 @@ Armando Neto (8)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: update prci template
-   `commit <https://pagure.io/freeipa/c/b3085b830>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3085b830>`__
 -  ipatests: update definitions for custom COPR nightlies
-   `commit <https://pagure.io/freeipa/c/1101b22b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1101b22b5>`__
 -  ipatests: bump PR-CI rawhide template
-   `commit <https://pagure.io/freeipa/c/c780504d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c780504d4>`__
 -  ipatests: bump rawhide template for PR-CI
-   `commit <https://pagure.io/freeipa/c/d6d413628>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6d413628>`__
 -  ipatests: Bump PR-CI rawhide template
-   `commit <https://pagure.io/freeipa/c/c14d52f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c14d52f43>`__
 -  ipatests: Bump PR-CI Rawhide template
-   `commit <https://pagure.io/freeipa/c/c572697d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c572697d9>`__
 -  ipatests: Update gating to Fedora 33
-   `commit <https://pagure.io/freeipa/c/a6b487130>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6b487130>`__
 -  ipatests: update PR-CI templates to Fedora 33
-   `commit <https://pagure.io/freeipa/c/3e8e83654>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e8e83654>`__
 
 
 
@@ -201,11 +201,11 @@ Alexander Bokovoy (3)
 ----------------------------------------------------------------------------------------------
 
 -  Fix use of comparison functions to avoid GCC bug 95189
-   `commit <https://pagure.io/freeipa/c/9043b8d53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9043b8d53>`__
 -  doc/designs: fix formatting in LDAPI autobind design
-   `commit <https://pagure.io/freeipa/c/3d809c706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d809c706>`__
 -  Contributors: add new contributors to the list
-   `commit <https://pagure.io/freeipa/c/bef78d16e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bef78d16e>`__
 
 
 
@@ -213,7 +213,7 @@ Mohammad Rizwan (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: Test ipa-cert-fix fails when startup directive is missing
-   from CS.cfg `commit <https://pagure.io/freeipa/c/16057898a>`__
+   from CS.cfg `commit <https://codeberg.org/freeipa/freeipa/commit/16057898a>`__
 
 
 
@@ -221,10 +221,10 @@ Christian Heimes (2)
 ----------------------------------------------------------------------------------------------
 
 -  Add design for LDAPI autobind
-   `commit <https://pagure.io/freeipa/c/5b8f37f88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b8f37f88>`__
    `#8544 <https://pagure.io/freeipa/issue/8544>`__
 -  LDAP autobind authenticateAsDN for BIND named
-   `commit <https://pagure.io/freeipa/c/16e1cbdc5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16e1cbdc5>`__
    `#8544 <https://pagure.io/freeipa/issue/8544>`__
 
 
@@ -233,7 +233,7 @@ François Cami (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix nightly_latest_testing_selinux template
-   `commit <https://pagure.io/freeipa/c/87304c78a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87304c78a>`__
 
 
 
@@ -241,10 +241,10 @@ Antonio Torres (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add test for ipa-cacert-manage prune
-   `commit <https://pagure.io/freeipa/c/8a2e6ec32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a2e6ec32>`__
    `#7404 <https://pagure.io/freeipa/issue/7404>`__
 -  ipa-cacert-manage: add prune option
-   `commit <https://pagure.io/freeipa/c/5d8cb1dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d8cb1dd1>`__
    `#7404 <https://pagure.io/freeipa/issue/7404>`__
 
 
@@ -253,8 +253,8 @@ Peter Keresztes Schmidt (3)
 ----------------------------------------------------------------------------------------------
 
 -  configure: Do not set -Wno-strict-aliasing -Wno-sign-compare
-   `commit <https://pagure.io/freeipa/c/f9357cb98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9357cb98>`__
 -  build: Unify compiler warning flags used
-   `commit <https://pagure.io/freeipa/c/a355646c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a355646c3>`__
 -  configure: Fix source tree detection to enable more warnings
-   `commit <https://pagure.io/freeipa/c/54b42f72f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54b42f72f>`__

--- a/src/page/Releases/4.10.1.rst
+++ b/src/page/Releases/4.10.1.rst
@@ -232,7 +232,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  webui: Do not allow empty pagination size
-   `commit <https://pagure.io/freeipa/c/02d3fb8266d8199fd1ed983de6c57b269546df82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02d3fb8266d8199fd1ed983de6c57b269546df82>`__
    `#9192 <https://pagure.io/freeipa/issue/9192>`__
 
 
@@ -241,32 +241,32 @@ Alexander Bokovoy (10)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: fix comment to make sure we talk about krb5 1.20 or later
-   `commit <https://pagure.io/freeipa/c/d3c7a4faae8fd58a8d08bf6191d47fefe276ddba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3c7a4faae8fd58a8d08bf6191d47fefe276ddba>`__
 -  ipa-kdb: fix PAC requester check
-   `commit <https://pagure.io/freeipa/c/88c1293f3a92451b6d5d5f7cb1a81d55a789b793>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88c1293f3a92451b6d5d5f7cb1a81d55a789b793>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: handle empty S4U proxy in allowed_to_delegate
-   `commit <https://pagure.io/freeipa/c/1d4db340461298fed66607bde5fb0ca0f033c5aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d4db340461298fed66607bde5fb0ca0f033c5aa>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: handle cross-realm TGT entries when generating PAC
-   `commit <https://pagure.io/freeipa/c/a5ca25003da5906703e8bd12b0759d48bc52e6b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5ca25003da5906703e8bd12b0759d48bc52e6b2>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: add krb5 1.20 support
-   `commit <https://pagure.io/freeipa/c/e9ae0e350dcee5c9bbcd5a6932b4eb0daa90fea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9ae0e350dcee5c9bbcd5a6932b4eb0daa90fea7>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: refactor MS-PAC processing to prepare for krb5 1.20
-   `commit <https://pagure.io/freeipa/c/f0c72dcb87f86b9b00d0c087a959e64ce10eea98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0c72dcb87f86b9b00d0c087a959e64ce10eea98>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipaclient: do not set TLS CA options in ldap.conf anymore
-   `commit <https://pagure.io/freeipa/c/93b0e6a96a1aea45adc0d4c8bb26b226ce683573>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93b0e6a96a1aea45adc0d4c8bb26b226ce683573>`__
    `#9258 <https://pagure.io/freeipa/issue/9258>`__
 -  Remove empty translation for 'si' which breaks linter
-   `commit <https://pagure.io/freeipa/c/41ba166c77ca8011a35f80f2791a211c429a271e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ba166c77ca8011a35f80f2791a211c429a271e>`__
 -  fix canonicalization issue in Web UI
-   `commit <https://pagure.io/freeipa/c/a0928fe164712303a7c24ee61500ac7326bd9e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0928fe164712303a7c24ee61500ac7326bd9e4a>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 -  ipa-otpd: initialize local pointers and handle gcc 10
-   `commit <https://pagure.io/freeipa/c/9441d7ed1ac67dc74ca6177b474d10da97b06a2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9441d7ed1ac67dc74ca6177b474d10da97b06a2f>`__
    `#9230 <https://pagure.io/freeipa/issue/9230>`__
 
 
@@ -275,7 +275,7 @@ Anuja More (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests : Test query to AD specific attributes is successful.
-   `commit <https://pagure.io/freeipa/c/db7cd79858ec8fad7d094ca883d8b7d82c7c1ac1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db7cd79858ec8fad7d094ca883d8b7d82c7c1ac1>`__
    `#9127 <https://pagure.io/freeipa/issue/9127>`__
 
 
@@ -284,7 +284,7 @@ Andika Triwidada (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/3885bd6fd75e984f990dc0e0f760f61815139181>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3885bd6fd75e984f990dc0e0f760f61815139181>`__
 
 
 
@@ -292,7 +292,7 @@ Antonio Torres (1)
 ----------------------------------------------------------------------------------------------
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/c9d9fb3a3a63f66d60541f21f2f3466b6d9a89b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9d9fb3a3a63f66d60541f21f2f3466b6d9a89b3>`__
 
 
 
@@ -301,12 +301,12 @@ Alexey Tikhonov (3)
 
 -  extdom: avoid sss_nss_getorigby*() calls when get*_r_wrapper()
    returns object from a wrong domain (performance optimization)
-   `commit <https://pagure.io/freeipa/c/1360c8b09f0862fe961fbb015f55d6b3cbd9aee9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1360c8b09f0862fe961fbb015f55d6b3cbd9aee9>`__
 -  extdom: make sure result doesn't miss domain part
-   `commit <https://pagure.io/freeipa/c/4685f9d881c09fa317cb68fba1b94c29e48a7a8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4685f9d881c09fa317cb68fba1b94c29e48a7a8b>`__
    `#9245 <https://pagure.io/freeipa/issue/9245>`__
 -  extdom: internal functions should be static
-   `commit <https://pagure.io/freeipa/c/113cb8d715cf7bed8bcc36845940acc20fed8e60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/113cb8d715cf7bed8bcc36845940acc20fed8e60>`__
 
 
 
@@ -314,25 +314,25 @@ Carla Martinez (7)
 ----------------------------------------------------------------------------------------------
 
 -  Update API and VERSION
-   `commit <https://pagure.io/freeipa/c/48b9cc3345f8596904bce14d580cd4b19bfbda15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48b9cc3345f8596904bce14d580cd4b19bfbda15>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  webui: Set 'SOA serial' field as read-only
-   `commit <https://pagure.io/freeipa/c/9b274bc5d01c58806f18e549b566d93e25b40214>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b274bc5d01c58806f18e549b566d93e25b40214>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  ipatest: Remove warning message for 'idnssoaserial'
-   `commit <https://pagure.io/freeipa/c/3d34673b8c04c9ec849f8276876fd8bbd4fe2234>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d34673b8c04c9ec849f8276876fd8bbd4fe2234>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  Set 'idnssoaserial' to deprecated
-   `commit <https://pagure.io/freeipa/c/242ed2e500510f33f4595fb1b29adb25b1517982>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/242ed2e500510f33f4595fb1b29adb25b1517982>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  webui: Show 'Sudo order' column
-   `commit <https://pagure.io/freeipa/c/54b81617674be79577b8c3abf0949725d9a428c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54b81617674be79577b8c3abf0949725d9a428c7>`__
    `#9237 <https://pagure.io/freeipa/issue/9237>`__
 -  Set pkeys in test_selinuxusermap.py::test_misc::delete_record
-   `commit <https://pagure.io/freeipa/c/ea792e11eb85a5b05b2b78f0215c147a52d2d265>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea792e11eb85a5b05b2b78f0215c147a52d2d265>`__
    `#9161 <https://pagure.io/freeipa/issue/9161>`__
 -  webui: Allow grace login limit
-   `commit <https://pagure.io/freeipa/c/7a1e1d9f1cb13679c28f12d05b156a08bcc4d856>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a1e1d9f1cb13679c28f12d05b156a08bcc4d856>`__
    `#9211 <https://pagure.io/freeipa/issue/9211>`__
 
 
@@ -341,33 +341,33 @@ Jan Kuparinen (14)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/d4b9203376115508f596c6469c9c3be24d719ff2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4b9203376115508f596c6469c9c3be24d719ff2>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/242a0dadcf86bb27efccdc1be1946c39f0ba2931>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/242a0dadcf86bb27efccdc1be1946c39f0ba2931>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/98e80985bae7fa7104d8dd621c73c2b848630417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98e80985bae7fa7104d8dd621c73c2b848630417>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/2b0c9d91285282df5f545fc6c331b5b9a219048e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b0c9d91285282df5f545fc6c331b5b9a219048e>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/dbe49df1b3d2fb254315ed26190792c8aaf89c38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbe49df1b3d2fb254315ed26190792c8aaf89c38>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/0caffa37c01a7a77301368413854473520e5e055>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0caffa37c01a7a77301368413854473520e5e055>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/63fceacb176162210cd5d64f73ecf10b1bf8d402>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63fceacb176162210cd5d64f73ecf10b1bf8d402>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/606ce6d52aa4b29e1af787c7830d30d6846c932e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/606ce6d52aa4b29e1af787c7830d30d6846c932e>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/10a51197f27d90fab78bdf6a4a0cae6779589299>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10a51197f27d90fab78bdf6a4a0cae6779589299>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/1c1187beedb23f91614f131fda15c6c6f6264556>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c1187beedb23f91614f131fda15c6c6f6264556>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/a1c0031c9044135ae00ac9f3e22beb22bd5fbb07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1c0031c9044135ae00ac9f3e22beb22bd5fbb07>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/bcc5819830e23867a5c1471f3a37576d705ce8d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcc5819830e23867a5c1471f3a37576d705ce8d8>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/3452c6fcf0730351b45ecbeb7d89ff318319f7c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3452c6fcf0730351b45ecbeb7d89ff318319f7c0>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/a4202264936dca51b476178f5061692cd569373b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4202264936dca51b476178f5061692cd569373b>`__
 
 
 
@@ -375,9 +375,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: fix prci checker target masked return code & add pylint
-   `commit <https://pagure.io/freeipa/c/51f1321b9c2263edd3f725abe3f90e56678adf94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51f1321b9c2263edd3f725abe3f90e56678adf94>`__
 -  ipatests: Checker script for prci definitions
-   `commit <https://pagure.io/freeipa/c/3d827979d2688607bd5376501ef71c2b63124603>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d827979d2688607bd5376501ef71c2b63124603>`__
 
 
 
@@ -385,7 +385,7 @@ Erik (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: healthcheck: test if system is FIPS enabled
-   `commit <https://pagure.io/freeipa/c/c55185d3dc3c6cd2ffebab77fbf8caa40a32bcd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c55185d3dc3c6cd2ffebab77fbf8caa40a32bcd1>`__
    `#8951 <https://pagure.io/freeipa/issue/8951>`__
 
 
@@ -394,7 +394,7 @@ Endi Sukma Dewata (1)
 ----------------------------------------------------------------------------------------------
 
 -  Remove pki_restart_configured_instance
-   `commit <https://pagure.io/freeipa/c/79f765586e8f18e37f3dbe036b12715bef49e442>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79f765586e8f18e37f3dbe036b12715bef49e442>`__
 
 
 
@@ -402,46 +402,46 @@ Florence Blanc-Renaud (15)
 ----------------------------------------------------------------------------------------------
 
 -  Spec file: bump the selinux-policy version
-   `commit <https://pagure.io/freeipa/c/4e201ec97e5c54ad8d5fa02285e628d1a36d9ea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e201ec97e5c54ad8d5fa02285e628d1a36d9ea7>`__
    `#9198 <https://pagure.io/freeipa/issue/9198>`__
 -  webui tests: fix test_subid suite
-   `commit <https://pagure.io/freeipa/c/9936379c9f0d6c888785ccca8766ed7074054270>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9936379c9f0d6c888785ccca8766ed7074054270>`__
    `#9214 <https://pagure.io/freeipa/issue/9214>`__
 -  ipatests: mark xfail tests using dnssec
-   `commit <https://pagure.io/freeipa/c/3d093c66f21c57afeb8cfc242390d0d032509ab3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d093c66f21c57afeb8cfc242390d0d032509ab3>`__
    `#9216 <https://pagure.io/freeipa/issue/9216>`__
 -  ipatests: mark xfail tests using sssctl domain-status
-   `commit <https://pagure.io/freeipa/c/40b9c6fc4746cfa32d8bf7c2038745cc037c673b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b9c6fc4746cfa32d8bf7c2038745cc037c673b>`__
    `#9234 <https://pagure.io/freeipa/issue/9234>`__
 -  Tests: test on f37 and f36
-   `commit <https://pagure.io/freeipa/c/a6485d6325585d0f80b659c473b3675728556ce1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6485d6325585d0f80b659c473b3675728556ce1>`__
 -  ipa man page: format the EXAMPLES section
-   `commit <https://pagure.io/freeipa/c/1546c0b206e02902b4aba631ee83f2f7ba5acb1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1546c0b206e02902b4aba631ee83f2f7ba5acb1f>`__
    `#9252 <https://pagure.io/freeipa/issue/9252>`__
 -  ipatests: add negative test for otptoken-sync
-   `commit <https://pagure.io/freeipa/c/d9f33b7cd7e336be90d889e2db4c4bce18753918>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9f33b7cd7e336be90d889e2db4c4bce18753918>`__
    `#9248 <https://pagure.io/freeipa/issue/9248>`__
 -  ipa otptoken-sync: return error when sync fails
-   `commit <https://pagure.io/freeipa/c/221768f882784755c6449ff70f291fab780cce16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/221768f882784755c6449ff70f291fab780cce16>`__
    `#9248 <https://pagure.io/freeipa/issue/9248>`__
 -  ipa-cacert-manage prune: remove all expired certs
-   `commit <https://pagure.io/freeipa/c/c5bcaab8f1e09ab7a0464f5a532f154d43ffcadb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5bcaab8f1e09ab7a0464f5a532f154d43ffcadb>`__
    `#9244 <https://pagure.io/freeipa/issue/9244>`__
 -  gitignore: add install/oddjob/org.freeipa.server.config-enable-sid
-   `commit <https://pagure.io/freeipa/c/458dcebd2542de70c987ca89fe49f15d3f40ee82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/458dcebd2542de70c987ca89fe49f15d3f40ee82>`__
 -  ipatests: Fix expected object classes
-   `commit <https://pagure.io/freeipa/c/b6520bef2ef05dd87636d8b57e3247d451af81d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6520bef2ef05dd87636d8b57e3247d451af81d8>`__
    `#9062 <https://pagure.io/freeipa/issue/9062>`__
 -  check_repl_update: in progress is a boolean
-   `commit <https://pagure.io/freeipa/c/2003eb6b3d4a27a5de5eaa79418f115dd99886cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2003eb6b3d4a27a5de5eaa79418f115dd99886cd>`__
    `#9218 <https://pagure.io/freeipa/issue/9218>`__
 -  azure tests: disable TestInstallDNSSECFirst
-   `commit <https://pagure.io/freeipa/c/eb9f606ffd1ad3ccd846173c152c52a171be8f86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb9f606ffd1ad3ccd846173c152c52a171be8f86>`__
    `#9216 <https://pagure.io/freeipa/issue/9216>`__
 -  Nightly tests: fix template for nightly_ipa-4-10_latest.yaml
-   `commit <https://pagure.io/freeipa/c/4499c7379b5531501bb1a5ea58ab575bf3b08907>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4499c7379b5531501bb1a5ea58ab575bf3b08907>`__
 -  ipatests: add nightly definitions for ipa-4-10 branch
-   `commit <https://pagure.io/freeipa/c/6c6a43c9090b5f61726512182a36958cbdafc9a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c6a43c9090b5f61726512182a36958cbdafc9a4>`__
 
 
 
@@ -449,10 +449,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  install: suggest --skip-mem-check when mem check fails
-   `commit <https://pagure.io/freeipa/c/cebfb8792006af1a41c4c26c49372f0ea822dbaf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cebfb8792006af1a41c4c26c49372f0ea822dbaf>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  man: add --skip-mem-check to man pages
-   `commit <https://pagure.io/freeipa/c/e7bee5b668fee083d8ada167f307857761c25d80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7bee5b668fee083d8ada167f307857761c25d80>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 
 
@@ -461,7 +461,7 @@ Jesse Sandberg (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix ipa-ccache-sweeper activation timer and clean up service file
-   `commit <https://pagure.io/freeipa/c/f6a661bdaf0560eac99ca63ffb25ec739281a19a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6a661bdaf0560eac99ca63ffb25ec739281a19a>`__
    `#9231 <https://pagure.io/freeipa/issue/9231>`__
 
 
@@ -470,7 +470,7 @@ Nikola Knazekova (1)
 ----------------------------------------------------------------------------------------------
 
 -  Exclude installed policy module file from RPM verification
-   `commit <https://pagure.io/freeipa/c/ad7bdd46fb64c3fbb8104a9599459795fc193389>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad7bdd46fb64c3fbb8104a9599459795fc193389>`__
    `#9254 <https://pagure.io/freeipa/issue/9254>`__
 
 
@@ -479,15 +479,15 @@ Weblate (5)
 ----------------------------------------------------------------------------------------------
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/357dd550ce3568e37edebd4bb3394a706eb81182>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/357dd550ce3568e37edebd4bb3394a706eb81182>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/c8c4e93fd64329df76b4754f74d70cfceed6c452>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8c4e93fd64329df76b4754f74d70cfceed6c452>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/921fdd2ca879b8d6c1e601a17eb3eb9b197f9797>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/921fdd2ca879b8d6c1e601a17eb3eb9b197f9797>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/3500d05f8904d7bab84d950c81563d9bfb6d1474>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3500d05f8904d7bab84d950c81563d9bfb6d1474>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/d0b336025fd0408e1f81811330cac6682ba0bed6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0b336025fd0408e1f81811330cac6682ba0bed6>`__
 
 
 
@@ -495,9 +495,9 @@ Piotr Drąg (2)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/31f7860d089a628a4ccfaf8db507ecadfaa75805>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31f7860d089a628a4ccfaf8db507ecadfaa75805>`__
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/f9419bdad41a87aa4454fcb1d725988b27c634a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9419bdad41a87aa4454fcb1d725988b27c634a1>`__
 
 
 
@@ -505,34 +505,34 @@ Rob Crittenden (10)
 ----------------------------------------------------------------------------------------------
 
 -  Move client certificate request after krb5.conf is created
-   `commit <https://pagure.io/freeipa/c/f3c861b9fcbf7815161b46e5eab582813c1021dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3c861b9fcbf7815161b46e5eab582813c1021dc>`__
    `#9246 <https://pagure.io/freeipa/issue/9246>`__
 -  Defer creating the final krb5.conf on clients
-   `commit <https://pagure.io/freeipa/c/3cbf2b25422100cc4105dfb09ee8c7bf87232198>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cbf2b25422100cc4105dfb09ee8c7bf87232198>`__
    `#9228 <https://pagure.io/freeipa/issue/9228>`__
 -  Fix upper bound of password policy grace limit
-   `commit <https://pagure.io/freeipa/c/3c4386ce057a0fd50c7494db43c71405c9674b8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c4386ce057a0fd50c7494db43c71405c9674b8f>`__
    `#9243 <https://pagure.io/freeipa/issue/9243>`__
 -  Set default on group pwpolicy with no grace limit in upgrade
-   `commit <https://pagure.io/freeipa/c/de6f074538f6641fd9d84bed204a3d4d50eccbe5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de6f074538f6641fd9d84bed204a3d4d50eccbe5>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  Set default gracelimit on group password policies to -1
-   `commit <https://pagure.io/freeipa/c/45e6d49b94da78cd82eb016b3266a17a1359a087>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45e6d49b94da78cd82eb016b3266a17a1359a087>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  doc: Update LDAP grace period design with default values
-   `commit <https://pagure.io/freeipa/c/1aa39529cda4ab9620539dbad705cedd23c21b42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1aa39529cda4ab9620539dbad705cedd23c21b42>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  upgrades: Don't restart the CA on ACME and profile schema change
-   `commit <https://pagure.io/freeipa/c/459b81b196b7bf36100aa2f4e5c4d36b1e4526f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/459b81b196b7bf36100aa2f4e5c4d36b1e4526f6>`__
    `#9204 <https://pagure.io/freeipa/issue/9204>`__
 -  Disabling gracelimit does not prevent LDAP binds
-   `commit <https://pagure.io/freeipa/c/1bb4ff9ed2313fb3c2bd1418258c5bcec557b6a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bb4ff9ed2313fb3c2bd1418258c5bcec557b6a5>`__
    `#9206 <https://pagure.io/freeipa/issue/9206>`__
 -  Warn for permissions with read/write/search/compare and no attrs
-   `commit <https://pagure.io/freeipa/c/499f71729b8689d40608d9c99db703eb2c00a934>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/499f71729b8689d40608d9c99db703eb2c00a934>`__
    `#9188 <https://pagure.io/freeipa/issue/9188>`__
 -  Only calculate LDAP password grace when the password is expired
-   `commit <https://pagure.io/freeipa/c/33cd62e0daa68fa6a9b3ca495d97ac5ce8713349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33cd62e0daa68fa6a9b3ca495d97ac5ce8713349>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 
 
@@ -541,11 +541,11 @@ Ricky Tigg (3)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/67c54ce7a9b7c11a56475e1d8de586b18abce228>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67c54ce7a9b7c11a56475e1d8de586b18abce228>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/86f828a7e52ee09ae6e666dce11183c0dd091540>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86f828a7e52ee09ae6e666dce11183c0dd091540>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/4b10b6dab45c87472bb1fe0baeeee987ae1b23ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b10b6dab45c87472bb1fe0baeeee987ae1b23ba>`__
 
 
 
@@ -553,7 +553,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: do not fail if certmap rule cannot be added
-   `commit <https://pagure.io/freeipa/c/ae445f72a009d14135e11ff932eded2dc2dc9c86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae445f72a009d14135e11ff932eded2dc2dc9c86>`__
 
 
 
@@ -561,13 +561,13 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/d5ea8d6c9f7208a2ae8b5379c88ae36e7c4f62e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5ea8d6c9f7208a2ae8b5379c88ae36e7c4f62e6>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/4ea9b5ef0f3ee1361a59622e4d6c3274cf2e7ad4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ea9b5ef0f3ee1361a59622e4d6c3274cf2e7ad4>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/9d1541f17d44cbb38bc9a477c5e88eaee71ce6d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d1541f17d44cbb38bc9a477c5e88eaee71ce6d8>`__
 -  Added translation using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f420c19bb62fb3c735563cb462fd6be7b8018691>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f420c19bb62fb3c735563cb462fd6be7b8018691>`__
 
 
 
@@ -575,22 +575,22 @@ Stanislav Levin (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipapython: Support openldap 2.6
-   `commit <https://pagure.io/freeipa/c/51c31e0ad3387c07aad1035f00871bdcc201812a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51c31e0ad3387c07aad1035f00871bdcc201812a>`__
    `#9255 <https://pagure.io/freeipa/issue/9255>`__
 -  x509: Replace removed register_interface with subclassing
-   `commit <https://pagure.io/freeipa/c/a7beaa0b4de6b6b00ee1b5b770f0d2e72fad58df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7beaa0b4de6b6b00ee1b5b770f0d2e72fad58df>`__
    `#9160 <https://pagure.io/freeipa/issue/9160>`__
 -  ap: Constrain supported docutils
-   `commit <https://pagure.io/freeipa/c/e5f7356e7e83b605a821ece9f242ac924925f27e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5f7356e7e83b605a821ece9f242ac924925f27e>`__
    `#9208 <https://pagure.io/freeipa/issue/9208>`__
 -  ap: Rearrange overloaded jobs
-   `commit <https://pagure.io/freeipa/c/8ff0c1a5ee33946202031a8bc83e855216cd0c95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ff0c1a5ee33946202031a8bc83e855216cd0c95>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 -  ap: Disable azure's security daemon
-   `commit <https://pagure.io/freeipa/c/acd1d127938aa9feefbbc7ee325963a2e44ef3c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acd1d127938aa9feefbbc7ee325963a2e44ef3c3>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 -  ap: Raise dbus timeout
-   `commit <https://pagure.io/freeipa/c/260d6378ec59d244e5f247f4af81f7ae8c72ac87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/260d6378ec59d244e5f247f4af81f7ae8c72ac87>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 
 
@@ -599,15 +599,15 @@ Scott Poore (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add keycloak user login to ipa test
-   `commit <https://pagure.io/freeipa/c/e197c743f3ea1a98d444c0eb01339cc22eab64d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e197c743f3ea1a98d444c0eb01339cc22eab64d5>`__
    `#9250 <https://pagure.io/freeipa/issue/9250>`__
 -  ipatests: add prci definitions for test_sso jobs
-   `commit <https://pagure.io/freeipa/c/db1d05176d8072b05fea179af2ac97caaeb65dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db1d05176d8072b05fea179af2ac97caaeb65dd1>`__
 -  ipatests: add Keycloak Bridge test
-   `commit <https://pagure.io/freeipa/c/ac776987d30ecd3444a9b25f49a714fddc3c4232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac776987d30ecd3444a9b25f49a714fddc3c4232>`__
    `#9227 <https://pagure.io/freeipa/issue/9227>`__
 -  ipatests: Rename create_quarkus to create_keycloak
-   `commit <https://pagure.io/freeipa/c/a0a104a42c2ccd89394e48c2375bb0eb95183c5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0a104a42c2ccd89394e48c2375bb0eb95183c5b>`__
    `#9225 <https://pagure.io/freeipa/issue/9225>`__
 
 
@@ -617,16 +617,16 @@ Sumedh Sidhaye (3)
 
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
-   `commit <https://pagure.io/freeipa/c/5477a07d91ef2c506cc943699612e5e27d0c93e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5477a07d91ef2c506cc943699612e5e27d0c93e4>`__
    `#9238 <https://pagure.io/freeipa/issue/9238>`__
 -  Additional tests for RSN v3
-   `commit <https://pagure.io/freeipa/c/bfe074ed478c20a9537dc2a714bba50dbc2cd34f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfe074ed478c20a9537dc2a714bba50dbc2cd34f>`__
    `#2016 <https://pagure.io/freeipa/issue/2016>`__
 -  Added a check while removing 'cert_dir'. The teardown method is
    called even if all the tests are skipped since the required PKI
    version is not present. The teardown is trying to remove a
    non-existent directory.
-   `commit <https://pagure.io/freeipa/c/aca97507cd119ad55e0c3c18ca65087cb5576c82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aca97507cd119ad55e0c3c18ca65087cb5576c82>`__
    `#9179 <https://pagure.io/freeipa/issue/9179>`__
 
 
@@ -635,10 +635,10 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: ipa-client-install --subid adds entry in nsswitch.conf
-   `commit <https://pagure.io/freeipa/c/a39af6b7228d8ba85b9e97aa5decbc056d081c77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a39af6b7228d8ba85b9e97aa5decbc056d081c77>`__
    `#9159 <https://pagure.io/freeipa/issue/9159>`__
 -  ipatests: WebUI: do not allow subid range deletion
-   `commit <https://pagure.io/freeipa/c/38e5bcf719a0e7c7550837ffb14300db8efe09e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38e5bcf719a0e7c7550837ffb14300db8efe09e4>`__
    `#9150 <https://pagure.io/freeipa/issue/9150>`__
 
 
@@ -647,13 +647,13 @@ Temuri Doghonadze (4)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/3379aa0aa85ca40fbce94f9d2307c6b501054c5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3379aa0aa85ca40fbce94f9d2307c6b501054c5a>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/054bd14bcfe999e7722c812e7509c31e6f012bb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/054bd14bcfe999e7722c812e7509c31e6f012bb3>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/a1e66f5c050d8c9226f23af9b7d0c68bfd32a4d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1e66f5c050d8c9226f23af9b7d0c68bfd32a4d9>`__
 -  Added translation using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/a30db2030c730d835e28ceb8cdc3c64d18edb4f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a30db2030c730d835e28ceb8cdc3c64d18edb4f9>`__
 
 
 
@@ -661,7 +661,7 @@ Thomas Woerner (1)
 ----------------------------------------------------------------------------------------------
 
 -  DNSResolver: Fix use of nameservers with ports
-   `commit <https://pagure.io/freeipa/c/6c5530c509793f66a162ed4153d5425a0eda02d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c5530c509793f66a162ed4153d5425a0eda02d6>`__
    `#9158 <https://pagure.io/freeipa/issue/9158>`__
 
 
@@ -670,7 +670,7 @@ Viacheslav Sychov (1)
 ----------------------------------------------------------------------------------------------
 
 -  fix: Handle /proc/1/sched missing error
-   `commit <https://pagure.io/freeipa/c/7aa845730999951c8f340f43ed5872c54458c6a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7aa845730999951c8f340f43ed5872c54458c6a3>`__
 
 
 
@@ -678,14 +678,14 @@ Yuri Chornoivan (6)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/6846b953361bc96b322734e23e566c93a1879046>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6846b953361bc96b322734e23e566c93a1879046>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/867a38a4636915df62a28b61855780b02ff55d56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/867a38a4636915df62a28b61855780b02ff55d56>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/6de25a0f201f0591bc551503b95f8d22c79fe7aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6de25a0f201f0591bc551503b95f8d22c79fe7aa>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/63d332ff9ebbdd59fac65748025f8eea4270704d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63d332ff9ebbdd59fac65748025f8eea4270704d>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/d6d7c5d28bcf7ed341f0a5d4e1b0f167a195a4c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6d7c5d28bcf7ed341f0a5d4e1b0f167a195a4c2>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/a21bf7fe8213c6b041ab500ab533e2a5888d1c3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a21bf7fe8213c6b041ab500ab533e2a5888d1c3e>`__

--- a/src/page/Releases/4.10.2.rst
+++ b/src/page/Releases/4.10.2.rst
@@ -55,11 +55,11 @@ Highlights in 4.10.2
       1.21 or later. On older MIT Kerberos versions, the lack of the new
       ticket signature will be tolerated to allow gradual upgrades. More
       details are available at
-      https://pagure.io/freeipa/c/3f1b373cb2028416e40a26e3dd99b0f4c82525c7.
+      https://codeberg.org/freeipa/freeipa/commit/3f1b373cb2028416e40a26e3dd99b0f4c82525c7.
       In addition, a 'full PAC' signature type was added to MIT Kerberos
       1.21. FreeIPA will support the new signature when running against
       newer MIT Kerberos version. For older versions, please see
-      https://pagure.io/freeipa/c/9cd5f49c74f28dbe070b072b394747a039cef463.
+      https://codeberg.org/freeipa/freeipa/commit/9cd5f49c74f28dbe070b072b394747a039cef463.
       This new PAC signature will be required by default by Active
       Directory in July 2023 for S4U requests, and opt-out will no
       longer be possible after October 2023. We recommend upgrading to
@@ -297,73 +297,73 @@ Alexander Bokovoy (23)
 
 -  ipa-kdb: be compatible with krb5 1.19 when checking for server
    referral
-   `commit <https://pagure.io/freeipa/c/f2b821abca72e0d444c96598799c4947e2173d3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b821abca72e0d444c96598799c4947e2173d3f>`__
    `#9164 <https://pagure.io/freeipa/issue/9164>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
-   `commit <https://pagure.io/freeipa/c/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
 -  ipa-kdb: skip verification of PAC full checksum
-   `commit <https://pagure.io/freeipa/c/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
    `#9371 <https://pagure.io/freeipa/issue/9371>`__
 -  ipa-kdb: process out of realm server lookup during S4U
-   `commit <https://pagure.io/freeipa/c/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
    `#9164 <https://pagure.io/freeipa/issue/9164>`__
 -  ipa-kdb: postpone ticket checksum configuration
-   `commit <https://pagure.io/freeipa/c/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
 -  ipa-kdb: protect against context corruption
-   `commit <https://pagure.io/freeipa/c/803a44777f901217d634f8fd7feed8b66ece352a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/803a44777f901217d634f8fd7feed8b66ece352a>`__
 -  ipa-kdb: hint KDC to use aes256-sha1 for forest trust TGT
-   `commit <https://pagure.io/freeipa/c/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  Change doc theme to 'book'
-   `commit <https://pagure.io/freeipa/c/1c43d914d9a365097a80c5c2278017b91c619266>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c43d914d9a365097a80c5c2278017b91c619266>`__
 -  doc/designs/rbcd.md: document use of S-1-18-\* SIDs
-   `commit <https://pagure.io/freeipa/c/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  doc/designs/rbcd.md: add usage examples
-   `commit <https://pagure.io/freeipa/c/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  RBCD: add basic test for RBCD handling
-   `commit <https://pagure.io/freeipa/c/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  kdb: implement RBCD handling in KDB driver
-   `commit <https://pagure.io/freeipa/c/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  IPA API changes to support RBCD
-   `commit <https://pagure.io/freeipa/c/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  doc: add design document for Kerberos constrained delegation
-   `commit <https://pagure.io/freeipa/c/18cd909b4ad854147008a1010c97c75640a54177>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18cd909b4ad854147008a1010c97c75640a54177>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  ipa-kdb: search S4U2Proxy ACLs in cn=s4u2proxy,cn=etc,$BASEDN subtree
    only
-   `commit <https://pagure.io/freeipa/c/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
    `#5444 <https://pagure.io/freeipa/issue/5444>`__
 -  test_xmlrpc: adopt to automember plugin message changes in 389-ds
-   `commit <https://pagure.io/freeipa/c/52e6da9056697e2210736d5528826ae424fec9b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52e6da9056697e2210736d5528826ae424fec9b1>`__
 -  Ignore empty modification error in case cifs/.. principal already
    added
-   `commit <https://pagure.io/freeipa/c/e7506403a988b98cc3381d2d986b53aee48448cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7506403a988b98cc3381d2d986b53aee48448cb>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
-   `commit <https://pagure.io/freeipa/c/e07ead943abf070107a9669fc4564c9dc7518832>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e07ead943abf070107a9669fc4564c9dc7518832>`__
    `#9355 <https://pagure.io/freeipa/issue/9355>`__
 -  Fix tox in Azure CI
-   `commit <https://pagure.io/freeipa/c/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Use system-wide chromium for webui tests
-   `commit <https://pagure.io/freeipa/c/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Don't fail if optional RPM macros file is missing
-   `commit <https://pagure.io/freeipa/c/b93f6b52a29659663fae65be51dafe350606eb6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b93f6b52a29659663fae65be51dafe350606eb6d>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
-   `commit <https://pagure.io/freeipa/c/0206369eec8530e96c66986c4ca501d8962193ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0206369eec8530e96c66986c4ca501d8962193ce>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
-   `commit <https://pagure.io/freeipa/c/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -372,16 +372,16 @@ Anuja More (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test that non admin user can search hbac rule.
-   `commit <https://pagure.io/freeipa/c/051bbe36dce57837bd1769aa4a88569e39565774>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/051bbe36dce57837bd1769aa4a88569e39565774>`__
    `#5130 <https://pagure.io/freeipa/issue/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
-   `commit <https://pagure.io/freeipa/c/983a6516f147ae95a512435cd05d237233d0b5fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/983a6516f147ae95a512435cd05d237233d0b5fc>`__
    `#6044 <https://pagure.io/freeipa/issue/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
-   `commit <https://pagure.io/freeipa/c/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  Add test for SSH with GSSAPI auth.
-   `commit <https://pagure.io/freeipa/c/a6cb905de74da38d62f9c3bd7957018924282521>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6cb905de74da38d62f9c3bd7957018924282521>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 
 
@@ -390,27 +390,27 @@ Antonio Torres (10)
 ----------------------------------------------------------------------------------------------
 
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/03b92fb42f173e9ba26d6d19f0d6f35f6c5f38b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03b92fb42f173e9ba26d6d19f0d6f35f6c5f38b2>`__
 -  Update translations to FreeIPA ipa-4-10 state
-   `commit <https://pagure.io/freeipa/c/e3797ca2e03097a36bd3795fc1687a2ed4922e59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3797ca2e03097a36bd3795fc1687a2ed4922e59>`__
 -  Extend API documentation
-   `commit <https://pagure.io/freeipa/c/9c6b4f4445dbd1eefffbfff191063980a2f3a342>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c6b4f4445dbd1eefffbfff191063980a2f3a342>`__
 -  doc: allow notes on Param API Reference pages
-   `commit <https://pagure.io/freeipa/c/3eed25e92f951689658f6bbd178a5baca37442c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3eed25e92f951689658f6bbd178a5baca37442c6>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
-   `commit <https://pagure.io/freeipa/c/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
-   `commit <https://pagure.io/freeipa/c/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
 -  API doc: add note about ipa show-mappings to usage guide
-   `commit <https://pagure.io/freeipa/c/a20acb6f833a22baad214a466848cb5833954532>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a20acb6f833a22baad214a466848cb5833954532>`__
 -  API doc: validate generated reference
-   `commit <https://pagure.io/freeipa/c/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
    `#9287 <https://pagure.io/freeipa/issue/9287>`__
 -  API doc: add basic user management guide
-   `commit <https://pagure.io/freeipa/c/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/657a7b2556e22b70802809dd784fe576d3edea95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/657a7b2556e22b70802809dd784fe576d3edea95>`__
 
 
 
@@ -418,7 +418,7 @@ Carla Martinez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update 'Auth indicators' doc string
-   `commit <https://pagure.io/freeipa/c/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
    `#9338 <https://pagure.io/freeipa/issue/9338>`__
 
 
@@ -427,13 +427,13 @@ Christian Heimes (3)
 ----------------------------------------------------------------------------------------------
 
 -  Speed up installer by restarting DS after DNA plugin
-   `commit <https://pagure.io/freeipa/c/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
    `#9358 <https://pagure.io/freeipa/issue/9358>`__
 -  Don't block when kinit_pkinit() fails
-   `commit <https://pagure.io/freeipa/c/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
    `#9333 <https://pagure.io/freeipa/issue/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
-   `commit <https://pagure.io/freeipa/c/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
    `#9285 <https://pagure.io/freeipa/issue/9285>`__
 
 
@@ -442,7 +442,7 @@ Chris Kelley (1)
 ----------------------------------------------------------------------------------------------
 
 -  Check that CADogtagCertsConfigCheck can handle cert renewal
-   `commit <https://pagure.io/freeipa/c/a786d3d584c8696df3b18858df1c429cba03721f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a786d3d584c8696df3b18858df1c429cba03721f>`__
 
 
 
@@ -450,9 +450,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  doc: Use case examples for PR-CI checker tool
-   `commit <https://pagure.io/freeipa/c/41c32174b2b3cf71474ea74df32f1f763f4a2c5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41c32174b2b3cf71474ea74df32f1f763f4a2c5b>`__
 -  ipatests: fix (prci_checker) duplicated check & error return code
-   `commit <https://pagure.io/freeipa/c/1a965a3a6304607eb5acbdfee45843ebe8746c67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a965a3a6304607eb5acbdfee45843ebe8746c67>`__
 
 
 
@@ -461,7 +461,7 @@ Erik Belko (1)
 
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
-   `commit <https://pagure.io/freeipa/c/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -471,7 +471,7 @@ Filip Dvorak (1)
 
 -  ipa tests: Add LANG before kinit command to fix issue with locale
    settings
-   `commit <https://pagure.io/freeipa/c/2520a7adff7a49ddcddaaf19f0e586425dc0d878>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2520a7adff7a49ddcddaaf19f0e586425dc0d878>`__
 
 
 
@@ -479,159 +479,159 @@ Florence Blanc-Renaud (55)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: remove xfail from test_smb
-   `commit <https://pagure.io/freeipa/c/283f5463f091ac9fcc733092fc6becff586ae97f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/283f5463f091ac9fcc733092fc6becff586ae97f>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
-   `commit <https://pagure.io/freeipa/c/a6f485fcade619980f6538edadf115dca69e1314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6f485fcade619980f6538edadf115dca69e1314>`__
    `#9383 <https://pagure.io/freeipa/issue/9383>`__
 -  user or group name: explain the supported format
-   `commit <https://pagure.io/freeipa/c/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
 -  azure tests: move to fedora 38
-   `commit <https://pagure.io/freeipa/c/627c1101a08a281d07cd930193232e434a0cd9a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/627c1101a08a281d07cd930193232e434a0cd9a0>`__
 -  Tests: test on f37 and f38
-   `commit <https://pagure.io/freeipa/c/12d1aafe60de457815adb822bbef466926626d6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12d1aafe60de457815adb822bbef466926626d6f>`__
 -  idview: improve performance of idview-show
-   `commit <https://pagure.io/freeipa/c/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
    `#9372 <https://pagure.io/freeipa/issue/9372>`__
 -  spec file: force nodejs < 20 on fedora < 39
-   `commit <https://pagure.io/freeipa/c/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
    `#9374 <https://pagure.io/freeipa/issue/9374>`__
 -  Nightly test: add +15min for test_ipahealthcheck
-   `commit <https://pagure.io/freeipa/c/717228c908816c72b98cee86abfe7c22cb07c44e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/717228c908816c72b98cee86abfe7c22cb07c44e>`__
    `#9362 <https://pagure.io/freeipa/issue/9362>`__
 -  cert_find: fix call with --all
-   `commit <https://pagure.io/freeipa/c/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  ipatests: mark known failures for autoprivategroup
-   `commit <https://pagure.io/freeipa/c/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
    `#9295 <https://pagure.io/freeipa/issue/9295>`__
 -  ipatests: fix test definition for test_trust
-   `commit <https://pagure.io/freeipa/c/def07260da883b1d27330b308bd0337205bf53a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/def07260da883b1d27330b308bd0337205bf53a8>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: increase timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/ae014c6a3e17da7b0775be79a425d769a2717243>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae014c6a3e17da7b0775be79a425d769a2717243>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: adapt for new automembership fixup behavior
-   `commit <https://pagure.io/freeipa/c/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
    `#9313 <https://pagure.io/freeipa/issue/9313>`__
 -  ipatests: increase timeout for test_acme
-   `commit <https://pagure.io/freeipa/c/0a8a3922487b8029c509635c85b533474008bb9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a8a3922487b8029c509635c85b533474008bb9d>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
-   `commit <https://pagure.io/freeipa/c/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
-   `commit <https://pagure.io/freeipa/c/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
    `#9310 <https://pagure.io/freeipa/issue/9310>`__
 -  Spec file: use %autosetup instead of %setup
-   `commit <https://pagure.io/freeipa/c/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
 -  Spec file: unify with RHEL9 spec
-   `commit <https://pagure.io/freeipa/c/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
 -  Installer: create RID base before domain object
-   `commit <https://pagure.io/freeipa/c/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
    `#9309 <https://pagure.io/freeipa/issue/9309>`__
 -  Tests: force key type in ACME tests
-   `commit <https://pagure.io/freeipa/c/0fa95852c935c7b079f8ed966d4f194099217038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa95852c935c7b079f8ed966d4f194099217038>`__
    `#9298 <https://pagure.io/freeipa/issue/9298>`__
 -  server install: remove error log about missing bkup file
-   `commit <https://pagure.io/freeipa/c/894dca12c120f0bfa705307a0609da47326b8fb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/894dca12c120f0bfa705307a0609da47326b8fb2>`__
    `#9306 <https://pagure.io/freeipa/issue/9306>`__
 -  ipatests: mark test_smb as xfail
-   `commit <https://pagure.io/freeipa/c/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  pylint: disable deprecated-module message
-   `commit <https://pagure.io/freeipa/c/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix comparison-of-constants
-   `commit <https://pagure.io/freeipa/c/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable comparison-of-constants
-   `commit <https://pagure.io/freeipa/c/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix consider-iterating-dictionary
-   `commit <https://pagure.io/freeipa/c/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: globally disable useless-object-inheritance
-   `commit <https://pagure.io/freeipa/c/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable unhashable-member
-   `commit <https://pagure.io/freeipa/c/07111438389fde4a74845f9f797656712335795f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07111438389fde4a74845f9f797656712335795f>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable invalid-sequence-index
-   `commit <https://pagure.io/freeipa/c/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix deprecated-class SafeConfigParser
-   `commit <https://pagure.io/freeipa/c/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix duplicate-value
-   `commit <https://pagure.io/freeipa/c/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix implicit-str-concat
-   `commit <https://pagure.io/freeipa/c/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable missing-timeout message
-   `commit <https://pagure.io/freeipa/c/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: globally disable unnecessary-lambda-assignment message
-   `commit <https://pagure.io/freeipa/c/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable unnecessary-dunder-call message
-   `commit <https://pagure.io/freeipa/c/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable using-constant-test
-   `commit <https://pagure.io/freeipa/c/5434c12b6012f035528f0b137c1af5c1be113542>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5434c12b6012f035528f0b137c1af5c1be113542>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove arguments-renamed warnings
-   `commit <https://pagure.io/freeipa/c/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable modified-iterating-list
-   `commit <https://pagure.io/freeipa/c/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: replace deprecated distutils module
-   `commit <https://pagure.io/freeipa/c/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable used-before-assignment
-   `commit <https://pagure.io/freeipa/c/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable redefined-slots-in-subclass
-   `commit <https://pagure.io/freeipa/c/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove useless suppression
-   `commit <https://pagure.io/freeipa/c/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove unneeded disable=unused-private-member
-   `commit <https://pagure.io/freeipa/c/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  azure tests: move to fedora 37
-   `commit <https://pagure.io/freeipa/c/782873a2277ca7defa5554d2b7859f1c14767d68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/782873a2277ca7defa5554d2b7859f1c14767d68>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/304978924a09677805fd3b73614aad6a2de232a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/304978924a09677805fd3b73614aad6a2de232a2>`__
    `#9135 <https://pagure.io/freeipa/issue/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
-   `commit <https://pagure.io/freeipa/c/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
 -  FIPS setup: fix typo filtering camellia encryption
-   `commit <https://pagure.io/freeipa/c/dfba6ebf9ab7b7d17e65f928c90ae63b31d9cae7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfba6ebf9ab7b7d17e65f928c90ae63b31d9cae7>`__
 -  cert utilities: MAC verification is incompatible with FIPS mode
-   `commit <https://pagure.io/freeipa/c/c853cfde56fb56798424bd402012d78ed47647c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c853cfde56fb56798424bd402012d78ed47647c0>`__
 -  ipatests: update the fake fips mode expected message
-   `commit <https://pagure.io/freeipa/c/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
    `#9002 <https://pagure.io/freeipa/issue/9002>`__
 -  ipatests: xfail on all fedora for test_ipa_login_with_sso_user
-   `commit <https://pagure.io/freeipa/c/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
    `#9264 <https://pagure.io/freeipa/issue/9264>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
-   `commit <https://pagure.io/freeipa/c/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
    `#9290 <https://pagure.io/freeipa/issue/9290>`__
 -  webui tests: fix assertion in test_subid.py
-   `commit <https://pagure.io/freeipa/c/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
    `#9282 <https://pagure.io/freeipa/issue/9282>`__
 -  PRCI: update memory reqs for each topology
-   `commit <https://pagure.io/freeipa/c/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
 -  API reference: update dnszone_add generated doc
-   `commit <https://pagure.io/freeipa/c/660da9ab1d93fd8e561643728ae3821193953433>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/660da9ab1d93fd8e561643728ae3821193953433>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  API reference: update vault doc
-   `commit <https://pagure.io/freeipa/c/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
    `#9259 <https://pagure.io/freeipa/issue/9259>`__
 
 
@@ -640,7 +640,7 @@ s1341 (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform: add initial nixos support
-   `commit <https://pagure.io/freeipa/c/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
    `#9299 <https://pagure.io/freeipa/issue/9299>`__
 
 
@@ -649,10 +649,10 @@ Jarl Gullberg (2)
 ----------------------------------------------------------------------------------------------
 
 -  install: Fix missing dyndb keytab directive
-   `commit <https://pagure.io/freeipa/c/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
    `#9344 <https://pagure.io/freeipa/issue/9344>`__
 -  ipaplatform/debian: fix path to ldap.so
-   `commit <https://pagure.io/freeipa/c/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
 
 
 
@@ -660,13 +660,13 @@ Julien Rische (3)
 ----------------------------------------------------------------------------------------------
 
 -  Filter out constrained delegation ACL from KDB entry
-   `commit <https://pagure.io/freeipa/c/7ea3b86696f5451f1d227d365018ab7dc53024af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ea3b86696f5451f1d227d365018ab7dc53024af>`__
 -  Tolerate absence of PAC ticket signature depending of server
    capabilities
-   `commit <https://pagure.io/freeipa/c/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
    `#9371 <https://pagure.io/freeipa/issue/9371>`__
 -  kdb: Use krb5_pac_full_sign_compat() when available
-   `commit <https://pagure.io/freeipa/c/630cda5c06428825dd5604493621b9cbdab70073>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/630cda5c06428825dd5604493621b9cbdab70073>`__
    `#9373 <https://pagure.io/freeipa/issue/9373>`__
 
 
@@ -675,7 +675,7 @@ Jerry James (1)
 ----------------------------------------------------------------------------------------------
 
 -  Change fontawesome-fonts requires to match fontawesome 4.x
-   `commit <https://pagure.io/freeipa/c/58173c021388dd31b4501d1c7bc1e6747cea8bb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58173c021388dd31b4501d1c7bc1e6747cea8bb8>`__
 
 
 
@@ -683,19 +683,19 @@ mbhalodi (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add remove automember condition tests
-   `commit <https://pagure.io/freeipa/c/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: Test for sequence processing failures with server context
-   `commit <https://pagure.io/freeipa/c/304fd550613e83d120c72f0dad89f6a89d31231c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/304fd550613e83d120c72f0dad89f6a89d31231c>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  ipatests: add missing automember-cli tests
-   `commit <https://pagure.io/freeipa/c/6db9bbd85a837950d9244502507535c1f79ab64a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6db9bbd85a837950d9244502507535c1f79ab64a>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/cd07413cba37150b12d6b279510941aad49b5afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd07413cba37150b12d6b279510941aad49b5afb>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/88b9be29036a3580a8bccd31986fc30faa9852df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88b9be29036a3580a8bccd31986fc30faa9852df>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 
 
@@ -704,10 +704,10 @@ Michal Polovka (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: commands: Wait for the SSSD to become available
-   `commit <https://pagure.io/freeipa/c/bc39443211e998d7088571f0ef70233b6e456e1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc39443211e998d7088571f0ef70233b6e456e1d>`__
    `#9377 <https://pagure.io/freeipa/issue/9377>`__
 -  ipatest: loginscreen: do not use hardcoded password
-   `commit <https://pagure.io/freeipa/c/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 
 
@@ -716,12 +716,12 @@ Mohammad Rizwan (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: wait for sssd-kcm to settle after date change
-   `commit <https://pagure.io/freeipa/c/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
 -  ipatests: fix tests in TestACMEPrune
-   `commit <https://pagure.io/freeipa/c/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  ipatests: tests for certificate pruning
-   `commit <https://pagure.io/freeipa/c/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 
 
@@ -730,49 +730,49 @@ Rob Crittenden (15)
 ----------------------------------------------------------------------------------------------
 
 -  Don't allow a group to be converted to POSIX and external
-   `commit <https://pagure.io/freeipa/c/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
    `#8990 <https://pagure.io/freeipa/issue/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
-   `commit <https://pagure.io/freeipa/c/325a13196b32c627854c8d7594e23b58167499f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/325a13196b32c627854c8d7594e23b58167499f0>`__
    `#8941 <https://pagure.io/freeipa/issue/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
-   `commit <https://pagure.io/freeipa/c/abe71fe145a3d16257043ccfbb43002607458cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abe71fe145a3d16257043ccfbb43002607458cee>`__
    `#9086 <https://pagure.io/freeipa/issue/9086>`__
 -  Return the value cert-find failures from the CA
-   `commit <https://pagure.io/freeipa/c/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
    `#9369 <https://pagure.io/freeipa/issue/9369>`__
 -  Use the OpenSSL certificate parser in cert-find
-   `commit <https://pagure.io/freeipa/c/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Enforce sizelimit in cert-find
-   `commit <https://pagure.io/freeipa/c/e2576670e692117c11987118abd5e9381bb90b1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2576670e692117c11987118abd5e9381bb90b1f>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  doc: Update pruning design with implement enable/disable options
-   `commit <https://pagure.io/freeipa/c/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
    `#9323 <https://pagure.io/freeipa/issue/9323>`__
 -  Wipe the ipa-ca DNS record when updating system records
-   `commit <https://pagure.io/freeipa/c/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
    `#9195 <https://pagure.io/freeipa/issue/9195>`__
 -  Fix setting values of 0 in ACME pruning
-   `commit <https://pagure.io/freeipa/c/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
    `#9325 <https://pagure.io/freeipa/issue/9325>`__
 -  tests: add wrapper around ACME RSNv3 test
-   `commit <https://pagure.io/freeipa/c/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
    `#9322 <https://pagure.io/freeipa/issue/9322>`__
 -  doc: add the --run command for manual job execution
-   `commit <https://pagure.io/freeipa/c/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  ipa-acme-manage: add certificate/request pruning management
-   `commit <https://pagure.io/freeipa/c/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
-   `commit <https://pagure.io/freeipa/c/6ca119686aadfa72c0474f72758b63cd671952d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ca119686aadfa72c0474f72758b63cd671952d4>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
-   `commit <https://pagure.io/freeipa/c/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  doc: Design for certificate pruning
-   `commit <https://pagure.io/freeipa/c/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 
 
@@ -781,10 +781,10 @@ Rafael Guterres Jeffman (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix "no entry" condition when searching PAC info
-   `commit <https://pagure.io/freeipa/c/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
    `#9368 <https://pagure.io/freeipa/issue/9368>`__
 -  Migrated to SPDX license.
-   `commit <https://pagure.io/freeipa/c/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
    `#9342 <https://pagure.io/freeipa/issue/9342>`__
 
 
@@ -793,68 +793,68 @@ Stanislav Levin (21)
 ----------------------------------------------------------------------------------------------
 
 -  ipasphinx: Correct import of progress_message for Sphinx 6.1.0+
-   `commit <https://pagure.io/freeipa/c/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
    `#9361 <https://pagure.io/freeipa/issue/9361>`__
 -  fastlint: Correct concatenation of file lists
-   `commit <https://pagure.io/freeipa/c/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
    `#9318 <https://pagure.io/freeipa/issue/9318>`__
 -  dns: Fix support for dnspython 1.1x
-   `commit <https://pagure.io/freeipa/c/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
    `#9339 <https://pagure.io/freeipa/issue/9339>`__
 -  tests: webui: Update vendored qunit
-   `commit <https://pagure.io/freeipa/c/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  AP: webui: List installed nodejs packages
-   `commit <https://pagure.io/freeipa/c/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Load qunit only once
-   `commit <https://pagure.io/freeipa/c/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Allow file access from files in tests
-   `commit <https://pagure.io/freeipa/c/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
-   `commit <https://pagure.io/freeipa/c/d662b125985369181a3ebcbad82a4a43215282f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d662b125985369181a3ebcbad82a4a43215282f6>`__
    `#9319 <https://pagure.io/freeipa/issue/9319>`__
 -  spec: Drop no longer used build dependency on paste
-   `commit <https://pagure.io/freeipa/c/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
    `#9314 <https://pagure.io/freeipa/issue/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
-   `commit <https://pagure.io/freeipa/c/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
    `#9315 <https://pagure.io/freeipa/issue/9315>`__
 -  pylint: Replace deprecated cgi module
-   `commit <https://pagure.io/freeipa/c/2009889d763ccc26479c966931ca1b60378496fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2009889d763ccc26479c966931ca1b60378496fd>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix useless-object-inheritance
-   `commit <https://pagure.io/freeipa/c/bccd3c942084c753543d63b4d409ac46f819d314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bccd3c942084c753543d63b4d409ac46f819d314>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix unhashable-member
-   `commit <https://pagure.io/freeipa/c/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix unnecessary-lambda-assignment
-   `commit <https://pagure.io/freeipa/c/dc8c8a7824565178333ef7ae8ac7934467424691>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc8c8a7824565178333ef7ae8ac7934467424691>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix modified-iterating-list
-   `commit <https://pagure.io/freeipa/c/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix used-before-assignment
-   `commit <https://pagure.io/freeipa/c/b12376560da944b0845b9ac0d424adaf5435670f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b12376560da944b0845b9ac0d424adaf5435670f>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Replace deprecated pipes
-   `commit <https://pagure.io/freeipa/c/1261bbf0016d4824f908a589d4943513e98f8b01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1261bbf0016d4824f908a589d4943513e98f8b01>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix cyclic-import
-   `commit <https://pagure.io/freeipa/c/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
    `#9232 <https://pagure.io/freeipa/issue/9232>`__,
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Replace deprecated extension-pkg-whitelist
-   `commit <https://pagure.io/freeipa/c/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: More allowed C extensions
-   `commit <https://pagure.io/freeipa/c/f9822697659f134146e1dcfce0c48e2279a8becb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9822697659f134146e1dcfce0c48e2279a8becb>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Lint in single process mode
-   `commit <https://pagure.io/freeipa/c/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 
 
@@ -863,9 +863,9 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: ipa-adtrust-install command test scenarios
-   `commit <https://pagure.io/freeipa/c/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
-   `commit <https://pagure.io/freeipa/c/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
    `#9279 <https://pagure.io/freeipa/issue/9279>`__
 
 
@@ -874,7 +874,7 @@ Timo Aaltonen (1)
 ----------------------------------------------------------------------------------------------
 
 -  Drop duplicate includedir from krb5.conf
-   `commit <https://pagure.io/freeipa/c/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
    `#9267 <https://pagure.io/freeipa/issue/9267>`__
 
 
@@ -883,9 +883,9 @@ Todd Zullinger (2)
 ----------------------------------------------------------------------------------------------
 
 -  spec: silence krb5 pkgconf errors in %krb5_base_version
-   `commit <https://pagure.io/freeipa/c/90d0f04987b5477efa64d64416d89890e6bcda75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90d0f04987b5477efa64d64416d89890e6bcda75>`__
 -  spec: verify upstream source signature
-   `commit <https://pagure.io/freeipa/c/3b64eaa153d89920cbb0be87e5c2b512c4bf2008>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b64eaa153d89920cbb0be87e5c2b512c4bf2008>`__
 
 
 
@@ -893,4 +893,4 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  external-idp: change idp server name to reference name
-   `commit <https://pagure.io/freeipa/c/9323bafb645a377192efe17b489124a440c055c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9323bafb645a377192efe17b489124a440c055c3>`__

--- a/src/page/Releases/4.3.3.rst
+++ b/src/page/Releases/4.3.3.rst
@@ -111,20 +111,20 @@ Alexander Bokovoy (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: search for password policies globally
-   `commit <https://pagure.io/freeipa/c/b9b919e127c453eda02ea142d7cd80c16aa5ca31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9b919e127c453eda02ea142d7cd80c16aa5ca31>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  ipa-kdb: simplify trusted domain parent search
-   `commit <https://pagure.io/freeipa/c/775c868bacc01286eafc97e8126937d76ee53e1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/775c868bacc01286eafc97e8126937d76ee53e1e>`__
    `#5738 <https://pagure.io/freeipa/issue/5738>`__
 -  trust: make sure ID range is created for the child domain even if it
    exists
-   `commit <https://pagure.io/freeipa/c/4dabab84e02afb15a0bd77f62343392ea17a7102>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4dabab84e02afb15a0bd77f62343392ea17a7102>`__
    `#5738 <https://pagure.io/freeipa/issue/5738>`__
 -  trust: automatically resolve DNS trust conflicts for triangle trusts
-   `commit <https://pagure.io/freeipa/c/324d5aa1d09431c64d817f628b18b01a12253ccf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/324d5aa1d09431c64d817f628b18b01a12253ccf>`__
    `#6076 <https://pagure.io/freeipa/issue/6076>`__
 -  ipaserver/dcerpc: reformat to make the code closer to pep8
-   `commit <https://pagure.io/freeipa/c/bc6990ebfe2e0bc4b29b9308682750651e3aaf4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc6990ebfe2e0bc4b29b9308682750651e3aaf4a>`__
    `#6076 <https://pagure.io/freeipa/issue/6076>`__
 
 
@@ -133,13 +133,13 @@ Christian Heimes (3)
 ----------------------------------------------------------------------------------------------
 
 -  Use RSA-OAEP instead of RSA PKCS#1 v1.5
-   `commit <https://pagure.io/freeipa/c/2e27b7077d280447dbf526b567566101d4c800c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e27b7077d280447dbf526b567566101d4c800c7>`__
    `#6278 <https://pagure.io/freeipa/issue/6278>`__
 -  Secure permissions of Custodia server.keys
-   `commit <https://pagure.io/freeipa/c/fc3b695b5969992d63fad12cdf9607b8e8a20aff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc3b695b5969992d63fad12cdf9607b8e8a20aff>`__
    `#6056 <https://pagure.io/freeipa/issue/6056>`__
 -  RedHatCAService should wait for local Dogtag instance
-   `commit <https://pagure.io/freeipa/c/16491d7949d4a0a088bbadf69a80866f491fd5b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16491d7949d4a0a088bbadf69a80866f491fd5b0>`__
    `#6016 <https://pagure.io/freeipa/issue/6016>`__
 
 
@@ -149,7 +149,7 @@ David Kupka (1)
 
 -  password policy: Add explicit default password policy for hosts and
    services
-   `commit <https://pagure.io/freeipa/c/42263a5a729096135702c0b974f255a058c0cdaf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42263a5a729096135702c0b974f255a058c0cdaf>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 
 
@@ -158,10 +158,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  certprofile-mod: correctly authorise config update
-   `commit <https://pagure.io/freeipa/c/278d7cf4708f1c6ac05d5fcb21db582d9aa7bab3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/278d7cf4708f1c6ac05d5fcb21db582d9aa7bab3>`__
    `#6560 <https://pagure.io/freeipa/issue/6560>`__
 -  cert-revoke: fix permission check bypass (CVE-2016-5404)
-   `commit <https://pagure.io/freeipa/c/7eb1502863408d869dc2e706a5e194ad122997bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7eb1502863408d869dc2e706a5e194ad122997bf>`__
    `#6232 <https://pagure.io/freeipa/issue/6232>`__
 
 
@@ -170,7 +170,7 @@ Ganna Kaihorodova (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix for integration tests replication layouts
-   `commit <https://pagure.io/freeipa/c/0412cd3dcee7c89707c859d534f8fe81e154a344>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0412cd3dcee7c89707c859d534f8fe81e154a344>`__
 
 
 
@@ -178,10 +178,10 @@ Jan Cholasta (2)
 ----------------------------------------------------------------------------------------------
 
 -  Revert "spec: add conflict with bind-chroot to freeipa-server-dns"
-   `commit <https://pagure.io/freeipa/c/56695d969325cb2cb754d0ea549c5b6face89c6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56695d969325cb2cb754d0ea549c5b6face89c6f>`__
    `#5696 <https://pagure.io/freeipa/issue/5696>`__
 -  install: fix external CA cert validation
-   `commit <https://pagure.io/freeipa/c/44401d26c29e35d38bc94a7a87b9f2dd205e0643>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44401d26c29e35d38bc94a7a87b9f2dd205e0643>`__
    `#6166 <https://pagure.io/freeipa/issue/6166>`__
 
 
@@ -190,25 +190,25 @@ Lenka Doudova (7)
 ----------------------------------------------------------------------------------------------
 
 -  Document make_delete_command method in UserTracker
-   `commit <https://pagure.io/freeipa/c/a825540932d8fc2bf7f7e799be2fda0b61763ec3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a825540932d8fc2bf7f7e799be2fda0b61763ec3>`__
    `#6485 <https://pagure.io/freeipa/issue/6485>`__
 -  Tests: Fix integration sudo test
-   `commit <https://pagure.io/freeipa/c/3ebc0d4d7d38f3f59da668aa08fd762e08280d32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ebc0d4d7d38f3f59da668aa08fd762e08280d32>`__
    `#6378 <https://pagure.io/freeipa/issue/6378>`__
 -  Tests: Fix integration sudo tests setup and checks
-   `commit <https://pagure.io/freeipa/c/6d04220dc3071782cf303b2e94e06da4ee26e512>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d04220dc3071782cf303b2e94e06da4ee26e512>`__
    `#6262 <https://pagure.io/freeipa/issue/6262>`__
 -  Tests: Avoid skipping tests due to missing files
-   `commit <https://pagure.io/freeipa/c/d472d26fc06dfe192a5385e620f4c30ca3dcf1be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d472d26fc06dfe192a5385e620f4c30ca3dcf1be>`__
    `#6284 <https://pagure.io/freeipa/issue/6284>`__
 -  Raise error when running ipa-adtrust-install with empty netbios--name
-   `commit <https://pagure.io/freeipa/c/6064b122f995ca5e8f9bfcc72a8565d1280f8876>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6064b122f995ca5e8f9bfcc72a8565d1280f8876>`__
    `#6120 <https://pagure.io/freeipa/issue/6120>`__
 -  Tests: Fix failing automember tests
-   `commit <https://pagure.io/freeipa/c/ffe146fbba2e9577a9af5dd1521a110570024455>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffe146fbba2e9577a9af5dd1521a110570024455>`__
    `#6147 <https://pagure.io/freeipa/issue/6147>`__
 -  Tests: Remove DNS configuration from trust tests
-   `commit <https://pagure.io/freeipa/c/40b1459ad0299e95331699be9684682fca02a570>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b1459ad0299e95331699be9684682fca02a570>`__
 
 
 
@@ -216,7 +216,7 @@ Martin Babinsky (1)
 ----------------------------------------------------------------------------------------------
 
 -  add python-libsss_nss_idmap and python-sss to BuildRequires
-   `commit <https://pagure.io/freeipa/c/b0e43d5ec879fc56c38328cd9f01b04d8b6a870d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0e43d5ec879fc56c38328cd9f01b04d8b6a870d>`__
    `#6244 <https://pagure.io/freeipa/issue/6244>`__
 
 
@@ -225,18 +225,18 @@ Martin Basti (5)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.3.3
-   `commit <https://pagure.io/freeipa/c/d1b59d5dac1c8d2d6edf3e22aadc30fddb2e56e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1b59d5dac1c8d2d6edf3e22aadc30fddb2e56e0>`__
 -  Update Contributors.txt
-   `commit <https://pagure.io/freeipa/c/4ce58141cce0a58ec896b93bc1409a56a88c7700>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ce58141cce0a58ec896b93bc1409a56a88c7700>`__
 -  Raise DuplicatedEnrty error when user exists in delete_container
-   `commit <https://pagure.io/freeipa/c/4b551743820f436807811415ab51d6ee238ee971>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b551743820f436807811415ab51d6ee238ee971>`__
    `#6199 <https://pagure.io/freeipa/issue/6199>`__,
    `#6316 <https://pagure.io/freeipa/issue/6316>`__
 -  Catch DNS exceptions during emptyzones named.conf upgrade
-   `commit <https://pagure.io/freeipa/c/93756dc719723bbec93497ecd6e06e325e6eecbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93756dc719723bbec93497ecd6e06e325e6eecbd>`__
    `#6205 <https://pagure.io/freeipa/issue/6205>`__
 -  Start named during configuration upgrade.
-   `commit <https://pagure.io/freeipa/c/2d011b97c8a56d9eabae2ca3d88c30314e0adb58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d011b97c8a56d9eabae2ca3d88c30314e0adb58>`__
    `#6205 <https://pagure.io/freeipa/issue/6205>`__
 
 
@@ -245,13 +245,13 @@ Oleg Fayans (3)
 ----------------------------------------------------------------------------------------------
 
 -  Changed addressing to the client hosts to be replicas
-   `commit <https://pagure.io/freeipa/c/8ed4a4ba6392deb7972ddc07593d649926065c72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ed4a4ba6392deb7972ddc07593d649926065c72>`__
    `#6287 <https://pagure.io/freeipa/issue/6287>`__
 -  Disabled raiseonerr in kinit call during topology level check
-   `commit <https://pagure.io/freeipa/c/fb6980d2263aae64ee35f2890542ed2b0ded9e02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb6980d2263aae64ee35f2890542ed2b0ded9e02>`__
    `#6254 <https://pagure.io/freeipa/issue/6254>`__
 -  Fixed incorrect domainlevel determination in tests
-   `commit <https://pagure.io/freeipa/c/ab29e560bdd03f2bb3742dbd122867979e26f108>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab29e560bdd03f2bb3742dbd122867979e26f108>`__
    `#6167 <https://pagure.io/freeipa/issue/6167>`__
 
 
@@ -260,7 +260,7 @@ Peter Lacko (1)
 ----------------------------------------------------------------------------------------------
 
 -  Test URIs in certificate.
-   `commit <https://pagure.io/freeipa/c/2a207dd637748a4c05e54755b755986fbed16d55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a207dd637748a4c05e54755b755986fbed16d55>`__
    `#5881 <https://pagure.io/freeipa/issue/5881>`__
 
 
@@ -269,15 +269,15 @@ Petr Spacek (3)
 ----------------------------------------------------------------------------------------------
 
 -  Tests: fix test_forward_zones in test_xmlrpc/test_dns_plugin
-   `commit <https://pagure.io/freeipa/c/505a7da9d4335adc39d06b29fde66e00b758d4a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/505a7da9d4335adc39d06b29fde66e00b758d4a2>`__
    `#6213 <https://pagure.io/freeipa/issue/6213>`__,
    `#6317 <https://pagure.io/freeipa/issue/6317>`__
 -  DNS server upgrade: do not fail when DNS server did not respond
-   `commit <https://pagure.io/freeipa/c/27534f8d7294536364147b18b76ecb2bac67870f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27534f8d7294536364147b18b76ecb2bac67870f>`__
    `#6205 <https://pagure.io/freeipa/issue/6205>`__
 -  Fix ipa-replica-prepare's error message about missing local CA
    instance
-   `commit <https://pagure.io/freeipa/c/fedee72a5a0e9fbb2b82c4105034857b17f8a5c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fedee72a5a0e9fbb2b82c4105034857b17f8a5c4>`__
    `#6134 <https://pagure.io/freeipa/issue/6134>`__
 
 
@@ -286,7 +286,7 @@ Petr Vobornik (1)
 ----------------------------------------------------------------------------------------------
 
 -  ca-less tests: fix getting cert in pem format from nssdb
-   `commit <https://pagure.io/freeipa/c/42d3ec37f5a2692a51cd7db878b7b745d8d4c846>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42d3ec37f5a2692a51cd7db878b7b745d8d4c846>`__
    `#6177 <https://pagure.io/freeipa/issue/6177>`__
 
 
@@ -295,13 +295,13 @@ Stanislav Laznicka (3)
 ----------------------------------------------------------------------------------------------
 
 -  Add debug log in case cookie retrieval went wrong
-   `commit <https://pagure.io/freeipa/c/71475e3153117e554d22a2a27d7882ba4f890be8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71475e3153117e554d22a2a27d7882ba4f890be8>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 -  Fix cookie with Max-Age processing
-   `commit <https://pagure.io/freeipa/c/0d66046e501a4a1a09a0a74a96a499cb88ffb03b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d66046e501a4a1a09a0a74a96a499cb88ffb03b>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 -  Remove update_from_dict() method
-   `commit <https://pagure.io/freeipa/c/126c7c6932bba62342eefdc910877df1075e4a70>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/126c7c6932bba62342eefdc910877df1075e4a70>`__
    `#6311 <https://pagure.io/freeipa/issue/6311>`__
 
 
@@ -310,5 +310,5 @@ Tomas Krizek (1)
 ----------------------------------------------------------------------------------------------
 
 -  Keep NSS trust flags of existing certificates
-   `commit <https://pagure.io/freeipa/c/b3e57f789ef7f697f8cc68f180dc8ce292954ed4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3e57f789ef7f697f8cc68f180dc8ce292954ed4>`__
    `#5791 <https://pagure.io/freeipa/issue/5791>`__

--- a/src/page/Releases/4.4.4.rst
+++ b/src/page/Releases/4.4.4.rst
@@ -74,7 +74,7 @@ Alexander Bokovoy (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: support KDB DAL version 6.1
-   `commit <https://pagure.io/freeipa/c/95daecbae86f51271f5ea48cb628ace72e676351>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95daecbae86f51271f5ea48cb628ace72e676351>`__
    `#6776 <https://pagure.io/freeipa/issue/6776>`__
 
 
@@ -83,7 +83,7 @@ David Kupka (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
-   `commit <https://pagure.io/freeipa/c/40e1eb695d648a03f45e9c8d6687cb3d8a99fd6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40e1eb695d648a03f45e9c8d6687cb3d8a99fd6d>`__
    `#6738 <https://pagure.io/freeipa/issue/6738>`__
 
 
@@ -92,7 +92,7 @@ Florence Blanc-Renaud (1)
 ----------------------------------------------------------------------------------------------
 
 -  Do not configure PKI ajp redirection to use "::1"
-   `commit <https://pagure.io/freeipa/c/4a30e9d53475d60fb76242a098f1d969d6b19f75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a30e9d53475d60fb76242a098f1d969d6b19f75>`__
    `#6575 <https://pagure.io/freeipa/issue/6575>`__
 
 
@@ -101,10 +101,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  ca: correctly authorise ca-del, ca-enable and ca-disable
-   `commit <https://pagure.io/freeipa/c/1aa314c79648c442473f19344387bfe11ec2141b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1aa314c79648c442473f19344387bfe11ec2141b>`__
    `#6713 <https://pagure.io/freeipa/issue/6713>`__
 -  Set up DS TLS on replica in CA-less topology
-   `commit <https://pagure.io/freeipa/c/cdb6ffb779b7e1e563494eb3234b2441ba74d692>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdb6ffb779b7e1e563494eb3234b2441ba74d692>`__
    `#6226 <https://pagure.io/freeipa/issue/6226>`__
 
 
@@ -113,7 +113,7 @@ Ganna Kaihorodova (1)
 ----------------------------------------------------------------------------------------------
 
 -  Tests: Add tree root domain role in legacy client tests
-   `commit <https://pagure.io/freeipa/c/52527d6323eec1a2ae4bf01dd64412a3822c516d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52527d6323eec1a2ae4bf01dd64412a3822c516d>`__
    `#6600 <https://pagure.io/freeipa/issue/6600>`__
 
 
@@ -122,7 +122,7 @@ Jan Cholasta (1)
 ----------------------------------------------------------------------------------------------
 
 -  compat: fix \`Any\` params in \`batch\` and \`dnsrecord\`
-   `commit <https://pagure.io/freeipa/c/e3b49abfe7a8d9540d77ed355595d9e44a3bdd27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3b49abfe7a8d9540d77ed355595d9e44a3bdd27>`__
    `#6647 <https://pagure.io/freeipa/issue/6647>`__
 
 
@@ -131,21 +131,21 @@ Martin Basti (7)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.4.4
-   `commit <https://pagure.io/freeipa/c/92fb05c41f3c7f639238928599f26277dafa7fcf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92fb05c41f3c7f639238928599f26277dafa7fcf>`__
 -  Update Contributors.txt
-   `commit <https://pagure.io/freeipa/c/b150a7a9941893d11d4bccc4f0e1e2bd4b27d289>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b150a7a9941893d11d4bccc4f0e1e2bd4b27d289>`__
 -  FreeIPA 4.4.4 translations
-   `commit <https://pagure.io/freeipa/c/e7beb9a2ae5349525119ee072eebcc385f01c68e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7beb9a2ae5349525119ee072eebcc385f01c68e>`__
 -  Bump python-dns to improve processing of non-complete resolv.conf
-   `commit <https://pagure.io/freeipa/c/951d27ecc591a71c4a1297623b6920136c01bb4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/951d27ecc591a71c4a1297623b6920136c01bb4b>`__
    `#6070 <https://pagure.io/freeipa/issue/6070>`__
 -  Use proper logging for error messages
-   `commit <https://pagure.io/freeipa/c/74020d07dbf14202f696a0c8521829abc735d4c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74020d07dbf14202f696a0c8521829abc735d4c7>`__
 -  Wait until HTTPS principal entry is replicated to replica
-   `commit <https://pagure.io/freeipa/c/5bddcdb47b40baeae7379e00e8d87297ed3f1cd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bddcdb47b40baeae7379e00e8d87297ed3f1cd4>`__
    `#6588 <https://pagure.io/freeipa/issue/6588>`__
 -  wait_for_entry: use only DN as parameter
-   `commit <https://pagure.io/freeipa/c/3d0a0728766aed7245427b9eaf210e31fd40e440>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d0a0728766aed7245427b9eaf210e31fd40e440>`__
    `#6588 <https://pagure.io/freeipa/issue/6588>`__
 
 
@@ -154,10 +154,10 @@ Stanislav Laznicka (2)
 ----------------------------------------------------------------------------------------------
 
 -  Add debug log in case cookie retrieval went wrong
-   `commit <https://pagure.io/freeipa/c/5caade99127ff46141d2f6b7137f7aa62c0ff3bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5caade99127ff46141d2f6b7137f7aa62c0ff3bc>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 -  Fix cookie with Max-Age processing
-   `commit <https://pagure.io/freeipa/c/40f3b8f8a3d33864528138e517ce3240da6c9a4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40f3b8f8a3d33864528138e517ce3240da6c9a4a>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 
 
@@ -166,7 +166,7 @@ Tomas Krizek (1)
 ----------------------------------------------------------------------------------------------
 
 -  server install: require IPv6 stack to be enabled
-   `commit <https://pagure.io/freeipa/c/a572e61cb5153df8a040757eaba0c47531f0fe85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a572e61cb5153df8a040757eaba0c47531f0fe85>`__
    `#6608 <https://pagure.io/freeipa/issue/6608>`__
 
 
@@ -175,5 +175,5 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  added ssl verification using IPA trust anchor
-   `commit <https://pagure.io/freeipa/c/f784e33b1e2630aaa2e433da904cbb241d76e502>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f784e33b1e2630aaa2e433da904cbb241d76e502>`__
    `#6686 <https://pagure.io/freeipa/issue/6686>`__

--- a/src/page/Releases/4.5.0.rst
+++ b/src/page/Releases/4.5.0.rst
@@ -637,21 +637,21 @@ Jan Barta (8)
 ----------------------------------------------------------------------------------------------
 
 -  pylint: fix bad-mcs-method-argument
-   `commit <https://pagure.io/freeipa/c/71b3352ad0e0aa105c90e490a41645dfcc46ce87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71b3352ad0e0aa105c90e490a41645dfcc46ce87>`__
 -  pylint: fix bad-mcs-classmethod-argument
-   `commit <https://pagure.io/freeipa/c/8420d04f383b958660934ccf3c7c3bf9b27ac30c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8420d04f383b958660934ccf3c7c3bf9b27ac30c>`__
 -  pylint: fix bad-classmethod-argument
-   `commit <https://pagure.io/freeipa/c/f252f50987cfb1234671ca1742c11a0eebe8633c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f252f50987cfb1234671ca1742c11a0eebe8633c>`__
 -  pylint: fix old-style-class
-   `commit <https://pagure.io/freeipa/c/9bc57a01e1c0942e1a94ac0d948c8c5f8c0d4dcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bc57a01e1c0942e1a94ac0d948c8c5f8c0d4dcc>`__
 -  pylint: fix redefine-in-handler
-   `commit <https://pagure.io/freeipa/c/568f9da331af14e5f05764c46f51a0410da1e49c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/568f9da331af14e5f05764c46f51a0410da1e49c>`__
 -  pylint: fix pointless-statement
-   `commit <https://pagure.io/freeipa/c/cdecbcd0a175e010057beae6f7fb74fd67856ca1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdecbcd0a175e010057beae6f7fb74fd67856ca1>`__
 -  pylint: fix unneeded-not
-   `commit <https://pagure.io/freeipa/c/275e85d076607ce317b3aeca467167fac55bf396>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/275e85d076607ce317b3aeca467167fac55bf396>`__
 -  pylint: fix simplifiable-if-statement warnings
-   `commit <https://pagure.io/freeipa/c/36484e8672f5ee1fdc2bd57622e330ab8dbb7671>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36484e8672f5ee1fdc2bd57622e330ab8dbb7671>`__
 
 
 
@@ -659,26 +659,26 @@ Alexander Bokovoy (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipaserver/dcerpc.py: use arcfour_encrypt from samba
-   `commit <https://pagure.io/freeipa/c/7657754e02a5fa62265327937a6c7fd19b381610>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7657754e02a5fa62265327937a6c7fd19b381610>`__
    `#6697 <https://pagure.io/freeipa/issue/6697>`__
 -  add whoami command
-   `commit <https://pagure.io/freeipa/c/381c1c7a8fe63526d21cb65decb75fb5ffda676a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/381c1c7a8fe63526d21cb65decb75fb5ffda676a>`__
    `#6643 <https://pagure.io/freeipa/issue/6643>`__
 -  pkinit: make sure to have proper dictionary for Kerberos instance on
    upgrade
-   `commit <https://pagure.io/freeipa/c/14d84daf29543978c6383da10f4f2d913346f013>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14d84daf29543978c6383da10f4f2d913346f013>`__
    `#6670 <https://pagure.io/freeipa/issue/6670>`__
 -  ipa-kdb: support KDB DAL version 6.1
-   `commit <https://pagure.io/freeipa/c/593ea7da9a732647052cb56c08ad367e40be3912>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/593ea7da9a732647052cb56c08ad367e40be3912>`__
    `#6619 <https://pagure.io/freeipa/issue/6619>`__
 -  ipa-kdb: search for password policies globally
-   `commit <https://pagure.io/freeipa/c/73f33569c8893610e246b2f44a7aeaec872b37e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73f33569c8893610e246b2f44a7aeaec872b37e6>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  adtrust: remove FILE: prefix from 'dedicated keytab file' in smb.conf
-   `commit <https://pagure.io/freeipa/c/38cc01b1c92da36653e0ce4d8f7066282fd1d102>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38cc01b1c92da36653e0ce4d8f7066282fd1d102>`__
    `#6551 <https://pagure.io/freeipa/issue/6551>`__
 -  trustdomain-del: fix the way how subdomain is searched
-   `commit <https://pagure.io/freeipa/c/e8b94ef352400f9045837ed69266686b6b117301>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8b94ef352400f9045837ed69266686b6b117301>`__
    `#6445 <https://pagure.io/freeipa/issue/6445>`__
 
 
@@ -687,37 +687,37 @@ Abhijeet Kasurde (11)
 ----------------------------------------------------------------------------------------------
 
 -  Minor typo fix in DNS install plugin
-   `commit <https://pagure.io/freeipa/c/cc446fb44870592f73af9c0dc2a35c5d37ce7a5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc446fb44870592f73af9c0dc2a35c5d37ce7a5c>`__
 -  Update warning message for replica install
-   `commit <https://pagure.io/freeipa/c/c913f810715705c560ae8bd05a33084785f59583>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c913f810715705c560ae8bd05a33084785f59583>`__
    `#6352 <https://pagure.io/freeipa/issue/6352>`__
 -  Add fix for ipa plugins command
-   `commit <https://pagure.io/freeipa/c/b3c41f21e51e5389d95b5486dcdfdc3f9a8b0424>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3c41f21e51e5389d95b5486dcdfdc3f9a8b0424>`__
    `#6513 <https://pagure.io/freeipa/issue/6513>`__
 -  Update man page of ipa-server-install
-   `commit <https://pagure.io/freeipa/c/08b8bfa9b59b30e1bec1fa8c1cfce992dc80c49f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08b8bfa9b59b30e1bec1fa8c1cfce992dc80c49f>`__
    `#6634 <https://pagure.io/freeipa/issue/6634>`__
 -  Remove deprecated ipa-upgradeconfig command
-   `commit <https://pagure.io/freeipa/c/c56e02b3c5257edbfd3709848ca7eda07e271e38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c56e02b3c5257edbfd3709848ca7eda07e271e38>`__
    `#6620 <https://pagure.io/freeipa/issue/6620>`__
 -  Update warning message for ipa server uninstall
-   `commit <https://pagure.io/freeipa/c/ae2d0a221772267ecda30896dc8897a3f4b4a97b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae2d0a221772267ecda30896dc8897a3f4b4a97b>`__
    `#6548 <https://pagure.io/freeipa/issue/6548>`__
 -  Fix for handling CalledProcessError in authconfig
-   `commit <https://pagure.io/freeipa/c/6d52c0fe6acb09f3b8525840dfacc3f0885eac37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d52c0fe6acb09f3b8525840dfacc3f0885eac37>`__
    `#5244 <https://pagure.io/freeipa/issue/5244>`__
 -  Enumerate available options in IPA installer
-   `commit <https://pagure.io/freeipa/c/80c0e5cb8d689cf1ec6a883d2c7000f9dadbf7d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80c0e5cb8d689cf1ec6a883d2c7000f9dadbf7d8>`__
    `#5435 <https://pagure.io/freeipa/issue/5435>`__
 -  Provide user hint about IP address in IPA install
-   `commit <https://pagure.io/freeipa/c/28bc54f91dfbd76887180fa67ceecb46977a4fb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28bc54f91dfbd76887180fa67ceecb46977a4fb8>`__
    `#5949 <https://pagure.io/freeipa/issue/5949>`__
 -  Add fix for no-hbac-allow option in server install
-   `commit <https://pagure.io/freeipa/c/a42059228018839ae2656c27f5b00d96bc935ee3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a42059228018839ae2656c27f5b00d96bc935ee3>`__
    `#6357 <https://pagure.io/freeipa/issue/6357>`__
 -  Added a fix for setting Priority as required field in Password Policy
    Details facet
-   `commit <https://pagure.io/freeipa/c/8149b762b424d1ce7a26847386715ca98038b230>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8149b762b424d1ce7a26847386715ca98038b230>`__
    `#6335 <https://pagure.io/freeipa/issue/6335>`__
 
 
@@ -726,28 +726,28 @@ Ben Lipton (8)
 ----------------------------------------------------------------------------------------------
 
 -  csrgen: Support encrypted private keys
-   `commit <https://pagure.io/freeipa/c/ada91c20588046bb147fc701718d3da4d2c080ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ada91c20588046bb147fc701718d3da4d2c080ca>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Allow overriding the CSR generation profile
-   `commit <https://pagure.io/freeipa/c/4350dcdea22fd2284836315d0ae7d38733a7620e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4350dcdea22fd2284836315d0ae7d38733a7620e>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Automate full cert request flow
-   `commit <https://pagure.io/freeipa/c/39a5d9c5aae77687f67d9be02457733bdfb99ead>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39a5d9c5aae77687f67d9be02457733bdfb99ead>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  tests: Add tests for CSR autogeneration
-   `commit <https://pagure.io/freeipa/c/a26cf0d7910dd4c0a4da08682b4be8d3d94ba520>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a26cf0d7910dd4c0a4da08682b4be8d3d94ba520>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Use data_sources option to define which fields are rendered
-   `commit <https://pagure.io/freeipa/c/afd7c05d11432304bfdf183832a21d419f363689>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afd7c05d11432304bfdf183832a21d419f363689>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Add a CSR generation profile for user certificates
-   `commit <https://pagure.io/freeipa/c/f1a1c6eca1b294f24174d7b0e1f78de46d9d5b05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1a1c6eca1b294f24174d7b0e1f78de46d9d5b05>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Add CSR generation profile for caIPAserviceCert
-   `commit <https://pagure.io/freeipa/c/fc58eff6a3d7fe805e612b8b002304d8b9cd4ba9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc58eff6a3d7fe805e612b8b002304d8b9cd4ba9>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Add code to generate scripts that generate CSRs
-   `commit <https://pagure.io/freeipa/c/10ef5947860f5098182b1f95c08c1158e2da15f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10ef5947860f5098182b1f95c08c1158e2da15f9>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 
 
@@ -756,219 +756,219 @@ Christian Heimes (88)
 ----------------------------------------------------------------------------------------------
 
 -  Add PYTHON_INSTALL_EXTRA_OPTIONS and --install-layout=deb
-   `commit <https://pagure.io/freeipa/c/b280c7bb0192485dfb622c731e31deb89d517b6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b280c7bb0192485dfb622c731e31deb89d517b6f>`__
    `#6764 <https://pagure.io/freeipa/issue/6764>`__
 -  Make pylint and jsl optional
-   `commit <https://pagure.io/freeipa/c/f1f63506caf88e4d86ea2bfdc7d25eceaf689bc5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1f63506caf88e4d86ea2bfdc7d25eceaf689bc5>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 -  Ignore ipapython/.DEFAULT_PLUGINS
-   `commit <https://pagure.io/freeipa/c/a30d31b0c6122b44e1b4e84451e4196c3d0d7fe7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a30d31b0c6122b44e1b4e84451e4196c3d0d7fe7>`__
    `#6597 <https://pagure.io/freeipa/issue/6597>`__
 -  Run test_ipaclient test suite
-   `commit <https://pagure.io/freeipa/c/08fc9d7a68220fc147177e6f757387823fea0f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08fc9d7a68220fc147177e6f757387823fea0f43>`__
 -  Chain CSR generator file loaders
-   `commit <https://pagure.io/freeipa/c/177f07e163d6d591a1e609d35e0a6f6f5347551e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/177f07e163d6d591a1e609d35e0a6f6f5347551e>`__
 -  Move csrgen templates into ipaclient package
-   `commit <https://pagure.io/freeipa/c/80be18162921268be9c8981495c9e8a4de0c85cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80be18162921268be9c8981495c9e8a4de0c85cd>`__
    `#6714 <https://pagure.io/freeipa/issue/6714>`__
 -  Use https to get security domain from Dogtag
-   `commit <https://pagure.io/freeipa/c/d1c5d92897d3e262edd2e43295c1270590aebd3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1c5d92897d3e262edd2e43295c1270590aebd3d>`__
 -  Cleanup certdb
-   `commit <https://pagure.io/freeipa/c/22d7492c94837342a559c368454c223f566490ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22d7492c94837342a559c368454c223f566490ac>`__
 -  Default to pkginstall=true without duplicated definitions
-   `commit <https://pagure.io/freeipa/c/bc1f60b3ba74032cb0895e154e02971aa380a6b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc1f60b3ba74032cb0895e154e02971aa380a6b3>`__
 -  pylint: ignore pypi placeholders
-   `commit <https://pagure.io/freeipa/c/60cfacc54167b7b94b63874ade62740d980e3746>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60cfacc54167b7b94b63874ade62740d980e3746>`__
 -  Python build: use --build-base everywhere
-   `commit <https://pagure.io/freeipa/c/ab9f42d6eeefeaca2e4a5a9acfbb07b428be4616>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab9f42d6eeefeaca2e4a5a9acfbb07b428be4616>`__
 -  Add with_wheels global to install wheel and PyPI packaging
    dependencies
-   `commit <https://pagure.io/freeipa/c/b4c1bf1c7d1a63e802abe6334bd1112d2d468513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4c1bf1c7d1a63e802abe6334bd1112d2d468513>`__
 -  Add placeholders for ipaplatform, ipaserver and ipatests
-   `commit <https://pagure.io/freeipa/c/acdd1f59782bb836d6c4c255689918368adb8dab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acdd1f59782bb836d6c4c255689918368adb8dab>`__
 -  Add python-wheel as build requirement
-   `commit <https://pagure.io/freeipa/c/e2b9ea2fd58b98edbb8d6aec97aadeea7cf11dcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2b9ea2fd58b98edbb8d6aec97aadeea7cf11dcb>`__
 -  Packaging: Add placeholder packages
-   `commit <https://pagure.io/freeipa/c/2e784336b0fe99baa47cf3e024f744ed56dc12ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e784336b0fe99baa47cf3e024f744ed56dc12ec>`__
 -  Vault: port key wrapping to python-cryptography
-   `commit <https://pagure.io/freeipa/c/ed7a03a1af8b556247b929635e2972be4f2b32e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed7a03a1af8b556247b929635e2972be4f2b32e4>`__
    `#6650 <https://pagure.io/freeipa/issue/6650>`__
 -  Remove NSPRError exception from platform tasks
-   `commit <https://pagure.io/freeipa/c/88fd936a761dfce099c4b03529d679256c9860d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88fd936a761dfce099c4b03529d679256c9860d6>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove import nss from test_ldap
-   `commit <https://pagure.io/freeipa/c/79c0e6d355c9e7bcc7cacc37faaba8e999d56400>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79c0e6d355c9e7bcc7cacc37faaba8e999d56400>`__
 -  certdb: Don't restore_context() of new NSSDB
-   `commit <https://pagure.io/freeipa/c/a163ad77b3d12f2da2b135de29f594c06190b41a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a163ad77b3d12f2da2b135de29f594c06190b41a>`__
 -  Finish port to PyCA cryptography
-   `commit <https://pagure.io/freeipa/c/135d0b5dd111d40632e2cd5be8f5315684b45fc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/135d0b5dd111d40632e2cd5be8f5315684b45fc6>`__
 -  Drop in-memory copy of schema zip file
-   `commit <https://pagure.io/freeipa/c/3be696c92f6948ea0ced9784920600b73703e414>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3be696c92f6948ea0ced9784920600b73703e414>`__
 -  Speed up client schema cache
-   `commit <https://pagure.io/freeipa/c/332dbab1ff09eb719eb9e0a7a90bbf5b6e69ddc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/332dbab1ff09eb719eb9e0a7a90bbf5b6e69ddc9>`__
    `#6690 <https://pagure.io/freeipa/issue/6690>`__
 -  C compilation fixes and hardening
-   `commit <https://pagure.io/freeipa/c/2828a2b92b89932d66b640e5047161448d522e2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2828a2b92b89932d66b640e5047161448d522e2e>`__
 -  lite-server: validate LDAP connection and cache schema
-   `commit <https://pagure.io/freeipa/c/dcb618152572ca013a447336e13d24399b5f7960>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcb618152572ca013a447336e13d24399b5f7960>`__
    `#6679 <https://pagure.io/freeipa/issue/6679>`__
 -  Add --without-ipatests option
-   `commit <https://pagure.io/freeipa/c/2747f2ad782c7640ecc6949098f0d43411182255>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2747f2ad782c7640ecc6949098f0d43411182255>`__
 -  Add missing include of stdint.h for uint8_t
-   `commit <https://pagure.io/freeipa/c/20c1eb9844223d892da47da1ea10662d37953ff8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20c1eb9844223d892da47da1ea10662d37953ff8>`__
 -  Client-only builds with --disable-server
-   `commit <https://pagure.io/freeipa/c/70554938d4f9ba5b347cd4bc8001428e905198e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70554938d4f9ba5b347cd4bc8001428e905198e4>`__
    `#6517 <https://pagure.io/freeipa/issue/6517>`__
 -  New lite-server implementation
-   `commit <https://pagure.io/freeipa/c/ff6e701b0077d9c8e2aacdcaecf70f885018db92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff6e701b0077d9c8e2aacdcaecf70f885018db92>`__
 -  Explain more performance tricks in doc string
-   `commit <https://pagure.io/freeipa/c/1d7fcfe15d279e50d9ac29464a30f8e594db1802>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d7fcfe15d279e50d9ac29464a30f8e594db1802>`__
 -  Fix test, nested lists are no longer converted to nested tuples
-   `commit <https://pagure.io/freeipa/c/2ff07b958079e5a8972b2e7a06881521361746cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ff07b958079e5a8972b2e7a06881521361746cc>`__
 -  Pretty print JSON in debug mode (debug level >= 2)
-   `commit <https://pagure.io/freeipa/c/3cac0378e94efc2ee1070eff2984eb1147bcf463>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cac0378e94efc2ee1070eff2984eb1147bcf463>`__
 -  Convert list to tuples
-   `commit <https://pagure.io/freeipa/c/b12b1e4c0b19a84ccffcc702ab608d818382a697>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b12b1e4c0b19a84ccffcc702ab608d818382a697>`__
 -  Faster JSON encoder/decoder
-   `commit <https://pagure.io/freeipa/c/8159c2883bf66980582d1227c364df4e592bdd7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8159c2883bf66980582d1227c364df4e592bdd7e>`__
    `#6655 <https://pagure.io/freeipa/issue/6655>`__
 -  Backup /root/kracert.p12
-   `commit <https://pagure.io/freeipa/c/11ef2cacbf2ebb67f80a0cf4a3e7b39da700188b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11ef2cacbf2ebb67f80a0cf4a3e7b39da700188b>`__
    `#6659 <https://pagure.io/freeipa/issue/6659>`__
 -  Ditch version_info and use version number from ipapython.version
-   `commit <https://pagure.io/freeipa/c/8d3bea8accb9814b3a973f4a606110fee78baf72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d3bea8accb9814b3a973f4a606110fee78baf72>`__
 -  test_StrEnum: use int as bad type
-   `commit <https://pagure.io/freeipa/c/4965735382425356ece27e7827e2a91bc2ab2055>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4965735382425356ece27e7827e2a91bc2ab2055>`__
 -  Stable \_is_null check
-   `commit <https://pagure.io/freeipa/c/e6129a76e7093b8f9f7717e5f63ed06f9e9ef30a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6129a76e7093b8f9f7717e5f63ed06f9e9ef30a>`__
 -  cryptography has deprecated serial in favor of serial_number
-   `commit <https://pagure.io/freeipa/c/3d9bec2e879d60e6bb7b2602084d3314765a6283>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d9bec2e879d60e6bb7b2602084d3314765a6283>`__
 -  Enable additional warnings (BytesWarning, DeprecationWarning)
-   `commit <https://pagure.io/freeipa/c/a33b25dea988aa34844869a8adc57d5cd396d3aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a33b25dea988aa34844869a8adc57d5cd396d3aa>`__
    `#6631 <https://pagure.io/freeipa/issue/6631>`__
 -  Print test env information
-   `commit <https://pagure.io/freeipa/c/b20f6fb29478de6b4f25741bc4fd975a5e0be671>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b20f6fb29478de6b4f25741bc4fd975a5e0be671>`__
 -  Clean / ignore make check artefact
-   `commit <https://pagure.io/freeipa/c/d8343a96dd206c9f25cf032a50f3b48fb8166db1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8343a96dd206c9f25cf032a50f3b48fb8166db1>`__
 -  ipapython: Add dependencies on version.py
-   `commit <https://pagure.io/freeipa/c/504f4417070a308ef54b8f98ff25d02c6604a6f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/504f4417070a308ef54b8f98ff25d02c6604a6f6>`__
 -  pytest: set rules to find test files and functions
-   `commit <https://pagure.io/freeipa/c/68cb4d2b0f6b28f20513371e46b279d80c0b3070>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68cb4d2b0f6b28f20513371e46b279d80c0b3070>`__
 -  Fix used before assignment bug in host_port_open()
-   `commit <https://pagure.io/freeipa/c/deaad95247fa9624bef0108bf3813f358fb17ee5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deaad95247fa9624bef0108bf3813f358fb17ee5>`__
 -  Use pytest conftest.py and drop pytest.ini
-   `commit <https://pagure.io/freeipa/c/1e06a5195bafe0224d77371987f2509f5508ca2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e06a5195bafe0224d77371987f2509f5508ca2f>`__
 -  Catch ValueError raised by pytest.config.getoption()
-   `commit <https://pagure.io/freeipa/c/3387734e6c6d47a756b5e914e7e515d2610a424f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3387734e6c6d47a756b5e914e7e515d2610a424f>`__
 -  Silence pylint import errors of ipaserver in ipalib and ipaclient
-   `commit <https://pagure.io/freeipa/c/987d24f784e05e911bf4e87bd1156abb1dd56210>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/987d24f784e05e911bf4e87bd1156abb1dd56210>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Relax check for .git to support freeipa in submodules
-   `commit <https://pagure.io/freeipa/c/cac0c2d951e10d49372a038c73f796dc3beb62b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cac0c2d951e10d49372a038c73f796dc3beb62b9>`__
 -  Ignore backup~ files like config.h.in~
-   `commit <https://pagure.io/freeipa/c/86295a8c2ea5c0546b070053d490b3a8b8013012>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86295a8c2ea5c0546b070053d490b3a8b8013012>`__
 -  Fetch correct exception in IPA_CONFDIR test
-   `commit <https://pagure.io/freeipa/c/34bd2b63377772f3dabc0eb36f7021238df286a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34bd2b63377772f3dabc0eb36f7021238df286a6>`__
 -  Use env var IPA_CONFDIR to get confdir
-   `commit <https://pagure.io/freeipa/c/d4916254e995be1118ab8dbce5b60091305f97fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4916254e995be1118ab8dbce5b60091305f97fe>`__
 -  Set explicit confdir option for global contexts
-   `commit <https://pagure.io/freeipa/c/1e6a204b4372bbbfb722a00370a5ce4e34406b9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e6a204b4372bbbfb722a00370a5ce4e34406b9f>`__
    `#6389 <https://pagure.io/freeipa/issue/6389>`__
 -  Remove import of ipaplatform.paths from test_ipalib
-   `commit <https://pagure.io/freeipa/c/98f0077360884da6df31b351caaed7510dec94de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98f0077360884da6df31b351caaed7510dec94de>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  Remove BIN_FALSE and BIN_TRUE
-   `commit <https://pagure.io/freeipa/c/3e3b5462b28f2133fd4170645cad762c0a0fbb4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e3b5462b28f2133fd4170645cad762c0a0fbb4f>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  Add pylint guard to import of ipaplatform in ipapython.certdb
-   `commit <https://pagure.io/freeipa/c/fb307ba582d4e7339b7026cbe26c3b170221e249>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb307ba582d4e7339b7026cbe26c3b170221e249>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  Require python-gssapi >= 1.2.0, take 2
-   `commit <https://pagure.io/freeipa/c/5dc5960e715b378b6090935ba133d6f332427de5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5dc5960e715b378b6090935ba133d6f332427de5>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Backwards compatibility with setuptools 0.9.8
-   `commit <https://pagure.io/freeipa/c/027fc32fe0424659c5aecb4531299fe8d4a503d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/027fc32fe0424659c5aecb4531299fe8d4a503d3>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Require python-cryptography >= 1.3.1
-   `commit <https://pagure.io/freeipa/c/289982e02fa6bef700fe2c1900ddbed864876faa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/289982e02fa6bef700fe2c1900ddbed864876faa>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Wheel bundles fixes
-   `commit <https://pagure.io/freeipa/c/235f68524767c1eb2e12fb6d1d9f6a520414c583>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/235f68524767c1eb2e12fb6d1d9f6a520414c583>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  Require python-gssapi >= 1.2.0
-   `commit <https://pagure.io/freeipa/c/8559791e0d520f4a3503e35d1975ac31448b1390>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8559791e0d520f4a3503e35d1975ac31448b1390>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Adjustments for setup requirements
-   `commit <https://pagure.io/freeipa/c/ed9645b2ac58fd4664810f05970ea258c7948420>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed9645b2ac58fd4664810f05970ea258c7948420>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  wrap long line
-   `commit <https://pagure.io/freeipa/c/6bbbce44733761fda1fc588397b8baddbc7f8de3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bbbce44733761fda1fc588397b8baddbc7f8de3>`__
 -  Silence import warnings for Samba bindings
-   `commit <https://pagure.io/freeipa/c/fef6f18aa27c3c5286c48dce4419db6ff9ac967b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fef6f18aa27c3c5286c48dce4419db6ff9ac967b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Fix Python 3 bugs discovered by pylint
-   `commit <https://pagure.io/freeipa/c/7fef9cbec725beed62eb425449083c59416ed975>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fef9cbec725beed62eb425449083c59416ed975>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Python3 pylint fixes
-   `commit <https://pagure.io/freeipa/c/38e8719f728e6d54289507fe2c7f79f9272c45c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38e8719f728e6d54289507fe2c7f79f9272c45c0>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Add main guards to a couple of Python scripts
-   `commit <https://pagure.io/freeipa/c/a8376a244758494db31341442bc2163e1807b7ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8376a244758494db31341442bc2163e1807b7ac>`__
 -  Break ipaplatform / ipalib import cycle of hell
-   `commit <https://pagure.io/freeipa/c/6409abf1a60f3548203e6607a2b157ff72af2c89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6409abf1a60f3548203e6607a2b157ff72af2c89>`__
 -  Replace LooseVersion
-   `commit <https://pagure.io/freeipa/c/2cbaf156045769b54150e4d4c3c1071f164a16fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2cbaf156045769b54150e4d4c3c1071f164a16fb>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Don't ship install subpackages with wheels
-   `commit <https://pagure.io/freeipa/c/526bcea705d04895aa6b09bce996ac340783d1d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/526bcea705d04895aa6b09bce996ac340783d1d0>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Minor fixes for IPAVersion class
-   `commit <https://pagure.io/freeipa/c/29947fe1a304ff6f913e5d94d56d8108a7c94087>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29947fe1a304ff6f913e5d94d56d8108a7c94087>`__
    `#6473 <https://pagure.io/freeipa/issue/6473>`__
 -  Pylint: whitelist packages with extension modules
-   `commit <https://pagure.io/freeipa/c/573eee444e1746fd5949897294c96a1793e74511>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/573eee444e1746fd5949897294c96a1793e74511>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Add 'ipa localenv' subcommand
-   `commit <https://pagure.io/freeipa/c/1166fbc4946596fcc2ed51a1ec6990fc7dae8964>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1166fbc4946596fcc2ed51a1ec6990fc7dae8964>`__
    `#6490 <https://pagure.io/freeipa/issue/6490>`__
 -  ipapython and ipatest no longer require lxml
-   `commit <https://pagure.io/freeipa/c/c93bfda594723357f3ff9f4eb8191f3d76df680f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c93bfda594723357f3ff9f4eb8191f3d76df680f>`__
 -  Register entry points of Custodia plugins
-   `commit <https://pagure.io/freeipa/c/9102fb3b02fbe55480428e60fb8df4fd668d7753>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9102fb3b02fbe55480428e60fb8df4fd668d7753>`__
    `#6492 <https://pagure.io/freeipa/issue/6492>`__
 -  Use xml.etree in ipa-client-automount script
-   `commit <https://pagure.io/freeipa/c/9fbd29cc106660865bc6cda225d6a8a338a78d31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fbd29cc106660865bc6cda225d6a8a338a78d31>`__
 -  Port ipapython.dnssec.odsmgr to xml.etree
-   `commit <https://pagure.io/freeipa/c/64af88fee4a482b3f393d38ff2c7f9494e689a7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64af88fee4a482b3f393d38ff2c7f9494e689a7b>`__
    `#6469 <https://pagure.io/freeipa/issue/6469>`__
 -  Add install requirements to Python packages
-   `commit <https://pagure.io/freeipa/c/8346e1b067483d4d836627a267805bbe8d6e7efa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8346e1b067483d4d836627a267805bbe8d6e7efa>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Make api.env.nss_dir relative to api.env.confdir
-   `commit <https://pagure.io/freeipa/c/9006ed34bb1edfaafc3345c1128800dc802c14ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9006ed34bb1edfaafc3345c1128800dc802c14ff>`__
    `#6386 <https://pagure.io/freeipa/issue/6386>`__
 -  Don't modify redhat_system_units
-   `commit <https://pagure.io/freeipa/c/94a9dfb9d72ecd25a01316febbf2ffec50912e2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94a9dfb9d72ecd25a01316febbf2ffec50912e2e>`__
 -  Use correct classifiers to make setup.py files PyPI compatible
-   `commit <https://pagure.io/freeipa/c/2dd66c6366454f9edd9b89861530e97c75b2d869>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dd66c6366454f9edd9b89861530e97c75b2d869>`__
 -  Use api.env.nss_dir instead of paths.IPA_NSSDB_DIR
-   `commit <https://pagure.io/freeipa/c/a22a5dd676f581910ac7872c1a20322278fc7d4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a22a5dd676f581910ac7872c1a20322278fc7d4a>`__
    `#6386 <https://pagure.io/freeipa/issue/6386>`__
 -  Add \__name_\_ == \__main_\_ guards to setup.pys
-   `commit <https://pagure.io/freeipa/c/91920e7cb48cbf143ae281c9c073df14b2c2dddf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91920e7cb48cbf143ae281c9c073df14b2c2dddf>`__
 -  Remove ipapython/ipa.conf
-   `commit <https://pagure.io/freeipa/c/e12a70a8b1aa5daac4b8ab7ac681b09f664a8357>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e12a70a8b1aa5daac4b8ab7ac681b09f664a8357>`__
 -  Port all setup.py to setuptools
-   `commit <https://pagure.io/freeipa/c/4cd83fb51cc35a2ba7773b62a7aa8d295a1e1e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cd83fb51cc35a2ba7773b62a7aa8d295a1e1e4a>`__
 -  Replace ipaplatform's symlinks with a meta importer
-   `commit <https://pagure.io/freeipa/c/8f98fa1bd5f1da207fab6f89b75e0cdc19d00797>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f98fa1bd5f1da207fab6f89b75e0cdc19d00797>`__
 -  Move ipa.1 man file
-   `commit <https://pagure.io/freeipa/c/b9d68b5c3503bb708f637be6bb173a742b4105b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9d68b5c3503bb708f637be6bb173a742b4105b4>`__
 -  Add iSecStore.span
-   `commit <https://pagure.io/freeipa/c/ac94d32c4fd543e33211c0331330c80c619e0058>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac94d32c4fd543e33211c0331330c80c619e0058>`__
    `#6365 <https://pagure.io/freeipa/issue/6365>`__
 -  Use RSA-OAEP instead of RSA PKCS#1 v1.5
-   `commit <https://pagure.io/freeipa/c/4ae4d0d6909e99892442a170288f0eee9610d1c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ae4d0d6909e99892442a170288f0eee9610d1c2>`__
    `#6278 <https://pagure.io/freeipa/issue/6278>`__
 
 
@@ -978,66 +978,66 @@ David Kupka (20)
 
 -  rpcserver: x509_login: Handle unsuccessful certificate login
    gracefully
-   `commit <https://pagure.io/freeipa/c/70889d4d5e7e2bd65ab1d4a28e5eda4a51c9b0c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70889d4d5e7e2bd65ab1d4a28e5eda4a51c9b0c0>`__
    `#6225 <https://pagure.io/freeipa/issue/6225>`__
 -  Bump required version of gssproxy to 0.7.0
-   `commit <https://pagure.io/freeipa/c/c37254e1b124c95d6ea874f6513979ca165fb31d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c37254e1b124c95d6ea874f6513979ca165fb31d>`__
    `#6671 <https://pagure.io/freeipa/issue/6671>`__,
    `#6698 <https://pagure.io/freeipa/issue/6698>`__
 -  tests: Add tests for kerberos principal aliases in stageuser
-   `commit <https://pagure.io/freeipa/c/8e139d4b559a6f19d859e078e1940a69d8977fdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e139d4b559a6f19d859e078e1940a69d8977fdb>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  tests: kerberos_principal_aliases: Deduplicate tests
-   `commit <https://pagure.io/freeipa/c/9382efde4fbc027dcfb5dc5f22d25296f232e0a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9382efde4fbc027dcfb5dc5f22d25296f232e0a6>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  tests: Stageuser-{add,remove}-cert
-   `commit <https://pagure.io/freeipa/c/c5c98af99db53b5f9453bf70e9fd4c11e219cf3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5c98af99db53b5f9453bf70e9fd4c11e219cf3e>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  tests: add-remove-cert: Use harcoded certificates instead of
    requesting them
-   `commit <https://pagure.io/freeipa/c/7b68cc5b08c5563535486d72f37b766209791dbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b68cc5b08c5563535486d72f37b766209791dbf>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  ipalib.x509: Handle missing SAN gracefully
-   `commit <https://pagure.io/freeipa/c/308c790ee90f00e0bc2c40abf51c30e5250631e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/308c790ee90f00e0bc2c40abf51c30e5250631e9>`__
 -  stageuser: Add stageuser-{add,remove}-principal
-   `commit <https://pagure.io/freeipa/c/7e2d185ba09382a815e9b0530aeae3d56f9378d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e2d185ba09382a815e9b0530aeae3d56f9378d1>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  stageuser: Add stageuser-{add,remove}-cert
-   `commit <https://pagure.io/freeipa/c/9c0e86530ec693606ca4f69e74a9dfe4118a21aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c0e86530ec693606ca4f69e74a9dfe4118a21aa>`__
    `#6623 <https://pagure.io/freeipa/issue/6623>`__
 -  build: Add missing dependency on libxmlrpc{,_util}
-   `commit <https://pagure.io/freeipa/c/f4088b3a00b3cbd1a0133ac90cba85e501573f76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4088b3a00b3cbd1a0133ac90cba85e501573f76>`__
    `#6637 <https://pagure.io/freeipa/issue/6637>`__
 -  ipaclient: schema cache: Handle malformed server info data gracefully
-   `commit <https://pagure.io/freeipa/c/d15ccde20fcc97a597180255ee9f5eb38caa206c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d15ccde20fcc97a597180255ee9f5eb38caa206c>`__
    `#6578 <https://pagure.io/freeipa/issue/6578>`__
 -  schema_cache: Make handling of string compatible with python3
-   `commit <https://pagure.io/freeipa/c/388ed93935de56adbf1db976e9df276327c9a1e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/388ed93935de56adbf1db976e9df276327c9a1e4>`__
    `#6559 <https://pagure.io/freeipa/issue/6559>`__
 -  installer: Stop adding distro-specific NTP servers into ntp.conf
-   `commit <https://pagure.io/freeipa/c/a15fdea615fa4e1153fbbed234113a235135572e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a15fdea615fa4e1153fbbed234113a235135572e>`__
    `#6486 <https://pagure.io/freeipa/issue/6486>`__
 -  tests: Expect krbpwdpolicyreference in result of
    {host,service}-{find,show} --all
-   `commit <https://pagure.io/freeipa/c/b1a20599c4f9fdcd208998694185b65460126703>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1a20599c4f9fdcd208998694185b65460126703>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  password policy: Add explicit default password policy for hosts and
    services
-   `commit <https://pagure.io/freeipa/c/6f1d927467e7907fd1991f88388d96c67c9bff61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f1d927467e7907fd1991f88388d96c67c9bff61>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  ipaclient.plugins: Use api_version from internally called commands
-   `commit <https://pagure.io/freeipa/c/d841a79dc104521f736469eff7154c2f4266082b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d841a79dc104521f736469eff7154c2f4266082b>`__
    `#6539 <https://pagure.io/freeipa/issue/6539>`__
 -  tests: Mark 389-ds acceptance tests
-   `commit <https://pagure.io/freeipa/c/4225484356426a73cc11211bceda7f06ee23d093>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4225484356426a73cc11211bceda7f06ee23d093>`__
 -  tests: Mark Dogtag acceptance tests
-   `commit <https://pagure.io/freeipa/c/3e53bbcc34bd256da36209fd8cf8ac5d33ec8093>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e53bbcc34bd256da36209fd8cf8ac5d33ec8093>`__
 -  UnsafeIPAddress: Implement \__(g|s)etstate_\_ and to ensure proper
    (un)pickling
-   `commit <https://pagure.io/freeipa/c/fb85230e25bd37a2a02a9d90793f337aad40a037>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb85230e25bd37a2a02a9d90793f337aad40a037>`__
    `#6385 <https://pagure.io/freeipa/issue/6385>`__
 -  schema cache: Store and check info for pre-schema servers
-   `commit <https://pagure.io/freeipa/c/ec2401917456d6f643532c0d0218c9e75172c2d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec2401917456d6f643532c0d0218c9e75172c2d8>`__
    `#6095 <https://pagure.io/freeipa/issue/6095>`__
 
 
@@ -1046,65 +1046,65 @@ Florence Blanc-Renaud (20)
 ----------------------------------------------------------------------------------------------
 
 -  Installation must publish CA cert in /usr/share/ipa/html/ca.crt
-   `commit <https://pagure.io/freeipa/c/d4ad2c98aa43f03ecbd8e0a44410888acd83df6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ad2c98aa43f03ecbd8e0a44410888acd83df6e>`__
    `#6750 <https://pagure.io/freeipa/issue/6750>`__
 -  IdM Server: list all Employees with matching Smart Card
-   `commit <https://pagure.io/freeipa/c/ea34e17a46a60efb9c4dc81dab919a1639dec73b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea34e17a46a60efb9c4dc81dab919a1639dec73b>`__
    `#6646 <https://pagure.io/freeipa/issue/6646>`__
 -  ipa systemd unit should define Wants=network instead of
    Requires=network
-   `commit <https://pagure.io/freeipa/c/f447489707812643ee918266f99ca1ac82a408af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f447489707812643ee918266f99ca1ac82a408af>`__
    `#6723 <https://pagure.io/freeipa/issue/6723>`__
 -  Support for Certificate Identity Mapping
-   `commit <https://pagure.io/freeipa/c/9e24918c89f30a6d7064844dc0dd848bb35140df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e24918c89f30a6d7064844dc0dd848bb35140df>`__
    `#6542 <https://pagure.io/freeipa/issue/6542>`__
 -  Define template version in certmap.conf
-   `commit <https://pagure.io/freeipa/c/c49320435ddc67210c0d95be273e971ea8ffad6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c49320435ddc67210c0d95be273e971ea8ffad6d>`__
    `#6354 <https://pagure.io/freeipa/issue/6354>`__
 -  Fix ipa.service unit re. gssproxy
-   `commit <https://pagure.io/freeipa/c/98e3b14a0477232054b02065c857fb1b16ce85a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98e3b14a0477232054b02065c857fb1b16ce85a6>`__
    `#6705 <https://pagure.io/freeipa/issue/6705>`__
 -  Do not configure PKI ajp redirection to use "::1"
-   `commit <https://pagure.io/freeipa/c/eaa87c75b9f57500265b2dc9480b996b2b92e1e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eaa87c75b9f57500265b2dc9480b996b2b92e1e3>`__
    `#6575 <https://pagure.io/freeipa/issue/6575>`__
 -  ipa-kra-install must create directory if it does not exist
-   `commit <https://pagure.io/freeipa/c/066f5b7c904208d0fd79862dfaa7166fff42fd30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/066f5b7c904208d0fd79862dfaa7166fff42fd30>`__
    `#6606 <https://pagure.io/freeipa/issue/6606>`__
 -  ipa-restore must stop tracking PKINIT cert in the preparation phase
-   `commit <https://pagure.io/freeipa/c/ceec512b09002e8cf9388873418644ec584db30a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ceec512b09002e8cf9388873418644ec584db30a>`__
    `#6570 <https://pagure.io/freeipa/issue/6570>`__
 -  Increase the timeout waiting for certificate issuance in installer
-   `commit <https://pagure.io/freeipa/c/9e3c17c6ded868b4261aa76137c703a4fb866578>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e3c17c6ded868b4261aa76137c703a4fb866578>`__
    `#6433 <https://pagure.io/freeipa/issue/6433>`__
 -  Check the result of cert request in replica installer
-   `commit <https://pagure.io/freeipa/c/dbb98765d73519289ee22f3de1a5ccde140f6f5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbb98765d73519289ee22f3de1a5ccde140f6f5d>`__
    `#6514 <https://pagure.io/freeipa/issue/6514>`__
 -  Fix ipa-replica-install when upgrade from ca-less to ca-full
-   `commit <https://pagure.io/freeipa/c/044d887e81d433b43c33b076a21fd1054796786e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/044d887e81d433b43c33b076a21fd1054796786e>`__
    `#6375 <https://pagure.io/freeipa/issue/6375>`__
 -  Fix ipa migrate-ds when it finds a search reference
-   `commit <https://pagure.io/freeipa/c/efb3700389ff46244189fa95779484eb099d63b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efb3700389ff46244189fa95779484eb099d63b4>`__
    `#6358 <https://pagure.io/freeipa/issue/6358>`__
 -  Fix renewal lock issues on installation
-   `commit <https://pagure.io/freeipa/c/198cd5fab3937fd8948bea4b4949e30db4e490a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/198cd5fab3937fd8948bea4b4949e30db4e490a4>`__
    `#6433 <https://pagure.io/freeipa/issue/6433>`__
 -  Refactor installer code requesting certificates
-   `commit <https://pagure.io/freeipa/c/808b1436b4158cb6f926ac2b5bd0979df6ea7e9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/808b1436b4158cb6f926ac2b5bd0979df6ea7e9f>`__
    `#6433 <https://pagure.io/freeipa/issue/6433>`__
 -  Use autobind instead of host keytab authentication in
    dogtag-ipa-ca-renew-agent
-   `commit <https://pagure.io/freeipa/c/7462adec13c5b25b6868d2863dc38062c97d0ff7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7462adec13c5b25b6868d2863dc38062c97d0ff7>`__
 -  Fix ipa-cacert-manage man page
-   `commit <https://pagure.io/freeipa/c/eb75578cbb2447fc2fafb8a79d8500b27e3edff0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb75578cbb2447fc2fafb8a79d8500b27e3edff0>`__
    `#6381 <https://pagure.io/freeipa/issue/6381>`__
 -  Add cert checks in ipa-server-certinstall
-   `commit <https://pagure.io/freeipa/c/0c4a91348a57ee941db94b31f59952eb1fcd4565>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c4a91348a57ee941db94b31f59952eb1fcd4565>`__
    `#6263 <https://pagure.io/freeipa/issue/6263>`__
 -  Fix regression introduced in ipa-certupdate
-   `commit <https://pagure.io/freeipa/c/cd75eb3b2557cbd97e93be3e1ceeef21b948a694>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd75eb3b2557cbd97e93be3e1ceeef21b948a694>`__
    `#6288 <https://pagure.io/freeipa/issue/6288>`__
 -  Fix ipa-certupdate for CA-less installation
-   `commit <https://pagure.io/freeipa/c/b36ee723b77a2721f4200d5df02268a9bd6a60b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36ee723b77a2721f4200d5df02268a9bd6a60b5>`__
    `#6288 <https://pagure.io/freeipa/issue/6288>`__
 
 
@@ -1113,164 +1113,164 @@ Fraser Tweedale (52)
 ----------------------------------------------------------------------------------------------
 
 -  rabase.get_certificate: make serial number arg mandatory
-   `commit <https://pagure.io/freeipa/c/3ba0375c831eca673c2df146b565a32dbc03fdb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ba0375c831eca673c2df146b565a32dbc03fdb3>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  Extract method to map principal to princpal type
-   `commit <https://pagure.io/freeipa/c/11c9df25774fbc8ed24b30f75c205d12ca3c5b90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11c9df25774fbc8ed24b30f75c205d12ca3c5b90>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  Remove redundant principal_type argument
-   `commit <https://pagure.io/freeipa/c/2066a80be21258d9311ae374fe124d9ac3b79acd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2066a80be21258d9311ae374fe124d9ac3b79acd>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  dogtag: remove redundant property definition
-   `commit <https://pagure.io/freeipa/c/49f87f34be5f04f18a6d916276153e9ef1e5852c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49f87f34be5f04f18a6d916276153e9ef1e5852c>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__
 -  ca: correctly authorise ca-del, ca-enable and ca-disable
-   `commit <https://pagure.io/freeipa/c/b81ac59640f0b76fa9f53cf8be441f085a7089c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b81ac59640f0b76fa9f53cf8be441f085a7089c4>`__
    `#6713 <https://pagure.io/freeipa/issue/6713>`__
 -  replica install: relax domain level check for promotion
-   `commit <https://pagure.io/freeipa/c/f51869bf5214e2d2322f85bf72b7ae86b6893974>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f51869bf5214e2d2322f85bf72b7ae86b6893974>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  Fix reference before assignment
-   `commit <https://pagure.io/freeipa/c/924794f62b9d3d0f46ca18e4f9338eaed865c03e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/924794f62b9d3d0f46ca18e4f9338eaed865c03e>`__
    `#6636 <https://pagure.io/freeipa/issue/6636>`__
 -  private_ccache: yield ccache name
-   `commit <https://pagure.io/freeipa/c/caca181d3b73c045abd72e464a195c6b61c251c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/caca181d3b73c045abd72e464a195c6b61c251c7>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  Add sanity checks for use of --ca-subject and --subject-base
-   `commit <https://pagure.io/freeipa/c/0c95a00147b1dd508736dacc847873ddddafb504>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c95a00147b1dd508736dacc847873ddddafb504>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  Indicate that ca subject / subject base uses LDAP RDN order
-   `commit <https://pagure.io/freeipa/c/3f5660973251fe4b178e6486b6b86fbdd162d4d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f5660973251fe4b178e6486b6b86fbdd162d4d6>`__
    `#6455 <https://pagure.io/freeipa/issue/6455>`__
 -  Allow full customisability of IPA CA subject DN
-   `commit <https://pagure.io/freeipa/c/3d01ec14c6e36fa962d0c54b2e08df0ecd401bd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d01ec14c6e36fa962d0c54b2e08df0ecd401bd6>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  Reuse self.api when executing ca_enabled_check
-   `commit <https://pagure.io/freeipa/c/09a65df6842411d42966111e50924df3de0b7031>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09a65df6842411d42966111e50924df3de0b7031>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  dsinstance: extract function for writing certmap.conf
-   `commit <https://pagure.io/freeipa/c/f54df62abae4a15064bf297634558eb9be83ce33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f54df62abae4a15064bf297634558eb9be83ce33>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  ipa-ca-install: add missing --subject-base option
-   `commit <https://pagure.io/freeipa/c/46bf0e89ae054b34adc66d08f205a5155e6f3fd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46bf0e89ae054b34adc66d08f205a5155e6f3fd6>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  Extract function for computing default subject base
-   `commit <https://pagure.io/freeipa/c/6f3eb85c302f54bec561337e6627c89144b589ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f3eb85c302f54bec561337e6627c89144b589ff>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  installer: rename --subject to --subject-base
-   `commit <https://pagure.io/freeipa/c/c6db493b06320455a2366945911939a605df2a73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6db493b06320455a2366945911939a605df2a73>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  installutils: remove hardcoded subject DN assumption
-   `commit <https://pagure.io/freeipa/c/db6674096c598918ea6b12ca33a96cf5e617a434>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db6674096c598918ea6b12ca33a96cf5e617a434>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  Refactor and relocate set_subject_base_in_config
-   `commit <https://pagure.io/freeipa/c/324183cd63aeadbaa9678d610ba59e1295a606fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/324183cd63aeadbaa9678d610ba59e1295a606fe>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  dsinstance: minor string fixes
-   `commit <https://pagure.io/freeipa/c/a5fb5f2da1be158cde585a087aaf97eca6218dd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5fb5f2da1be158cde585a087aaf97eca6218dd7>`__
    `#6586 <https://pagure.io/freeipa/issue/6586>`__
 -  Set up DS TLS on replica in CA-less topology
-   `commit <https://pagure.io/freeipa/c/6f7d982fe2e2d2f042e85710b8d8d59167e5796f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f7d982fe2e2d2f042e85710b8d8d59167e5796f>`__
    `#6226 <https://pagure.io/freeipa/issue/6226>`__
 -  Remove "Request Certificate with SubjectAltName" permission
-   `commit <https://pagure.io/freeipa/c/bdbb1c34a2f5ef864cd3a943dcd047cde20de681>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdbb1c34a2f5ef864cd3a943dcd047cde20de681>`__
    `#6526 <https://pagure.io/freeipa/issue/6526>`__
 -  Fix DL1 replica installation in CA-less topology
-   `commit <https://pagure.io/freeipa/c/4028ad73e74fe62bd4871e842dbb69ff660125f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4028ad73e74fe62bd4871e842dbb69ff660125f9>`__
    `#6573 <https://pagure.io/freeipa/issue/6573>`__
 -  certprofile-mod: correctly authorise config update
-   `commit <https://pagure.io/freeipa/c/fec4c32ff15a96736740cf7d2f713a21af0b227e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fec4c32ff15a96736740cf7d2f713a21af0b227e>`__
    `#6560 <https://pagure.io/freeipa/issue/6560>`__
 -  Fix regression in test suite
-   `commit <https://pagure.io/freeipa/c/74b8cf2c4a8dd36577d76c35a9ef08352ef025b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74b8cf2c4a8dd36577d76c35a9ef08352ef025b7>`__
    `#6178 <https://pagure.io/freeipa/issue/6178>`__
 -  Add options to write lightweight CA cert or chain to file
-   `commit <https://pagure.io/freeipa/c/32b1743e5fb318b226a602ec8d9a4b6ef2a25c9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32b1743e5fb318b226a602ec8d9a4b6ef2a25c9d>`__
    `#6178 <https://pagure.io/freeipa/issue/6178>`__
 -  certdb: accumulate extracted certs as list of PEMs
-   `commit <https://pagure.io/freeipa/c/cc5b88e5d4ac1171374be9ae8e6e60730243dd3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc5b88e5d4ac1171374be9ae8e6e60730243dd3d>`__
    `#6178 <https://pagure.io/freeipa/issue/6178>`__
 -  Add function for extracting PEM certs from PKCS #7
-   `commit <https://pagure.io/freeipa/c/c7ea56c049ec8ab1a5500852eca6faf750b1479f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7ea56c049ec8ab1a5500852eca6faf750b1479f>`__
    `#6178 <https://pagure.io/freeipa/issue/6178>`__
 -  cert-request: match names against principal aliases
-   `commit <https://pagure.io/freeipa/c/dfbdb5323863e6c3d681c1b33b1eb9d2efefd6c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfbdb5323863e6c3d681c1b33b1eb9d2efefd6c7>`__
    `#6295 <https://pagure.io/freeipa/issue/6295>`__
 -  Remove references to ds_newinst.pl
-   `commit <https://pagure.io/freeipa/c/687ebd18a1927cd6dcbb6cb884b979096c8a44aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/687ebd18a1927cd6dcbb6cb884b979096c8a44aa>`__
    `#6496 <https://pagure.io/freeipa/issue/6496>`__
 -  cert-request: accept CSRs with extraneous data
-   `commit <https://pagure.io/freeipa/c/e1df2e0792a6a423563c4787215b284948f51582>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1df2e0792a6a423563c4787215b284948f51582>`__
    `#6472 <https://pagure.io/freeipa/issue/6472>`__
 -  Ensure correct IPA CA nickname in DS and HTTP NSSDBs
-   `commit <https://pagure.io/freeipa/c/cdd41e06e6ef97efafd36ee9e4c8d3be9e4099e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdd41e06e6ef97efafd36ee9e4c8d3be9e4099e7>`__
    `#6415 <https://pagure.io/freeipa/issue/6415>`__
 -  Remove \__main_\_ code from ipalib.x509 and ipalib.pkcs10
-   `commit <https://pagure.io/freeipa/c/b0430b67dc90fddf1e35fde9a0cf2977a07d7cbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0430b67dc90fddf1e35fde9a0cf2977a07d7cbd>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  x509: use python-cryptography to process certs
-   `commit <https://pagure.io/freeipa/c/db116f73fe5fc199bb2e28103cf5e3e2a24eab4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db116f73fe5fc199bb2e28103cf5e3e2a24eab4c>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  x509: use pyasn1-modules X.509 specs
-   `commit <https://pagure.io/freeipa/c/c57dc890b2bf447ab575f2e91249179bce3f05d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c57dc890b2bf447ab575f2e91249179bce3f05d5>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  x509: avoid use of nss.data_to_hex
-   `commit <https://pagure.io/freeipa/c/44c2d685f01eb4c03e4659125e41d73b8be47c19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44c2d685f01eb4c03e4659125e41d73b8be47c19>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  pkcs10: remove pyasn1 PKCS #10 spec
-   `commit <https://pagure.io/freeipa/c/85487281cdc09720f6a0385ebb7157742d762a0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85487281cdc09720f6a0385ebb7157742d762a0c>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  pkcs10: use python-cryptography for CSR processing
-   `commit <https://pagure.io/freeipa/c/66637f766dd0ddc50888013962be2294fd8d0e9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66637f766dd0ddc50888013962be2294fd8d0e9a>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  dn: support conversion from python-cryptography Name
-   `commit <https://pagure.io/freeipa/c/9522970bfa28900abc90e959de483f59c79a3e5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9522970bfa28900abc90e959de483f59c79a3e5f>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  cert-show: show validity in default output
-   `commit <https://pagure.io/freeipa/c/b6a3c9dc74ccef6f8e7df4123670d7e11269198c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6a3c9dc74ccef6f8e7df4123670d7e11269198c>`__
    `#6419 <https://pagure.io/freeipa/issue/6419>`__
 -  Do not create Object Signing certificate
-   `commit <https://pagure.io/freeipa/c/eb6bfd82f363405e3377b2a912b1152ba76625ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb6bfd82f363405e3377b2a912b1152ba76625ae>`__
    `#6399 <https://pagure.io/freeipa/issue/6399>`__
 -  Add commentary about CA deletion to plugin doc
-   `commit <https://pagure.io/freeipa/c/2b8163ab5dfcf28a9eba319ef685046ae9d8b5e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b8163ab5dfcf28a9eba319ef685046ae9d8b5e8>`__
    `#6256 <https://pagure.io/freeipa/issue/6256>`__
 -  spec: require Dogtag >= 10.3.5-6
-   `commit <https://pagure.io/freeipa/c/6b3f4984296f3caff8f29490eae3ed1dca64b8c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b3f4984296f3caff8f29490eae3ed1dca64b8c3>`__
    `#6256 <https://pagure.io/freeipa/issue/6256>`__
 -  sudorule: add SELinux transition examples to plugin doc
-   `commit <https://pagure.io/freeipa/c/ff490b6c403f9fe14fcc2d1558c43dae5b80f493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff490b6c403f9fe14fcc2d1558c43dae5b80f493>`__
    `#3461 <https://pagure.io/freeipa/issue/3461>`__
 -  Fix cert revocation when removing all certs via host/service-mod
-   `commit <https://pagure.io/freeipa/c/97d4ffc2dc5db00fd7ed10b0b290cc97a506d0ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97d4ffc2dc5db00fd7ed10b0b290cc97a506d0ef>`__
    `#6305 <https://pagure.io/freeipa/issue/6305>`__
 -  cert-request: raise error when request fails
-   `commit <https://pagure.io/freeipa/c/1f1c93d2b5023f8d491252c605dbcf05c8ecc7e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f1c93d2b5023f8d491252c605dbcf05c8ecc7e3>`__
    `#6309 <https://pagure.io/freeipa/issue/6309>`__
 -  Make host/service cert revocation aware of lightweight CAs
-   `commit <https://pagure.io/freeipa/c/daeaf2a8234ba684352d98fbc8d734100e6d63d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/daeaf2a8234ba684352d98fbc8d734100e6d63d1>`__
    `#6221 <https://pagure.io/freeipa/issue/6221>`__
 -  cert-request: raise CertificateOperationError if CA disabled
-   `commit <https://pagure.io/freeipa/c/520ad7d865ff147d3ff8819d3e384d7cbd69bfb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/520ad7d865ff147d3ff8819d3e384d7cbd69bfb7>`__
    `#6260 <https://pagure.io/freeipa/issue/6260>`__
 -  Use Dogtag REST API for certificate requests
-   `commit <https://pagure.io/freeipa/c/4c35afccf3cf3a5176e598872c4fcff80b416335>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c35afccf3cf3a5176e598872c4fcff80b416335>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#6260 <https://pagure.io/freeipa/issue/6260>`__
 -  Add HTTPRequestError class
-   `commit <https://pagure.io/freeipa/c/c5cbc8de89c7d88c443bff937fe9aa965e4c1c94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5cbc8de89c7d88c443bff937fe9aa965e4c1c94>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#6260 <https://pagure.io/freeipa/issue/6260>`__
 -  Allow Dogtag RestClient to perform requests without logging in
-   `commit <https://pagure.io/freeipa/c/2a42a7e90eb8154a6722ae93d93f8cf6796f4a21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a42a7e90eb8154a6722ae93d93f8cf6796f4a21>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#6260 <https://pagure.io/freeipa/issue/6260>`__
 -  Add ca-disable and ca-enable commands
-   `commit <https://pagure.io/freeipa/c/c7e0dbc4e174d0bb7577de18cdb2f414f4199c57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7e0dbc4e174d0bb7577de18cdb2f414f4199c57>`__
    `#6257 <https://pagure.io/freeipa/issue/6257>`__
 -  Track lightweight CAs on replica installation
-   `commit <https://pagure.io/freeipa/c/08b768313020c45bfa82d67cd214afabf605f4b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08b768313020c45bfa82d67cd214afabf605f4b3>`__
    `#6019 <https://pagure.io/freeipa/issue/6019>`__
 
 
@@ -1279,25 +1279,25 @@ Ganna Kaihorodova (7)
 ----------------------------------------------------------------------------------------------
 
 -  Tests: Basic coverage with tree root domain
-   `commit <https://pagure.io/freeipa/c/10494b1bb34b6ff9c1b810cc0739c761b017202c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10494b1bb34b6ff9c1b810cc0739c761b017202c>`__
    `#6489 <https://pagure.io/freeipa/issue/6489>`__
 -  User Tracker: Test to create user with minimal values
-   `commit <https://pagure.io/freeipa/c/91c050b4e093802d8c6b510a22d6e435faba965f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91c050b4e093802d8c6b510a22d6e435faba965f>`__
    `#6126 <https://pagure.io/freeipa/issue/6126>`__
 -  User Tracker: creation of user with minimal values
-   `commit <https://pagure.io/freeipa/c/fa7aaef1de2c97ac9d24925ca9adb25c7151055f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa7aaef1de2c97ac9d24925ca9adb25c7151055f>`__
    `#6126 <https://pagure.io/freeipa/issue/6126>`__
 -  Stage User: Test to create stage user with minimal values
-   `commit <https://pagure.io/freeipa/c/c391f6ba58a61e046e49e1b4526b62d7ce250301>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c391f6ba58a61e046e49e1b4526b62d7ce250301>`__
    `#6448 <https://pagure.io/freeipa/issue/6448>`__
 -  Tests: Stage User Tracker implementation
-   `commit <https://pagure.io/freeipa/c/a336de630e9d1ef95a507cc3ee9200c001ab9193>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a336de630e9d1ef95a507cc3ee9200c001ab9193>`__
    `#6448 <https://pagure.io/freeipa/issue/6448>`__
 -  Tests: Add tree root domain role in legacy client tests
-   `commit <https://pagure.io/freeipa/c/822a119100f8ab93aacdb14b982609f1dc69531d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/822a119100f8ab93aacdb14b982609f1dc69531d>`__
    `#6600 <https://pagure.io/freeipa/issue/6600>`__
 -  Unaccessible variable self.attrs in Tracker
-   `commit <https://pagure.io/freeipa/c/9b0b97073304ba6bfdd6292b07533ab3e7fe8bcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b0b97073304ba6bfdd6292b07533ab3e7fe8bcb>`__
    `#6125 <https://pagure.io/freeipa/issue/6125>`__
 
 
@@ -1306,317 +1306,317 @@ Jan Cholasta (106)
 ----------------------------------------------------------------------------------------------
 
 -  spec file: always provide python package aliases
-   `commit <https://pagure.io/freeipa/c/990ce9eef314622440b2036742bbf34f57ba2699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/990ce9eef314622440b2036742bbf34f57ba2699>`__
 -  spec file: support client-only build
-   `commit <https://pagure.io/freeipa/c/417f1926c48b426b34b18edb28869f4f06824873>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/417f1926c48b426b34b18edb28869f4f06824873>`__
    `#6517 <https://pagure.io/freeipa/issue/6517>`__
 -  spec file: support build without ipatests
-   `commit <https://pagure.io/freeipa/c/e42a846506ee7ad5e8a395da154bec64f6be3654>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e42a846506ee7ad5e8a395da154bec64f6be3654>`__
    `#6517 <https://pagure.io/freeipa/issue/6517>`__
 -  slapi plugins: fix CFLAGS
-   `commit <https://pagure.io/freeipa/c/b7329e31f5c985b9721e3a21b1cd1bec6430129d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7329e31f5c985b9721e3a21b1cd1bec6430129d>`__
 -  spec file: add unconditional python-setuptools BuildRequires
-   `commit <https://pagure.io/freeipa/c/7ef4e9eb810063243fcc575434d856c854b14eee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ef4e9eb810063243fcc575434d856c854b14eee>`__
 -  httpinstance: disable system trust module in /etc/httpd/alias
-   `commit <https://pagure.io/freeipa/c/f037bfa48356a5fb28eebdb76f9dbd5cb461c2d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f037bfa48356a5fb28eebdb76f9dbd5cb461c2d2>`__
    `#6132 <https://pagure.io/freeipa/issue/6132>`__
 -  csrgen: hide cert-get-requestdata in CLI
-   `commit <https://pagure.io/freeipa/c/72de679eb445c975ec70cd265d37d4927823ce5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72de679eb445c975ec70cd265d37d4927823ce5b>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  cert: include certificate chain in cert command output
-   `commit <https://pagure.io/freeipa/c/8ed891cb619abd2efd428f767edf760ebf5eec5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ed891cb619abd2efd428f767edf760ebf5eec5d>`__
    `#6547 <https://pagure.io/freeipa/issue/6547>`__
 -  cert: add output file option to cert-request
-   `commit <https://pagure.io/freeipa/c/c60d9c9744b1f8a7b55bcdda65cce8bb36700bf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c60d9c9744b1f8a7b55bcdda65cce8bb36700bf6>`__
    `#6547 <https://pagure.io/freeipa/issue/6547>`__
 -  Travis CI: run tests in development mode
-   `commit <https://pagure.io/freeipa/c/fe4489ede2b40902fb7d734d04a1f997c6df86fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe4489ede2b40902fb7d734d04a1f997c6df86fb>`__
    `#6625 <https://pagure.io/freeipa/issue/6625>`__
 -  backend plugins: fix crashes in development mode
-   `commit <https://pagure.io/freeipa/c/8fdd7a9ffc263c1198afa5479cda41d319f11d91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fdd7a9ffc263c1198afa5479cda41d319f11d91>`__
    `#6625 <https://pagure.io/freeipa/issue/6625>`__
 -  vault: cache the transport certificate on client
-   `commit <https://pagure.io/freeipa/c/98bb5397c535e5e1a6c5ade9f0fb918be1d282c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98bb5397c535e5e1a6c5ade9f0fb918be1d282c3>`__
    `#6652 <https://pagure.io/freeipa/issue/6652>`__
 -  rpc: fix crash in verbose mode
-   `commit <https://pagure.io/freeipa/c/8295848bfec6f96410ab8383107fdaf565f02974>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8295848bfec6f96410ab8383107fdaf565f02974>`__
    `#6734 <https://pagure.io/freeipa/issue/6734>`__
 -  install: re-introduce option groups
-   `commit <https://pagure.io/freeipa/c/2fc9feddd02bb17c3a9eb7efde83277fcf93252c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fc9feddd02bb17c3a9eb7efde83277fcf93252c>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install CLI: remove magic option groups
-   `commit <https://pagure.io/freeipa/c/774d8d0a5dc0ac175ab0cecc76001632c2a79744>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/774d8d0a5dc0ac175ab0cecc76001632c2a79744>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client install: split off SSSD options into a separate class
-   `commit <https://pagure.io/freeipa/c/1cfe06c79eb0b98a0f4bd663165156596b59e85f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cfe06c79eb0b98a0f4bd663165156596b59e85f>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  server install: remove duplicate knob definitions
-   `commit <https://pagure.io/freeipa/c/94f362d7b0b6c838752eb2f6674149e96d3ae95b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94f362d7b0b6c838752eb2f6674149e96d3ae95b>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: add missing space in realm_name description
-   `commit <https://pagure.io/freeipa/c/5efa55c88d73d9f5db77df4be9fedf03f9b323d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5efa55c88d73d9f5db77df4be9fedf03f9b323d1>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  server install: remove duplicate -w option
-   `commit <https://pagure.io/freeipa/c/00f49dd7bbf277757902c94990d33758fec56b23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00f49dd7bbf277757902c94990d33758fec56b23>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  certmap: load certificate from file in certmap-match CLI
-   `commit <https://pagure.io/freeipa/c/0298ecf441ba38858d7909b8c3b4cc2b4c4e53c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0298ecf441ba38858d7909b8c3b4cc2b4c4e53c4>`__
    `#6646 <https://pagure.io/freeipa/issue/6646>`__
 -  pylint_plugins: add forbidden import checker
-   `commit <https://pagure.io/freeipa/c/5d489ac5604ca959cfe439c0594b8739073f3cea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d489ac5604ca959cfe439c0594b8739073f3cea>`__
 -  ipapython: fix DEFAULT_PLUGINS in version.py
-   `commit <https://pagure.io/freeipa/c/abf25d3cb6570e6ae7cd094ea6a5f4a1bd75d8a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abf25d3cb6570e6ae7cd094ea6a5f4a1bd75d8a7>`__
    `#6597 <https://pagure.io/freeipa/issue/6597>`__
 -  config: re-add \`init_config\` and \`config\`
-   `commit <https://pagure.io/freeipa/c/0c7ca279c78bc23d45582e92bb1638865ec3059e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c7ca279c78bc23d45582e92bb1638865ec3059e>`__
    `#6707 <https://pagure.io/freeipa/issue/6707>`__
 -  dns: fix \`dnsrecord_add\` interactive mode
-   `commit <https://pagure.io/freeipa/c/1e912f5b83166154806e0382f3f028d0eac81731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e912f5b83166154806e0382f3f028d0eac81731>`__
    `#6457 <https://pagure.io/freeipa/issue/6457>`__
 -  server install: do not attempt to issue PKINIT cert in CA-less
-   `commit <https://pagure.io/freeipa/c/ba3c201a03cd0b224b43e45245147e48b7291f9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba3c201a03cd0b224b43e45245147e48b7291f9f>`__
    `#5678 <https://pagure.io/freeipa/issue/5678>`__
 -  compat: fix \`Any\` params in \`batch\` and \`dnsrecord\`
-   `commit <https://pagure.io/freeipa/c/19060db1b8fa9d1d3e8f3ac3fcd1f387e9a39c94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19060db1b8fa9d1d3e8f3ac3fcd1f387e9a39c94>`__
    `#6647 <https://pagure.io/freeipa/issue/6647>`__
 -  scripts, tests: explicitly set confdir in the rest of server code
-   `commit <https://pagure.io/freeipa/c/fe6f2b6f6effcf9f3c58e1e3f6d0874609c10c25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe6f2b6f6effcf9f3c58e1e3f6d0874609c10c25>`__
    `#6389 <https://pagure.io/freeipa/issue/6389>`__
 -  server upgrade: uninstall ipa_memcached properly
-   `commit <https://pagure.io/freeipa/c/6d34c2169fcd520cc726e58e01d008ae3637aad4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d34c2169fcd520cc726e58e01d008ae3637aad4>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  server upgrade: always upgrade KRA agent PEM file
-   `commit <https://pagure.io/freeipa/c/0862e320916e0123df7e8505ba61229db0cb1e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0862e320916e0123df7e8505ba61229db0cb1e4a>`__
    `#6675 <https://pagure.io/freeipa/issue/6675>`__
 -  server upgrade: fix upgrade from pre-4.0
-   `commit <https://pagure.io/freeipa/c/97e838e10da3b42e3605d230e0b8e01b9148876f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97e838e10da3b42e3605d230e0b8e01b9148876f>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  server upgrade: fix upgrade in CA-less
-   `commit <https://pagure.io/freeipa/c/ba8a10fbdb39cab672038e1a6dc9c7507070cdf9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba8a10fbdb39cab672038e1a6dc9c7507070cdf9>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  client install: create /etc/ipa/nssdb with correct mode
-   `commit <https://pagure.io/freeipa/c/b4fa354f500bcf3ac23ee3805f2c166c6a635b92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4fa354f500bcf3ac23ee3805f2c166c6a635b92>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  ipaldap: preserve order of values in LDAPEntry._sync()
-   `commit <https://pagure.io/freeipa/c/e920ae22525d34e1f524e2e59159ac50c603bc8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e920ae22525d34e1f524e2e59159ac50c603bc8c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  replica install: do not log host OTP
-   `commit <https://pagure.io/freeipa/c/054c1e013aee6fdbee2e9966c32df02d91f0c2c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/054c1e013aee6fdbee2e9966c32df02d91f0c2c1>`__
    `#6633 <https://pagure.io/freeipa/issue/6633>`__
 -  tests: add test for PEM certificate files with leading text
-   `commit <https://pagure.io/freeipa/c/89dfbab3ca076812590f371c21abcb51b350170b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89dfbab3ca076812590f371c21abcb51b350170b>`__
 -  ipa-ca-install: do not fail without --subject-base and --ca-subject
-   `commit <https://pagure.io/freeipa/c/87400cdec1054971f50f90a0c63f18ab045f3833>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87400cdec1054971f50f90a0c63f18ab045f3833>`__
    `#2614 <https://pagure.io/freeipa/issue/2614>`__
 -  cert: fix search limit handling in cert-find
-   `commit <https://pagure.io/freeipa/c/85834abad655c6aed54c0253bc194ece81d78774>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85834abad655c6aed54c0253bc194ece81d78774>`__
    `#6564 <https://pagure.io/freeipa/issue/6564>`__
 -  dogtag: search past the first 100 certificates
-   `commit <https://pagure.io/freeipa/c/d84edc43e55c2f7c30614a4a5268aeb58e33a087>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d84edc43e55c2f7c30614a4a5268aeb58e33a087>`__
    `#6564 <https://pagure.io/freeipa/issue/6564>`__
 -  ipaldap: properly escape raw binary values in LDAP filters
-   `commit <https://pagure.io/freeipa/c/84a9611cb885f04c72cd657c3a3e7bc4aff39d93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84a9611cb885f04c72cd657c3a3e7bc4aff39d93>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  client install: correctly report all failures
-   `commit <https://pagure.io/freeipa/c/26630db9d0fb1d9c8a02840b71b3fb3e8bdf3e0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26630db9d0fb1d9c8a02840b71b3fb3e8bdf3e0d>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  cainstance: do not configure renewal guard
-   `commit <https://pagure.io/freeipa/c/926fe2049a1839fd7e68c9fa55f64154ee83c841>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/926fe2049a1839fd7e68c9fa55f64154ee83c841>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  dogtaginstance: track server certificate with our renew agent
-   `commit <https://pagure.io/freeipa/c/ad49bda907b3c2ec5b98946a2c4000bb6edaf835>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad49bda907b3c2ec5b98946a2c4000bb6edaf835>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  renew agent: handle non-replicated certificates
-   `commit <https://pagure.io/freeipa/c/d5af11f65cc2a2d6860579a63a173b67cb12bcf3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5af11f65cc2a2d6860579a63a173b67cb12bcf3>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  ca: fix ca-find with --pkey-only
-   `commit <https://pagure.io/freeipa/c/ceb26f5ac428cdbed8ec1fa89e9ed6f1d903a5a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ceb26f5ac428cdbed8ec1fa89e9ed6f1d903a5a0>`__
    `#6178 <https://pagure.io/freeipa/issue/6178>`__
 -  spec file: revert to the previous Release tag
-   `commit <https://pagure.io/freeipa/c/eb1f05d598d821f8e7eb5b8cfe606f570052f263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb1f05d598d821f8e7eb5b8cfe606f570052f263>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  x509: use PyASN1 to parse PKCS#7
-   `commit <https://pagure.io/freeipa/c/556fc21482e8061847556c653095edba7e7531f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/556fc21482e8061847556c653095edba7e7531f1>`__
    `#6550 <https://pagure.io/freeipa/issue/6550>`__
 -  server install: fix KRA agent PEM file not being created
-   `commit <https://pagure.io/freeipa/c/998c87af2b7b2c704d34dd27fe99bda495a59e23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/998c87af2b7b2c704d34dd27fe99bda495a59e23>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  spec file: do not define with_lint inside a comment
-   `commit <https://pagure.io/freeipa/c/1b85e59ceeb115dfb24e9c6bacb665b935f9543c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b85e59ceeb115dfb24e9c6bacb665b935f9543c>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  certdb: fix PKCS#12 import with empty password
-   `commit <https://pagure.io/freeipa/c/a35f5181c0af459e9f054838805628f31316cbe9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a35f5181c0af459e9f054838805628f31316cbe9>`__
    `#6541 <https://pagure.io/freeipa/issue/6541>`__
 -  server install: fix external CA install
-   `commit <https://pagure.io/freeipa/c/4fff09978eab520d130d87c0112b5caac907e651>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fff09978eab520d130d87c0112b5caac907e651>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: track the RA agent certificate again
-   `commit <https://pagure.io/freeipa/c/4221266562778806f02748fee2dfbd814261f2b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4221266562778806f02748fee2dfbd814261f2b4>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  ipaclient: remove hard dependency on ipaplatform
-   `commit <https://pagure.io/freeipa/c/a260fd8058d757b631dd4eb39ee8a58b91cf2efb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a260fd8058d757b631dd4eb39ee8a58b91cf2efb>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipaclient: move install modules to the install subpackage
-   `commit <https://pagure.io/freeipa/c/70c3cd7f482bee7d5ad12062daa7ad6181a29094>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70c3cd7f482bee7d5ad12062daa7ad6181a29094>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipalib: remove hard dependency on ipapython
-   `commit <https://pagure.io/freeipa/c/d43b57d2ce8552ed4977dcc33667b4226fe3333b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d43b57d2ce8552ed4977dcc33667b4226fe3333b>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  constants: remove CACERT
-   `commit <https://pagure.io/freeipa/c/977050c66bccd7b8cf468c115d73250505a01034>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/977050c66bccd7b8cf468c115d73250505a01034>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipalib: move certstore to the install subpackage
-   `commit <https://pagure.io/freeipa/c/a2c58889735c794cd1e93331c755b6f9ba273773>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2c58889735c794cd1e93331c755b6f9ba273773>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipapython: remove hard dependency on ipaplatform
-   `commit <https://pagure.io/freeipa/c/528012fe8a8976961203021ef36353b7a4c3b8a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/528012fe8a8976961203021ef36353b7a4c3b8a8>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: move file encryption functions to installutils
-   `commit <https://pagure.io/freeipa/c/6e50fae9ec6dea35e12a65dbc46228a1e6276e07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e50fae9ec6dea35e12a65dbc46228a1e6276e07>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: move kinit functions to ipalib.install
-   `commit <https://pagure.io/freeipa/c/7d5c680ace7ccea3b0f7f1471cf8dbc07b3da5a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d5c680ace7ccea3b0f7f1471cf8dbc07b3da5a1>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: move is_fips_enabled() to ipaplatform.tasks
-   `commit <https://pagure.io/freeipa/c/75b70e3f0d52a9c98f443d3fc2f7cef92bdc7b1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75b70e3f0d52a9c98f443d3fc2f7cef92bdc7b1a>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: remove the timeout argument of run()
-   `commit <https://pagure.io/freeipa/c/d911f493482d29829199cce2f91f88a9b53369e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d911f493482d29829199cce2f91f88a9b53369e1>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: remove get_domain_name()
-   `commit <https://pagure.io/freeipa/c/7b966e8577fdb56f069cf26a6ab4d6c77b8743b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b966e8577fdb56f069cf26a6ab4d6c77b8743b9>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipautil: remove SHARE_DIR and PLUGIN_SHARE_DIR
-   `commit <https://pagure.io/freeipa/c/d6b755e3fcaf32158f4ee36d45e3344b4a03fbc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6b755e3fcaf32158f4ee36d45e3344b4a03fbc2>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  certdb: use a temporary file to pass password to pk12util
-   `commit <https://pagure.io/freeipa/c/f919ab4ee0ec26d77ee6978e75de5daba4073402>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f919ab4ee0ec26d77ee6978e75de5daba4073402>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  certdb: move IPA NSS DB install functions to ipaclient.install
-   `commit <https://pagure.io/freeipa/c/fba6c21da3fbe0a62a96118eb32f205249ab3736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fba6c21da3fbe0a62a96118eb32f205249ab3736>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipapython: move certmonger and sysrestore to ipalib.install
-   `commit <https://pagure.io/freeipa/c/26c46a447f82b4cf37a5076b72cf6328857d5f35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26c46a447f82b4cf37a5076b72cf6328857d5f35>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  ipapython: move dnssec, p11helper and secrets to ipaserver
-   `commit <https://pagure.io/freeipa/c/a1f260d021bf5d018e634438fde6b7c81ebbbcef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1f260d021bf5d018e634438fde6b7c81ebbbcef>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  custodiainstance: automatic restart on config file update
-   `commit <https://pagure.io/freeipa/c/8e5d2c7014ff6371a3b306e666c301aea1f7a488>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e5d2c7014ff6371a3b306e666c301aea1f7a488>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  paths: remove DEV_NULL
-   `commit <https://pagure.io/freeipa/c/9117a5d5a6ae7b3b97407e46f81a06c387974d7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9117a5d5a6ae7b3b97407e46f81a06c387974d7f>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  install: migrate client install to the new class hierarchy
-   `commit <https://pagure.io/freeipa/c/09423acb6574a3773d7783f9ddec022bed3539c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09423acb6574a3773d7783f9ddec022bed3539c8>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: allow specifying verbosity and console log format in CLI
-   `commit <https://pagure.io/freeipa/c/714699a81fa377e6033cbc7564f0f0fd10cd9f1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/714699a81fa377e6033cbc7564f0f0fd10cd9f1a>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: migrate server installers to the new class hierarchy
-   `commit <https://pagure.io/freeipa/c/225fae841882832668c0842479ab11c89dfcd1a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/225fae841882832668c0842479ab11c89dfcd1a5>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: introduce installer class hierarchy
-   `commit <https://pagure.io/freeipa/c/a8fdb8de8248fe24f382e44b05293405b0b309ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8fdb8de8248fe24f382e44b05293405b0b309ac>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: fix subclassing of knob groups
-   `commit <https://pagure.io/freeipa/c/08a446a6bc516936497c1e0f278a699148f6330c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08a446a6bc516936497c1e0f278a699148f6330c>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: make knob base declaration explicit
-   `commit <https://pagure.io/freeipa/c/269ca6c4547fc017bb3a88e994ca770047122b3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/269ca6c4547fc017bb3a88e994ca770047122b3e>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: declare knob CLI names using the argparse convention
-   `commit <https://pagure.io/freeipa/c/043c262ce48a0d667e914c315e21e6e1b3862202>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/043c262ce48a0d667e914c315e21e6e1b3862202>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: use standard Python classes to declare knob types
-   `commit <https://pagure.io/freeipa/c/a929ac333833a5cbf503d1fcbdee150658d933a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a929ac333833a5cbf503d1fcbdee150658d933a4>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: introduce updated knob constructor
-   `commit <https://pagure.io/freeipa/c/9fd1981ae8abf720f5234b6049c9beabbb1f2211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fd1981ae8abf720f5234b6049c9beabbb1f2211>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: simplify CLI option parsing
-   `commit <https://pagure.io/freeipa/c/be0c1afa74cdf9a6e7640cd4110519e61250ae93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be0c1afa74cdf9a6e7640cd4110519e61250ae93>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: improve CLI positional argument handling
-   `commit <https://pagure.io/freeipa/c/a641e279ff76e09f59c4d5fef1dc1f9355dbacf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a641e279ff76e09f59c4d5fef1dc1f9355dbacf7>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: use ldaps for pkispawn in ipa-ca-install
-   `commit <https://pagure.io/freeipa/c/87c3c1abecdfb8b5eb227239eeacfbee386a7ed7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87c3c1abecdfb8b5eb227239eeacfbee386a7ed7>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: fix DS restart failure during replica promotion
-   `commit <https://pagure.io/freeipa/c/8cb315af627d712dd21396164cfa2b5d03ccb466>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cb315af627d712dd21396164cfa2b5d03ccb466>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: merge KRA agent cert export into KRA install
-   `commit <https://pagure.io/freeipa/c/89bb5ed1ebc0b5952a1d5eae34e0f39c5ba540d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89bb5ed1ebc0b5952a1d5eae34e0f39c5ba540d7>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: merge RA cert import into CA install
-   `commit <https://pagure.io/freeipa/c/822e1bc82af3a6c1556546c4fbe96eeafad45762>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/822e1bc82af3a6c1556546c4fbe96eeafad45762>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  server install: do not restart httpd during CA install
-   `commit <https://pagure.io/freeipa/c/2dedfe5d33062fc7121bf36be12d7b423b62120a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dedfe5d33062fc7121bf36be12d7b423b62120a>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: merge all KRA install code paths into one
-   `commit <https://pagure.io/freeipa/c/0933e080aa9635bba12efc53d904d524b309027f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0933e080aa9635bba12efc53d904d524b309027f>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  install: merge all CA install code paths into one
-   `commit <https://pagure.io/freeipa/c/dc38d53de1eff71570ec5ef55db6de2c6f9b5bbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc38d53de1eff71570ec5ef55db6de2c6f9b5bbd>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: use one remote KRA host name everywhere
-   `commit <https://pagure.io/freeipa/c/0e232b5f526168af6bb0b52244f79dfacb43a9b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e232b5f526168af6bb0b52244f79dfacb43a9b7>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replica install: use one remote CA host name everywhere
-   `commit <https://pagure.io/freeipa/c/8a7e79a7a6fad8dc87c8f148cb5098434f988ea3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a7e79a7a6fad8dc87c8f148cb5098434f988ea3>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  spec file: bump minimal required version of 389-ds-base
-   `commit <https://pagure.io/freeipa/c/f12abfb852dfb1a7759928b05defde68d5d7a3df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f12abfb852dfb1a7759928b05defde68d5d7a3df>`__
    `#6369 <https://pagure.io/freeipa/issue/6369>`__
 -  pwpolicy: do not run klist on import
-   `commit <https://pagure.io/freeipa/c/cc5ad6b3f951a6cb8298181690248d680c39922b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc5ad6b3f951a6cb8298181690248d680c39922b>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  client: remove unused libcurl build dependency
-   `commit <https://pagure.io/freeipa/c/9477e39b4b267922dbdd86a65869f773d980df8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9477e39b4b267922dbdd86a65869f773d980df8e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  makeapi, makeaci: do not fail on missing imports
-   `commit <https://pagure.io/freeipa/c/9b534238157e003d2d7c3e1a7fd27531ab1dfd25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b534238157e003d2d7c3e1a7fd27531ab1dfd25>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  ipaserver: remove ipalib import from setup.py
-   `commit <https://pagure.io/freeipa/c/0b91735c79a0ba577f9540e946180760a97913a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b91735c79a0ba577f9540e946180760a97913a4>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  pylint: enable the import-error check
-   `commit <https://pagure.io/freeipa/c/0d370a959b6b55f995661b2febe55c379065c4d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d370a959b6b55f995661b2febe55c379065c4d9>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  spec file: do not include BuildRequires for lint by default
-   `commit <https://pagure.io/freeipa/c/1077743d90902fc776f837f8486fa7f08b560673>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1077743d90902fc776f837f8486fa7f08b560673>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  spec file: clean up BuildRequires
-   `commit <https://pagure.io/freeipa/c/21395d1724e6bf044438a8bc25ba028ed38cde8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21395d1724e6bf044438a8bc25ba028ed38cde8c>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  cert: add revocation reason back to cert-find output
-   `commit <https://pagure.io/freeipa/c/16dad1c3cb09acee946bc5b2409447279a8bc0de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16dad1c3cb09acee946bc5b2409447279a8bc0de>`__
    `#6269 <https://pagure.io/freeipa/issue/6269>`__
 -  test_plugable: update the rest of test_init
-   `commit <https://pagure.io/freeipa/c/09a8f62d12c0be26741c24845cda2be83f14c503>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09a8f62d12c0be26741c24845cda2be83f14c503>`__
    `#6313 <https://pagure.io/freeipa/issue/6313>`__
 -  dns: re-introduce --raw in dnsrecord-del
-   `commit <https://pagure.io/freeipa/c/e5f7a612fbfdaa9ee12ef16cef550931011abe4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5f7a612fbfdaa9ee12ef16cef550931011abe4c>`__
    `#5644 <https://pagure.io/freeipa/issue/5644>`__
 -  client: remove hard dependency on pam_krb5
-   `commit <https://pagure.io/freeipa/c/984ae3858d8fb25d30b886bb953df1b06ab34ec7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/984ae3858d8fb25d30b886bb953df1b06ab34ec7>`__
    `#5557 <https://pagure.io/freeipa/issue/5557>`__
 -  cert: fix cert-find --certificate when the cert is not in LDAP
-   `commit <https://pagure.io/freeipa/c/b7b6faf14aaa8ac677ab9ebc2bcbf87e6b2a1146>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7b6faf14aaa8ac677ab9ebc2bcbf87e6b2a1146>`__
    `#6304 <https://pagure.io/freeipa/issue/6304>`__
 -  dns: fix crash in interactive mode against old servers
-   `commit <https://pagure.io/freeipa/c/38a51fa984a6aa92f383d7f8176057de8e057d52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38a51fa984a6aa92f383d7f8176057de8e057d52>`__
    `#6203 <https://pagure.io/freeipa/issue/6203>`__
 -  dns: prompt for missing record parts in CLI
-   `commit <https://pagure.io/freeipa/c/dce95a14595a37ce83bcf3e28f41feab715d0c81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dce95a14595a37ce83bcf3e28f41feab715d0c81>`__
    `#6203 <https://pagure.io/freeipa/issue/6203>`__
 -  dns: normalize record type read interactively in dnsrecord_add
-   `commit <https://pagure.io/freeipa/c/afea9616318fbbffc2c296b7c41890db8595e3cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afea9616318fbbffc2c296b7c41890db8595e3cc>`__
    `#6203 <https://pagure.io/freeipa/issue/6203>`__
 -  cli: use full name when executing a command
-   `commit <https://pagure.io/freeipa/c/a3d178b86ddff9335228d99fe06e8fc89a00235a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3d178b86ddff9335228d99fe06e8fc89a00235a>`__
    `#6279 <https://pagure.io/freeipa/issue/6279>`__
 
 
@@ -1625,74 +1625,74 @@ Lenka Doudova (23)
 ----------------------------------------------------------------------------------------------
 
 -  Document make_delete_command method in UserTracker
-   `commit <https://pagure.io/freeipa/c/4b3bd5424246d8386a33a73f9a98c6958823093e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b3bd5424246d8386a33a73f9a98c6958823093e>`__
    `#6485 <https://pagure.io/freeipa/issue/6485>`__
 -  Tests: Providing trust tests with tree root domain
-   `commit <https://pagure.io/freeipa/c/4df1d9d1a566af57b23d45ca4377ab77ed9e4d60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4df1d9d1a566af57b23d45ca4377ab77ed9e4d60>`__
    `#6347 <https://pagure.io/freeipa/issue/6347>`__
 -  Tests: Verify that validity info is present in cert-show and
    cert-find command
-   `commit <https://pagure.io/freeipa/c/414ed0d182e55dfe18f31ebbbc97095b989fc162>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/414ed0d182e55dfe18f31ebbbc97095b989fc162>`__
    `#6419 <https://pagure.io/freeipa/issue/6419>`__
 -  Add file_exists method as a member of transport object
-   `commit <https://pagure.io/freeipa/c/46aa41444521a1746d584b703054e2a971915dc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46aa41444521a1746d584b703054e2a971915dc6>`__
    `#6400 <https://pagure.io/freeipa/issue/6400>`__
 -  Tests: Provide AD cleanup for legacy client tests
-   `commit <https://pagure.io/freeipa/c/3938698e07404acfd7ae84fcaae9c02850d1afa7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3938698e07404acfd7ae84fcaae9c02850d1afa7>`__
    `#6396 <https://pagure.io/freeipa/issue/6396>`__
 -  Tests: Provide AD cleanup for trust tests
-   `commit <https://pagure.io/freeipa/c/8a177732afc404a830b75cab03fb420af93fa441>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a177732afc404a830b75cab03fb420af93fa441>`__
    `#6396 <https://pagure.io/freeipa/issue/6396>`__
 -  Tests: Fix integration sudo test
-   `commit <https://pagure.io/freeipa/c/e3b7d235d5e59e496f3d99a05e3dd379f845e4ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3b7d235d5e59e496f3d99a05e3dd379f845e4ea>`__
    `#6378 <https://pagure.io/freeipa/issue/6378>`__
 -  Tests: Verify that cert commands show CA without --all
-   `commit <https://pagure.io/freeipa/c/42d1a06bd1e856c14110c06ba0d9d946df36331d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42d1a06bd1e856c14110c06ba0d9d946df36331d>`__
    `#6410 <https://pagure.io/freeipa/issue/6410>`__
 -  Tests: Certificate revocation
-   `commit <https://pagure.io/freeipa/c/8f04d1a793b8ff01804bc03eac9b7aaa4f7a7f78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f04d1a793b8ff01804bc03eac9b7aaa4f7a7f78>`__
    `#6349 <https://pagure.io/freeipa/issue/6349>`__
 -  Tests: Remove invalid certplugin tests
-   `commit <https://pagure.io/freeipa/c/c9c92e3a7f4961d91e0395daf17f5aeb34c20178>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9c92e3a7f4961d91e0395daf17f5aeb34c20178>`__
    `#6349 <https://pagure.io/freeipa/issue/6349>`__
 -  Tests: Fix failing test_ipalib/test_parameters
-   `commit <https://pagure.io/freeipa/c/c3e3130a35f05348405701731ec2d5b85a772997>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3e3130a35f05348405701731ec2d5b85a772997>`__
    `#6292 <https://pagure.io/freeipa/issue/6292>`__
 -  Tests: Remove silent deleting and creating entries by tracker
-   `commit <https://pagure.io/freeipa/c/74e52e86867372365d1d63561f7d1ff961b89ee0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74e52e86867372365d1d63561f7d1ff961b89ee0>`__
    `#6123 <https://pagure.io/freeipa/issue/6123>`__
 -  Tests: Remove usage of krb5 ccache from test_ipaserver/test_ldap
-   `commit <https://pagure.io/freeipa/c/a7c49e455e4f1f06f621f4c634a79b3ae0585cd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7c49e455e4f1f06f621f4c634a79b3ae0585cd8>`__
    `#6323 <https://pagure.io/freeipa/issue/6323>`__
 -  Tests: Fix host attributes in ipa-join host test
-   `commit <https://pagure.io/freeipa/c/8a947e2fd0d62df9a68252c1f7505451347b0c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a947e2fd0d62df9a68252c1f7505451347b0c7d>`__
    `#6326 <https://pagure.io/freeipa/issue/6326>`__
 -  Tests: Update host test with ipa-join
-   `commit <https://pagure.io/freeipa/c/c0fcfb31ecb2d17c3484d752edf55a42ef04ead7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0fcfb31ecb2d17c3484d752edf55a42ef04ead7>`__
    `#6326 <https://pagure.io/freeipa/issue/6326>`__
 -  Tests: Add krb5kdc.service restart to integration trust tests
-   `commit <https://pagure.io/freeipa/c/936a6a38b8e7ece83933090db5840ebd37c26c20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/936a6a38b8e7ece83933090db5840ebd37c26c20>`__
    `#6322 <https://pagure.io/freeipa/issue/6322>`__
 -  Tests: Remove unnecessary attributes from base tracker
-   `commit <https://pagure.io/freeipa/c/522766a565f6845984c98dc3ea67d66a3e00e4c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/522766a565f6845984c98dc3ea67d66a3e00e4c7>`__
    `#6128 <https://pagure.io/freeipa/issue/6128>`__
 -  Tests: Remove --force options from tracker base class
-   `commit <https://pagure.io/freeipa/c/a07c4bdd4fda0ed1cca93d5a56ef67205be1a9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a07c4bdd4fda0ed1cca93d5a56ef67205be1a9d1>`__
    `#6124 <https://pagure.io/freeipa/issue/6124>`__
 -  Tests: Remove SSSD restart from integration tests
-   `commit <https://pagure.io/freeipa/c/361105a3d5b509bafee83934eb31d10f69d512f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/361105a3d5b509bafee83934eb31d10f69d512f6>`__
    `#6338 <https://pagure.io/freeipa/issue/6338>`__
 -  Tests: Fix integration sudo tests setup and checks
-   `commit <https://pagure.io/freeipa/c/7cac8392036bf6d6bbd74f5a781986dec21149d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cac8392036bf6d6bbd74f5a781986dec21149d6>`__
    `#6262 <https://pagure.io/freeipa/issue/6262>`__
 -  Tests: Fix failing ldap.backend test
-   `commit <https://pagure.io/freeipa/c/8c6f677a166d01a120e6b2a9361d7e5d3888c1c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c6f677a166d01a120e6b2a9361d7e5d3888c1c7>`__
    `#6312 <https://pagure.io/freeipa/issue/6312>`__
 -  Tests: Add cleanup to integration trust tests
-   `commit <https://pagure.io/freeipa/c/b8240133866bb8fabd3962b44789a0315f2e7dd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8240133866bb8fabd3962b44789a0315f2e7dd8>`__
    `#6306 <https://pagure.io/freeipa/issue/6306>`__
 -  Tests: Fix regex errors in integration trust tests
-   `commit <https://pagure.io/freeipa/c/fc5a99274c2ea0301a539fe9a8b2dc9b61786a8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc5a99274c2ea0301a539fe9a8b2dc9b61786a8a>`__
    `#6285 <https://pagure.io/freeipa/issue/6285>`__
 
 
@@ -1701,7 +1701,7 @@ Ludwig Krispenz (1)
 ----------------------------------------------------------------------------------------------
 
 -  Check for conflict entries before raising domain level
-   `commit <https://pagure.io/freeipa/c/26bd7ebfa27d15221e5d3fa1e3871a0085c31e0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26bd7ebfa27d15221e5d3fa1e3871a0085c31e0f>`__
    `#6534 <https://pagure.io/freeipa/issue/6534>`__
 
 
@@ -1710,20 +1710,20 @@ Lukas Slebodnik (6)
 ----------------------------------------------------------------------------------------------
 
 -  CONFIGURE: Improve detection of xmlrpc_c flags
-   `commit <https://pagure.io/freeipa/c/2a4f7f2cfaf6ac5ffaf4cc2b43fa0e9b5fa3ebe4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a4f7f2cfaf6ac5ffaf4cc2b43fa0e9b5fa3ebe4>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  CONFIGURE: Properly detect libpopt on el7
-   `commit <https://pagure.io/freeipa/c/4fe9166ac9f9a100d69ce37f19ae1ae971bb2ce1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fe9166ac9f9a100d69ce37f19ae1ae971bb2ce1>`__
 -  ipa_pwd: remove unnecessary dependency on dirsrv plugins
-   `commit <https://pagure.io/freeipa/c/41d7ae54fafc6deb602e1a990eaec37c6ae4880b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41d7ae54fafc6deb602e1a990eaec37c6ae4880b>`__
 -  SPEC: Fix build in mock
-   `commit <https://pagure.io/freeipa/c/b82d285a4a75e11cc9291ecca12d2fcc26f43ed1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b82d285a4a75e11cc9291ecca12d2fcc26f43ed1>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 -  CONFIGURE: Update help message for jslint
-   `commit <https://pagure.io/freeipa/c/3f91469f327d8d9f3b27e0b67c54a4f47ad845c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f91469f327d8d9f3b27e0b67c54a4f47ad845c1>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 -  CONFIGURE: Fix detection of pylint
-   `commit <https://pagure.io/freeipa/c/5c18feaa206bbaee692fc3640b7b79c8d9d6a638>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c18feaa206bbaee692fc3640b7b79c8d9d6a638>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 
 
@@ -1732,338 +1732,338 @@ Martin Babinsky (113)
 ----------------------------------------------------------------------------------------------
 
 -  Try out anonymous PKINIT after it is configured
-   `commit <https://pagure.io/freeipa/c/a1686a90c0cc8c16c89ef1bada7f507729bf3252>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1686a90c0cc8c16c89ef1bada7f507729bf3252>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  check for replica's KDC entry on master before requesting PKINIT cert
-   `commit <https://pagure.io/freeipa/c/b45629fc480e61464b402ac2fc52c6f9fc61df0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b45629fc480e61464b402ac2fc52c6f9fc61df0e>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  check that the master requesting PKINIT cert has KDC enabled
-   `commit <https://pagure.io/freeipa/c/8f4abf7bc1607fc44f528b8a443b69cb82269e69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f4abf7bc1607fc44f528b8a443b69cb82269e69>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  Make wait_for_entry raise exceptions
-   `commit <https://pagure.io/freeipa/c/069948466e81d99a0dd48ffffa32af50351d0189>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/069948466e81d99a0dd48ffffa32af50351d0189>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  Move PKINIT configuration to a later stage of server/replica install
-   `commit <https://pagure.io/freeipa/c/bd18b5f91e3f98fa877def245c54c1cd33bd372e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd18b5f91e3f98fa877def245c54c1cd33bd372e>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  Request PKINIT cert directly from Dogtag API on first master
-   `commit <https://pagure.io/freeipa/c/b5b23e073e59930e4dcf14ea8031c2c0441e6344>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5b23e073e59930e4dcf14ea8031c2c0441e6344>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  Make PKINIT certificate request logic consistent with other
    installers
-   `commit <https://pagure.io/freeipa/c/95768de06fbef78169329af12b29e4d65e4bf157>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95768de06fbef78169329af12b29e4d65e4bf157>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__
 -  idviews: correctly handle modification of non-existent view
-   `commit <https://pagure.io/freeipa/c/1cdd5dee006426c996f67240b6cb2c1aa05e5168>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cdd5dee006426c996f67240b6cb2c1aa05e5168>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  Re-use trust domain retrieval code in certmap validators
-   `commit <https://pagure.io/freeipa/c/4e5e3eebb223b7f2760e21f22e42775982104b0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e5e3eebb223b7f2760e21f22e42775982104b0d>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  idview: add domain_resolution_order attribute
-   `commit <https://pagure.io/freeipa/c/544d66b7109300e570fb6849f0f9bab8020f3b66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/544d66b7109300e570fb6849f0f9bab8020f3b66>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  ipaconfig: add the ability to manipulate domain resolution order
-   `commit <https://pagure.io/freeipa/c/1b5f56d15455b6019dd532cb9635fa2c44cb0022>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b5f56d15455b6019dd532cb9635fa2c44cb0022>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  Short name resolution: introduce the required schema
-   `commit <https://pagure.io/freeipa/c/594c87daf873ceec0c0cf3464bcb1aadb9f2b92a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/594c87daf873ceec0c0cf3464bcb1aadb9f2b92a>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  ipa-managed-entries: only permit running the command on IPA master
-   `commit <https://pagure.io/freeipa/c/5cb98496aa2e1e190219cf2f4a6208a38fa368d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cb98496aa2e1e190219cf2f4a6208a38fa368d5>`__
    `#6735 <https://pagure.io/freeipa/issue/6735>`__
 -  ipa-managed-entries: use server-mode API
-   `commit <https://pagure.io/freeipa/c/715367506b11549aae69f913594ebc6d9c4d3e76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/715367506b11549aae69f913594ebc6d9c4d3e76>`__
    `#6735 <https://pagure.io/freeipa/issue/6735>`__
 -  Allow login to WebUI using Kerberos aliases/enterprise principals
-   `commit <https://pagure.io/freeipa/c/f8d7e37a091c1df4c989b80b8d19e12ab35533c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8d7e37a091c1df4c989b80b8d19e12ab35533c8>`__
    `#6343 <https://pagure.io/freeipa/issue/6343>`__
 -  Provide basic integration tests for built-in AD trust installer
-   `commit <https://pagure.io/freeipa/c/612ea7f66e102c57c2b213eff99ad8f1c91e59a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/612ea7f66e102c57c2b213eff99ad8f1c91e59a5>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Update server/replica installer man pages
-   `commit <https://pagure.io/freeipa/c/23cebe1356bbf84ddfde2a622a795061c4924edf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23cebe1356bbf84ddfde2a622a795061c4924edf>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Fix erroneous short name options in ipa-adtrust-install man page
-   `commit <https://pagure.io/freeipa/c/f62f0b74855beff8db1ad6a24bf76fa66c3c4771>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f62f0b74855beff8db1ad6a24bf76fa66c3c4771>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Merge AD trust configurator into replica installer
-   `commit <https://pagure.io/freeipa/c/eee319dba12a6ab7daa06ca0d7d8ac8fc754f961>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eee319dba12a6ab7daa06ca0d7d8ac8fc754f961>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Merge AD trust configurator into server installer
-   `commit <https://pagure.io/freeipa/c/aa353c5f21bf040579a4aeda6840b56ae93b4309>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa353c5f21bf040579a4aeda6840b56ae93b4309>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  expose AD trust related knobs in composite installers
-   `commit <https://pagure.io/freeipa/c/13b5821fa4d32b5a1cc69a97386853fad44236ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13b5821fa4d32b5a1cc69a97386853fad44236ec>`__
 -  Add AD trust installer interface for composite installer
-   `commit <https://pagure.io/freeipa/c/77857ea77662e005b1a23039e2f9173c0a9b080b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77857ea77662e005b1a23039e2f9173c0a9b080b>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  check for installed dependencies when \*not\* in standalone mode
-   `commit <https://pagure.io/freeipa/c/289060dd98a3ed8e2a916ed25eaa1824c795e842>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/289060dd98a3ed8e2a916ed25eaa1824c795e842>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  print the installation info only in standalone mode
-   `commit <https://pagure.io/freeipa/c/ef37c42ab9d3530dc78fa4b754cd11c585b69d77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef37c42ab9d3530dc78fa4b754cd11c585b69d77>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  adtrust.py: Use logging to emit error messages
-   `commit <https://pagure.io/freeipa/c/c17215ea3db58c7a5fe6e30b6b38f4f3012e25d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c17215ea3db58c7a5fe6e30b6b38f4f3012e25d2>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Refactor the code searching and presenting missing trust agents
-   `commit <https://pagure.io/freeipa/c/9348cfa996ce450bc88a4b35ee3f3bf52adfff39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9348cfa996ce450bc88a4b35ee3f3bf52adfff39>`__
    `#6639 <https://pagure.io/freeipa/issue/6639>`__
 -  only check for netbios name when LDAP backend is connected
-   `commit <https://pagure.io/freeipa/c/c5bae577597fbababdd25ab3ae6463c490d90a40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5bae577597fbababdd25ab3ae6463c490d90a40>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  Refactor the code checking for missing SIDs
-   `commit <https://pagure.io/freeipa/c/4ba6b968399204aac66d82d917a8cc159e77ad4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6b968399204aac66d82d917a8cc159e77ad4d>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  use the methods of the parent class to retrieve CIFS kerberos keys
-   `commit <https://pagure.io/freeipa/c/8bac62b7f5d01ceb20388599e8549b1b222f283e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8bac62b7f5d01ceb20388599e8549b1b222f283e>`__
    `#6638 <https://pagure.io/freeipa/issue/6638>`__
 -  httpinstance: re-use parent's methods to retrieve anonymous keytab
-   `commit <https://pagure.io/freeipa/c/ce3baf28ce81458e1c5bf57188858d3d120ec3dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce3baf28ce81458e1c5bf57188858d3d120ec3dd>`__
    `#6638 <https://pagure.io/freeipa/issue/6638>`__
 -  Make request_service_keytab into a public method
-   `commit <https://pagure.io/freeipa/c/6c0baa6208c2bf97b5ed7ea6e9836963dced64b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c0baa6208c2bf97b5ed7ea6e9836963dced64b0>`__
    `#6638 <https://pagure.io/freeipa/issue/6638>`__
 -  allow for more flexibility when requesting service keytab
-   `commit <https://pagure.io/freeipa/c/af998c4d30175fb3ecc148e1b3a7aca03ef9239a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af998c4d30175fb3ecc148e1b3a7aca03ef9239a>`__
    `#6638 <https://pagure.io/freeipa/issue/6638>`__
 -  Move AD trust installation code to a separate module
-   `commit <https://pagure.io/freeipa/c/98bf0cc9663ac281247ac8d9ee8488e3ab8102eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98bf0cc9663ac281247ac8d9ee8488e3ab8102eb>`__
    `#6629 <https://pagure.io/freeipa/issue/6629>`__
 -  Replace exit() calls with exceptions
-   `commit <https://pagure.io/freeipa/c/d7cfbb870fce40b50f6df2446c864099f8ea833e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7cfbb870fce40b50f6df2446c864099f8ea833e>`__
    `#6629 <https://pagure.io/freeipa/issue/6629>`__
 -  Remove unused variables in exception handling
-   `commit <https://pagure.io/freeipa/c/e27f6bfdc31b767be9ded411e869716b76f478ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e27f6bfdc31b767be9ded411e869716b76f478ce>`__
    `#6629 <https://pagure.io/freeipa/issue/6629>`__
 -  ipa-adtrust-install: format the code for PEP-8 compliance
-   `commit <https://pagure.io/freeipa/c/847be3a8a85cd58e5a011c0c2bc7e1123eb4a1aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/847be3a8a85cd58e5a011c0c2bc7e1123eb4a1aa>`__
    `#6629 <https://pagure.io/freeipa/issue/6629>`__
 -  Travis CI: Upload the logs from failed jobs to transfer.sh
-   `commit <https://pagure.io/freeipa/c/91341f4035e0d78b0adbe9a09ba69e1fd35ec26d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91341f4035e0d78b0adbe9a09ba69e1fd35ec26d>`__
 -  Explicitly handle quoting/unquoting of NSSNickname directive
-   `commit <https://pagure.io/freeipa/c/86f4a93fb3aeb6742acab5abaa1c17b525ea4223>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86f4a93fb3aeb6742acab5abaa1c17b525ea4223>`__
    `#6460 <https://pagure.io/freeipa/issue/6460>`__
 -  Delegate directive value quoting/unquoting to separate functions
-   `commit <https://pagure.io/freeipa/c/2831b30e9a9de947481c058d8d32e174f951b1c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2831b30e9a9de947481c058d8d32e174f951b1c0>`__
    `#6460 <https://pagure.io/freeipa/issue/6460>`__
 -  installutils: improve directive value parsing in \`get_directive\`
-   `commit <https://pagure.io/freeipa/c/517d43e78b8d8ea0b796a6ff6a379236eaae21df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/517d43e78b8d8ea0b796a6ff6a379236eaae21df>`__
    `#6460 <https://pagure.io/freeipa/issue/6460>`__
 -  Fix the installutils.set_directive docstring
-   `commit <https://pagure.io/freeipa/c/e1ed8b5eff40331ba532d37f3fb08814d8a55b77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1ed8b5eff40331ba532d37f3fb08814d8a55b77>`__
    `#6460 <https://pagure.io/freeipa/issue/6460>`__
 -  disable hostname canonicalization by Kerberos library
-   `commit <https://pagure.io/freeipa/c/566c86a782bfd7d50938866e9f89faf56cea773f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/566c86a782bfd7d50938866e9f89faf56cea773f>`__
    `#6584 <https://pagure.io/freeipa/issue/6584>`__
 -  Travis CI: actually return non-zero exit status when the test job
    fails
-   `commit <https://pagure.io/freeipa/c/9b5b7131502a73fa24dc56c72a9648528c5aceee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b5b7131502a73fa24dc56c72a9648528c5aceee>`__
 -  Trim the test runner log to show only pytest failures/errors
-   `commit <https://pagure.io/freeipa/c/0ef55a91ef9c591cee3a7e1ff0e391cdc32423c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ef55a91ef9c591cee3a7e1ff0e391cdc32423c3>`__
 -  Add license headers to the files used by Travis CI
-   `commit <https://pagure.io/freeipa/c/4abd3f554a436e6446ba59c75c09fb0ff8b7fe4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4abd3f554a436e6446ba59c75c09fb0ff8b7fe4a>`__
 -  Travis CI: use specific Python version during build
-   `commit <https://pagure.io/freeipa/c/f48d6fc168253209bed3f1dd5a543f15d1f54669>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f48d6fc168253209bed3f1dd5a543f15d1f54669>`__
 -  introduce install step to .travis.yml and cache pip installs
-   `commit <https://pagure.io/freeipa/c/b6216756f6c7a950e9bf2afe56a582dd8195c513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6216756f6c7a950e9bf2afe56a582dd8195c513>`__
 -  split out lint to a separate Travis job
-   `commit <https://pagure.io/freeipa/c/b8423492f5dce32183b34d718e4619fe3ca8bfef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8423492f5dce32183b34d718e4619fe3ca8bfef>`__
 -  Travis: offload test execution to a separate script
-   `commit <https://pagure.io/freeipa/c/149d86de14b00b73f625fefe73c2322a2fffac06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/149d86de14b00b73f625fefe73c2322a2fffac06>`__
 -  Travis CI: a separate script to run test tasks
-   `commit <https://pagure.io/freeipa/c/1267e3e72305ee6bda0dd348ae1737b6f68f4371>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1267e3e72305ee6bda0dd348ae1737b6f68f4371>`__
 -  Put the commands informing and displaying build logs on single line
-   `commit <https://pagure.io/freeipa/c/aff4e684e1f13d7da4248d17c0b8b2adf2e37033>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aff4e684e1f13d7da4248d17c0b8b2adf2e37033>`__
 -  travis: mark FreeIPA as python project
-   `commit <https://pagure.io/freeipa/c/758731088eee0294af59812dbd1976db89b9dda0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/758731088eee0294af59812dbd1976db89b9dda0>`__
 -  Bump up ipa-docker-test-runner version
-   `commit <https://pagure.io/freeipa/c/d86cae7748a8a629c942f1eafc0a0267f2c9611e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d86cae7748a8a629c942f1eafc0a0267f2c9611e>`__
 -  Add a basic test suite for \`kadmin.local\` interface
-   `commit <https://pagure.io/freeipa/c/d95bdbbfd505dde1348413fc7a1233ac834ce344>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d95bdbbfd505dde1348413fc7a1233ac834ce344>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  Make \`kadmin\` family of functions return the result of ipautil.run
-   `commit <https://pagure.io/freeipa/c/f59673506493e0199c17000538adb7c80b477aa0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f59673506493e0199c17000538adb7c80b477aa0>`__
    `#6561 <https://pagure.io/freeipa/issue/6561>`__
 -  gracefully handle setting replica bind dn group on old masters
-   `commit <https://pagure.io/freeipa/c/95e602598a481f9c4a3b69ce8a861bf3816aa8ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95e602598a481f9c4a3b69ce8a861bf3816aa8ba>`__
    `#6532 <https://pagure.io/freeipa/issue/6532>`__
 -  add missing attribute to ipaca replica during CA topology update
-   `commit <https://pagure.io/freeipa/c/6d0e450c8226a8e23d88cf21487a77db66a2968b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d0e450c8226a8e23d88cf21487a77db66a2968b>`__
    `#6508 <https://pagure.io/freeipa/issue/6508>`__
 -  Revert "upgrade: add replica bind DN group check interval to CA
    topology config"
-   `commit <https://pagure.io/freeipa/c/6086a6dbad21d93ed584d508f9844d73f64a4542>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6086a6dbad21d93ed584d508f9844d73f64a4542>`__
    `#6508 <https://pagure.io/freeipa/issue/6508>`__
 -  bindinstance: use data in named.conf to determine configuration
    status
-   `commit <https://pagure.io/freeipa/c/f0e09c42b76f229486e5dea097cd2b6602999943>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0e09c42b76f229486e5dea097cd2b6602999943>`__
    `#6503 <https://pagure.io/freeipa/issue/6503>`__
 -  Use ipa-docker-test-runner to run tests in Travis CI
-   `commit <https://pagure.io/freeipa/c/6d6fbc010ec2b607a11e0ff69c8cbdcd3c1d47d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d6fbc010ec2b607a11e0ff69c8cbdcd3c1d47d9>`__
 -  Configuration file for ipa-docker-test-runner
-   `commit <https://pagure.io/freeipa/c/5ecaea6bc4f49c2665597ca38fc52f4fae8a9d24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ecaea6bc4f49c2665597ca38fc52f4fae8a9d24>`__
 -  Add 'env_confdir' to constants
-   `commit <https://pagure.io/freeipa/c/1300381d45a23073261e62cb031cf4285a34f641>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1300381d45a23073261e62cb031cf4285a34f641>`__
    `#6389 <https://pagure.io/freeipa/issue/6389>`__
 -  Fix pep-8 transgressions in ipalib/misc.py
-   `commit <https://pagure.io/freeipa/c/64a4be26febf19e427760115912a858a804208a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64a4be26febf19e427760115912a858a804208a0>`__
    `#6490 <https://pagure.io/freeipa/issue/6490>`__
 -  Make \`env\` and \`plugins\` commands local again
-   `commit <https://pagure.io/freeipa/c/0ae7bebb7690620b69fd9c84b7a385c2086c1ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ae7bebb7690620b69fd9c84b7a385c2086c1ee1>`__
    `#6490 <https://pagure.io/freeipa/issue/6490>`__
 -  Revert "Add 'ipa localenv' subcommand"
-   `commit <https://pagure.io/freeipa/c/42307ae2dc4d9be06d3fd9b7e5af2e0761b8d6ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42307ae2dc4d9be06d3fd9b7e5af2e0761b8d6ad>`__
    `#6490 <https://pagure.io/freeipa/issue/6490>`__
 -  Enhance \__repr_\_ method of Principal
-   `commit <https://pagure.io/freeipa/c/38cc40ddb5bf965801500bb4f66fd965b12e3c88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38cc40ddb5bf965801500bb4f66fd965b12e3c88>`__
    `#6505 <https://pagure.io/freeipa/issue/6505>`__
 -  replication: ensure bind DN group check interval is set on replica
    config
-   `commit <https://pagure.io/freeipa/c/266b9d9c6c9b9dec10b8a70382445fa2f800dd69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/266b9d9c6c9b9dec10b8a70382445fa2f800dd69>`__
    `#6508 <https://pagure.io/freeipa/issue/6508>`__
 -  upgrade: add replica bind DN group check interval to CA topology
    config
-   `commit <https://pagure.io/freeipa/c/73d0d03891c8585a925f5b49739990c579999f6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73d0d03891c8585a925f5b49739990c579999f6e>`__
    `#6508 <https://pagure.io/freeipa/issue/6508>`__
 -  Improve the robustness FreeIPA's i18n module and its tests
-   `commit <https://pagure.io/freeipa/c/211c944a353dbc241ae6e280c9474145ab48dbe4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/211c944a353dbc241ae6e280c9474145ab48dbe4>`__
    `#6512 <https://pagure.io/freeipa/issue/6512>`__
 -  Use common procedure to setup initial replication in both domain
    levels
-   `commit <https://pagure.io/freeipa/c/ce2bb47cca03eda1ff85f4725abb92c639f34ecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce2bb47cca03eda1ff85f4725abb92c639f34ecc>`__
    `#6406 <https://pagure.io/freeipa/issue/6406>`__
 -  ensure that the initial sync using GSSAPI works agains old masters
-   `commit <https://pagure.io/freeipa/c/8378e1e39f44d49c2c90d2d0e7acd75a4fa95787>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8378e1e39f44d49c2c90d2d0e7acd75a4fa95787>`__
    `#6406 <https://pagure.io/freeipa/issue/6406>`__
 -  replication: refactor the code setting principals as replica bind DNs
-   `commit <https://pagure.io/freeipa/c/cf6048a3ba9998a65858993e52bd4895749f2a79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf6048a3ba9998a65858993e52bd4895749f2a79>`__
    `#6406 <https://pagure.io/freeipa/issue/6406>`__
 -  replication: augment setup_promote_replication method
-   `commit <https://pagure.io/freeipa/c/3dc9ab162141c7d2e4affe73f520e1599e9f8c30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dc9ab162141c7d2e4affe73f520e1599e9f8c30>`__
    `#6406 <https://pagure.io/freeipa/issue/6406>`__
 -  Turn replication manager group into ReplicationManager class member
-   `commit <https://pagure.io/freeipa/c/9d7943f3da7fb84975cc8f45047aafee13bf85dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d7943f3da7fb84975cc8f45047aafee13bf85dc>`__
    `#6406 <https://pagure.io/freeipa/issue/6406>`__
 -  Fix the naming of ipa-dnskeysyncd service principal
-   `commit <https://pagure.io/freeipa/c/6ca96b3db03d4f3c5dbf465ca3d36bd563771c47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ca96b3db03d4f3c5dbf465ca3d36bd563771c47>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  installutils: remove 'install_service_keytab' function
-   `commit <https://pagure.io/freeipa/c/7cd3b1bfa76c846b7ffec18e380b71a6617d97ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cd3b1bfa76c846b7ffec18e380b71a6617d97ec>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  domain-level agnostic keytab retrieval in httpinstance
-   `commit <https://pagure.io/freeipa/c/73fc15556d28706b0b9a10480fee8d56b2be9ab7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73fc15556d28706b0b9a10480fee8d56b2be9ab7>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  installers: restart DS after KDC is configured
-   `commit <https://pagure.io/freeipa/c/4e97a0171a862e20089863e4bf0ec88d0ba98a53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e97a0171a862e20089863e4bf0ec88d0ba98a53>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  dsinstance: use keytab retrieval method from parent class
-   `commit <https://pagure.io/freeipa/c/3129b874a2c222ff207f1302e5d85ae12df2eac9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3129b874a2c222ff207f1302e5d85ae12df2eac9>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  use DM credentials to retrieve service keytab only in DLO
-   `commit <https://pagure.io/freeipa/c/6181844c0ce62b8d7d35554032346396b20ad3c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6181844c0ce62b8d7d35554032346396b20ad3c0>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  Service: common method for service keytab requests
-   `commit <https://pagure.io/freeipa/c/4286f3885b173da9ceeb2d13d66f90336b9ef094>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4286f3885b173da9ceeb2d13d66f90336b9ef094>`__
    `#6405 <https://pagure.io/freeipa/issue/6405>`__
 -  Turn Kerberos-related properties to Service class members
-   `commit <https://pagure.io/freeipa/c/32599987fdc998e104846e8a176f70399cca2af2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32599987fdc998e104846e8a176f70399cca2af2>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Make service user name a class member of Service
-   `commit <https://pagure.io/freeipa/c/81bf72dc350b9c7daab669aaa796e96aee6ecbb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81bf72dc350b9c7daab669aaa796e96aee6ecbb8>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  service installers: clean up the inheritance
-   `commit <https://pagure.io/freeipa/c/15f282cf2c4a5315aa3e259bd923718685d88245>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15f282cf2c4a5315aa3e259bd923718685d88245>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  fix incorrect invocation of ipa-getkeytab during DL0 host enrollment
-   `commit <https://pagure.io/freeipa/c/19912796edf5d6427920ff67c33e6288223e0466>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19912796edf5d6427920ff67c33e6288223e0466>`__
    `#6434 <https://pagure.io/freeipa/issue/6434>`__
 -  do partial host enrollment in domain level 0 replica install
-   `commit <https://pagure.io/freeipa/c/a6ec37255441294285fac58c9bf08129db110fac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6ec37255441294285fac58c9bf08129db110fac>`__
    `#6434 <https://pagure.io/freeipa/issue/6434>`__
 -  Separate function to purge IPA host principals from keytab
-   `commit <https://pagure.io/freeipa/c/3d5161d7e943fc6d4d092d18fc980fd40d21a59f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d5161d7e943fc6d4d092d18fc980fd40d21a59f>`__
    `#6434 <https://pagure.io/freeipa/issue/6434>`__
 -  certs: do not re-create NSS database when requesting service cert
-   `commit <https://pagure.io/freeipa/c/8e36e030910a4a6ec5ddb37cc19824f37b25ab51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e36e030910a4a6ec5ddb37cc19824f37b25ab51>`__
    `#6429 <https://pagure.io/freeipa/issue/6429>`__
 -  initialize empty /etc/http/alias during server/replica install
-   `commit <https://pagure.io/freeipa/c/b1283c1e56976a3019c81c3be88fa821431ac6a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1283c1e56976a3019c81c3be88fa821431ac6a6>`__
    `#6429 <https://pagure.io/freeipa/issue/6429>`__
 -  CertDB: add API for non-destructive initialization from PKCS#12
    bundle
-   `commit <https://pagure.io/freeipa/c/2fdc2d0cb7fa98992fe6c2070cb5dc34c500ac09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fdc2d0cb7fa98992fe6c2070cb5dc34c500ac09>`__
    `#6429 <https://pagure.io/freeipa/issue/6429>`__
 -  test_ipagetkeytab: use system-wide IPA CA cert location in tests
-   `commit <https://pagure.io/freeipa/c/3ecda74d14066f6609d72422041bcc0c6499de77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ecda74d14066f6609d72422041bcc0c6499de77>`__
    `#6409 <https://pagure.io/freeipa/issue/6409>`__
 -  Extend keytab retrieval test suite to cover new options
-   `commit <https://pagure.io/freeipa/c/2725e440bf1e4930f9b1d19223424bcb0d4b7066>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2725e440bf1e4930f9b1d19223424bcb0d4b7066>`__
    `#6409 <https://pagure.io/freeipa/issue/6409>`__
 -  Modernize ipa-getkeytab test suite
-   `commit <https://pagure.io/freeipa/c/8480d0e3333f6813439e7b3321a0e33ce80d30f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8480d0e3333f6813439e7b3321a0e33ce80d30f1>`__
    `#6409 <https://pagure.io/freeipa/issue/6409>`__
 -  extend ipa-getkeytab to support other LDAP bind methods
-   `commit <https://pagure.io/freeipa/c/0c68c27e51c2a30265a760382d7d4fab7d21937b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c68c27e51c2a30265a760382d7d4fab7d21937b>`__
    `#6409 <https://pagure.io/freeipa/issue/6409>`__
 -  ipa-getkeytab: expose CA cert path as option
-   `commit <https://pagure.io/freeipa/c/294fc3dc5645eeb7942908c3e351c06aa0af329e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/294fc3dc5645eeb7942908c3e351c06aa0af329e>`__
    `#6409 <https://pagure.io/freeipa/issue/6409>`__
 -  server-del: fix incorrect check for one IPA master
-   `commit <https://pagure.io/freeipa/c/7a183bad66b91821a75e2a1cdbd3106fc31dcab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a183bad66b91821a75e2a1cdbd3106fc31dcab4>`__
    `#6417 <https://pagure.io/freeipa/issue/6417>`__
 -  Revert "Fix install scripts debugging"
-   `commit <https://pagure.io/freeipa/c/dc873007f8616ab9e77f903e235ba49f45ecde37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc873007f8616ab9e77f903e235ba49f45ecde37>`__
 -  do not use keys() method when iterating through dictionaries
-   `commit <https://pagure.io/freeipa/c/71f642f75132fe30b40062ce5abc8558a275b9bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71f642f75132fe30b40062ce5abc8558a275b9bb>`__
    `#6391 <https://pagure.io/freeipa/issue/6391>`__
 -  remove trailing newlines form python modules
-   `commit <https://pagure.io/freeipa/c/29829cc55a6be697abf881ea7867ef834bb66be7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29829cc55a6be697abf881ea7867ef834bb66be7>`__
    `#6391 <https://pagure.io/freeipa/issue/6391>`__
 -  mod_nss: use more robust quoting of NSSNickname directive
-   `commit <https://pagure.io/freeipa/c/ee96384c3ed5d93c8042e05461253e0c2ed5f721>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee96384c3ed5d93c8042e05461253e0c2ed5f721>`__
    `#5809 <https://pagure.io/freeipa/issue/5809>`__
 -  Move character escaping function to ipautil
-   `commit <https://pagure.io/freeipa/c/4d994bee60560438178ad9f0215f611ca60e32c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d994bee60560438178ad9f0215f611ca60e32c3>`__
    `#5809 <https://pagure.io/freeipa/issue/5809>`__
 -  Make Continuous installer continuous only during execution phase
-   `commit <https://pagure.io/freeipa/c/f7764cda6824a2fe73abe11f6daa28758a185319>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7764cda6824a2fe73abe11f6daa28758a185319>`__
    `#5725 <https://pagure.io/freeipa/issue/5725>`__
 -  use separate exception handlers for executors and validators
-   `commit <https://pagure.io/freeipa/c/347f5ca0e145491d387f60f95b67ef59e7c28316>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/347f5ca0e145491d387f60f95b67ef59e7c28316>`__
    `#5725 <https://pagure.io/freeipa/issue/5725>`__
 -  ipa passwd: use correct normalizer for user principals
-   `commit <https://pagure.io/freeipa/c/f3f9087ee8d1b1531730cf1e91fe404092e8c81d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3f9087ee8d1b1531730cf1e91fe404092e8c81d>`__
    `#6329 <https://pagure.io/freeipa/issue/6329>`__
 -  trust-fetch-domains: contact forest DCs when fetching trust domain
    info
-   `commit <https://pagure.io/freeipa/c/b0d40b80e8d9a4960296ce70d843ad987657696b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0d40b80e8d9a4960296ce70d843ad987657696b>`__
    `#6328 <https://pagure.io/freeipa/issue/6328>`__
 -  netgroup: avoid extraneous LDAP search when retrieving primary key
    from DN
-   `commit <https://pagure.io/freeipa/c/003b364c5a06a5adc89bac7371f46d534cfb4616>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/003b364c5a06a5adc89bac7371f46d534cfb4616>`__
    `#5855 <https://pagure.io/freeipa/issue/5855>`__
 -  advise: Use \`name\` instead of \`__name__\` to get plugin names
-   `commit <https://pagure.io/freeipa/c/5b9516753cae324126fac7e17b6918c08e210d59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b9516753cae324126fac7e17b6918c08e210d59>`__
 -  Use Travis-CI for basic sanity checks
-   `commit <https://pagure.io/freeipa/c/37f3ad8867f347289adcadcc473871c54aa9ca9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37f3ad8867f347289adcadcc473871c54aa9ca9d>`__
 -  ldapupdate: Use proper inheritance in BadSyntax exception
-   `commit <https://pagure.io/freeipa/c/415600fe451fe806cce7dbe39ad1e9f3d676f2f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/415600fe451fe806cce7dbe39ad1e9f3d676f2f9>`__
    `#6294 <https://pagure.io/freeipa/issue/6294>`__
 -  raise ValidationError when deprecated param is passed to command
-   `commit <https://pagure.io/freeipa/c/82e754e9c5e46317c7c060d9bc9c00ee259101a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82e754e9c5e46317c7c060d9bc9c00ee259101a1>`__
    `#6190 <https://pagure.io/freeipa/issue/6190>`__
 -  Always fetch forest info from root DCs when establishing one-way
    trust
-   `commit <https://pagure.io/freeipa/c/4ca671788cc54a00de6a55a2529df6126da14d88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ca671788cc54a00de6a55a2529df6126da14d88>`__
    `#6057 <https://pagure.io/freeipa/issue/6057>`__
 -  factor out \`populate_remote_domain\` method into module-level
    function
-   `commit <https://pagure.io/freeipa/c/c789b17b2e28ed9008fee076a0db72fe90f7e93f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c789b17b2e28ed9008fee076a0db72fe90f7e93f>`__
    `#6057 <https://pagure.io/freeipa/issue/6057>`__
 -  Always fetch forest info from root DCs when establishing two-way
    trust
-   `commit <https://pagure.io/freeipa/c/33f8685513e06f6a398036a78407d61c3ac2db86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33f8685513e06f6a398036a78407d61c3ac2db86>`__
    `#6057 <https://pagure.io/freeipa/issue/6057>`__
 
 
@@ -2072,382 +2072,382 @@ Martin Basti (134)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.5.0
-   `commit <https://pagure.io/freeipa/c/a0947d94c8f478d57fd20ffbcfe8bde7ee2ba80c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0947d94c8f478d57fd20ffbcfe8bde7ee2ba80c>`__
 -  Update 4.5 translations
-   `commit <https://pagure.io/freeipa/c/474e6a7a71a9e51db80367018927c078f0bf1296>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/474e6a7a71a9e51db80367018927c078f0bf1296>`__
 -  Add copy-schema-to-ca for RHEL6 to contrib/
-   `commit <https://pagure.io/freeipa/c/ca5b53adccdd581bc39233378c422ca448e6edd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca5b53adccdd581bc39233378c422ca448e6edd2>`__
    `#6540 <https://pagure.io/freeipa/issue/6540>`__
 -  Remove copy-schema-to-ca.py from master branch
-   `commit <https://pagure.io/freeipa/c/f4c7f1dd8a9ce530a8291219a904686ee47e59c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4c7f1dd8a9ce530a8291219a904686ee47e59c7>`__
    `#6540 <https://pagure.io/freeipa/issue/6540>`__
 -  pylint: bump dependency to version >= 1.6
-   `commit <https://pagure.io/freeipa/c/4514ec150586fb43fa66566cce8a69b3ac15b86c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4514ec150586fb43fa66566cce8a69b3ac15b86c>`__
 -  backup: backup anonymous keytab
-   `commit <https://pagure.io/freeipa/c/8fb61a55fe32438752567bde8af73d6b8230a386>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fb61a55fe32438752567bde8af73d6b8230a386>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  tests: use --setup-kra in tests
-   `commit <https://pagure.io/freeipa/c/25fa2bb6c9fa1b498330b13c9a6116b646eb75ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25fa2bb6c9fa1b498330b13c9a6116b646eb75ba>`__
    `#6731 <https://pagure.io/freeipa/issue/6731>`__
 -  KRA: add --setup-kra to ipa-server-install
-   `commit <https://pagure.io/freeipa/c/4006cbbc02c368ac9e5e3721613158decb34fd37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4006cbbc02c368ac9e5e3721613158decb34fd37>`__
    `#6731 <https://pagure.io/freeipa/issue/6731>`__
 -  man: add missing --setup-adtrust option to manpage
-   `commit <https://pagure.io/freeipa/c/6c95f33d37a2c346fc56d9890d594f1e40029c77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c95f33d37a2c346fc56d9890d594f1e40029c77>`__
    `#6630 <https://pagure.io/freeipa/issue/6630>`__
 -  ipactl restart: log httplib failues as debug
-   `commit <https://pagure.io/freeipa/c/53c8e9a53f026d83d5328896d1ea0cf72690cf24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53c8e9a53f026d83d5328896d1ea0cf72690cf24>`__
    `#6674 <https://pagure.io/freeipa/issue/6674>`__
 -  Tests: search for disabled users
-   `commit <https://pagure.io/freeipa/c/79b3fbf97d66adb1f5c960e5473b90f85cbe145a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79b3fbf97d66adb1f5c960e5473b90f85cbe145a>`__
 -  Test: DNS nsupdate from dns-update-system-records
-   `commit <https://pagure.io/freeipa/c/5bd82174233095a3cccfbbf8524622440c31b10c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bd82174233095a3cccfbbf8524622440c31b10c>`__
    `#6585 <https://pagure.io/freeipa/issue/6585>`__
 -  DNS: dns-update-system-record can create nsupdate file
-   `commit <https://pagure.io/freeipa/c/7eb2ef61905a5c6ddf04237f0aa84e7585e1186d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7eb2ef61905a5c6ddf04237f0aa84e7585e1186d>`__
    `#6585 <https://pagure.io/freeipa/issue/6585>`__
 -  py3: ipa_generate_password: do not compare None and Int
-   `commit <https://pagure.io/freeipa/c/dd119f8aadb13e95e4db43053bc36c70977b001e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd119f8aadb13e95e4db43053bc36c70977b001e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: change_admin_password: use textual mode
-   `commit <https://pagure.io/freeipa/c/69072cb80f8c4b7f6eff0c7cdfe6545fe59ea7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69072cb80f8c4b7f6eff0c7cdfe6545fe59ea7b5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: create DNS zonefile: use textual mode
-   `commit <https://pagure.io/freeipa/c/488d01ced715929d47f6766a63b7d6c597125562>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/488d01ced715929d47f6766a63b7d6c597125562>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: upgradeinstance: use bytes literals with LDIF operations
-   `commit <https://pagure.io/freeipa/c/47f912e16ba6de2f3579de610b0d902cf3e621a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47f912e16ba6de2f3579de610b0d902cf3e621a2>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: upgradeinstance: decode data before storing them as backup...
-   `commit <https://pagure.io/freeipa/c/7fd36e4d3651f327a8c3a2f13b92a2a304352dfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fd36e4d3651f327a8c3a2f13b92a2a304352dfd>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: upgradeinstance: open dse.ldif in textual mode
-   `commit <https://pagure.io/freeipa/c/f31d73b79aaa1746f7d32576658fcd4136870115>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f31d73b79aaa1746f7d32576658fcd4136870115>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  custodia: kem.set_keys: replace too-broad exception
-   `commit <https://pagure.io/freeipa/c/d4aa75d10582443b38447985c3fce8e65fcd48a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4aa75d10582443b38447985c3fce8e65fcd48a6>`__
 -  py3: kem.py: user bytes with ldap values
-   `commit <https://pagure.io/freeipa/c/8660b9e96801a764e808ca69c3c14a4a019d4eb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8660b9e96801a764e808ca69c3c14a4a019d4eb8>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: custodia: basedn must be unicode
-   `commit <https://pagure.io/freeipa/c/c27a46177c710fb18bf5b02beab4bd82c191a4bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c27a46177c710fb18bf5b02beab4bd82c191a4bc>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: configparser: use raw keyword
-   `commit <https://pagure.io/freeipa/c/2674a217acc2864a5fed98d7ef1e7031eae4f866>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2674a217acc2864a5fed98d7ef1e7031eae4f866>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: modify_s: attribute name must be str not bytes
-   `commit <https://pagure.io/freeipa/c/88b192a37ead1538e6d840c2f686f8d21a948542>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88b192a37ead1538e6d840c2f686f8d21a948542>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ldapupdate: fix logging str(bytes) issue
-   `commit <https://pagure.io/freeipa/c/b24787a67fd8b19b9222979a963a8f28b22153ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b24787a67fd8b19b9222979a963a8f28b22153ee>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  DNSSEC: forwarders validation improvement
-   `commit <https://pagure.io/freeipa/c/387a1513bb9dc0dc546753bfaa8a59aae8f30b83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/387a1513bb9dc0dc546753bfaa8a59aae8f30b83>`__
 -  py3: test_ipaserver: fix BytesWarnings
-   `commit <https://pagure.io/freeipa/c/a5ccdc16cbcec433ef061dfe65515e32c3021ea2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5ccdc16cbcec433ef061dfe65515e32c3021ea2>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: get_memberofindirect: fix ByteWarnings
-   `commit <https://pagure.io/freeipa/c/6bb5af7bea21d44b4e5ee20cfaa2f76b12ea0929>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bb5af7bea21d44b4e5ee20cfaa2f76b12ea0929>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: DN: fix BytesWarning
-   `commit <https://pagure.io/freeipa/c/d38540acd614bcaa489023401fc8db7c02cd3892>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d38540acd614bcaa489023401fc8db7c02cd3892>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Tests: fix wait_for_replication task
-   `commit <https://pagure.io/freeipa/c/ad1a5551d5ec716dc745f39e82d38cc634229cb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad1a5551d5ec716dc745f39e82d38cc634229cb0>`__
 -  py3: send Decimal number as string instead of base64 encoded value
-   `commit <https://pagure.io/freeipa/c/4c84341b8bc14cd19a4e2c2df4c13b95ff7eeb05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c84341b8bc14cd19a4e2c2df4c13b95ff7eeb05>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipaldap: properly encode DNSName to bytes
-   `commit <https://pagure.io/freeipa/c/ab53d80883320060769b7bfada2a813b345b9e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab53d80883320060769b7bfada2a813b345b9e4a>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: \_convert_to_idna: fix bytes/unicode mistmatch
-   `commit <https://pagure.io/freeipa/c/a584758cfb87567a9c640ae107903b0f6c9fec30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a584758cfb87567a9c640ae107903b0f6c9fec30>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: DNS: get_record_entry_attrs: do not modify dict during iteration
-   `commit <https://pagure.io/freeipa/c/03d0a55e8a21a334ca4dc625527cae93633a7314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03d0a55e8a21a334ca4dc625527cae93633a7314>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: \_ptrrecord_precallaback: use bytes with labels
-   `commit <https://pagure.io/freeipa/c/a3d3b0ad2537c9d11d9c6108c31e079f0dfcf31c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3d3b0ad2537c9d11d9c6108c31e079f0dfcf31c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: remove_entry_from_group: attribute name must be string
-   `commit <https://pagure.io/freeipa/c/a93b2bea5ce88a934ba2ab39bdaa518fb55064c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a93b2bea5ce88a934ba2ab39bdaa518fb55064c4>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: base64 encoding/decoding returns always bytes don't mix it
-   `commit <https://pagure.io/freeipa/c/caa560ca79e4038b161b27d11e3f144606dbbcdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/caa560ca79e4038b161b27d11e3f144606dbbcdb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  pki-base: use pki-base-python2 as dependency
-   `commit <https://pagure.io/freeipa/c/bd83fdf51621fe777c1f7823dcb13c4dfa26fa8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd83fdf51621fe777c1f7823dcb13c4dfa26fa8e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  pki: add missing depedency pki-base[-python3]
-   `commit <https://pagure.io/freeipa/c/66fa0585aa3a7219aa3f5b548a0a84f052d62b8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66fa0585aa3a7219aa3f5b548a0a84f052d62b8e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: x509.py: return principal as unicode string
-   `commit <https://pagure.io/freeipa/c/91ab650ac42d34d4958e33da7ef0641842511a89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91ab650ac42d34d4958e33da7ef0641842511a89>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__,
    `#6640 <https://pagure.io/freeipa/issue/6640>`__
 -  py3: tests_xmlrpc: do not call str() on bytes
-   `commit <https://pagure.io/freeipa/c/5de70e31999eb219bd47aa81b0c003a6c15cf748>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5de70e31999eb219bd47aa81b0c003a6c15cf748>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: normalize_certificate: support both bytes and unicode
-   `commit <https://pagure.io/freeipa/c/980c8a5f9e4ccbcd3c11def9cab33d0e61e945ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/980c8a5f9e4ccbcd3c11def9cab33d0e61e945ae>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: strip_header: support both bytes and unicode
-   `commit <https://pagure.io/freeipa/c/b8d6524d43dd0667184aebc79fb77a9b8a46939a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8d6524d43dd0667184aebc79fb77a9b8a46939a>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: fingerprint_hex_sha256: fix encoding/decoding
-   `commit <https://pagure.io/freeipa/c/47e76e16ef2e5d714881f3cce204611a95b4e5c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47e76e16ef2e5d714881f3cce204611a95b4e5c8>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: fix CSR encoding inside framework
-   `commit <https://pagure.io/freeipa/c/d5ab0637fe89cbcb61491fe08b7376aeaf7ccdb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5ab0637fe89cbcb61491fe08b7376aeaf7ccdb8>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Principal: validate type of input parameter
-   `commit <https://pagure.io/freeipa/c/1023cfebff99af165212dee94290a05754297270>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1023cfebff99af165212dee94290a05754297270>`__
 -  Use dict comprehension
-   `commit <https://pagure.io/freeipa/c/deaf9ae2473833dacb64c4961db3ae9f7c570ebd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deaf9ae2473833dacb64c4961db3ae9f7c570ebd>`__
 -  py3: can_read: attributelevelrights is already string
-   `commit <https://pagure.io/freeipa/c/b37d18288d40b4ec0b5a8df676456e09ae5f26c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b37d18288d40b4ec0b5a8df676456e09ae5f26c1>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: get_effective_rights: values passed to ldap must be bytes
-   `commit <https://pagure.io/freeipa/c/49333058c869dd4bd654a7974e6e144ffd3f0dc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49333058c869dd4bd654a7974e6e144ffd3f0dc3>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipaldap: update encode/decode methods
-   `commit <https://pagure.io/freeipa/c/dd3d9f1ca61946ea5d7daa17ba1d8a883922d526>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd3d9f1ca61946ea5d7daa17ba1d8a883922d526>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: rpcserver fix undefined variable
-   `commit <https://pagure.io/freeipa/c/aa036e5f332ef0b1ebbff6b824e236b1eeaf076e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa036e5f332ef0b1ebbff6b824e236b1eeaf076e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: WSGI executioners must return bytes in list
-   `commit <https://pagure.io/freeipa/c/cca9aa43e146f15e235eee1197209d0ca88eb39c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cca9aa43e146f15e235eee1197209d0ca88eb39c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: session: fix r/w ccache data
-   `commit <https://pagure.io/freeipa/c/35e135c4e3a7f0bf21ed4c838b8f76b43701a047>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35e135c4e3a7f0bf21ed4c838b8f76b43701a047>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Py3: Fix undefined variable
-   `commit <https://pagure.io/freeipa/c/7e8eb533752bbf5e2f05ec6bfb0ffefa8e9dcddf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e8eb533752bbf5e2f05ec6bfb0ffefa8e9dcddf>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: rpcserver: decode input because json requires string
-   `commit <https://pagure.io/freeipa/c/9739d0354a8ac5fd357f7d131b3f75aa05df058b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9739d0354a8ac5fd357f7d131b3f75aa05df058b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: session.py decode server name to str
-   `commit <https://pagure.io/freeipa/c/a9fec1de1aa2b3c0f4c4ec6eff25ff2e75c774b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9fec1de1aa2b3c0f4c4ec6eff25ff2e75c774b0>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Use proper logging for error messages
-   `commit <https://pagure.io/freeipa/c/f2ec44f2705fe87b71c6290ae8b35bc0a05f68d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2ec44f2705fe87b71c6290ae8b35bc0a05f68d2>`__
 -  wait_for_entry: use only DN as parameter
-   `commit <https://pagure.io/freeipa/c/38fd8b356d66553d21a3e64374fdc39427a05baf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38fd8b356d66553d21a3e64374fdc39427a05baf>`__
    `#6588 <https://pagure.io/freeipa/issue/6588>`__
 -  py3: decode bytes for json.loads()
-   `commit <https://pagure.io/freeipa/c/18337bf7f7c31a47fe0c7280f82fca043b548bd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18337bf7f7c31a47fe0c7280f82fca043b548bd5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  dogtag.py: fix exception logging of JSON data
-   `commit <https://pagure.io/freeipa/c/0eb5a0e0ec2d232d2921ae5f9e8d0885146a5610>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0eb5a0e0ec2d232d2921ae5f9e8d0885146a5610>`__
 -  py3: convert_attribute_members: don't use bytes as parameter for DN
-   `commit <https://pagure.io/freeipa/c/1e0f98a146ecedf84b8e3e07fbd41a897ddd399d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e0f98a146ecedf84b8e3e07fbd41a897ddd399d>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: make_filter_from_attr: use string instead of bytes
-   `commit <https://pagure.io/freeipa/c/746d4ffc583a847834a592150644fa4270486c89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/746d4ffc583a847834a592150644fa4270486c89>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: \__add_acl: use standard ipaldap methods
-   `commit <https://pagure.io/freeipa/c/4b148c8ca3d022020fa6caccf02729c090c8dbcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b148c8ca3d022020fa6caccf02729c090c8dbcb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: add_entry_to_group: attribute name must be string not bytes
-   `commit <https://pagure.io/freeipa/c/0a1d7f2e01819ad6e4a19d0416b3a01883dea7d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a1d7f2e01819ad6e4a19d0416b3a01883dea7d0>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: HTTPResponse has no 'dict' attribute in 'msg'
-   `commit <https://pagure.io/freeipa/c/51578882fc8456788d69a57de1a1d45ead58ba14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51578882fc8456788d69a57de1a1d45ead58ba14>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: \_httplib_request: don't convert string to bytes
-   `commit <https://pagure.io/freeipa/c/c0b5c6709d9e3a51117994fc8b605ba54e6263d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0b5c6709d9e3a51117994fc8b605ba54e6263d7>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: cainstance: replace mkstemp with NamedTemporaryFile
-   `commit <https://pagure.io/freeipa/c/232ceed5bbfb0afa45078d8e95b84dabe4d7cafd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/232ceed5bbfb0afa45078d8e95b84dabe4d7cafd>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: write CA/KRA config into file opened in text mode
-   `commit <https://pagure.io/freeipa/c/2547bca8df69e6c4d5f4c67a63fbc3c06ccc95c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2547bca8df69e6c4d5f4c67a63fbc3c06ccc95c6>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: CA/KRA: config parser requires string
-   `commit <https://pagure.io/freeipa/c/0d4074b4f1a57ed6545d819aa5a48e4b35237568>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d4074b4f1a57ed6545d819aa5a48e4b35237568>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipautil: open tempfiles in text mode
-   `commit <https://pagure.io/freeipa/c/7ae5e5f66919141821fdffbd6f8683c6d7afddd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ae5e5f66919141821fdffbd6f8683c6d7afddd7>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ldap modlist must have keys as string, not bytes
-   `commit <https://pagure.io/freeipa/c/bbe8849a654ed0764e1834f24d1837df41a79881>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe8849a654ed0764e1834f24d1837df41a79881>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: open temporary ldif file in text mode
-   `commit <https://pagure.io/freeipa/c/63b5d4a8594c5c6bc9ade69996fbbc1bcf19a2bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63b5d4a8594c5c6bc9ade69996fbbc1bcf19a2bf>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: service.py: replace mkstemp by NamedTemporaryFile
-   `commit <https://pagure.io/freeipa/c/e0641092770530e3b93c00de415172751d031210>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0641092770530e3b93c00de415172751d031210>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: create_cert_db: write to file in a compatible way
-   `commit <https://pagure.io/freeipa/c/23239bccc18f2fdc10431134a1c6a777f450704e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23239bccc18f2fdc10431134a1c6a777f450704e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  \_resolve_records: fix assert, nameserver_ip can be none
-   `commit <https://pagure.io/freeipa/c/ccea23138ba6e9b54c08d472341ddbd64ffc45df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ccea23138ba6e9b54c08d472341ddbd64ffc45df>`__
 -  Remove duplicated step from DS install
-   `commit <https://pagure.io/freeipa/c/083b4241d287a731e2cf7fed5c61b30da52a8e37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/083b4241d287a731e2cf7fed5c61b30da52a8e37>`__
 -  py3: enable py3 pylint
-   `commit <https://pagure.io/freeipa/c/d648c6a6925298a1db0c61381d72b6c4d0500c10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d648c6a6925298a1db0c61381d72b6c4d0500c10>`__
 -  Py3: Fix ToASCII method
-   `commit <https://pagure.io/freeipa/c/35ba724de90b270773d91596de310291df745df0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35ba724de90b270773d91596de310291df745df0>`__
    `#5935 <https://pagure.io/freeipa/issue/5935>`__
 -  fix: regression in API version comparison
-   `commit <https://pagure.io/freeipa/c/0663faf2585be4af3501965934703da0ede41610>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0663faf2585be4af3501965934703da0ede41610>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  ipactl: pass api as argument to services
-   `commit <https://pagure.io/freeipa/c/15351ab6e7c188fb492e6815026d1d75c4d4d29b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15351ab6e7c188fb492e6815026d1d75c4d4d29b>`__
 -  DNS: URI records: bump python-dns requirements
-   `commit <https://pagure.io/freeipa/c/a291c6ded91611ea2bd1a1fdb96314721d73a75f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a291c6ded91611ea2bd1a1fdb96314721d73a75f>`__
    `#6344 <https://pagure.io/freeipa/issue/6344>`__
 -  remove Knob function
-   `commit <https://pagure.io/freeipa/c/55b14abcb561422cf48755dae6b0638656535fe5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55b14abcb561422cf48755dae6b0638656535fe5>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  KRA: don't add KRA container when KRA replica
-   `commit <https://pagure.io/freeipa/c/61094a2a20f5cacdb7c87940d0db8d8593a87505>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61094a2a20f5cacdb7c87940d0db8d8593a87505>`__
 -  Zanata: exlude testing ipa.pot file
-   `commit <https://pagure.io/freeipa/c/ad32bf147ed6996c0967bb8e8cfb803113ceaf5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad32bf147ed6996c0967bb8e8cfb803113ceaf5f>`__
    `#6435 <https://pagure.io/freeipa/issue/6435>`__
 -  client: use correct code for failed uninstall
-   `commit <https://pagure.io/freeipa/c/847b6eddab00973740413b4c46f86940cb73d25a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/847b6eddab00973740413b4c46f86940cb73d25a>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: use exceptions instead of return states
-   `commit <https://pagure.io/freeipa/c/5249eb817efbb5708d097173a8d5f1e322fb201e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5249eb817efbb5708d097173a8d5f1e322fb201e>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: move install part to else branch
-   `commit <https://pagure.io/freeipa/c/c38ce49e8d280e52c61f722b0e5ad7aa9f53cc1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c38ce49e8d280e52c61f722b0e5ad7aa9f53cc1a>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: move install cleanup from ipa-client-install to module
-   `commit <https://pagure.io/freeipa/c/b3786730e50080fa4dadeffa86388592c10b3a62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3786730e50080fa4dadeffa86388592c10b3a62>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: move clean CCACHE to module
-   `commit <https://pagure.io/freeipa/c/bbad08900bbe8f76e59b159cd2af800f5c089ca1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbad08900bbe8f76e59b159cd2af800f5c089ca1>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: fix script execution
-   `commit <https://pagure.io/freeipa/c/8cbbb5359155446be22a5efb1e2372e527d2d745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cbbb5359155446be22a5efb1e2372e527d2d745>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: Remove useless except in ipa-client-install
-   `commit <https://pagure.io/freeipa/c/1f65c07524c8cf80996de9f6250a4e19c3a043c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f65c07524c8cf80996de9f6250a4e19c3a043c9>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: move custom env variable into client module
-   `commit <https://pagure.io/freeipa/c/83fe6b626fd2fb7f43ddf3568aaffca1ce569079>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83fe6b626fd2fb7f43ddf3568aaffca1ce569079>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: extract checks from uninstall to uninstall_check
-   `commit <https://pagure.io/freeipa/c/fcea3b3fb88ede0e9414f83ac2372e000e728587>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fcea3b3fb88ede0e9414f83ac2372e000e728587>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: extract checks from install to install_check
-   `commit <https://pagure.io/freeipa/c/3f690a0a3a7e039183eca1578a3cb13f2c0632ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f690a0a3a7e039183eca1578a3cb13f2c0632ef>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: move checks to client.install_check
-   `commit <https://pagure.io/freeipa/c/2c226ebc27e2a4e2677549003c4c70a777794296>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c226ebc27e2a4e2677549003c4c70a777794296>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: make statestore and fstore consistent with server
-   `commit <https://pagure.io/freeipa/c/33537f555636db935dd809b62498e2415d765e8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33537f555636db935dd809b62498e2415d765e8e>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  IPAChangeConf: use constant for empty line
-   `commit <https://pagure.io/freeipa/c/31a9ef4f8b8e2d6bb11f68ce34a7575ced9816aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31a9ef4f8b8e2d6bb11f68ce34a7575ced9816aa>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: import IPAChangeConf directly instead the module
-   `commit <https://pagure.io/freeipa/c/1c9267803c6f41cc7d7485024f8864fbd62c9128>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c9267803c6f41cc7d7485024f8864fbd62c9128>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: remove extra return from hardcode_ldap_server
-   `commit <https://pagure.io/freeipa/c/c30b45ab157f611312c0cd0f4f7c3a12d7a02c11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c30b45ab157f611312c0cd0f4f7c3a12d7a02c11>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: install function: return constant not hardcoded number
-   `commit <https://pagure.io/freeipa/c/cc6efb97985bb93e3cdb2a6c2943d45e1132e122>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc6efb97985bb93e3cdb2a6c2943d45e1132e122>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: remove unneded return from configure_ipa_conf
-   `commit <https://pagure.io/freeipa/c/49f201e2b2523c83fa2b20fe91c91733e2ee947f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49f201e2b2523c83fa2b20fe91c91733e2ee947f>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: remove unneded return configure_krb5_conf
-   `commit <https://pagure.io/freeipa/c/5c16608a0d5d4abe98319a077917f5424b72d031>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c16608a0d5d4abe98319a077917f5424b72d031>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  ipa-client-install: move client install to module
-   `commit <https://pagure.io/freeipa/c/f98faec47847022879b8bceb63839fcfd6e45402>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f98faec47847022879b8bceb63839fcfd6e45402>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  CI: Disable KRA install tests on DL0
-   `commit <https://pagure.io/freeipa/c/9408085c58a1e9627c1fb4e1ba0343700e36d7e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9408085c58a1e9627c1fb4e1ba0343700e36d7e7>`__
    `#6088 <https://pagure.io/freeipa/issue/6088>`__
 -  CI: use --setup-kra with replica installation
-   `commit <https://pagure.io/freeipa/c/11d7b774c4d731896e3ab6109b6ed7d5524c1bec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11d7b774c4d731896e3ab6109b6ed7d5524c1bec>`__
    `#6088 <https://pagure.io/freeipa/issue/6088>`__
 -  CI: extend replication layouts tests with KRA
-   `commit <https://pagure.io/freeipa/c/84ca1fc220c329b58fb6a22c8eb9bf17d3622c55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84ca1fc220c329b58fb6a22c8eb9bf17d3622c55>`__
    `#6088 <https://pagure.io/freeipa/issue/6088>`__
 -  CI: workaround: wait for dogtag before replica-prepare
-   `commit <https://pagure.io/freeipa/c/91b51e702f1e105329ebea29c633d94516cd673c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91b51e702f1e105329ebea29c633d94516cd673c>`__
    `#6274 <https://pagure.io/freeipa/issue/6274>`__
 -  Pylint: fix the rest of unused local variables
-   `commit <https://pagure.io/freeipa/c/4628522c532c6df0295308e5f749989c2536caa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4628522c532c6df0295308e5f749989c2536caa6>`__
 -  Pylint: remove unused variables in tests
-   `commit <https://pagure.io/freeipa/c/49b29591aa979560068449b78fd547915420ff08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49b29591aa979560068449b78fd547915420ff08>`__
 -  Pylint: remove unused variables in ipaserver package
-   `commit <https://pagure.io/freeipa/c/135047d03c1780d682998369aaa531585b39a069>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/135047d03c1780d682998369aaa531585b39a069>`__
 -  Pylint: remove unused variables from installers and scripts
-   `commit <https://pagure.io/freeipa/c/d9375881460d63cdd696bb0705da0ac205db9870>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9375881460d63cdd696bb0705da0ac205db9870>`__
 -  Fix: find OSCP certificate test
-   `commit <https://pagure.io/freeipa/c/95aa9369cb2f84ab71fa84e254d0bb3af264e97e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95aa9369cb2f84ab71fa84e254d0bb3af264e97e>`__
    `#6359 <https://pagure.io/freeipa/issue/6359>`__
 -  Pylint: enable check for unused-variables
-   `commit <https://pagure.io/freeipa/c/45e3aee35219c89c07d590003a334f8db658a3b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45e3aee35219c89c07d590003a334f8db658a3b2>`__
 -  Remove unused variables in tests
-   `commit <https://pagure.io/freeipa/c/9d83be3647547cfca4e129cfeb63771213232cf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d83be3647547cfca4e129cfeb63771213232cf7>`__
 -  Remove unused variables in the code
-   `commit <https://pagure.io/freeipa/c/0f88f8fe889ae4801fc8d5ece1ad51c5246718ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f88f8fe889ae4801fc8d5ece1ad51c5246718ac>`__
 -  test_text: add test ipa.pot file for tests
-   `commit <https://pagure.io/freeipa/c/452b08754d02b89c0e3117b83d9156e6110943c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/452b08754d02b89c0e3117b83d9156e6110943c9>`__
    `#6333 <https://pagure.io/freeipa/issue/6333>`__
 -  Pylint: enable global-variable-not-assigned check
-   `commit <https://pagure.io/freeipa/c/9b68d2a1f858854bc3cf2d6024f3fd3d79c2f696>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b68d2a1f858854bc3cf2d6024f3fd3d79c2f696>`__
 -  Pylint: enable cyclic-import check
-   `commit <https://pagure.io/freeipa/c/4d7d53c9664c9e68d7c6cda1a65cae7551423df7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d7d53c9664c9e68d7c6cda1a65cae7551423df7>`__
 -  Test: dont use global variable for iteration in test_cert_plugin
-   `commit <https://pagure.io/freeipa/c/929086e0992cc32a654b4dfa435f536ecb0c665b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/929086e0992cc32a654b4dfa435f536ecb0c665b>`__
    `#5755 <https://pagure.io/freeipa/issue/5755>`__
 -  Use constant for user and group patterns
-   `commit <https://pagure.io/freeipa/c/8f8e3d008f1de91337a83ea6d271662432209767>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f8e3d008f1de91337a83ea6d271662432209767>`__
    `#5822 <https://pagure.io/freeipa/issue/5822>`__
 -  Fix regexp patterns in parameters to not enforce length
-   `commit <https://pagure.io/freeipa/c/37200806118d39ef8afe84ad5887a294d54e2659>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37200806118d39ef8afe84ad5887a294d54e2659>`__
    `#5822 <https://pagure.io/freeipa/issue/5822>`__
 -  Add check for IP addresses into DNS installer
-   `commit <https://pagure.io/freeipa/c/d13a4c2f395c08b514a51a19eaad3fa7d32e7538>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d13a4c2f395c08b514a51a19eaad3fa7d32e7538>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Fix missing config.ips in promote_check
-   `commit <https://pagure.io/freeipa/c/cd2c10d7ca97ffc76682159ad58161eab413532d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd2c10d7ca97ffc76682159ad58161eab413532d>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Abstract procedures for IP address warnings
-   `commit <https://pagure.io/freeipa/c/1c96ff7a6c7e1733a6492f9b3c93265f5bc8ff5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c96ff7a6c7e1733a6492f9b3c93265f5bc8ff5b>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Catch DNS exceptions during emptyzones named.conf upgrade
-   `commit <https://pagure.io/freeipa/c/271a4f098230112ee0e3ea3ffb3a509977ee7330>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/271a4f098230112ee0e3ea3ffb3a509977ee7330>`__
    `#6205 <https://pagure.io/freeipa/issue/6205>`__
 -  Start named during configuration upgrade.
-   `commit <https://pagure.io/freeipa/c/22fd6f020940b5b2a1258f8e0e6058c95f7a1ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22fd6f020940b5b2a1258f8e0e6058c95f7a1ba5>`__
    `#6205 <https://pagure.io/freeipa/issue/6205>`__
 -  Tests: extend DNS cmdline tests with lowercased record type
-   `commit <https://pagure.io/freeipa/c/866e59bdcee74ea9aea4e65f193339ae9cab5ce3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/866e59bdcee74ea9aea4e65f193339ae9cab5ce3>`__
    `#6203 <https://pagure.io/freeipa/issue/6203>`__
 -  Show warning when net/broadcast IP address is used in installer
-   `commit <https://pagure.io/freeipa/c/b232ad463cf43596cdf397e51469df13a89e83fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b232ad463cf43596cdf397e51469df13a89e83fa>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Allow multicast addresses in A/AAAA records
-   `commit <https://pagure.io/freeipa/c/f3d379071a9af50e38fcc07491bc68b8d3d172a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3d379071a9af50e38fcc07491bc68b8d3d172a4>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Allow broadcast ip addresses
-   `commit <https://pagure.io/freeipa/c/71ad8d4fc982b5349248d50338e1d16ce45c523e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71ad8d4fc982b5349248d50338e1d16ce45c523e>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Allow network ip addresses
-   `commit <https://pagure.io/freeipa/c/81d64d530cca148198312d3d993502575b288f63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81d64d530cca148198312d3d993502575b288f63>`__
    `#5814 <https://pagure.io/freeipa/issue/5814>`__
 -  Fix parse errors with link-local addresses
-   `commit <https://pagure.io/freeipa/c/db55bde15dd83a0ed29205a127cefabe691e81b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db55bde15dd83a0ed29205a127cefabe691e81b1>`__
    `#6296 <https://pagure.io/freeipa/issue/6296>`__
 -  Fix ScriptError to always return string from \__str_\_
-   `commit <https://pagure.io/freeipa/c/00d43095da211f542189c95c88fc2e2c32e75565>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00d43095da211f542189c95c88fc2e2c32e75565>`__
    `#6294 <https://pagure.io/freeipa/issue/6294>`__
 -  Bump master IPA devel version to 4.4.90
-   `commit <https://pagure.io/freeipa/c/371254fc4b36cb4d89351edb19c88a85e5a33a1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/371254fc4b36cb4d89351edb19c88a85e5a33a1b>`__
 
 
 
@@ -2455,7 +2455,7 @@ Martin Kosek (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update Contributors.txt
-   `commit <https://pagure.io/freeipa/c/b367c3a622c8c8b96777e4ce50334d2a4477bbe7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b367c3a622c8c8b96777e4ce50334d2a4477bbe7>`__
 
 
 
@@ -2463,16 +2463,16 @@ Milan Kubík (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fix assert_deepequal outside of pytest process
-   `commit <https://pagure.io/freeipa/c/e54109c167526ae6b1cd4c977915da884482891b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e54109c167526ae6b1cd4c977915da884482891b>`__
    `#6420 <https://pagure.io/freeipa/issue/6420>`__
 -  ipatests: Implement tests with CSRs requesting SAN
-   `commit <https://pagure.io/freeipa/c/10b4b155b6b411ab339bce92c1a335b4914cfc1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10b4b155b6b411ab339bce92c1a335b4914cfc1c>`__
    `#6366 <https://pagure.io/freeipa/issue/6366>`__
 -  ipatests: Fix name property on a service tracker
-   `commit <https://pagure.io/freeipa/c/7eb78aa8dbc167c36869ddd6cfa525139aff7bbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7eb78aa8dbc167c36869ddd6cfa525139aff7bbc>`__
    `#6366 <https://pagure.io/freeipa/issue/6366>`__
 -  ipatests: provide context manager for keytab usage in RPC tests
-   `commit <https://pagure.io/freeipa/c/4f8e212c428b1fff63f38ea15d7ce9f230085c5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f8e212c428b1fff63f38ea15d7ce9f230085c5c>`__
    `#6366 <https://pagure.io/freeipa/issue/6366>`__
 
 
@@ -2481,7 +2481,7 @@ Michal Reznik (1)
 ----------------------------------------------------------------------------------------------
 
 -  test_csrgen: adjusted comparison test scripts for CSRGenerator
-   `commit <https://pagure.io/freeipa/c/83e2c2b65eeb5a3aa4a59c0535e9177aac5e4637>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83e2c2b65eeb5a3aa4a59c0535e9177aac5e4637>`__
    `#6724 <https://pagure.io/freeipa/issue/6724>`__
 
 
@@ -2490,7 +2490,7 @@ Michal Židek (1)
 ----------------------------------------------------------------------------------------------
 
 -  git: Add commit template
-   `commit <https://pagure.io/freeipa/c/2df709838905dec3ee2c2eaec47f506336d85a6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2df709838905dec3ee2c2eaec47f506336d85a6e>`__
 
 
 
@@ -2498,12 +2498,12 @@ Nathaniel McCallum (3)
 ----------------------------------------------------------------------------------------------
 
 -  Migrate OTP import script to python-cryptography
-   `commit <https://pagure.io/freeipa/c/d00ae870dda2889545c9d93e82e44526bfd4f431>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d00ae870dda2889545c9d93e82e44526bfd4f431>`__
    `#5192 <https://pagure.io/freeipa/issue/5192>`__
 -  Use RemoveOnStop to cleanup systemd sockets
-   `commit <https://pagure.io/freeipa/c/d05d1115e409962fee3576a4bfc5cecfacef4fd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d05d1115e409962fee3576a4bfc5cecfacef4fd3>`__
 -  Properly handle LDAP socket closures in ipa-otpd
-   `commit <https://pagure.io/freeipa/c/0756ce7d53133793b82674757e125524eede4721>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0756ce7d53133793b82674757e125524eede4721>`__
    `#6368 <https://pagure.io/freeipa/issue/6368>`__
 
 
@@ -2512,111 +2512,111 @@ Oleg Fayans (45)
 ----------------------------------------------------------------------------------------------
 
 -  Test: uniqueness of certificate renewal master
-   `commit <https://pagure.io/freeipa/c/fad87a9962ee33cfebc4fa59aba589e98b076cea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fad87a9962ee33cfebc4fa59aba589e98b076cea>`__
    `#6504 <https://pagure.io/freeipa/issue/6504>`__
 -  Test: basic kerberos over http functionality
-   `commit <https://pagure.io/freeipa/c/503d0929e9265dfc0c6c28ac49146b72a0a7edea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/503d0929e9265dfc0c6c28ac49146b72a0a7edea>`__
    `#6446 <https://pagure.io/freeipa/issue/6446>`__
 -  Test: made kinit_admin a returning function
-   `commit <https://pagure.io/freeipa/c/c7fd46e42a9f5b4676415910b800e0340f77dc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7fd46e42a9f5b4676415910b800e0340f77dc88>`__
 -  tests: Added basic tests for certs in idoverrides
-   `commit <https://pagure.io/freeipa/c/452dc97aba12288a23c20f519f4c1c0d4408b765>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/452dc97aba12288a23c20f519f4c1c0d4408b765>`__
    `#6412 <https://pagure.io/freeipa/issue/6412>`__
 -  Created idview tracker
-   `commit <https://pagure.io/freeipa/c/ccd3677b50eab2223ddf1e1b6682c20fc695ad24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ccd3677b50eab2223ddf1e1b6682c20fc695ad24>`__
    `#6412 <https://pagure.io/freeipa/issue/6412>`__
 -  Test for installing rules with service principals
-   `commit <https://pagure.io/freeipa/c/232a0391d33429a71da865c55be582ebdbc5b3db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/232a0391d33429a71da865c55be582ebdbc5b3db>`__
    `#6481 <https://pagure.io/freeipa/issue/6481>`__
 -  Test: integration tests for certs in idoverrides feature
-   `commit <https://pagure.io/freeipa/c/91c8911a9efc32024cb8bf29af26f61cf3a24e28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91c8911a9efc32024cb8bf29af26f61cf3a24e28>`__
    `#6005 <https://pagure.io/freeipa/issue/6005>`__
 -  Added interface to certutil
-   `commit <https://pagure.io/freeipa/c/f1c9c56f40b542068b512e2010d40e87a2dd83df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1c9c56f40b542068b512e2010d40e87a2dd83df>`__
 -  Automated ipa-replica-manage del tests
-   `commit <https://pagure.io/freeipa/c/dc58f8f2a17adc642ae6f32fe9c9eb05d993c9d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc58f8f2a17adc642ae6f32fe9c9eb05d993c9d0>`__
 -  tests: Automated clean-ruv subcommand tests
-   `commit <https://pagure.io/freeipa/c/6d812a0d52ff89dd337aac50c1a107c9dddce73f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d812a0d52ff89dd337aac50c1a107c9dddce73f>`__
    `#6451 <https://pagure.io/freeipa/issue/6451>`__
 -  Reverted the essertion for replica uninstall returncode
-   `commit <https://pagure.io/freeipa/c/5710ecddcaea7b00fbbc2ee24b845f7a4ac90f57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5710ecddcaea7b00fbbc2ee24b845f7a4ac90f57>`__
    `#6401 <https://pagure.io/freeipa/issue/6401>`__
 -  Test: disabled wrong client domain tests for domlevel 0
-   `commit <https://pagure.io/freeipa/c/8b0faa25d1c47f605bc6c91933469bb2370276c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b0faa25d1c47f605bc6c91933469bb2370276c1>`__
    `#6382 <https://pagure.io/freeipa/issue/6382>`__
 -  tests: Fixed code styling in caless tests to make pep8 happy
-   `commit <https://pagure.io/freeipa/c/47c808afa35f0708ca00ac8e98851c9f8d75badc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47c808afa35f0708ca00ac8e98851c9f8d75badc>`__
 -  tests: Reverted erroneous asserts in 4 tests
-   `commit <https://pagure.io/freeipa/c/9870c5804a65ae320ebbcb313f8facb21963f710>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9870c5804a65ae320ebbcb313f8facb21963f710>`__
 -  tests: fixed certinstall method
-   `commit <https://pagure.io/freeipa/c/7412f0cb20801e1608f8cf388210e57ef7d27497>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7412f0cb20801e1608f8cf388210e57ef7d27497>`__
 -  tests: fixed super method invocation
-   `commit <https://pagure.io/freeipa/c/f1f94a7b9fe354d93f31ce8cd606d985dd44703b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1f94a7b9fe354d93f31ce8cd606d985dd44703b>`__
 -  tests: added verbose assert to test_service_disable_doesnt_revoke
-   `commit <https://pagure.io/freeipa/c/8be0906b04bbf995af6326b560151d15901b544e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8be0906b04bbf995af6326b560151d15901b544e>`__
 -  tests: Standardized replica_preparation in test_no_certs
-   `commit <https://pagure.io/freeipa/c/106f37c26f64492f771214409d229feb5d70a113>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/106f37c26f64492f771214409d229feb5d70a113>`__
 -  tests: Implemented check for domainlevel before installation
    verification
-   `commit <https://pagure.io/freeipa/c/b8968d923cedbbeb931c3ed33b81b299a55baf4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8968d923cedbbeb931c3ed33b81b299a55baf4a>`__
 -  tests: Fixed Usage of improper certs in ca-less tests
-   `commit <https://pagure.io/freeipa/c/43994e669743bb8f54e32b52f2410ebde3660f04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43994e669743bb8f54e32b52f2410ebde3660f04>`__
 -  tests: fixed expects of incorrect error messages
-   `commit <https://pagure.io/freeipa/c/804aae81966f23e307ec86364489f808fd0c3357>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/804aae81966f23e307ec86364489f808fd0c3357>`__
 -  tests: Replaced unused setUp method with install
-   `commit <https://pagure.io/freeipa/c/b8cf212e8bbe301f6d44551ecac063d12a042520>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8cf212e8bbe301f6d44551ecac063d12a042520>`__
 -  tests: Replaced hardcoded certutil with imported from paths
-   `commit <https://pagure.io/freeipa/c/dbf0d141c5a4d1ccd1b681ac49cb57e47234aaa4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbf0d141c5a4d1ccd1b681ac49cb57e47234aaa4>`__
 -  tests: Enabled negative testing for cleaning replication agreements
-   `commit <https://pagure.io/freeipa/c/bb4205b582038669888544786a5611b18e52bf42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb4205b582038669888544786a5611b18e52bf42>`__
 -  tests: Made unapply_fixes call optional at master uninstallation
-   `commit <https://pagure.io/freeipa/c/9217bcc871468615110c85b1131b62735f9e5092>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9217bcc871468615110c85b1131b62735f9e5092>`__
 -  tests: Updated master and replica installation methods to enable
    negative testing
-   `commit <https://pagure.io/freeipa/c/e0b67dfa7e957cc134043b265b87ed71bb09a7d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0b67dfa7e957cc134043b265b87ed71bb09a7d3>`__
 -  tests: Added necessary xfails
-   `commit <https://pagure.io/freeipa/c/24f218f4ebe203213eebede59ff79b89c657ee76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24f218f4ebe203213eebede59ff79b89c657ee76>`__
 -  tests: Added necessary getkeytabs calls to fixtures
-   `commit <https://pagure.io/freeipa/c/d17d13d77a7c09cbc99c8bb0a3f7af3b72da8aca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d17d13d77a7c09cbc99c8bb0a3f7af3b72da8aca>`__
 -  tests: Removed outdated command options test
-   `commit <https://pagure.io/freeipa/c/759bbcdfcbeade91c77b201c439c939d6477cd08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/759bbcdfcbeade91c77b201c439c939d6477cd08>`__
 -  tests: Applied correct teardown methods
-   `commit <https://pagure.io/freeipa/c/a81d8472042f4909020c073ecb00a37d8e05ec33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a81d8472042f4909020c073ecb00a37d8e05ec33>`__
 -  tests: Fixed incorrect assert in verify_installation
-   `commit <https://pagure.io/freeipa/c/84db13f676771746f9ab7769073837a29f6de464>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84db13f676771746f9ab7769073837a29f6de464>`__
 -  tests: Adapted installation methods to utilize methods from tasks
-   `commit <https://pagure.io/freeipa/c/fad6ec8256a97fbf06b3e4509d93af1d159e6b81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fad6ec8256a97fbf06b3e4509d93af1d159e6b81>`__
 -  tests: Removed call for install method from parent class
-   `commit <https://pagure.io/freeipa/c/725d8d0cac16f6a41ad54ae319e3822d44047031>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/725d8d0cac16f6a41ad54ae319e3822d44047031>`__
 -  tests: Added teardown methods for server and replica installation
-   `commit <https://pagure.io/freeipa/c/48ca465a12a91977eb57bb791cf0b098e5e5a4b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48ca465a12a91977eb57bb791cf0b098e5e5a4b3>`__
 -  tests: Create a method that cleans all ipa certs
-   `commit <https://pagure.io/freeipa/c/c0e16aa3b9c380fb7936dc18c4bfc04e7f8327b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0e16aa3b9c380fb7936dc18c4bfc04e7f8327b5>`__
 -  tests: Updated ipa server installation stdin text
-   `commit <https://pagure.io/freeipa/c/38ad864342bb3fcbf65397b763c240f034f3e2c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38ad864342bb3fcbf65397b763c240f034f3e2c7>`__
 -  tests: Added generation of missing certs
-   `commit <https://pagure.io/freeipa/c/0c635686ddc6dbba54285a9c7844e12342083b9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c635686ddc6dbba54285a9c7844e12342083b9b>`__
 -  tests: Added basic constraints extension to the CA certs
-   `commit <https://pagure.io/freeipa/c/2f6ffa326adb4d4e9152463ffa733d559f7be2af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f6ffa326adb4d4e9152463ffa733d559f7be2af>`__
 -  tests: Fixed method failures during second call for the method
-   `commit <https://pagure.io/freeipa/c/bbac233b5ee487ab0e035cf0b861144769a0b738>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbac233b5ee487ab0e035cf0b861144769a0b738>`__
    `#5880 <https://pagure.io/freeipa/issue/5880>`__
 -  Xfailed a test that fails due to 6250
-   `commit <https://pagure.io/freeipa/c/3e4740f788aee00ae03a61d39238f605779fcece>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e4740f788aee00ae03a61d39238f605779fcece>`__
    `#6250 <https://pagure.io/freeipa/issue/6250>`__
 -  Fixed segment naming in topology tests
-   `commit <https://pagure.io/freeipa/c/49fbbb0641df2adab28fd3440686cb7430645c85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49fbbb0641df2adab28fd3440686cb7430645c85>`__
 -  Xfailed the tests due to a known bug with replica preparation
-   `commit <https://pagure.io/freeipa/c/1e484d010b653b8ac06425ca602ba5c9e950ed89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e484d010b653b8ac06425ca602ba5c9e950ed89>`__
    `#6274 <https://pagure.io/freeipa/issue/6274>`__
 -  Changed addressing to the client hosts to be replicas
-   `commit <https://pagure.io/freeipa/c/ac78d191ded6721cf1051413cdd6862c0362e66b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac78d191ded6721cf1051413cdd6862c0362e66b>`__
    `#6287 <https://pagure.io/freeipa/issue/6287>`__
 -  Several fixes in replica_promotion tests
-   `commit <https://pagure.io/freeipa/c/39c15ecdcdcbc2a0b651b0f89080789dd806e998>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39c15ecdcdcbc2a0b651b0f89080789dd806e998>`__
    `#6301 <https://pagure.io/freeipa/issue/6301>`__
 -  Removed incorrect check for returncode
-   `commit <https://pagure.io/freeipa/c/22b0e8a9eb9eb3d47131c6784d70dd409d5b889b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22b0e8a9eb9eb3d47131c6784d70dd409d5b889b>`__
    `#6300 <https://pagure.io/freeipa/issue/6300>`__
 
 
@@ -2625,7 +2625,7 @@ Petr Čech (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: nested netgroups (intg)
-   `commit <https://pagure.io/freeipa/c/dc99d3c04e43b08d2364209a641b8b9111e5986c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc99d3c04e43b08d2364209a641b8b9111e5986c>`__
    `#6439 <https://pagure.io/freeipa/issue/6439>`__
 
 
@@ -2634,388 +2634,388 @@ Petr Spacek (126)
 ----------------------------------------------------------------------------------------------
 
 -  ipa_generate_password algorithm change
-   `commit <https://pagure.io/freeipa/c/fb7c111ac13510609e2cba14ecf88cd2ed291a4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb7c111ac13510609e2cba14ecf88cd2ed291a4b>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove named-pkcs11 workarounds from DNSSEC tests.
-   `commit <https://pagure.io/freeipa/c/8bc677512296a7e94c29edd0c1a96aa7273f352a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8bc677512296a7e94c29edd0c1a96aa7273f352a>`__
    `#5348 <https://pagure.io/freeipa/issue/5348>`__
 -  Build: forbid builds in working directories containing white spaces
-   `commit <https://pagure.io/freeipa/c/19aba7c555edf065b9f2fa95142da81b92396264>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19aba7c555edf065b9f2fa95142da81b92396264>`__
    `#6537 <https://pagure.io/freeipa/issue/6537>`__
 -  Build: always use Pylint from Python version used for rest of the
    build
-   `commit <https://pagure.io/freeipa/c/9c87c39e65547004031284080749bc66dab1a8f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c87c39e65547004031284080749bc66dab1a8f9>`__
    `#157 <https://pagure.io/freeipa/issue/157>`__
 -  Build: specify BuildRequires for Python 3 pylint
-   `commit <https://pagure.io/freeipa/c/21a0987601dc4fa9de3fe63a18a604337a5edb7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21a0987601dc4fa9de3fe63a18a604337a5edb7b>`__
    `#157 <https://pagure.io/freeipa/issue/157>`__
 -  Build: makerpms.sh generates Python 2 & 3 packages at the same time
-   `commit <https://pagure.io/freeipa/c/b7d70baee73c64898de91e2fa59b3f9f417c8e01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7d70baee73c64898de91e2fa59b3f9f417c8e01>`__
    `#157 <https://pagure.io/freeipa/issue/157>`__
 -  Accept server host names resolvable only using /etc/hosts
-   `commit <https://pagure.io/freeipa/c/0e093f938d8126f11fed920b7381ba6e3d07da5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e093f938d8126f11fed920b7381ba6e3d07da5b>`__
    `#6518 <https://pagure.io/freeipa/issue/6518>`__
 -  Build: properly integrate ipa.pot into build system tests
-   `commit <https://pagure.io/freeipa/c/a89f63c5a62c4a02fc248a095f539a099a9c28c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a89f63c5a62c4a02fc248a095f539a099a9c28c5>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: properly integrate ipasetup.py into build system
-   `commit <https://pagure.io/freeipa/c/6aa360775a781bee5a2fdd884cbfa33b545fcbb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6aa360775a781bee5a2fdd884cbfa33b545fcbb4>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: properly integrate version.py into build system
-   `commit <https://pagure.io/freeipa/c/6fcfe689f47a02df023de69f62c889d9b4dc26fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fcfe689f47a02df023de69f62c889d9b4dc26fe>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: properly integrate loader.js into build system
-   `commit <https://pagure.io/freeipa/c/89739a6c910461a3cac3abc1bf2ff162c7c5bc82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89739a6c910461a3cac3abc1bf2ff162c7c5bc82>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: properly integrate freeipa.spec.in into build system
-   `commit <https://pagure.io/freeipa/c/6857de02f3a9c2d7e99e33863be3c65f71fa0d58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6857de02f3a9c2d7e99e33863be3c65f71fa0d58>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: properly integrate ipa-version.h.in into build system
-   `commit <https://pagure.io/freeipa/c/ba6ae666acaf8b930d18f45efc7c9c9faad3526b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba6ae666acaf8b930d18f45efc7c9c9faad3526b>`__
    `#6498 <https://pagure.io/freeipa/issue/6498>`__
 -  Build: workaround bug while calling parallel make from rpmbuild
-   `commit <https://pagure.io/freeipa/c/132b475c2586f3ced68724355e9c45722dccf604>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132b475c2586f3ced68724355e9c45722dccf604>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove ipa.pot from Git as it can be re-generated at any time
-   `commit <https://pagure.io/freeipa/c/4c133837d149352a68e1d6cbefbb28e4ae048755>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c133837d149352a68e1d6cbefbb28e4ae048755>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: integrate translation system tests again
-   `commit <https://pagure.io/freeipa/c/8a7962585069d7b0ff7e8d87ce094f07c16b3cd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a7962585069d7b0ff7e8d87ce094f07c16b3cd4>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: automatically generate list of files to be translated in
    configure
-   `commit <https://pagure.io/freeipa/c/9ef5a7de781f2508c2925225533973417458d0ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ef5a7de781f2508c2925225533973417458d0ea>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: clean in po/ removes \*~ files as well
-   `commit <https://pagure.io/freeipa/c/166257ec5b33dd2c95bbaf8463867c77fd6ef5db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/166257ec5b33dd2c95bbaf8463867c77fd6ef5db>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: support strip-po target for translations
-   `commit <https://pagure.io/freeipa/c/d40c376ccc1ec9292df0306134c7bfdfd096566e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d40c376ccc1ec9292df0306134c7bfdfd096566e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: use standard infrastructure for translations
-   `commit <https://pagure.io/freeipa/c/4842231074683ff68be50b147560f5383aa305b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4842231074683ff68be50b147560f5383aa305b6>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix path in ipa-ods-exporter.socket unit file
-   `commit <https://pagure.io/freeipa/c/5862eaa1a0e3fbced79d6c209016c1138e692888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5862eaa1a0e3fbced79d6c209016c1138e692888>`__
    `#6495 <https://pagure.io/freeipa/issue/6495>`__
 -  Build: fix file dependencies for make-css.sh
-   `commit <https://pagure.io/freeipa/c/6b9977f04199bf161d7171aedae9f97648c415c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b9977f04199bf161d7171aedae9f97648c415c8>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: update makerpms.sh to use same paths as rpmbuild
-   `commit <https://pagure.io/freeipa/c/e2060e8e5562ed6a4fe760eba1babb5c1761576a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2060e8e5562ed6a4fe760eba1babb5c1761576a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove incorrect use of MAINTAINERCLEANFILES
-   `commit <https://pagure.io/freeipa/c/d5683726d290b71eb44ab3b3150381f062e74df1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5683726d290b71eb44ab3b3150381f062e74df1>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: enable silent build in makerpms.sh
-   `commit <https://pagure.io/freeipa/c/1cbd823990da0e931b666c4bc5c72f10d9de8115>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cbd823990da0e931b666c4bc5c72f10d9de8115>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: support --enable-silent-rules for Python packages
-   `commit <https://pagure.io/freeipa/c/46b6b9e3091d08412912c37f46af497ddd0b8afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46b6b9e3091d08412912c37f46af497ddd0b8afb>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: workaround bug 1005235 related to Python paths in
    auto-generated Requires
-   `commit <https://pagure.io/freeipa/c/27e7a89a6289d0d3009f5f7feb9802b7db171a15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27e7a89a6289d0d3009f5f7feb9802b7db171a15>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: document what should be in %install section of SPEC file
-   `commit <https://pagure.io/freeipa/c/5a5373464fa67289c9a178b1c0569f585dc6dc34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a5373464fa67289c9a178b1c0569f585dc6dc34>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: move web UI file installation from SPEC to Makefile.am
-   `commit <https://pagure.io/freeipa/c/1fa0ed954bb45b6e3858c1c54470b1d16ab204d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fa0ed954bb45b6e3858c1c54470b1d16ab204d9>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: move server directory handling from SPEC to Makefile.am
-   `commit <https://pagure.io/freeipa/c/20918579acb43391d5d04ee8050b37142a55df76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20918579acb43391d5d04ee8050b37142a55df76>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: move client directory handling from SPEC to Makefile.am
-   `commit <https://pagure.io/freeipa/c/636aaa7dbc649e685233f382cb8dd424345bebd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/636aaa7dbc649e685233f382cb8dd424345bebd3>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Update man page for ipa-adtrust-install by removing --no-msdcs option
-   `commit <https://pagure.io/freeipa/c/623cc428cfd79ea228bda6e88dc48bad9aaf61aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/623cc428cfd79ea228bda6e88dc48bad9aaf61aa>`__
    `#6480 <https://pagure.io/freeipa/issue/6480>`__
 -  Build: pass down %{release} from SPEC to configure
-   `commit <https://pagure.io/freeipa/c/961773bd0455e6fc723dbbed4f53e4b483360c32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/961773bd0455e6fc723dbbed4f53e4b483360c32>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: update IPA_VERSION_IS_GIT_SNAPSHOT to comply with PEP440
-   `commit <https://pagure.io/freeipa/c/8c81c6c5b8ea62addbc175308a4e357c75d65ef0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c81c6c5b8ea62addbc175308a4e357c75d65ef0>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add make srpms target
-   `commit <https://pagure.io/freeipa/c/0023fb59240cb53a541763a89db038c186312154>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0023fb59240cb53a541763a89db038c186312154>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: IPA_VERSION_IS_GIT_SNAPSHOT re-generates version number on RPM
    build
-   `commit <https://pagure.io/freeipa/c/a691b7d1837595fecd37bf88a875cb0753f7e698>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a691b7d1837595fecd37bf88a875cb0753f7e698>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: use POSIX 1003.1-1988 (ustar) file format for tar archives
-   `commit <https://pagure.io/freeipa/c/3dc5d2c6f9a0fc134616c615634ae505ef753f77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dc5d2c6f9a0fc134616c615634ae505ef753f77>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: IPA_VERSION_IS_GIT_SNAPSHOT checks if source directory is Git
    repo
-   `commit <https://pagure.io/freeipa/c/f6f5708a5ac56392f7a4b82f63c5e16cc1f1fd99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6f5708a5ac56392f7a4b82f63c5e16cc1f1fd99>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove unused and redundant code from configure.ac and
    po/Makefile.in
-   `commit <https://pagure.io/freeipa/c/394edf5f055766fa0cdf70afab6d263f75d0d065>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/394edf5f055766fa0cdf70afab6d263f75d0d065>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix make clean to remove build artifacts from top-level
    directory
-   `commit <https://pagure.io/freeipa/c/d20f6a5ef2467e780026f1040f5a11a7a77594ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d20f6a5ef2467e780026f1040f5a11a7a77594ca>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix make clean for web UI
-   `commit <https://pagure.io/freeipa/c/c0674e89d1e6b5abd82cf3b7bf8054eec0fa6418>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0674e89d1e6b5abd82cf3b7bf8054eec0fa6418>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add polint target for i18n tests
-   `commit <https://pagure.io/freeipa/c/4498998f1763d673056423a73d3b3ff22f94954f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4498998f1763d673056423a73d3b3ff22f94954f>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add makeapi lint target
-   `commit <https://pagure.io/freeipa/c/e3b537af18afa03b1f04530b42cdba5c1fc3ff97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3b537af18afa03b1f04530b42cdba5c1fc3ff97>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add makeaci lint target
-   `commit <https://pagure.io/freeipa/c/b54e9e86dfaed1320f7ccce560f82c233f67bf1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b54e9e86dfaed1320f7ccce560f82c233f67bf1a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add JS lint target
-   `commit <https://pagure.io/freeipa/c/f31a489d246e01250536b7187225fb7ca6398ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f31a489d246e01250536b7187225fb7ca6398ba5>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add Python lint target
-   `commit <https://pagure.io/freeipa/c/14c1c8dfd0aa894af2d60dfa4f2ce2510d791328>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14c1c8dfd0aa894af2d60dfa4f2ce2510d791328>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove obsolete instructions about BuildRequires from
    BUILD.txt
-   `commit <https://pagure.io/freeipa/c/2df98772556de0d964028bbb78a9efbdd13ecd40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2df98772556de0d964028bbb78a9efbdd13ecd40>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: add make rpms target and convenience script makerpms.sh
-   `commit <https://pagure.io/freeipa/c/fee9bbd85afeac3593abd791de2d002bed300c8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fee9bbd85afeac3593abd791de2d002bed300c8e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix KDC proxy installation and remove unused kdcproxy.conf
-   `commit <https://pagure.io/freeipa/c/75a944e980c64061e51f4ec7215033c118f39863>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75a944e980c64061e51f4ec7215033c118f39863>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove unused dirs /var/cache/ipa/{sysupgrade,sysrestore} from
    SPEC
-   `commit <https://pagure.io/freeipa/c/4ce3aa3b12004ca4eb29e4bbca415a585fbd432f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ce3aa3b12004ca4eb29e4bbca415a585fbd432f>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: do not compress manual pages at install time
-   `commit <https://pagure.io/freeipa/c/dc5699a8a40dd27ffd25d9ad3185ba40d93ec95b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc5699a8a40dd27ffd25d9ad3185ba40d93ec95b>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: distribute doc directory
-   `commit <https://pagure.io/freeipa/c/cc6382550fcf32bd4b843c922c10c5a5d247dd38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc6382550fcf32bd4b843c922c10c5a5d247dd38>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: create /var/run directories at install time
-   `commit <https://pagure.io/freeipa/c/6cb0271509fe95ae38fc743f2a13faf32fe29a99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cb0271509fe95ae38fc743f2a13faf32fe29a99>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: integrate init and init/systemd into build system
-   `commit <https://pagure.io/freeipa/c/288d624336d502a7df9856cdc2f6543b6e7c0b79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/288d624336d502a7df9856cdc2f6543b6e7c0b79>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove init/SystemV directory
-   `commit <https://pagure.io/freeipa/c/a027bf739848371fa91b5ba9766e031c9003d322>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a027bf739848371fa91b5ba9766e031c9003d322>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: integrate contrib directory into build system
-   `commit <https://pagure.io/freeipa/c/d3cab75d7e79fbc89ef08df3e6d2b1e28b4ef163>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3cab75d7e79fbc89ef08df3e6d2b1e28b4ef163>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove ancient checks/check-ra.py
-   `commit <https://pagure.io/freeipa/c/8ffd3bdf142f0f852918186ce0a338a7818bbe8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ffd3bdf142f0f852918186ce0a338a7818bbe8e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: integrate daemons/dnssec into build system
-   `commit <https://pagure.io/freeipa/c/312e780041fc9025ca3c189e6c9fcb54c7340714>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/312e780041fc9025ca3c189e6c9fcb54c7340714>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/topology files
-   `commit <https://pagure.io/freeipa/c/f229bb56b73487758ed9bd9c7f0a4cc74134992b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f229bb56b73487758ed9bd9c7f0a4cc74134992b>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-winsync
    files
-   `commit <https://pagure.io/freeipa/c/39b17ef2abd885ab87c1a39d3036f762b6b084c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39b17ef2abd885ab87c1a39d3036f762b6b084c8>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-sidgen files
-   `commit <https://pagure.io/freeipa/c/74820fe3d8774244476357036406014680d54211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74820fe3d8774244476357036406014680d54211>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-pwd-extop
    files
-   `commit <https://pagure.io/freeipa/c/53cd71a63c7d6ba97a5593e5a8922af71c5a4b6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53cd71a63c7d6ba97a5593e5a8922af71c5a4b6f>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of
    daemons/ipa-slapi-plugins/ipa-otp-lasttoken files
-   `commit <https://pagure.io/freeipa/c/278cda7ede3777f61f31ec77199d02954512e133>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/278cda7ede3777f61f31ec77199d02954512e133>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-otp-counter
    files
-   `commit <https://pagure.io/freeipa/c/c1652f92af6bea13ecd96c0ad7be38784e2faeb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1652f92af6bea13ecd96c0ad7be38784e2faeb5>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-exdom-extop
    files
-   `commit <https://pagure.io/freeipa/c/14bce67cf0cad1aecc132a2c67ad2dc686bcd2af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14bce67cf0cad1aecc132a2c67ad2dc686bcd2af>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-cldap files
-   `commit <https://pagure.io/freeipa/c/4fb2f535ca73dd16738ce4a3b692931fb26227aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fb2f535ca73dd16738ce4a3b692931fb26227aa>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of ipa-slapi-plugins/common files
-   `commit <https://pagure.io/freeipa/c/684a2c6a58b99a72f68e4c7f827d6601007cea26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/684a2c6a58b99a72f68e4c7f827d6601007cea26>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of daemon/ipa-kdb files
-   `commit <https://pagure.io/freeipa/c/125bf25577e58d11252cb41d34065d49f581e0ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/125bf25577e58d11252cb41d34065d49f581e0ac>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of client header file
-   `commit <https://pagure.io/freeipa/c/0d5fe1dba0459b09bc7518d34c58444c96435801>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d5fe1dba0459b09bc7518d34c58444c96435801>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of asn1/asn1c files
-   `commit <https://pagure.io/freeipa/c/c951a491a9082b8b5931782f45f82e251eb93c3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c951a491a9082b8b5931782f45f82e251eb93c3c>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of install/REDME.schema file
-   `commit <https://pagure.io/freeipa/c/886d9167eb939a3ab5226ca420c404a9810186cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/886d9167eb939a3ab5226ca420c404a9810186cf>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of oddjob files
-   `commit <https://pagure.io/freeipa/c/dabc65f6b1989fb8f938e4b7249fcf5d41706e17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dabc65f6b1989fb8f938e4b7249fcf5d41706e17>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: Remove spurious EXTRA_DIST from install/share/Makefile.am
-   `commit <https://pagure.io/freeipa/c/a125370becb045b6e757df88e520ef3f8ab4ca09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a125370becb045b6e757df88e520ef3f8ab4ca09>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: cleanup unused LDIFs from install/share
-   `commit <https://pagure.io/freeipa/c/deec97abaec933709718464c4aa233a04de1844a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deec97abaec933709718464c4aa233a04de1844a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution of libexec scripts
-   `commit <https://pagure.io/freeipa/c/04be25082c60da01552d5e7c73d12930b10bd02e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04be25082c60da01552d5e7c73d12930b10bd02e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution and installation of update LDIFs
-   `commit <https://pagure.io/freeipa/c/b910683e19356390351a6b82240762969ecf89c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b910683e19356390351a6b82240762969ecf89c0>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Web UI: Remove offline version of Web UI
-   `commit <https://pagure.io/freeipa/c/24525fd086450616d4edd2aaf26dec868ff80ea9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24525fd086450616d4edd2aaf26dec868ff80ea9>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  Build: fix distribution of static files for web UI
-   `commit <https://pagure.io/freeipa/c/441acf7797b2069e8d9a123aa11bb33fd42d9187>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/441acf7797b2069e8d9a123aa11bb33fd42d9187>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: stop build when a step in web UI build fails
-   `commit <https://pagure.io/freeipa/c/f95098b2b645a62497dc6e1d66be2b7397567d25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f95098b2b645a62497dc6e1d66be2b7397567d25>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distribution and installation of static files in top-level
    directory
-   `commit <https://pagure.io/freeipa/c/021a52d6801b74ded03cfdf6c7fb73bd1cab978f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/021a52d6801b74ded03cfdf6c7fb73bd1cab978f>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix man page distribution
-   `commit <https://pagure.io/freeipa/c/2f6712893be5e66260a169c367a4607be6043d11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f6712893be5e66260a169c367a4607be6043d11>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix distdir target for translations
-   `commit <https://pagure.io/freeipa/c/7282776c05c2fb254ae65b63977ba604be316038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7282776c05c2fb254ae65b63977ba604be316038>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: rename project from ipa-server to freeipa
-   `commit <https://pagure.io/freeipa/c/fa8a468dba0ed866497669bd9c08b7de3a2cfbe3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa8a468dba0ed866497669bd9c08b7de3a2cfbe3>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove non-existing README files from Makefile.am
-   `commit <https://pagure.io/freeipa/c/b8d81ba3a12d93c38c4a0a8d439845746a32ae35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8d81ba3a12d93c38c4a0a8d439845746a32ae35>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix Makefile.am files to separate source and build directories
-   `commit <https://pagure.io/freeipa/c/24feae47f26f40f757fbdd711399128d88c9b62c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24feae47f26f40f757fbdd711399128d88c9b62c>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: respect --prefix for systemdsystemunitdir
-   `commit <https://pagure.io/freeipa/c/820fd4c7ce6ccc80272f45d6f64227567692dd39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/820fd4c7ce6ccc80272f45d6f64227567692dd39>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix make install in asn1 subdirectory
-   `commit <https://pagure.io/freeipa/c/3a41b3bb8860cf73fef7efd54db2da5ecbd608d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a41b3bb8860cf73fef7efd54db2da5ecbd608d5>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix ipaplatform detection for out-of-tree builds
-   `commit <https://pagure.io/freeipa/c/3d6b8f8bdd5568c44d293cba960209941e4d2545>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d6b8f8bdd5568c44d293cba960209941e4d2545>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: Makefiles for Python packages
-   `commit <https://pagure.io/freeipa/c/8de11b091fc705f235b1304fb101c27a82dcda6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8de11b091fc705f235b1304fb101c27a82dcda6f>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: fix module name in ipaserver/setup.py
-   `commit <https://pagure.io/freeipa/c/81da45ffb13d126c9b56a2022d88ba8bed2ee18c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81da45ffb13d126c9b56a2022d88ba8bed2ee18c>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: replace hand-made Makefile with one generated by Automake
-   `commit <https://pagure.io/freeipa/c/0a17155e5b0434d4cab4d1696fac7f5ef88f0808>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a17155e5b0434d4cab4d1696fac7f5ef88f0808>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: move version handling from Makefile to configure
-   `commit <https://pagure.io/freeipa/c/c48e5fd811326dc64e19490f88003e442815a052>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c48e5fd811326dc64e19490f88003e442815a052>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Docs: update docs about ipaplatform to match reality
-   `commit <https://pagure.io/freeipa/c/3e79d8ad4aef1f62372a2169699df345348ba3e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e79d8ad4aef1f62372a2169699df345348ba3e9>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: replace ipaplatform magic with symlinks generated by configure
-   `commit <https://pagure.io/freeipa/c/c70a2873f8a4447f8b38ad7b8468fc78c91bbb63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c70a2873f8a4447f8b38ad7b8468fc78c91bbb63>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build docs: update platform selection instructions
-   `commit <https://pagure.io/freeipa/c/c954d0e1ba2a9ba8e8da679bc7246788d086d976>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c954d0e1ba2a9ba8e8da679bc7246788d086d976>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: split out egg-info Makefile target from version-update target
-   `commit <https://pagure.io/freeipa/c/f25c0cb0c5f309944904fd32e781c27ae7e45a62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f25c0cb0c5f309944904fd32e781c27ae7e45a62>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: split API/ACI checks into separate Makefile targets
-   `commit <https://pagure.io/freeipa/c/38628e46f05bde5ccc0fbb997f79364860713b48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38628e46f05bde5ccc0fbb997f79364860713b48>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: use default error handling for PKG_CHECK_MODULES
-   `commit <https://pagure.io/freeipa/c/1a4f287931edf0f3a76e97875f4af622716475af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a4f287931edf0f3a76e97875f4af622716475af>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: use libutil convenience library for client
-   `commit <https://pagure.io/freeipa/c/c8be979b3263723a9ab7b3c71efbe85b42d981e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8be979b3263723a9ab7b3c71efbe85b42d981e9>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: cleanup INI library detection
-   `commit <https://pagure.io/freeipa/c/8acb1f37f581e92a56951c069c990c77e83f3c42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8acb1f37f581e92a56951c069c990c77e83f3c42>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: modernize XMLRPC-client library detection
-   `commit <https://pagure.io/freeipa/c/1e0143c159134337a00a91d4ae64e614f72da62e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e0143c159134337a00a91d4ae64e614f72da62e>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: modernize CURL library detection
-   `commit <https://pagure.io/freeipa/c/b12da59a6cde3580f97e4ceb7303bc85857faf4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b12da59a6cde3580f97e4ceb7303bc85857faf4d>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: modernize SASL library detection
-   `commit <https://pagure.io/freeipa/c/fd3176a72951a2baece36620341991feb94b230a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd3176a72951a2baece36620341991feb94b230a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: modernize POPT library detection
-   `commit <https://pagure.io/freeipa/c/1f1648691de6687e748c5b8267f43cf196bd7cc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f1648691de6687e748c5b8267f43cf196bd7cc9>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: merge client/configure.ac into top-level configure.ac
-   `commit <https://pagure.io/freeipa/c/0d7d6f3904287bb4903ffaa9d8c61e7593ae76d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d7d6f3904287bb4903ffaa9d8c61e7593ae76d6>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove Transifex support
-   `commit <https://pagure.io/freeipa/c/881ab4edffa5e9c6c8bd8fb9762e04d776c4a573>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/881ab4edffa5e9c6c8bd8fb9762e04d776c4a573>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: move translations from install/po/ to top-level po/
-   `commit <https://pagure.io/freeipa/c/0d37619db41abddabdd313f036f453821f438c8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d37619db41abddabdd313f036f453821f438c8a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: merge install/configure.ac into top-level configure.ac
-   `commit <https://pagure.io/freeipa/c/927ddcb95aeb5c9bcc0cb08c5f08cecdccd0acb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/927ddcb95aeb5c9bcc0cb08c5f08cecdccd0acb8>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: merge ipatests/man/configure.ac to top-level configure.ac
-   `commit <https://pagure.io/freeipa/c/5e028b59bcd3c485cc034f491a0171f26b03ce3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e028b59bcd3c485cc034f491a0171f26b03ce3a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: merge asn1/configure.ac to top-level configure.ac
-   `commit <https://pagure.io/freeipa/c/6e1d777d2878de1e90e1dab4949075d31ffb0d52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e1d777d2878de1e90e1dab4949075d31ffb0d52>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: transform util directory to libutil convenience library
-   `commit <https://pagure.io/freeipa/c/b0cb6afa2308b9d96456f0355771ecbef0ca7263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0cb6afa2308b9d96456f0355771ecbef0ca7263>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: promote daemons/configure.ac to top-level configure.ac
-   `commit <https://pagure.io/freeipa/c/25dab77301f9e0289b94b0a672aed5067384c8ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25dab77301f9e0289b94b0a672aed5067384c8ce>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: adjust include paths in daemons/ipa-kdb/tests/ipa_kdb_tests.c
-   `commit <https://pagure.io/freeipa/c/41da8732051c193166fa69cd9bc1152d39ad8720>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41da8732051c193166fa69cd9bc1152d39ad8720>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: pass down LIBDIR definition from RPM SPEC to Makefile
-   `commit <https://pagure.io/freeipa/c/329f080e6ac832ffd568e79ebca9907771f8ad61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/329f080e6ac832ffd568e79ebca9907771f8ad61>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Build: remove deprecated AC_STDC_HEADERS macro
-   `commit <https://pagure.io/freeipa/c/7de597425f8fb6d8c5cadc8fc039729368c43ddf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de597425f8fb6d8c5cadc8fc039729368c43ddf>`__
 -  Build: require Python >= 2.7
-   `commit <https://pagure.io/freeipa/c/8b458ce4de9cb0e072849c4fbd9257377cd4a654>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b458ce4de9cb0e072849c4fbd9257377cd4a654>`__
 -  Build: remove traces of mozldap library
-   `commit <https://pagure.io/freeipa/c/2ea66483791ef060c54f525786fbac2730813bbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ea66483791ef060c54f525786fbac2730813bbc>`__
 -  Build: modernize crypto library detection
-   `commit <https://pagure.io/freeipa/c/01072fc8f2833e9316f534875c75714803384377>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01072fc8f2833e9316f534875c75714803384377>`__
 -  Build: modernize UUID library detection
-   `commit <https://pagure.io/freeipa/c/7b801682a64b2ba132ba9892831f8c3f5a51caf8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b801682a64b2ba132ba9892831f8c3f5a51caf8>`__
 -  Build: modernize Kerberos library detection
-   `commit <https://pagure.io/freeipa/c/651f1acac8212346fb579ff8911b43a3faf3867b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/651f1acac8212346fb579ff8911b43a3faf3867b>`__
 -  Build: add missing KRB5_LIBS to daemons/ipa-otpd
-   `commit <https://pagure.io/freeipa/c/152ed75ff6e55489e27c201b27ee6eb5c4db0480>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/152ed75ff6e55489e27c201b27ee6eb5c4db0480>`__
 -  Tests: print what was expected from callables in xmlrpc_tests
-   `commit <https://pagure.io/freeipa/c/8683cbf1242230fff8cd94da8aa27b27e9307535>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8683cbf1242230fff8cd94da8aa27b27e9307535>`__
 -  DNS: Improve field descriptions for SRV records
-   `commit <https://pagure.io/freeipa/c/bf96b80200c3e8d1795a913db4e0222ea558e609>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf96b80200c3e8d1795a913db4e0222ea558e609>`__
 -  DNS: Support URI resource record type
-   `commit <https://pagure.io/freeipa/c/f363dfbeed7aeba51d694a60b29389d94c7bda44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f363dfbeed7aeba51d694a60b29389d94c7bda44>`__
    `#6344 <https://pagure.io/freeipa/issue/6344>`__
 -  Fix compatibility with python-dns 1.15.0
-   `commit <https://pagure.io/freeipa/c/8e02652e7c889ce7d32b592b5235917a0f519503>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e02652e7c889ce7d32b592b5235917a0f519503>`__
    `#6390 <https://pagure.io/freeipa/issue/6390>`__
 -  Raise errors from service.py:_ldap_mod() by default
-   `commit <https://pagure.io/freeipa/c/c56256e2a29f076e6afa559225a66f58b0773eb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c56256e2a29f076e6afa559225a66f58b0773eb5>`__
 
 
 
@@ -3024,19 +3024,19 @@ Petr Vobornik (6)
 
 -  permissions: add permissions for read and mod of external group
    members
-   `commit <https://pagure.io/freeipa/c/da5487c407bee9bce41f4012d07970916b9456c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da5487c407bee9bce41f4012d07970916b9456c1>`__
    `#5504 <https://pagure.io/freeipa/issue/5504>`__
 -  webui: do not warn about CAs if there is only one master
-   `commit <https://pagure.io/freeipa/c/6027a8111fa9ed7a058fb222f4f96b12039deb8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6027a8111fa9ed7a058fb222f4f96b12039deb8b>`__
    `#6598 <https://pagure.io/freeipa/issue/6598>`__
 -  webui: fixes normalization of value in attributes widget
-   `commit <https://pagure.io/freeipa/c/56a2642af0a29328df4defef138b9fa65624335a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56a2642af0a29328df4defef138b9fa65624335a>`__
 -  Change README to use Markdown
-   `commit <https://pagure.io/freeipa/c/5e0ca17ca06ad26f291d4738766e194b3784c5bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e0ca17ca06ad26f291d4738766e194b3784c5bd>`__
 -  Raise errors.EnvironmentError if IPA_CONFDIR var is incorrectly used
-   `commit <https://pagure.io/freeipa/c/c2934aaa7eacb8390209a38029145b1c240d864c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2934aaa7eacb8390209a38029145b1c240d864c>`__
 -  replicainstall: log ACI and LDAP errors in promotion check
-   `commit <https://pagure.io/freeipa/c/d0c17b4d9afb95db2abcd93096fa6626fd61870e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0c17b4d9afb95db2abcd93096fa6626fd61870e>`__
 
 
 
@@ -3044,199 +3044,199 @@ Pavel Vomacka (69)
 ----------------------------------------------------------------------------------------------
 
 -  Remove allow_constrained_delegation from gssproxy.conf
-   `commit <https://pagure.io/freeipa/c/f4cd61f3011877fc9cc2a809438059b07362b0aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4cd61f3011877fc9cc2a809438059b07362b0aa>`__
    `#6225 <https://pagure.io/freeipa/issue/6225>`__
 -  WebUI: Add support for management of user short name resolution
-   `commit <https://pagure.io/freeipa/c/2c194d793cd588d595c5ff639fbf5dac93e50e23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c194d793cd588d595c5ff639fbf5dac93e50e23>`__
    `#6372 <https://pagure.io/freeipa/issue/6372>`__
 -  WebUI: add link to login page which for login using certificate
-   `commit <https://pagure.io/freeipa/c/585547ee9478ea0173106d88d40d7807baab8bcf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/585547ee9478ea0173106d88d40d7807baab8bcf>`__
    `#6225 <https://pagure.io/freeipa/issue/6225>`__
 -  Support certificate login after installation and upgrade
-   `commit <https://pagure.io/freeipa/c/75c592d3b9081474cae51c929e6af29c7a0eebb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75c592d3b9081474cae51c929e6af29c7a0eebb6>`__
    `#6225 <https://pagure.io/freeipa/issue/6225>`__
 -  TESTS WebUI: Vaults management
-   `commit <https://pagure.io/freeipa/c/f95275748465ffacecfbf55ca2cd2fc54f3860b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f95275748465ffacecfbf55ca2cd2fc54f3860b7>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  TESTS: Add support for sidebar with facets
-   `commit <https://pagure.io/freeipa/c/0808504ba1ab743acdf4231876d49c26dbae6621>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0808504ba1ab743acdf4231876d49c26dbae6621>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  TESTS: Add support for KRA in ui_driver
-   `commit <https://pagure.io/freeipa/c/ab8c69f4c602c0eaefbb058c108428ca30a80e98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab8c69f4c602c0eaefbb058c108428ca30a80e98>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  WebUI: add vault management
-   `commit <https://pagure.io/freeipa/c/39d7ef3de4b0345274b4b8e8f6918e3b714879ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39d7ef3de4b0345274b4b8e8f6918e3b714879ad>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  WebUI: allow to show rows with same pkey in tables
-   `commit <https://pagure.io/freeipa/c/587b7324fb1f6899deb151c30662362c18c5258e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/587b7324fb1f6899deb151c30662362c18c5258e>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  WebUI: search facet's default actions might be overriden
-   `commit <https://pagure.io/freeipa/c/de4d4a51b542b8e473919dbc14f7a0810944b544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de4d4a51b542b8e473919dbc14f7a0810944b544>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Add possibility to hide only one tab in sidebar
-   `commit <https://pagure.io/freeipa/c/8dfe692251d38934a21ad3bc648d839d83e27caa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8dfe692251d38934a21ad3bc648d839d83e27caa>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Possibility to set list of table attributes which will be added to
    \_del command
-   `commit <https://pagure.io/freeipa/c/039a6f7b4ff392974408cb9e274f8a3777e009fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/039a6f7b4ff392974408cb9e274f8a3777e009fd>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Extend \_show command after \_find command in table facets
-   `commit <https://pagure.io/freeipa/c/2e6e0698865e7d530c6ebf87a12e46f990ac1d87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e6e0698865e7d530c6ebf87a12e46f990ac1d87>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Add possibility to pass url parameter to update command of details
    page
-   `commit <https://pagure.io/freeipa/c/042e113db9bc66dcd0da0d5e8b8d025212695705>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/042e113db9bc66dcd0da0d5e8b8d025212695705>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Add property which allows refresh command to use url value
-   `commit <https://pagure.io/freeipa/c/bbca1d9219bfab9f204cb0217495cbd94b7098be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbca1d9219bfab9f204cb0217495cbd94b7098be>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Added optional option in refreshing after modifying association table
-   `commit <https://pagure.io/freeipa/c/6d1374f7f82d144b8aa361e9e637c5388f8f7edb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d1374f7f82d144b8aa361e9e637c5388f8f7edb>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Possibility to skip checking writable according to metadata
-   `commit <https://pagure.io/freeipa/c/93a7f4c88db159664664bd82d1d00e5e0033ac22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93a7f4c88db159664664bd82d1d00e5e0033ac22>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Allow to set another other_entity name
-   `commit <https://pagure.io/freeipa/c/ec63456b7c1fba6bd8d9073e63c27ef685f08c60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec63456b7c1fba6bd8d9073e63c27ef685f08c60>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  Additional option to add and del operations can be set
-   `commit <https://pagure.io/freeipa/c/c3115fa617fb049ba48d356d280fdb23c312ebca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3115fa617fb049ba48d356d280fdb23c312ebca>`__
    `#5426 <https://pagure.io/freeipa/issue/5426>`__
 -  WebUI: Add cermapmatch module
-   `commit <https://pagure.io/freeipa/c/61cd4372e142662c06c881886709fe1b573102a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61cd4372e142662c06c881886709fe1b573102a9>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Add Adapter for certmap_match result table
-   `commit <https://pagure.io/freeipa/c/358caa7da44c997b505f54ec70cb6be58d188751>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/358caa7da44c997b505f54ec70cb6be58d188751>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Possibility to choose object when API call returns list of
    objects
-   `commit <https://pagure.io/freeipa/c/1d6cc35c03669ea67d9e9ee9ca0ff62401d1b157>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d6cc35c03669ea67d9e9ee9ca0ff62401d1b157>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Add possibility to turn of autoload when details.load is
    called
-   `commit <https://pagure.io/freeipa/c/6be32edde0ae16473d4d109747adae78f9d725e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6be32edde0ae16473d4d109747adae78f9d725e4>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: don't change casing of Auth Indicators values
-   `commit <https://pagure.io/freeipa/c/ad3451067ad474ea52872913d6789b1652f9a9c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3451067ad474ea52872913d6789b1652f9a9c4>`__
    `#6308 <https://pagure.io/freeipa/issue/6308>`__
 -  WebUI: Allow disabling lowering text in custom_checkbox_widget
-   `commit <https://pagure.io/freeipa/c/0220fc8986e4fef017185bde675dc9cf0f90afd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0220fc8986e4fef017185bde675dc9cf0f90afd8>`__
    `#6308 <https://pagure.io/freeipa/issue/6308>`__
 -  Add support for custom table pagination size
-   `commit <https://pagure.io/freeipa/c/e1dfc51e48050ac1ad431d56003dc26e17ca653e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1dfc51e48050ac1ad431d56003dc26e17ca653e>`__
    `#5742 <https://pagure.io/freeipa/issue/5742>`__
 -  Make singleton from config module
-   `commit <https://pagure.io/freeipa/c/f78cc8932626de667c6e3a4461141a10a5d9c2e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f78cc8932626de667c6e3a4461141a10a5d9c2e6>`__
    `#5742 <https://pagure.io/freeipa/issue/5742>`__
 -  Add javascript integer validator
-   `commit <https://pagure.io/freeipa/c/7b699105a52d4d8c26a73044ba182d752b4a9833>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b699105a52d4d8c26a73044ba182d752b4a9833>`__
    `#5742 <https://pagure.io/freeipa/issue/5742>`__
 -  WebUI: Add certmap module
-   `commit <https://pagure.io/freeipa/c/19426f32ff99feb7c64a4174728cd2b6b946a49a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19426f32ff99feb7c64a4174728cd2b6b946a49a>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Add Custom command multivalued adder dialog
-   `commit <https://pagure.io/freeipa/c/d3700275c1b63aeeab13c7dd9e09249bc2c8e4d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3700275c1b63aeeab13c7dd9e09249bc2c8e4d7>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Create non editable row widget for mutlivalued widget
-   `commit <https://pagure.io/freeipa/c/fba318b83337b71ccb3421690071a130171fbdfe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fba318b83337b71ccb3421690071a130171fbdfe>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Add possibility to set field always writable
-   `commit <https://pagure.io/freeipa/c/27027bbc9cf7faa29c3c94686635559cbcbde98a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27027bbc9cf7faa29c3c94686635559cbcbde98a>`__
    `#6601 <https://pagure.io/freeipa/issue/6601>`__
 -  WebUI: Change structure of Identity submenu
-   `commit <https://pagure.io/freeipa/c/070bc48dd6c9bce32caa0f0f2de8d44b4e5bbbb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/070bc48dd6c9bce32caa0f0f2de8d44b4e5bbbb1>`__
    `#6717 <https://pagure.io/freeipa/issue/6717>`__
 -  WebUI: add sizelimit:0 to cert-find
-   `commit <https://pagure.io/freeipa/c/aa8530b7af8f04a4ba868f73ea9f171911162638>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa8530b7af8f04a4ba868f73ea9f171911162638>`__
    `#6712 <https://pagure.io/freeipa/issue/6712>`__
 -  WebUI: fix incorrect behavior of ESC button on combobox
-   `commit <https://pagure.io/freeipa/c/6c6c68df544ac1046741d91dfdc59ef8d96b863c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c6c68df544ac1046741d91dfdc59ef8d96b863c>`__
    `#6388 <https://pagure.io/freeipa/issue/6388>`__
 -  WebUI: add default on_cancel function in adder_dialog
-   `commit <https://pagure.io/freeipa/c/1a96e7f9e737941480436269668ccde0a50395f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a96e7f9e737941480436269668ccde0a50395f9>`__
    `#6388 <https://pagure.io/freeipa/issue/6388>`__
 -  Coverity: removed useless semicolon which ends statement earlier
-   `commit <https://pagure.io/freeipa/c/9d2ef64fb9e1357dc4a3cde8d93c796daefd2f6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d2ef64fb9e1357dc4a3cde8d93c796daefd2f6e>`__
 -  Coverity: Fix possibility of access to attribute of undefined
-   `commit <https://pagure.io/freeipa/c/a69c4448c58b2438952fd806e2515eea7575b27b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a69c4448c58b2438952fd806e2515eea7575b27b>`__
 -  Change activity text while loading metadata
-   `commit <https://pagure.io/freeipa/c/be7865bf4f9b6774a17f31380e96b76d0473f982>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7865bf4f9b6774a17f31380e96b76d0473f982>`__
    `#6144 <https://pagure.io/freeipa/issue/6144>`__
 -  Refactoring of rpc module
-   `commit <https://pagure.io/freeipa/c/5a950aeb29963ed22a2c3c1b80723589ac4097de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a950aeb29963ed22a2c3c1b80723589ac4097de>`__
    `#6144 <https://pagure.io/freeipa/issue/6144>`__
 -  WebUI: update Patternfly and Bootstrap
-   `commit <https://pagure.io/freeipa/c/18425dbbe7b7c311cf947074d505225b235df769>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18425dbbe7b7c311cf947074d505225b235df769>`__
    `#6394 <https://pagure.io/freeipa/issue/6394>`__
 -  WebUI: Hide incorrectly shown buttons on hosts tab in ID Views
-   `commit <https://pagure.io/freeipa/c/17392b0ef754781775a10973b2fee8a6d1697f5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17392b0ef754781775a10973b2fee8a6d1697f5d>`__
    `#6546 <https://pagure.io/freeipa/issue/6546>`__
 -  Lowered the version of gettext
-   `commit <https://pagure.io/freeipa/c/e5686c0ccb4a71fa0ab460fd45280d9adba91cca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5686c0ccb4a71fa0ab460fd45280d9adba91cca>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Add python-pyasn1-modules into dependencies
-   `commit <https://pagure.io/freeipa/c/a8b7dbff8ac660a28faf7ef43c7a0952171423b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8b7dbff8ac660a28faf7ef43c7a0952171423b8>`__
    `#6398 <https://pagure.io/freeipa/issue/6398>`__
 -  Adjustments for setup requirements v2
-   `commit <https://pagure.io/freeipa/c/7f301b00ce50814d098e7e42324ef741c71b6853>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f301b00ce50814d098e7e42324ef741c71b6853>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  TESTS: Update group type name
-   `commit <https://pagure.io/freeipa/c/6e475988e1ec1b89d44b495cd667a444526733a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e475988e1ec1b89d44b495cd667a444526733a7>`__
    `#6334 <https://pagure.io/freeipa/issue/6334>`__
 -  Coverity - null pointer dereference
-   `commit <https://pagure.io/freeipa/c/2644c955489ee5b22ecc0227c5cd8ed1e90ee648>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2644c955489ee5b22ecc0227c5cd8ed1e90ee648>`__
 -  Coverity - accessing attribute of variable which can point to null
-   `commit <https://pagure.io/freeipa/c/aa8a904c4a3953e799278de192d1613d21cde42a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa8a904c4a3953e799278de192d1613d21cde42a>`__
 -  Coverity - opens dialog which might not be created
-   `commit <https://pagure.io/freeipa/c/cd74f78ed74f8898c492024d0901cef9778df067>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd74f78ed74f8898c492024d0901cef9778df067>`__
 -  Coverity - iterating over variable which could be null
-   `commit <https://pagure.io/freeipa/c/4af31c70c57fc223920b71fedfb40d1de27622b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4af31c70c57fc223920b71fedfb40d1de27622b2>`__
 -  Coverity - null pointer dereference
-   `commit <https://pagure.io/freeipa/c/cad9f9b682d9bcc33fdfb1112e4cfb1a2c66a498>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cad9f9b682d9bcc33fdfb1112e4cfb1a2c66a498>`__
 -  Coverity - true branch can't be executed
-   `commit <https://pagure.io/freeipa/c/d94a2aa185defba38f2bbe2c5ee28f9b9defc0f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d94a2aa185defba38f2bbe2c5ee28f9b9defc0f2>`__
 -  Coverity - true branch can't be executed
-   `commit <https://pagure.io/freeipa/c/7be585dbb206ed12b25d09bfb2f5452ee9c125ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7be585dbb206ed12b25d09bfb2f5452ee9c125ae>`__
 -  Coverity - removed dead code
-   `commit <https://pagure.io/freeipa/c/ed74e14ab4a17c83cf6782e4b6fd41a2ce79594d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed74e14ab4a17c83cf6782e4b6fd41a2ce79594d>`__
 -  Coverity - Accesing attribute of null
-   `commit <https://pagure.io/freeipa/c/4b63ce26ebbef8ef1538aecb3cff8032df3357a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b63ce26ebbef8ef1538aecb3cff8032df3357a7>`__
 -  Coverity - identical code for different branches
-   `commit <https://pagure.io/freeipa/c/de8cb7585b652fd1a61e3020e37192cb1db74f46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de8cb7585b652fd1a61e3020e37192cb1db74f46>`__
 -  Coverity - not initialized variable
-   `commit <https://pagure.io/freeipa/c/fa3982c7c82add3d201aec860cb981a595f10be9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa3982c7c82add3d201aec860cb981a595f10be9>`__
 -  Coverity - null pointer exception
-   `commit <https://pagure.io/freeipa/c/d4ad0ca04c0ae445c784787a675ac84d2cbfd766>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ad0ca04c0ae445c784787a675ac84d2cbfd766>`__
 -  Coverity - null pointer exception
-   `commit <https://pagure.io/freeipa/c/a2525ff64518038eaa64b0d855154a984030f7f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2525ff64518038eaa64b0d855154a984030f7f3>`__
 -  WebUI: services without canonical name are shown correctly
-   `commit <https://pagure.io/freeipa/c/4f760dffa011a3656b6072c74088b497ff416a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f760dffa011a3656b6072c74088b497ff416a8d>`__
    `#6397 <https://pagure.io/freeipa/issue/6397>`__
 -  WebUI: fix API Browser menu label
-   `commit <https://pagure.io/freeipa/c/28c7644980186f50ee007cd5c2f2edcf103eb942>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28c7644980186f50ee007cd5c2f2edcf103eb942>`__
    `#6384 <https://pagure.io/freeipa/issue/6384>`__
 -  Add tooltip to all fields in DNS record adder dialog
-   `commit <https://pagure.io/freeipa/c/51af7a15981eca753dfbda133cc557d0512f6e95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51af7a15981eca753dfbda133cc557d0512f6e95>`__
 -  WebUI: hide buttons in certificate widget according to acl
-   `commit <https://pagure.io/freeipa/c/81ead980fb808b70d7590800518b655abe64948b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81ead980fb808b70d7590800518b655abe64948b>`__
    `#6341 <https://pagure.io/freeipa/issue/6341>`__
 -  WebUI: Change group name from 'normal' to 'Non-POSIX'
-   `commit <https://pagure.io/freeipa/c/0e6d6e403255649538224c409a0a279aaf9d5181>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e6d6e403255649538224c409a0a279aaf9d5181>`__
    `#6334 <https://pagure.io/freeipa/issue/6334>`__
 -  WebUI: Add handling for HTTP error 404
-   `commit <https://pagure.io/freeipa/c/b18a35145df92522ae990e020513d1a77e311493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b18a35145df92522ae990e020513d1a77e311493>`__
    `#4821 <https://pagure.io/freeipa/issue/4821>`__
 -  Add 'Restore' option to action dropdown menu
-   `commit <https://pagure.io/freeipa/c/c3374c6e16a10e8780401c58c04dcf8d95ea1a4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3374c6e16a10e8780401c58c04dcf8d95ea1a4d>`__
    `#5818 <https://pagure.io/freeipa/issue/5818>`__
 -  WebUI add support for sub-CAs while revoking certificates
-   `commit <https://pagure.io/freeipa/c/7fea3914fbfc0748f26dfe41445b5f0d12f406e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fea3914fbfc0748f26dfe41445b5f0d12f406e6>`__
    `#6216 <https://pagure.io/freeipa/issue/6216>`__
 -  WebUI: Fix showing certificates issued by sub-CA
-   `commit <https://pagure.io/freeipa/c/64ac981dddcecf1176585b6e7b729cf38b24bcea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64ac981dddcecf1176585b6e7b729cf38b24bcea>`__
    `#6238 <https://pagure.io/freeipa/issue/6238>`__
 -  Add support for additional options taken from table facet
-   `commit <https://pagure.io/freeipa/c/40f923f56b4777e3e18c9f76ba1a745ed69ef0a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40f923f56b4777e3e18c9f76ba1a745ed69ef0a6>`__
    `#6238 <https://pagure.io/freeipa/issue/6238>`__
 
 
@@ -3245,7 +3245,7 @@ Gabe (1)
 ----------------------------------------------------------------------------------------------
 
 -  Allow nsaccountlock to be searched in user-find command
-   `commit <https://pagure.io/freeipa/c/a930ec824da0337109d646ab3acb495dc1b6ba63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a930ec824da0337109d646ab3acb495dc1b6ba63>`__
 
 
 
@@ -3253,94 +3253,94 @@ Simo Sorce (31)
 ----------------------------------------------------------------------------------------------
 
 -  Store session cookie in a ccache option
-   `commit <https://pagure.io/freeipa/c/7cab95955539b5f9596dcda5886ea3d9755fb193>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cab95955539b5f9596dcda5886ea3d9755fb193>`__
    `#6661 <https://pagure.io/freeipa/issue/6661>`__
 -  Add support for searching policies in cn=accounts
-   `commit <https://pagure.io/freeipa/c/2e5cc369fd8b9d780697a9a286429cc2ca0f448a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e5cc369fd8b9d780697a9a286429cc2ca0f448a>`__
    `#6568 <https://pagure.io/freeipa/issue/6568>`__
 -  Add code to retrieve results from multiple bases
-   `commit <https://pagure.io/freeipa/c/9f13b330aaec468a018472dce5fc77131277de94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f13b330aaec468a018472dce5fc77131277de94>`__
 -  Use GSS-SPNEGO if connecting locally
-   `commit <https://pagure.io/freeipa/c/adf8aabf10a57383aa6216625921503b83575757>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adf8aabf10a57383aa6216625921503b83575757>`__
    `#6656 <https://pagure.io/freeipa/issue/6656>`__
 -  Limit sessions to 30 minutes by default
-   `commit <https://pagure.io/freeipa/c/d5e7a57e5b25b9cecb7a65096487a65374ad860d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5e7a57e5b25b9cecb7a65096487a65374ad860d>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Remove non-sensical kdestroy on https stop
-   `commit <https://pagure.io/freeipa/c/b8f304c66994ae82ea484a4e8bd057d4ccf1e6bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8f304c66994ae82ea484a4e8bd057d4ccf1e6bd>`__
    `#6673 <https://pagure.io/freeipa/issue/6673>`__
 -  Fix session logout
-   `commit <https://pagure.io/freeipa/c/908d2eaba46f5f123b49af400a8b696545c62b54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/908d2eaba46f5f123b49af400a8b696545c62b54>`__
    `#6685 <https://pagure.io/freeipa/issue/6685>`__
 -  Deduplicate session cookies in headers
-   `commit <https://pagure.io/freeipa/c/d0642bfa55e9c24429675f623bc0e35824bc9fb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0642bfa55e9c24429675f623bc0e35824bc9fb0>`__
    `#6676 <https://pagure.io/freeipa/issue/6676>`__
 -  Change session logout to kill only the cookie
-   `commit <https://pagure.io/freeipa/c/b895f4a34bcbd0b1787d2bfc1db25f34c3584b9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b895f4a34bcbd0b1787d2bfc1db25f34c3584b9c>`__
    `#6682 <https://pagure.io/freeipa/issue/6682>`__
 -  Insure removal of session on identity change
-   `commit <https://pagure.io/freeipa/c/e4d462ad53597fd5410aa4e94a57bb15b92a3f13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4d462ad53597fd5410aa4e94a57bb15b92a3f13>`__
    `#6543 <https://pagure.io/freeipa/issue/6543>`__
 -  Explicitly pass down ccache names for connections
-   `commit <https://pagure.io/freeipa/c/09c92e2bc1ca9db5b73d5ab8483b42dbd6b9a0e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09c92e2bc1ca9db5b73d5ab8483b42dbd6b9a0e9>`__
    `#6543 <https://pagure.io/freeipa/issue/6543>`__
 -  Allow rpc callers to pass ccache and service names
-   `commit <https://pagure.io/freeipa/c/41c1efc44a6b809445facd4772574595029553b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41c1efc44a6b809445facd4772574595029553b1>`__
    `#6543 <https://pagure.io/freeipa/issue/6543>`__
 -  Fix uninstall stopping ipa.service
-   `commit <https://pagure.io/freeipa/c/00a9d2f94dee17e28e39cdae0c32acc3d1fe51ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00a9d2f94dee17e28e39cdae0c32acc3d1fe51ed>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Rationalize creation of RA and HTTPD NSS databases
-   `commit <https://pagure.io/freeipa/c/4bd2d6ad46c9151e11f9223dd5383555fdedb249>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4bd2d6ad46c9151e11f9223dd5383555fdedb249>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Add a new user to run the framework code
-   `commit <https://pagure.io/freeipa/c/4fd89833ee5421b05c10329d627d0e0fc8496046>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fd89833ee5421b05c10329d627d0e0fc8496046>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Always use /etc/ipa/ca.crt as CA cert file
-   `commit <https://pagure.io/freeipa/c/c2b1b2a36200b50babfda1eca37fb4b51fefa9c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2b1b2a36200b50babfda1eca37fb4b51fefa9c6>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Simplify NSSDatabase password file handling
-   `commit <https://pagure.io/freeipa/c/f648c5631afa5e7954eee9a84fb1222d3bce3bf1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f648c5631afa5e7954eee9a84fb1222d3bce3bf1>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Separate RA cert store from the HTTP cert store
-   `commit <https://pagure.io/freeipa/c/d124e307f3b7d88bca53784f030ed6043b224432>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d124e307f3b7d88bca53784f030ed6043b224432>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Configure HTTPD to work via Gss-Proxy
-   `commit <https://pagure.io/freeipa/c/d2f5fc304f1938d23171ae330fa20b213ceed54e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2f5fc304f1938d23171ae330fa20b213ceed54e>`__
    `#4189 <https://pagure.io/freeipa/issue/4189>`__,
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Use Anonymous user to obtain FAST armor ccache
-   `commit <https://pagure.io/freeipa/c/b6741d81e187fc84177c12ef8ad900d3b5cda6a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6741d81e187fc84177c12ef8ad900d3b5cda6a4>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Drop use of kinit_as_http from trust code
-   `commit <https://pagure.io/freeipa/c/b109f5d850ce13585d4392ca48896dc069a746e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b109f5d850ce13585d4392ca48896dc069a746e5>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Generate tmpfiles config at install time
-   `commit <https://pagure.io/freeipa/c/38c66896de1769077cd5b057133606ec5eeaf62b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38c66896de1769077cd5b057133606ec5eeaf62b>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Change session handling
-   `commit <https://pagure.io/freeipa/c/c894ebefc5c4c4c7ea340d6ddc4cd3c081917e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c894ebefc5c4c4c7ea340d6ddc4cd3c081917e4a>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Use the tar Posix option for tarballs
-   `commit <https://pagure.io/freeipa/c/2bc01ec5b4a91a805912bdada429a91ab08ed196>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bc01ec5b4a91a805912bdada429a91ab08ed196>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  Add compatibility code to retrieve headers
-   `commit <https://pagure.io/freeipa/c/397f2be9dfd6475127742c0b710b37b443d97d67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/397f2be9dfd6475127742c0b710b37b443d97d67>`__
    `#6558 <https://pagure.io/freeipa/issue/6558>`__
 -  Configure Anonymous PKINIT on server install
-   `commit <https://pagure.io/freeipa/c/ca4e6c1fdfac9b545b26f885dc4865f22ca36ae6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca4e6c1fdfac9b545b26f885dc4865f22ca36ae6>`__
    `#5678 <https://pagure.io/freeipa/issue/5678>`__
 -  Properly handle multiple cookies in rpc lib.
-   `commit <https://pagure.io/freeipa/c/f1678693713dc2a573493e325e93f6f557a5ad5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1678693713dc2a573493e325e93f6f557a5ad5a>`__
 -  Properly handle multiple cookies in rpcclient
-   `commit <https://pagure.io/freeipa/c/560ab9e3176af8e59163155207cc2c1d631915dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/560ab9e3176af8e59163155207cc2c1d631915dd>`__
 -  Support DAL version 5 and version 6
-   `commit <https://pagure.io/freeipa/c/2775042787be4ea236c0b99dd75337414e24b89d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2775042787be4ea236c0b99dd75337414e24b89d>`__
    `#6466 <https://pagure.io/freeipa/issue/6466>`__
 -  Fix install scripts debugging
-   `commit <https://pagure.io/freeipa/c/d650c54fe4e327f95ffcb834418a5b6af59b212c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d650c54fe4e327f95ffcb834418a5b6af59b212c>`__
 -  Fix error message encoding
-   `commit <https://pagure.io/freeipa/c/2f567f0e8eb53306c5a3ecc04ac93e375b9c07d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f567f0e8eb53306c5a3ecc04ac93e375b9c07d1>`__
 
 
 
@@ -3348,237 +3348,237 @@ Stanislav Laznicka (78)
 ----------------------------------------------------------------------------------------------
 
 -  Remove pkinit from ipa-replica-prepare
-   `commit <https://pagure.io/freeipa/c/46d4d534c08d14756b989e157e87a078d174ad5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46d4d534c08d14756b989e157e87a078d174ad5c>`__
    `#6759 <https://pagure.io/freeipa/issue/6759>`__
 -  Backup KDC certificate pair
-   `commit <https://pagure.io/freeipa/c/ee6d031a6a0939c1f51a874b1f8f9b19ec727203>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee6d031a6a0939c1f51a874b1f8f9b19ec727203>`__
    `#6748 <https://pagure.io/freeipa/issue/6748>`__
 -  Don't fail more if cert req/cert creation failed
-   `commit <https://pagure.io/freeipa/c/8980f4098ebf6b62556e24f090718802d1e495d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8980f4098ebf6b62556e24f090718802d1e495d3>`__
    `#6755 <https://pagure.io/freeipa/issue/6755>`__
 -  Fix ipa-replica-prepare server-cert creation
-   `commit <https://pagure.io/freeipa/c/992e6ecd1ff33f4f872e8f174bd426507c55f5c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/992e6ecd1ff33f4f872e8f174bd426507c55f5c4>`__
    `#6755 <https://pagure.io/freeipa/issue/6755>`__
 -  Don't allow standalone KRA uninstalls
-   `commit <https://pagure.io/freeipa/c/5d3a0e6758866239c886e998a6d89c5a4b150184>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d3a0e6758866239c886e998a6d89c5a4b150184>`__
    `#6538 <https://pagure.io/freeipa/issue/6538>`__
 -  Add message about last KRA to WebUI Topology view
-   `commit <https://pagure.io/freeipa/c/1e8db4b5c7a55dac0008ad9b9bf5802ba30e8c2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e8db4b5c7a55dac0008ad9b9bf5802ba30e8c2a>`__
    `#6538 <https://pagure.io/freeipa/issue/6538>`__
 -  Add check to prevent removal of last KRA
-   `commit <https://pagure.io/freeipa/c/670f8fb1db109ec2c9ab7e5d2189325988220b23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/670f8fb1db109ec2c9ab7e5d2189325988220b23>`__
    `#6538 <https://pagure.io/freeipa/issue/6538>`__
 -  Don't use weak ciphers for client HTTPS connections
-   `commit <https://pagure.io/freeipa/c/fda22c33441d3b2c541a272e411ac1503a20fb01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fda22c33441d3b2c541a272e411ac1503a20fb01>`__
    `#6730 <https://pagure.io/freeipa/issue/6730>`__
 -  We don't offer no quickies
-   `commit <https://pagure.io/freeipa/c/30d7c210a4d153fcb5007651a80d8d53512abba3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30d7c210a4d153fcb5007651a80d8d53512abba3>`__
 -  Fix cookie with Max-Age processing
-   `commit <https://pagure.io/freeipa/c/24eeb4d6a3be678d652247a4a862ffde037514da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24eeb4d6a3be678d652247a4a862ffde037514da>`__
    `#6718 <https://pagure.io/freeipa/issue/6718>`__
 -  Fix CA-less upgrade
-   `commit <https://pagure.io/freeipa/c/a7c8077ce8f72eee26e8f5d4362239313ffdae3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7c8077ce8f72eee26e8f5d4362239313ffdae3d>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Fix replica with --setup-ca issues
-   `commit <https://pagure.io/freeipa/c/052de4308c64b126bee440e970be4cf8449c5ebc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/052de4308c64b126bee440e970be4cf8449c5ebc>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Moving ipaCert from HTTPD_ALIAS_DIR
-   `commit <https://pagure.io/freeipa/c/5ab85b365ae886558b1f077b0d039a0d24bebfa7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ab85b365ae886558b1f077b0d039a0d24bebfa7>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__,
    `#6680 <https://pagure.io/freeipa/issue/6680>`__
 -  Added a PEMFileHandler for Custodia store
-   `commit <https://pagure.io/freeipa/c/24b134c633390343ba76e4091fa612650976280a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24b134c633390343ba76e4091fa612650976280a>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Refactor certmonger for OpenSSL certificates
-   `commit <https://pagure.io/freeipa/c/51a2b1372936106ff95d5a45afc813f146653ae4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51a2b1372936106ff95d5a45afc813f146653ae4>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Workaround for certmonger's "Subject" representations
-   `commit <https://pagure.io/freeipa/c/595f9b64e31dc9e4f035119e834db7e6cb152dce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/595f9b64e31dc9e4f035119e834db7e6cb152dce>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove ipapython.nsslib as it is not used anymore
-   `commit <https://pagure.io/freeipa/c/76e8d7b35d110e5cf5494898950ab3607799c031>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76e8d7b35d110e5cf5494898950ab3607799c031>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove NSSConnection from otptoken plugin
-   `commit <https://pagure.io/freeipa/c/2a9d1fb7d9dda0299c6f7cd75a715182d15e04df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a9d1fb7d9dda0299c6f7cd75a715182d15e04df>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove pkcs12 handling functions from CertDB
-   `commit <https://pagure.io/freeipa/c/afea026a5c45ce24f3bf6da499b4d334eea3ca78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afea026a5c45ce24f3bf6da499b4d334eea3ca78>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove NSSConnection from Dogtag
-   `commit <https://pagure.io/freeipa/c/0a54fac02cecad3b9e3bf8ad0c8a44df3b701857>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a54fac02cecad3b9e3bf8ad0c8a44df3b701857>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Move publishing of CA cert to cainstance creation on master
-   `commit <https://pagure.io/freeipa/c/6b074ad833a12acbd4643795b2150fa7f019d6b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b074ad833a12acbd4643795b2150fa7f019d6b2>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Don't run kra.configure_instance if not necessary
-   `commit <https://pagure.io/freeipa/c/1e89d28aaf3a0a4b48fc09a5d98262f1000c52a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e89d28aaf3a0a4b48fc09a5d98262f1000c52a3>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Move RA agent certificate file export to a different location
-   `commit <https://pagure.io/freeipa/c/2a1494c9aef2e2b5c06e427e689787e5a2c4dc7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a1494c9aef2e2b5c06e427e689787e5a2c4dc7f>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__,
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Remove NSSConnection from the Python RPC module
-   `commit <https://pagure.io/freeipa/c/dfd560a190cb2ab13f34ed9e21c5fb5c6e793f18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfd560a190cb2ab13f34ed9e21c5fb5c6e793f18>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove md5_fingerprints from IPA
-   `commit <https://pagure.io/freeipa/c/e2d1b21c5049f68d0336dcaf3f8657b214a34e2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2d1b21c5049f68d0336dcaf3f8657b214a34e2b>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove DM password files after successfull pkispawn run
-   `commit <https://pagure.io/freeipa/c/a39effed7603d66acd238e3142f4df8081ff7bc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a39effed7603d66acd238e3142f4df8081ff7bc8>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Remove ra_db argument from CAInstance init
-   `commit <https://pagure.io/freeipa/c/728a6bd4229ba170b2e94f216127b19d5d94e2ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/728a6bd4229ba170b2e94f216127b19d5d94e2ba>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Fix ipa-server-upgrade
-   `commit <https://pagure.io/freeipa/c/32076df10231b381a80c9ef850c2c31d7a25feb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32076df10231b381a80c9ef850c2c31d7a25feb8>`__
    `#5959 <https://pagure.io/freeipa/issue/5959>`__
 -  Use newer Certificate.serial_number in krainstance.py
-   `commit <https://pagure.io/freeipa/c/8c2cd66269d7be976ae7fc990343ed8e9b5282a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c2cd66269d7be976ae7fc990343ed8e9b5282a3>`__
 -  Fix error in ca_cert_files validator
-   `commit <https://pagure.io/freeipa/c/0fffeabe0249d9c3c11e522fccf22ddeb1197b64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fffeabe0249d9c3c11e522fccf22ddeb1197b64>`__
    `#6694 <https://pagure.io/freeipa/issue/6694>`__
 -  Don't prepend option names with additional '--'
-   `commit <https://pagure.io/freeipa/c/9ac068ad04a2323192f9447986a3d1c5431f1e50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ac068ad04a2323192f9447986a3d1c5431f1e50>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Bump python-cryptography version in ipasetup.py.in
-   `commit <https://pagure.io/freeipa/c/66867319d903f7693a535471d3b81716a258ce9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66867319d903f7693a535471d3b81716a258ce9d>`__
    `#6631 <https://pagure.io/freeipa/issue/6631>`__
 -  custodiainstance: don't use IPA-specific CertDB
-   `commit <https://pagure.io/freeipa/c/b20b0489ea06931bfa7d46bdbd6623bc3f09219b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b20b0489ea06931bfa7d46bdbd6623bc3f09219b>`__
 -  Add password to certutil calls in NSSDatabase
-   `commit <https://pagure.io/freeipa/c/ca457eb5ce12291f555f1bf771114d6d7d191987>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca457eb5ce12291f555f1bf771114d6d7d191987>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Explicitly remove support of SSLv2/3
-   `commit <https://pagure.io/freeipa/c/ac6f573a3014aa09811ca1559d470afe75eadbec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac6f573a3014aa09811ca1559d470afe75eadbec>`__
    `#6607 <https://pagure.io/freeipa/issue/6607>`__
 -  Add FIPS-token password of HTTPD NSS database
-   `commit <https://pagure.io/freeipa/c/0b9b6b52d7f2e64a52ef8fd570839711311fa254>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b9b6b52d7f2e64a52ef8fd570839711311fa254>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Bump required python-cryptography version
-   `commit <https://pagure.io/freeipa/c/5b56952a547277fab4c68da02f213d40f931a4ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b56952a547277fab4c68da02f213d40f931a4ca>`__
    `#6631 <https://pagure.io/freeipa/issue/6631>`__
 -  Remove is_fips_enabled checks in installers and ipactl
-   `commit <https://pagure.io/freeipa/c/08c71703a44d8aec308781351c3a9dd4a4ba94a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08c71703a44d8aec308781351c3a9dd4a4ba94a7>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Generate sha256 ssh pubkey fingerprints for hosts
-   `commit <https://pagure.io/freeipa/c/721105c53de6fbc0abc7799ec7f48920e02089bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/721105c53de6fbc0abc7799ec7f48920e02089bd>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Unify password generation across FreeIPA
-   `commit <https://pagure.io/freeipa/c/8db5b277a079fdfe5efbd7d49311f14489cee0e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8db5b277a079fdfe5efbd7d49311f14489cee0e8>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Clarify meaning of --domain and --realm in installers
-   `commit <https://pagure.io/freeipa/c/25a6ddcce8e7b9effaf19431c421dc5b3497fa22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25a6ddcce8e7b9effaf19431c421dc5b3497fa22>`__
    `#6574 <https://pagure.io/freeipa/issue/6574>`__
 -  replicainstall: give correct error message on DL mismatch
-   `commit <https://pagure.io/freeipa/c/2dcbc9416f1de708336a9afe92a138da9360ec5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dcbc9416f1de708336a9afe92a138da9360ec5b>`__
    `#6510 <https://pagure.io/freeipa/issue/6510>`__
 -  Fix permission-find with sizelimit set
-   `commit <https://pagure.io/freeipa/c/a77627dd8cca43bd1131a7e186de0ab159763761>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a77627dd8cca43bd1131a7e186de0ab159763761>`__
    `#5640 <https://pagure.io/freeipa/issue/5640>`__
 -  Generalize filter generation in LDAPSearch
-   `commit <https://pagure.io/freeipa/c/0c044cb084780ee45860169dd5d12689cf05fa49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c044cb084780ee45860169dd5d12689cf05fa49>`__
    `#5640 <https://pagure.io/freeipa/issue/5640>`__
 -  permission-find: fix a sizelimit off-by-one bug
-   `commit <https://pagure.io/freeipa/c/2663a966dad138160a850e6af97c38a88ec83f93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2663a966dad138160a850e6af97c38a88ec83f93>`__
    `#5640 <https://pagure.io/freeipa/issue/5640>`__
 -  fix permission_find fail on low search size limit
-   `commit <https://pagure.io/freeipa/c/29aa4877eec89894cc3a6e50c4b6817a713d3177>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29aa4877eec89894cc3a6e50c4b6817a713d3177>`__
    `#5640 <https://pagure.io/freeipa/issue/5640>`__
 -  Make get_entries() not ignore its limit arguments
-   `commit <https://pagure.io/freeipa/c/0df65b6d035331322998ce5a15bdaae1bfd97c67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0df65b6d035331322998ce5a15bdaae1bfd97c67>`__
    `#5640 <https://pagure.io/freeipa/issue/5640>`__
 -  Do not log DM password in ca/kra installation logs
-   `commit <https://pagure.io/freeipa/c/e617f895e70e6812836870f504af6e22a5dc7def>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e617f895e70e6812836870f504af6e22a5dc7def>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  Fix CA replica install on DL1
-   `commit <https://pagure.io/freeipa/c/8c742b1539591b49474fe8ec871e1b523e9898bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c742b1539591b49474fe8ec871e1b523e9898bd>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Offer more general way to check domain level in replicainstall
-   `commit <https://pagure.io/freeipa/c/1e6366bc9f10de66de84b9506341f021fb3650d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e6366bc9f10de66de84b9506341f021fb3650d9>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Use same means of checking replication agreements on both DLs
-   `commit <https://pagure.io/freeipa/c/37578cfc2bbec99d75b19c94c337c406bf6a6ef7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37578cfc2bbec99d75b19c94c337c406bf6a6ef7>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replicainstall: move common checks to common_check()
-   `commit <https://pagure.io/freeipa/c/bc2e3386e7fa30211a46c0c2284d901cc2509147>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc2e3386e7fa30211a46c0c2284d901cc2509147>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Take advantage of the ca/kra code cleanup in replica installation
-   `commit <https://pagure.io/freeipa/c/835923750bff4f26d9b90df9870a961d16728488>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/835923750bff4f26d9b90df9870a961d16728488>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Use updated CA certs in replica installation
-   `commit <https://pagure.io/freeipa/c/606cac1c9e85633f54b1cc1c9fc1351e6d1a545f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/606cac1c9e85633f54b1cc1c9fc1351e6d1a545f>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Use os.path.join instead of concatenation
-   `commit <https://pagure.io/freeipa/c/928a4aa6f281df55e0f655d5cbf5a327794507b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/928a4aa6f281df55e0f655d5cbf5a327794507b6>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Remove redundant CA cert file existance check
-   `commit <https://pagure.io/freeipa/c/0b68899779e4500d231e974f11e428f8a3577538>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b68899779e4500d231e974f11e428f8a3577538>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Use host keytab to connect to remote server on DL0
-   `commit <https://pagure.io/freeipa/c/e40d6a2a53a931b4d2be3e45c84da99950e60a84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e40d6a2a53a931b4d2be3e45c84da99950e60a84>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Split install_http_certs() into two functions
-   `commit <https://pagure.io/freeipa/c/2de43e7aca7d4d4873ad3e5053ad75311e81dc68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2de43e7aca7d4d4873ad3e5053ad75311e81dc68>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  First step of merging replica installation of both DLs
-   `commit <https://pagure.io/freeipa/c/500327b7754e032738ab88ae19fad287f2d8cdab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/500327b7754e032738ab88ae19fad287f2d8cdab>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Properly bootstrap replica promotion api
-   `commit <https://pagure.io/freeipa/c/1fc128b05fd13a3f400346cc6d2e7fb5f66875ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fc128b05fd13a3f400346cc6d2e7fb5f66875ac>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Move the pki-tomcat restart to cainstance creation
-   `commit <https://pagure.io/freeipa/c/ba4df6449aaa0843ab43a1a2b3cb1df8bb022c24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba4df6449aaa0843ab43a1a2b3cb1df8bb022c24>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Move httpd restart to DNS installation
-   `commit <https://pagure.io/freeipa/c/bde1d82ebe32be339c30c85048fd18e1ce99867d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bde1d82ebe32be339c30c85048fd18e1ce99867d>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Import just IPAChangeConf instead of the whole module
-   `commit <https://pagure.io/freeipa/c/a3c9def4e982bcc90e9ece0900993ace53777906>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c9def4e982bcc90e9ece0900993ace53777906>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Added file permissions option to IPAChangeConf.newConf()
-   `commit <https://pagure.io/freeipa/c/b068d3336ad65748881d0dc74505f41dac9f0f13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b068d3336ad65748881d0dc74505f41dac9f0f13>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Fix to ipachangeconf docstrings
-   `commit <https://pagure.io/freeipa/c/990e1acb1a667b90619e7799bb96e2cd81e97e61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/990e1acb1a667b90619e7799bb96e2cd81e97e61>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  replicainstall: Unify default.conf file creation
-   `commit <https://pagure.io/freeipa/c/0914a3aeb778986dea4020ddf8ca550ebef02bad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0914a3aeb778986dea4020ddf8ca550ebef02bad>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Replaced EMPTY_LINE constant with a function call
-   `commit <https://pagure.io/freeipa/c/bddd4fac462c07458297d1cea5272bde97fb3707>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddd4fac462c07458297d1cea5272bde97fb3707>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  client: Making the configure functions more readable
-   `commit <https://pagure.io/freeipa/c/cf1c4e84e74ea15fe5cf7219872cf131bd53281e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf1c4e84e74ea15fe5cf7219872cf131bd53281e>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Moved update of DNA plugin among update plugins
-   `commit <https://pagure.io/freeipa/c/7279ef1d0f28dae9f3203362ca9e2245e56e111f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7279ef1d0f28dae9f3203362ca9e2245e56e111f>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Move ds.replica_populate to an update plugin
-   `commit <https://pagure.io/freeipa/c/83e72d704630b9cc5a1f713dfee30601950eb5e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83e72d704630b9cc5a1f713dfee30601950eb5e9>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Remove redundant dsinstance restart
-   `commit <https://pagure.io/freeipa/c/eac6f52957c361c219ad6048b515ddb62da31154>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eac6f52957c361c219ad6048b515ddb62da31154>`__
    `#6392 <https://pagure.io/freeipa/issue/6392>`__
 -  Fix missing file that fails DL1 replica installation
-   `commit <https://pagure.io/freeipa/c/842bf3d09f4b2de7d4b52005ac970594345455e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/842bf3d09f4b2de7d4b52005ac970594345455e0>`__
    `#6393 <https://pagure.io/freeipa/issue/6393>`__
 -  Make httpd publish its CA certificate on DL1
-   `commit <https://pagure.io/freeipa/c/5d15626b4db8f5e777e037680623badc86b6c31d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d15626b4db8f5e777e037680623badc86b6c31d>`__
    `#6393 <https://pagure.io/freeipa/issue/6393>`__
 -  Make installer quit more nicely on external CA installation
-   `commit <https://pagure.io/freeipa/c/889f0863b80a0c13a14aa69cd8563b5adde984b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/889f0863b80a0c13a14aa69cd8563b5adde984b2>`__
    `#6230 <https://pagure.io/freeipa/issue/6230>`__
 -  Fix test_util.test_assert_deepequal test
-   `commit <https://pagure.io/freeipa/c/d70d71846d6eb7d8e6a730965e54e737e7b49f15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d70d71846d6eb7d8e6a730965e54e737e7b49f15>`__
    `#6373 <https://pagure.io/freeipa/issue/6373>`__
 -  Pretty-print structures in assert_deepequal
-   `commit <https://pagure.io/freeipa/c/ecd6cb4e45096f8d6653c6bb2e4701e683ce4e61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecd6cb4e45096f8d6653c6bb2e4701e683ce4e61>`__
    `#6212 <https://pagure.io/freeipa/issue/6212>`__
 -  Remove update_from_dict() method
-   `commit <https://pagure.io/freeipa/c/330a3ca93101bcec82ec5d3add14586871864bdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/330a3ca93101bcec82ec5d3add14586871864bdd>`__
    `#6311 <https://pagure.io/freeipa/issue/6311>`__
 -  Updated help/man information about hostname
-   `commit <https://pagure.io/freeipa/c/2e0afab5f2a47149580b4bc79093cdbb77f489c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e0afab5f2a47149580b4bc79093cdbb77f489c3>`__
    `#5754 <https://pagure.io/freeipa/issue/5754>`__
 
 
@@ -3588,7 +3588,7 @@ Thierry Bordaz (1)
 
 -  IPA Allows Password Reuse with History value defined when admin
    resets the password.
-   `commit <https://pagure.io/freeipa/c/c223130d5f429278202aaf8bf87af53911a3b448>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c223130d5f429278202aaf8bf87af53911a3b448>`__
    `#6402 <https://pagure.io/freeipa/issue/6402>`__
 
 
@@ -3597,21 +3597,21 @@ Timo Aaltonen (8)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform/debian/paths: Add some missing values.
-   `commit <https://pagure.io/freeipa/c/e20ad9c251d9118959e501cd49997662de8cdbfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e20ad9c251d9118959e501cd49997662de8cdbfc>`__
 -  ipaplatform/debian/paths: Rename IPA_KEYTAB to OLD_IPA_KEYTAB.
-   `commit <https://pagure.io/freeipa/c/c194f74b12a92e3beb01f36b5cbe20255d8247c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c194f74b12a92e3beb01f36b5cbe20255d8247c5>`__
 -  ipaplatform/debian/paths: Add IPA_HTTPD_KDCPROXY.
-   `commit <https://pagure.io/freeipa/c/71db8c264e38502e80f05e9cb234185049450b62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71db8c264e38502e80f05e9cb234185049450b62>`__
 -  ipaplatform/debian/services: Fix is_running arguments.
-   `commit <https://pagure.io/freeipa/c/1a47fcd3ee7fe2878c77de0729e422c40a457600>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a47fcd3ee7fe2878c77de0729e422c40a457600>`__
 -  ipaplatform: Add Debian platform module.
-   `commit <https://pagure.io/freeipa/c/e04b75cb9e71fb2b9faa49aea7f2244b01fddbcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e04b75cb9e71fb2b9faa49aea7f2244b01fddbcb>`__
 -  client, platform: Use paths.SSH\* instead of get_config_dir().
-   `commit <https://pagure.io/freeipa/c/0ff12de338a8db32bb10e1b41f32255e7b971b6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ff12de338a8db32bb10e1b41f32255e7b971b6f>`__
 -  Move ipa-otpd to $libexecdir/ipa
-   `commit <https://pagure.io/freeipa/c/6c09d6f8788b5436d6c9a5af4cc079a843f00e33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c09d6f8788b5436d6c9a5af4cc079a843f00e33>`__
 -  Purge obsolete firefox extension
-   `commit <https://pagure.io/freeipa/c/6c53765ac1746ea3cb82554775a37fe43af062e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c53765ac1746ea3cb82554775a37fe43af062e8>`__
 
 
 
@@ -3619,201 +3619,201 @@ Tomas Krizek (68)
 ----------------------------------------------------------------------------------------------
 
 -  installer: update time estimates
-   `commit <https://pagure.io/freeipa/c/09c6b7578046fed0824fc0f0d9040be69c0f0eb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09c6b7578046fed0824fc0f0d9040be69c0f0eb6>`__
    `#6596 <https://pagure.io/freeipa/issue/6596>`__
 -  server install: require IPv6 stack to be enabled
-   `commit <https://pagure.io/freeipa/c/ecb450308d0a49afffb31dda1e405ad40552e70e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecb450308d0a49afffb31dda1e405ad40552e70e>`__
    `#6608 <https://pagure.io/freeipa/issue/6608>`__
 -  Add SHA256 fingerprints for certs
-   `commit <https://pagure.io/freeipa/c/a06c71b1268850e485e89049ed3654f893edff0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a06c71b1268850e485e89049ed3654f893edff0b>`__
    `#6701 <https://pagure.io/freeipa/issue/6701>`__
 -  man: update ipa-cacert-manage
-   `commit <https://pagure.io/freeipa/c/223a48b6d9916069971f79ab324ead26fa21c79d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/223a48b6d9916069971f79ab324ead26fa21c79d>`__
    `#6648 <https://pagure.io/freeipa/issue/6648>`__
 -  test_config: fix fips_mode key in Env
-   `commit <https://pagure.io/freeipa/c/5055b34cefd6e3f9b707aed076a49ae97b38aa3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5055b34cefd6e3f9b707aed076a49ae97b38aa3c>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Env \__setitem__: replace assert with exception
-   `commit <https://pagure.io/freeipa/c/770d4cda430803f8e020c57971c4dd8e802dc417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/770d4cda430803f8e020c57971c4dd8e802dc417>`__
 -  FIPS: perform replica installation check
-   `commit <https://pagure.io/freeipa/c/cf25ea7e300cdada57bd964acb4393cc11ad333e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf25ea7e300cdada57bd964acb4393cc11ad333e>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  replicainstall: add context manager for rpc client
-   `commit <https://pagure.io/freeipa/c/397ca71e897b42a23ed4ef294fca367c1542a2aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/397ca71e897b42a23ed4ef294fca367c1542a2aa>`__
 -  check_remote_version: update exception and docstring
-   `commit <https://pagure.io/freeipa/c/62e884ff7f037a28a15d61cc9fa9c46e5c40cda5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62e884ff7f037a28a15d61cc9fa9c46e5c40cda5>`__
 -  test_config: fix tests for env.fips_mode
-   `commit <https://pagure.io/freeipa/c/7292890042677ae40faa44753ebf570db6c19e7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7292890042677ae40faa44753ebf570db6c19e7c>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Add fips_mode variable to env
-   `commit <https://pagure.io/freeipa/c/3372ad2766c0d182fa88c8bc28cf43477dc4cb3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3372ad2766c0d182fa88c8bc28cf43477dc4cb3b>`__
    `#5695 <https://pagure.io/freeipa/issue/5695>`__
 -  Bump required version of bind-dyndb-ldap to 11.0-2
-   `commit <https://pagure.io/freeipa/c/6cb7bca68486a5ae4be6f93c1acacb7b9890ba9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cb7bca68486a5ae4be6f93c1acacb7b9890ba9a>`__
    `#6565 <https://pagure.io/freeipa/issue/6565>`__
 -  bindinstance: fix named.conf parsing regexs
-   `commit <https://pagure.io/freeipa/c/2f4442fff52090bad95a9b1f4f078e4d9acc8069>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f4442fff52090bad95a9b1f4f078e4d9acc8069>`__
    `#6565 <https://pagure.io/freeipa/issue/6565>`__
 -  PEP8: fix line length for regexs in bindinstance
-   `commit <https://pagure.io/freeipa/c/52582ae9284b80c22a272f0793f0cddfb761f6dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52582ae9284b80c22a272f0793f0cddfb761f6dc>`__
 -  bump required version of BIND, bind-dyndb-ldap
-   `commit <https://pagure.io/freeipa/c/5de7065fe5769e5c3d90205b0ecc963d96f4db58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5de7065fe5769e5c3d90205b0ecc963d96f4db58>`__
    `#6565 <https://pagure.io/freeipa/issue/6565>`__
 -  named.conf template: update API for bind 9.11
-   `commit <https://pagure.io/freeipa/c/e8a2abd548b594e6f22f38445ee32bcaa7f27303>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8a2abd548b594e6f22f38445ee32bcaa7f27303>`__
    `#6565 <https://pagure.io/freeipa/issue/6565>`__
 -  Remove obsolete serial_autoincrement from named.conf parsing
-   `commit <https://pagure.io/freeipa/c/c26dd805bdb020b12346d8cb66638883c1f46b9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c26dd805bdb020b12346d8cb66638883c1f46b9e>`__
    `#6565 <https://pagure.io/freeipa/issue/6565>`__
 -  certdb: remove unused valid_months property
-   `commit <https://pagure.io/freeipa/c/36f46a5301ce62b5549899e5d693fca0b88946fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36f46a5301ce62b5549899e5d693fca0b88946fb>`__
 -  certdb: remove unused keysize property
-   `commit <https://pagure.io/freeipa/c/47565c0fc75721f457e87b1c3e3325fff6a3b3ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47565c0fc75721f457e87b1c3e3325fff6a3b3ae>`__
 -  Fix coverity issue
-   `commit <https://pagure.io/freeipa/c/49855ca9dea9241ccd88e3a89b499b6fed4493c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49855ca9dea9241ccd88e3a89b499b6fed4493c9>`__
 -  ipautil: check for open ports on all resolved IPs
-   `commit <https://pagure.io/freeipa/c/a24cd01304aaef77b66d0e178585c9ec8bbce9b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a24cd01304aaef77b66d0e178585c9ec8bbce9b5>`__
    `#6522 <https://pagure.io/freeipa/issue/6522>`__
 -  replica-conncheck: improve message logging
-   `commit <https://pagure.io/freeipa/c/de981d348efed6dc58b2e355e65244853f06ebc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de981d348efed6dc58b2e355e65244853f06ebc1>`__
    `#6497 <https://pagure.io/freeipa/issue/6497>`__
 -  replica-conncheck: improve error message during replicainstall
-   `commit <https://pagure.io/freeipa/c/eb6905bbb45d246f9beddeea69da2236cf67bc68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb6905bbb45d246f9beddeea69da2236cf67bc68>`__
    `#6497 <https://pagure.io/freeipa/issue/6497>`__
 -  ipa-replica-conncheck: fix race condition
-   `commit <https://pagure.io/freeipa/c/a44974cdf8a6c53f2e86dac92aa579ba45f666e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a44974cdf8a6c53f2e86dac92aa579ba45f666e4>`__
    `#6487 <https://pagure.io/freeipa/issue/6487>`__
 -  ipa-replica-conncheck: do not close listening ports until required
-   `commit <https://pagure.io/freeipa/c/af0ba661889c2e2c9a35d4cff9681c2abab73649>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af0ba661889c2e2c9a35d4cff9681c2abab73649>`__
    `#6487 <https://pagure.io/freeipa/issue/6487>`__
 -  upgrade: ldap conn management
-   `commit <https://pagure.io/freeipa/c/0914fc6a6043846159f6d1c4bb433dcfe9ee3f46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0914fc6a6043846159f6d1c4bb433dcfe9ee3f46>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  services: replace admin_conn with api.Backend.ldap2
-   `commit <https://pagure.io/freeipa/c/68295bf8cfd57333deb50f58df1b336a4b48ffe7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68295bf8cfd57333deb50f58df1b336a4b48ffe7>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  upgrade: do not explicitly set principal for services
-   `commit <https://pagure.io/freeipa/c/2793cdc8593c40d8318ec3685408ade6bf9a5320>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2793cdc8593c40d8318ec3685408ade6bf9a5320>`__
    `#6500 <https://pagure.io/freeipa/issue/6500>`__
 -  Build: ignore rpmbuild for lint target
-   `commit <https://pagure.io/freeipa/c/28c5e128c823f32787a4bde87e6b248928a2cd0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28c5e128c823f32787a4bde87e6b248928a2cd0a>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  cainstance: use correct certificate for replica install check
-   `commit <https://pagure.io/freeipa/c/d6300dca285acaad296f6271421c23999e3c1071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6300dca285acaad296f6271421c23999e3c1071>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  dns: check if container exists using ldapi
-   `commit <https://pagure.io/freeipa/c/f183f70e0183e51d569ada972bd3ec73cad76a30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f183f70e0183e51d569ada972bd3ec73cad76a30>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: remove do_bind from LDAPClient
-   `commit <https://pagure.io/freeipa/c/a68c95d11612108375877ff45bdb53ce6fc8fbe4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a68c95d11612108375877ff45bdb53ce6fc8fbe4>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  gitignore: ignore tar ball
-   `commit <https://pagure.io/freeipa/c/9bb6d8643f4eb7214897de28821839a14a3bcb37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bb6d8643f4eb7214897de28821839a14a3bcb37>`__
    `#6418 <https://pagure.io/freeipa/issue/6418>`__
 -  libexec scripts: ldap conn management
-   `commit <https://pagure.io/freeipa/c/33f7b8dc32bc95e0db067ac4df49807ee2b5120e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33f7b8dc32bc95e0db067ac4df49807ee2b5120e>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ldap2: modify arguments for create_connection
-   `commit <https://pagure.io/freeipa/c/41098e3f7bb517f7445ed34d555bc3fb2083c6ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41098e3f7bb517f7445ed34d555bc3fb2083c6ce>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  replicainstall: use ldap_uri in ReplicationManager
-   `commit <https://pagure.io/freeipa/c/a9585ec563d1e54c3cd7de14789457f72cd00843>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9585ec563d1e54c3cd7de14789457f72cd00843>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  replicainstall: correct hostname in ReplicationManager
-   `commit <https://pagure.io/freeipa/c/7d028992ea2c2bf6acabe79f101621bdebbf9dbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d028992ea2c2bf6acabe79f101621bdebbf9dbc>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install tools: ldap conn management
-   `commit <https://pagure.io/freeipa/c/922062eb559d1bb82a9d787763aacb31c0cf9b8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/922062eb559d1bb82a9d787763aacb31c0cf9b8d>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ldap2: change default bind_dn
-   `commit <https://pagure.io/freeipa/c/36d95472d983ff342a43a5df36d932b9de8c32ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36d95472d983ff342a43a5df36d932b9de8c32ac>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipa-adtrust-install: ldap conn management
-   `commit <https://pagure.io/freeipa/c/1240262a0b01ff8408c06058d6d4d61fc5cde548>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1240262a0b01ff8408c06058d6d4d61fc5cde548>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install: remove adhoc dis/connect from services
-   `commit <https://pagure.io/freeipa/c/03d113cdd7c5f943d8937eb4fec1086bfe47e909>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03d113cdd7c5f943d8937eb4fec1086bfe47e909>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ldapupdate: use ldapi in LDAPUpdate
-   `commit <https://pagure.io/freeipa/c/c51b04fae77149a09e921495c5b3c9802d199076>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c51b04fae77149a09e921495c5b3c9802d199076>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  replicainstall: properly close adhoc connection in promote
-   `commit <https://pagure.io/freeipa/c/49ff159a5f0cfd2f9d037ad00e75d8ac5bfba585>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49ff159a5f0cfd2f9d037ad00e75d8ac5bfba585>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install: ldap conn management
-   `commit <https://pagure.io/freeipa/c/df86efdc69271cca0774868ab85b5be7df529136>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df86efdc69271cca0774868ab85b5be7df529136>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install: remove adhoc api.Backend.ldap2 (dis)connect
-   `commit <https://pagure.io/freeipa/c/a77469f5984b12e201a3d349efad1ca2925ee5af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a77469f5984b12e201a3d349efad1ca2925ee5af>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install: add restart_dirsrv for directory server restarts
-   `commit <https://pagure.io/freeipa/c/e05bdeb6cf4505ef84e485b95b37aabba625160b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e05bdeb6cf4505ef84e485b95b37aabba625160b>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  upgradeinstance: ldap conn management
-   `commit <https://pagure.io/freeipa/c/e8aa2627c7a3dcb0b0745e656ea58ccbbccd38fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8aa2627c7a3dcb0b0745e656ea58ccbbccd38fb>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  dsinstance: conn management
-   `commit <https://pagure.io/freeipa/c/8934d03b3b5bbf02e9e20a1644ef31d27fa0f483>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8934d03b3b5bbf02e9e20a1644ef31d27fa0f483>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ldap2: change default time/size limit
-   `commit <https://pagure.io/freeipa/c/e2780b2106a6e6bab0cb3f3d3ec06482cde9d374>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2780b2106a6e6bab0cb3f3d3ec06482cde9d374>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  cainstall: add dm_password to CA installation
-   `commit <https://pagure.io/freeipa/c/7a1c0db989cf59a778676635e160f73ebc610694>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a1c0db989cf59a778676635e160f73ebc610694>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  replicainstall: set ldapi uri in replica promotion
-   `commit <https://pagure.io/freeipa/c/9fca820b6bc2144cd827bddba69cb53f8ba3f42a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fca820b6bc2144cd827bddba69cb53f8ba3f42a>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  dsinstance: enable ldapi and autobind in ds
-   `commit <https://pagure.io/freeipa/c/24baccbd6ac8a19ba52619a3cc59366220c4ca1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24baccbd6ac8a19ba52619a3cc59366220c4ca1f>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  install: remove dirman_pw from services
-   `commit <https://pagure.io/freeipa/c/9340a1417acf120fed3e9ffbe9d658d3456743a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9340a1417acf120fed3e9ffbe9d658d3456743a1>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: merge IPAdmin to LDAPClient
-   `commit <https://pagure.io/freeipa/c/5b81dbfda1e4f0799d4ce87e9987a896af3ff299>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b81dbfda1e4f0799d4ce87e9987a896af3ff299>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: merge gssapi_bind to LDAPClient
-   `commit <https://pagure.io/freeipa/c/4f1a6a177666c475156f496d3f7719b37e66a7b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f1a6a177666c475156f496d3f7719b37e66a7b0>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: merge external_bind into LDAPClient
-   `commit <https://pagure.io/freeipa/c/60e38ecc7ff6b983f4f3af0a66c08eb3a3fda22d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60e38ecc7ff6b983f4f3af0a66c08eb3a3fda22d>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: merge simple_bind into LDAPClient
-   `commit <https://pagure.io/freeipa/c/de58a5c60596de8b45c8016c3318bac78305477a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de58a5c60596de8b45c8016c3318bac78305477a>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipaldap: remove wait/timeout during binds
-   `commit <https://pagure.io/freeipa/c/5760b7e983da6bda8f5383d9079551e4acb4c2da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5760b7e983da6bda8f5383d9079551e4acb4c2da>`__
    `#6461 <https://pagure.io/freeipa/issue/6461>`__
 -  ipa: check if provided config file exists
-   `commit <https://pagure.io/freeipa/c/0dea726466b5971cf74b9e8b7e33af0618e5842c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dea726466b5971cf74b9e8b7e33af0618e5842c>`__
    `#6114 <https://pagure.io/freeipa/issue/6114>`__
 -  ipa: allow relative paths for config file
-   `commit <https://pagure.io/freeipa/c/d7a2dfddbc2dc9ae4cea7d65e56d61a6a4d2b928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7a2dfddbc2dc9ae4cea7d65e56d61a6a4d2b928>`__
    `#6114 <https://pagure.io/freeipa/issue/6114>`__
 -  Prompt for forwarder in dnsforwardzone-add
-   `commit <https://pagure.io/freeipa/c/ef9c718e3a82fcbd5944cc993e2c9f3f1237f85c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef9c718e3a82fcbd5944cc993e2c9f3f1237f85c>`__
    `#6169 <https://pagure.io/freeipa/issue/6169>`__
 -  Update man/help for --server option
-   `commit <https://pagure.io/freeipa/c/07ff1f619c001181563886b5a0b5f1886b6638a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07ff1f619c001181563886b5a0b5f1886b6638a1>`__
    `#6202 <https://pagure.io/freeipa/issue/6202>`__
 -  Update ipa-server-install man page for hostname
-   `commit <https://pagure.io/freeipa/c/4e880f7ce96bc160af2383880b9c11e66c660a5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e880f7ce96bc160af2383880b9c11e66c660a5a>`__
    `#6330 <https://pagure.io/freeipa/issue/6330>`__
 -  Add help info about certificate revocation reasons
-   `commit <https://pagure.io/freeipa/c/75f77e0f2a55de4802b2ab74a0e6f50eaf728dc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75f77e0f2a55de4802b2ab74a0e6f50eaf728dc8>`__
    `#6327 <https://pagure.io/freeipa/issue/6327>`__
 -  Add log messages for IP checks during client install
-   `commit <https://pagure.io/freeipa/c/d6f6a291da5926217ac3acbbb959fd23227c7bd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6f6a291da5926217ac3acbbb959fd23227c7bd2>`__
    `#6331 <https://pagure.io/freeipa/issue/6331>`__
 -  Show error message for invalid IPs in client install
-   `commit <https://pagure.io/freeipa/c/ddf48f2fef344784b9e1918d2f2ee6feef9d4c04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddf48f2fef344784b9e1918d2f2ee6feef9d4c04>`__
    `#6340 <https://pagure.io/freeipa/issue/6340>`__
 -  Keep NSS trust flags of existing certificates
-   `commit <https://pagure.io/freeipa/c/2bc70a5d5f5eb953969e7341179c5083c147221a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bc70a5d5f5eb953969e7341179c5083c147221a>`__
    `#5791 <https://pagure.io/freeipa/issue/5791>`__
 -  Don't show error messages in bash completion
-   `commit <https://pagure.io/freeipa/c/9d49b4c7e740fb909d8955d23aeb50b5d73d0b23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d49b4c7e740fb909d8955d23aeb50b5d73d0b23>`__
    `#6273 <https://pagure.io/freeipa/issue/6273>`__
 
 
@@ -3822,10 +3822,10 @@ Thorsten Scherf (2)
 ----------------------------------------------------------------------------------------------
 
 -  added ssl verification using IPA trust anchor
-   `commit <https://pagure.io/freeipa/c/16dac0252e52c8de07fd8a6a86ec0896074cbe9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16dac0252e52c8de07fd8a6a86ec0896074cbe9d>`__
    `#6686 <https://pagure.io/freeipa/issue/6686>`__
 -  added help about default value for --external-ca-type option
-   `commit <https://pagure.io/freeipa/c/573a0f1ffe5035b75fb88ee7752029e34c6b37af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/573a0f1ffe5035b75fb88ee7752029e34c6b37af>`__
 
 
 
@@ -3833,4 +3833,4 @@ shanyin (1)
 ----------------------------------------------------------------------------------------------
 
 -  fix missing translation string
-   `commit <https://pagure.io/freeipa/c/0499ba5795cf483756ac980604fd2c26fda7ba39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0499ba5795cf483756ac980604fd2c26fda7ba39>`__

--- a/src/page/Releases/4.5.1.rst
+++ b/src/page/Releases/4.5.1.rst
@@ -276,20 +276,20 @@ Alexander Bokovoy (5)
 ----------------------------------------------------------------------------------------------
 
 -  trust: always use oddjobd helper for fetching trust information
-   `commit <https://pagure.io/freeipa/c/45e1998c51e281c8371ae31762016cb1ddec406f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45e1998c51e281c8371ae31762016cb1ddec406f>`__
 -  ipaserver/dcerpc: unify error processing
-   `commit <https://pagure.io/freeipa/c/bbb23fc87a51218960d54f9eccc23405c5c5ded6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbb23fc87a51218960d54f9eccc23405c5c5ded6>`__
    `#6859 <https://pagure.io/freeipa/issue/6859>`__
 -  adtrust: make sure that runtime hostname result is consistent with
    the configuration
-   `commit <https://pagure.io/freeipa/c/e430699024df06e1e6f819824548986eb0fa5fd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e430699024df06e1e6f819824548986eb0fa5fd2>`__
    `#6786 <https://pagure.io/freeipa/issue/6786>`__
 -  server: make sure we test for sss_nss_getlistbycert
-   `commit <https://pagure.io/freeipa/c/8be6987da72dff0ebd4e02c946b45b5b1705d880>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8be6987da72dff0ebd4e02c946b45b5b1705d880>`__
    `#6828 <https://pagure.io/freeipa/issue/6828>`__
 -  ldap2: use LDAP whoami operation to retrieve bind DN for current
    connection
-   `commit <https://pagure.io/freeipa/c/7d48fb841a23e9f036f3d449d80623d1225c820a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d48fb841a23e9f036f3d449d80623d1225c820a>`__
    `#6797 <https://pagure.io/freeipa/issue/6797>`__
 
 
@@ -298,10 +298,10 @@ Abhijeet Kasurde (2)
 ----------------------------------------------------------------------------------------------
 
 -  Hide PKI Client database password in log file
-   `commit <https://pagure.io/freeipa/c/1d911fc2186da1c6566648f94a6819c4e7a2a72b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d911fc2186da1c6566648f94a6819c4e7a2a72b>`__
    `#6904 <https://pagure.io/freeipa/issue/6904>`__
 -  Hide request_type doc string in cert-request help
-   `commit <https://pagure.io/freeipa/c/535e8610c556ab1a0eb83e9798e7e182355d8396>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/535e8610c556ab1a0eb83e9798e7e182355d8396>`__
    `#5734 <https://pagure.io/freeipa/issue/5734>`__,
    `#6494 <https://pagure.io/freeipa/issue/6494>`__
 
@@ -311,64 +311,64 @@ Christian Heimes (21)
 ----------------------------------------------------------------------------------------------
 
 -  Correct PyPI package dependencies
-   `commit <https://pagure.io/freeipa/c/b91ee1294bb3139f3d9df62c75dd429a5821bf40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b91ee1294bb3139f3d9df62c75dd429a5821bf40>`__
    `#6875 <https://pagure.io/freeipa/issue/6875>`__
 -  Vault: Explicitly default to 3DES CBC
-   `commit <https://pagure.io/freeipa/c/e94a1d18653fe2e9558ac0b70bdf2ddd1f78d150>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e94a1d18653fe2e9558ac0b70bdf2ddd1f78d150>`__
    `#6899 <https://pagure.io/freeipa/issue/6899>`__
 -  Use entry_points for ipa CLI
-   `commit <https://pagure.io/freeipa/c/1e1e4e8ef2d2486068e17228c8a0f8b1a2b099f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e1e4e8ef2d2486068e17228c8a0f8b1a2b099f5>`__
    `#6653 <https://pagure.io/freeipa/issue/6653>`__,
    `#6850 <https://pagure.io/freeipa/issue/6850>`__
 -  Skip test_session_storage in ipaclient unittest mode
-   `commit <https://pagure.io/freeipa/c/c80adf6e0d16f807f90479660af22540cd92d774>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c80adf6e0d16f807f90479660af22540cd92d774>`__
 -  Add make devcheck for developers
-   `commit <https://pagure.io/freeipa/c/89ab24f1fbb58feb603d60503c685ebad41a4237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89ab24f1fbb58feb603d60503c685ebad41a4237>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 -  Python 3: Fix session storage
-   `commit <https://pagure.io/freeipa/c/f1d731a79c384c7406c52232ff291644137e100b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1d731a79c384c7406c52232ff291644137e100b>`__
 -  Use Custodia 0.3.1 features
-   `commit <https://pagure.io/freeipa/c/403263df7a3be61086c87c5577698cf32a912065>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/403263df7a3be61086c87c5577698cf32a912065>`__
 -  Simplify KRA transport cert cache
-   `commit <https://pagure.io/freeipa/c/2723b5fa5edc75901c8fbaf110a37c87df0aec87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2723b5fa5edc75901c8fbaf110a37c87df0aec87>`__
    `#6787 <https://pagure.io/freeipa/issue/6787>`__
 -  Constrain wheel package versions
-   `commit <https://pagure.io/freeipa/c/7c93a518c8b6fb0e3a85bc1ae0ee807c71168213>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c93a518c8b6fb0e3a85bc1ae0ee807c71168213>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Move remaining util functions to tasks module
-   `commit <https://pagure.io/freeipa/c/cd791843da478625f51e98c502b65e186373a9fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd791843da478625f51e98c502b65e186373a9fa>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Ship ipatests.pytest_plugins.integration
-   `commit <https://pagure.io/freeipa/c/87b60f3cfb5e43fa0c37a09051872b496ad72829>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87b60f3cfb5e43fa0c37a09051872b496ad72829>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move function run_repeatedly to tasks module
-   `commit <https://pagure.io/freeipa/c/4c62c4138c443f78757bd519fad143729af27e53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c62c4138c443f78757bd519fad143729af27e53>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move hosts module to ipatests.pytest_plugins.integration.hosts
-   `commit <https://pagure.io/freeipa/c/6789dac7a09706036dd13555b4ff2ce244551bc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6789dac7a09706036dd13555b4ff2ce244551bc6>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move tasks module to ipatests.pytest_plugins.integration.tasks
-   `commit <https://pagure.io/freeipa/c/321437cc72b38bc055c74f0a4bdf54520afb57aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/321437cc72b38bc055c74f0a4bdf54520afb57aa>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move env_config module to
    ipatests.pytest_plugins.integration.env_config
-   `commit <https://pagure.io/freeipa/c/e257bbd805b319ed85e5bf8ce6eeac80e7c4139c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e257bbd805b319ed85e5bf8ce6eeac80e7c4139c>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move config module to ipatests.pytest_plugins.integration.config
-   `commit <https://pagure.io/freeipa/c/025a19c3bf2b446de5c9430142e75eac5887fb04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/025a19c3bf2b446de5c9430142e75eac5887fb04>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move helper code for integration plugin
-   `commit <https://pagure.io/freeipa/c/1199416d4e2dd1a653a7c1255e446970412fe1d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1199416d4e2dd1a653a7c1255e446970412fe1d6>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Increase Apache HTTPD's default keep alive timeout
-   `commit <https://pagure.io/freeipa/c/4b426fbfa2dc83f1f43abbc2b9396bd9f1b07f74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b426fbfa2dc83f1f43abbc2b9396bd9f1b07f74>`__
 -  Add debug logging for keep-alive
-   `commit <https://pagure.io/freeipa/c/f78439439c3c2ef6491fd5275de9d40b4b40a9b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f78439439c3c2ef6491fd5275de9d40b4b40a9b7>`__
 -  Use connection keep-alive
-   `commit <https://pagure.io/freeipa/c/25cf4a2e76ff976fe15029f9da7e4e3555f203d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25cf4a2e76ff976fe15029f9da7e4e3555f203d4>`__
    `#6641 <https://pagure.io/freeipa/issue/6641>`__
 -  Add options to run only ipaclient unittests
-   `commit <https://pagure.io/freeipa/c/29b885a8fac82e963f5ab98d178e81854056930e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29b885a8fac82e963f5ab98d178e81854056930e>`__
    `#6517 <https://pagure.io/freeipa/issue/6517>`__
 
 
@@ -378,35 +378,35 @@ David Kupka (10)
 
 -  ipapython.ipautil.run: Add option to set umask before executing
    command
-   `commit <https://pagure.io/freeipa/c/5cf5395eb51ff5ec8164075a5ee573abe76bc15e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cf5395eb51ff5ec8164075a5ee573abe76bc15e>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  otptoken-add-yubikey: When --digits not provided use default value
-   `commit <https://pagure.io/freeipa/c/749fc90d1fde0d012acb05ba64309f4a6ed63124>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/749fc90d1fde0d012acb05ba64309f4a6ed63124>`__
    `#6900 <https://pagure.io/freeipa/issue/6900>`__
 -  Bump version of ipa.conf file
-   `commit <https://pagure.io/freeipa/c/76e5ac59579f36f28bb247bf3173e95e57ee4af4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76e5ac59579f36f28bb247bf3173e95e57ee4af4>`__
    `#6860 <https://pagure.io/freeipa/issue/6860>`__
 -  Create system users for FreeIPA services during package installation
-   `commit <https://pagure.io/freeipa/c/e8a429d9e170955919f2e53e66b580be95e908d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8a429d9e170955919f2e53e66b580be95e908d9>`__
    `#6743 <https://pagure.io/freeipa/issue/6743>`__
 -  WebUI: cert login: Configure name of parameter used to pass username
-   `commit <https://pagure.io/freeipa/c/a9721e529e7a02eeb40d29cb7820e69cd86d9337>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9721e529e7a02eeb40d29cb7820e69cd86d9337>`__
    `#6860 <https://pagure.io/freeipa/issue/6860>`__
 -  httpinstance.disable_system_trust: Don't fail if module 'Root Certs'
    is not available
-   `commit <https://pagure.io/freeipa/c/2a499551ca5ddf2596cc19a77f47c34e9f5c10c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a499551ca5ddf2596cc19a77f47c34e9f5c10c5>`__
    `#6803 <https://pagure.io/freeipa/issue/6803>`__
 -  spec file: Bump requires to make Certificate Login in WebUI work
-   `commit <https://pagure.io/freeipa/c/aa24ed88006925e6d7e44567b087364b0116db9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa24ed88006925e6d7e44567b087364b0116db9c>`__
    `#6823 <https://pagure.io/freeipa/issue/6823>`__
 -  rpcserver.login_x509: Actually return reply from \__call_\_ method
-   `commit <https://pagure.io/freeipa/c/c80941e98bfd00c1c6e530aa4a592354adff8d90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c80941e98bfd00c1c6e530aa4a592354adff8d90>`__
    `#6819 <https://pagure.io/freeipa/issue/6819>`__
 -  Create temporaty directories at the begining of uninstall
-   `commit <https://pagure.io/freeipa/c/c0a395776f3c9e4f4612fa16bb6af40646c3cdbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0a395776f3c9e4f4612fa16bb6af40646c3cdbf>`__
    `#6715 <https://pagure.io/freeipa/issue/6715>`__
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
-   `commit <https://pagure.io/freeipa/c/8f0c7df198f8dd6ae742b099b3258c2383007c30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f0c7df198f8dd6ae742b099b3258c2383007c30>`__
    `#6738 <https://pagure.io/freeipa/issue/6738>`__
 
 
@@ -415,7 +415,7 @@ felipe (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixing replica install: fix ldap connection in domlvl 0
-   `commit <https://pagure.io/freeipa/c/af4531d26ea1082acf17252e7e81cb3cd4b0c12c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af4531d26ea1082acf17252e7e81cb3cd4b0c12c>`__
    `#6549 <https://pagure.io/freeipa/issue/6549>`__
 
 
@@ -424,7 +424,7 @@ Felipe Volpone (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixing adding authenticator indicators to host
-   `commit <https://pagure.io/freeipa/c/81ae5f4d655bb052c6c0961760dba34e70dcd3c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81ae5f4d655bb052c6c0961760dba34e70dcd3c3>`__
    `#6911 <https://pagure.io/freeipa/issue/6911>`__
 
 
@@ -433,7 +433,7 @@ Fabiano Fidêncio (1)
 ----------------------------------------------------------------------------------------------
 
 -  Allow erasing ipaDomainResolutionOrder attribute
-   `commit <https://pagure.io/freeipa/c/08a921cc08b5b841260caa2e45653a704b88542c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08a921cc08b5b841260caa2e45653a704b88542c>`__
    `#6825 <https://pagure.io/freeipa/issue/6825>`__
 
 
@@ -442,54 +442,54 @@ Florence Blanc-Renaud (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-ca-install: append CA cert chain into /etc/ipa/ca.crt
-   `commit <https://pagure.io/freeipa/c/653d2f412012bcef04599b512938f06084d267b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/653d2f412012bcef04599b512938f06084d267b1>`__
    `#6925 <https://pagure.io/freeipa/issue/6925>`__
 -  ipa-kra-install: fix pkispawn setting for
    pki_security_domain_hostname
-   `commit <https://pagure.io/freeipa/c/592cdf05413c0981d2085919357cc4e891306b79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/592cdf05413c0981d2085919357cc4e891306b79>`__
    `#6895 <https://pagure.io/freeipa/issue/6895>`__
 -  ipa-server-install: fix uninstall
-   `commit <https://pagure.io/freeipa/c/752e167497eca87632261dec7bbb352cd0e599c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/752e167497eca87632261dec7bbb352cd0e599c8>`__
    `#6950 <https://pagure.io/freeipa/issue/6950>`__
 -  ipa-kra-install manpage: document domain-level 1
-   `commit <https://pagure.io/freeipa/c/72d2e9e4c312576e1a62e210b4e5d9696bc70609>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72d2e9e4c312576e1a62e210b4e5d9696bc70609>`__
    `#6922 <https://pagure.io/freeipa/issue/6922>`__
 -  ipa-kra-install: fix check_host_keys
-   `commit <https://pagure.io/freeipa/c/b90dce88e227174aa33270beee9b3d6ff51cce59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b90dce88e227174aa33270beee9b3d6ff51cce59>`__
    `#6934 <https://pagure.io/freeipa/issue/6934>`__
 -  ipa-server-install with external CA: fix pkinit cert issuance
-   `commit <https://pagure.io/freeipa/c/8107125e177ac9f378d149d7b0fa1d3774c9be3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8107125e177ac9f378d149d7b0fa1d3774c9be3a>`__
    `#6921 <https://pagure.io/freeipa/issue/6921>`__
 -  ipa-client-install: remove extra space in pkinit_anchors definition
-   `commit <https://pagure.io/freeipa/c/a3c4e70650dbcd5dd3f00a7b2fecc051afeebec0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c4e70650dbcd5dd3f00a7b2fecc051afeebec0>`__
    `#6916 <https://pagure.io/freeipa/issue/6916>`__
 -  vault: piped input for ipa vault-add fails
-   `commit <https://pagure.io/freeipa/c/c8ca0f89a68b5d57c56344fdeb12fd436976c726>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8ca0f89a68b5d57c56344fdeb12fd436976c726>`__
    `#6907 <https://pagure.io/freeipa/issue/6907>`__
 -  upgrade: adtrust update_tdo_gidnumber plugin must check if adtrust is
    installed
-   `commit <https://pagure.io/freeipa/c/c05bd60585fb80e061b8582a648a65204c709f51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c05bd60585fb80e061b8582a648a65204c709f51>`__
    `#6881 <https://pagure.io/freeipa/issue/6881>`__
 -  tests: add non-reg for idrange-add
-   `commit <https://pagure.io/freeipa/c/ab2706721db217d55ae549d50a95ace571e65aa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab2706721db217d55ae549d50a95ace571e65aa6>`__
    `#6404 <https://pagure.io/freeipa/issue/6404>`__
 -  Upgrade: add gidnumber to trusted domain entry
-   `commit <https://pagure.io/freeipa/c/eddd29f1d52d63ea702437b0dd2a2826df52bc26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eddd29f1d52d63ea702437b0dd2a2826df52bc26>`__
    `#6827 <https://pagure.io/freeipa/issue/6827>`__
 -  ipa-sam: create the gidNumber attribute in the trusted domain entry
-   `commit <https://pagure.io/freeipa/c/91d36941653476abfff6a54ba7cb5a9f2c12c22d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91d36941653476abfff6a54ba7cb5a9f2c12c22d>`__
    `#6827 <https://pagure.io/freeipa/issue/6827>`__
 -  idrange-add: properly handle empty --dom-name option
-   `commit <https://pagure.io/freeipa/c/077a61524d79ac5ab6f0eb46450c82ad5594bd2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/077a61524d79ac5ab6f0eb46450c82ad5594bd2b>`__
    `#6404 <https://pagure.io/freeipa/issue/6404>`__
 -  ipa-ca-install man page: Add domain level 1 help
-   `commit <https://pagure.io/freeipa/c/262723b1be894e5d75cccdd92da838f544a3b222>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/262723b1be894e5d75cccdd92da838f544a3b222>`__
    `#5831 <https://pagure.io/freeipa/issue/5831>`__
 -  dogtag-ipa-ca-renew-agent-submit: fix the is_replicated() function
-   `commit <https://pagure.io/freeipa/c/8f738f1ea9f86a921e3dc0fd02e57419f3173ed9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f738f1ea9f86a921e3dc0fd02e57419f3173ed9>`__
    `#6813 <https://pagure.io/freeipa/issue/6813>`__
 -  man ipa-cacert-manage install needs clarification
-   `commit <https://pagure.io/freeipa/c/bb53a9ab6dce023dd51c2a434fd8597eab5bc0d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb53a9ab6dce023dd51c2a434fd8597eab5bc0d0>`__
    `#6795 <https://pagure.io/freeipa/issue/6795>`__
 
 
@@ -498,7 +498,7 @@ Fraser Tweedale (1)
 ----------------------------------------------------------------------------------------------
 
 -  Support 8192-bit RSA keys in default cert profile
-   `commit <https://pagure.io/freeipa/c/9118c08455d42f4e7f43370be1a858595a60bc9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9118c08455d42f4e7f43370be1a858595a60bc9a>`__
    `#6319 <https://pagure.io/freeipa/issue/6319>`__
 
 
@@ -507,120 +507,120 @@ Jan Cholasta (38)
 ----------------------------------------------------------------------------------------------
 
 -  server certinstall: support PKINIT
-   `commit <https://pagure.io/freeipa/c/e27b3e139ffff16f6e238ef6f9ff7d2ed02492bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e27b3e139ffff16f6e238ef6f9ff7d2ed02492bc>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  cacert manage: support PKINIT
-   `commit <https://pagure.io/freeipa/c/6f900ec60a426a2b97823d4612949a953fa6d49b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f900ec60a426a2b97823d4612949a953fa6d49b>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  replica install: respect --pkinit-cert-file
-   `commit <https://pagure.io/freeipa/c/77ef29ef30086c714025d97328507bd51e3f0421>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77ef29ef30086c714025d97328507bd51e3f0421>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  server install: fix KDC certificate validation in CA-less
-   `commit <https://pagure.io/freeipa/c/cbdf6693cc8707dda9c1db42fb05dc5b1d70b7af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbdf6693cc8707dda9c1db42fb05dc5b1d70b7af>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__,
    `#6869 <https://pagure.io/freeipa/issue/6869>`__
 -  certs: do not export CA certs in install_pem_from_p12
-   `commit <https://pagure.io/freeipa/c/bc8deb118dce93fc380793c75090d9108ce61541>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc8deb118dce93fc380793c75090d9108ce61541>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__,
    `#6869 <https://pagure.io/freeipa/issue/6869>`__
 -  certs: do not export keys world-readable in install_key_from_p12
-   `commit <https://pagure.io/freeipa/c/e6497f099c09dfa60bd6ae98e4692e99b7381752>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6497f099c09dfa60bd6ae98e4692e99b7381752>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  server install: fix KDC PKINIT configuration
-   `commit <https://pagure.io/freeipa/c/b83ebe0e3ff692de37f28834d09a423d04e6ad68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b83ebe0e3ff692de37f28834d09a423d04e6ad68>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  install: introduce generic Kerberos Augeas lens
-   `commit <https://pagure.io/freeipa/c/523a82652e2f95704a07ac25cc829a0782b9e22a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/523a82652e2f95704a07ac25cc829a0782b9e22a>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  client install: fix client PKINIT configuration
-   `commit <https://pagure.io/freeipa/c/63c4cbd619f81f16e0c08d3786b69d348c9dcfd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63c4cbd619f81f16e0c08d3786b69d348c9dcfd7>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  install: trust IPA CA for PKINIT
-   `commit <https://pagure.io/freeipa/c/16b295c5a8580accfbbab016f3cc4eef0a704163>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16b295c5a8580accfbbab016f3cc4eef0a704163>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb: use custom object for trust flags
-   `commit <https://pagure.io/freeipa/c/e68812331526269f3b556c339f65077f649110d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e68812331526269f3b556c339f65077f649110d3>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb, certs: make trust flags argument mandatory
-   `commit <https://pagure.io/freeipa/c/749d504f4335c375cf86bf44814177f03be61b52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/749d504f4335c375cf86bf44814177f03be61b52>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb: add named trust flag constants
-   `commit <https://pagure.io/freeipa/c/6338dbe47313a70b93bbf53855db451145d24544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6338dbe47313a70b93bbf53855db451145d24544>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  ipa-cacert-manage: add --external-ca-type
-   `commit <https://pagure.io/freeipa/c/c56d12aeaccb455a193271a31362b7412b2d2e60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c56d12aeaccb455a193271a31362b7412b2d2e60>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: get rid of virtual profiles
-   `commit <https://pagure.io/freeipa/c/bb952827b84d7b47ffd77549b3a7c9da2fe537ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb952827b84d7b47ffd77549b3a7c9da2fe537ae>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: always export CSR on IPA CA certificate renewal
-   `commit <https://pagure.io/freeipa/c/25b0a9cf6c60c709cacb74ad188cd6e91d4b60ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25b0a9cf6c60c709cacb74ad188cd6e91d4b60ea>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: allow reusing existing certs
-   `commit <https://pagure.io/freeipa/c/920d56a8f0321c4b092da6c173961c82aa1d6bd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/920d56a8f0321c4b092da6c173961c82aa1d6bd3>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  cainstance: use correct profile for lightweight CA certificates
-   `commit <https://pagure.io/freeipa/c/4a01114f1e49fd73e88e2d9f1512a11cbab0176e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a01114f1e49fd73e88e2d9f1512a11cbab0176e>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  server upgrade: always fix certmonger tracking request
-   `commit <https://pagure.io/freeipa/c/b55dd9cee5c2161002f56c63d7e0ae86e792fbbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b55dd9cee5c2161002f56c63d7e0ae86e792fbbd>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: respect CA renewal master setting
-   `commit <https://pagure.io/freeipa/c/36fc44b90ceb9e98abd93a3abb1e5b8d18df6ff0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36fc44b90ceb9e98abd93a3abb1e5b8d18df6ff0>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  spec file: bump python-netaddr Requires
-   `commit <https://pagure.io/freeipa/c/ecccd6cb843c44093449cc45a7d94bb14fa65513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecccd6cb843c44093449cc45a7d94bb14fa65513>`__
    `#6894 <https://pagure.io/freeipa/issue/6894>`__
 -  spec file: bump krb5 Requires for certauth fixes
-   `commit <https://pagure.io/freeipa/c/ec3a2a6063beb4ec96796b66abb82476a5c7bd0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec3a2a6063beb4ec96796b66abb82476a5c7bd0f>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  configure: fix AC_CHECK_LIB usage
-   `commit <https://pagure.io/freeipa/c/207864a61a748a9032e67bf0f1782379e44fb5aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/207864a61a748a9032e67bf0f1782379e44fb5aa>`__
    `#6846 <https://pagure.io/freeipa/issue/6846>`__
 -  cert: defer cert-find result post-processing
-   `commit <https://pagure.io/freeipa/c/49f9d799c171c7ae2ac546a33a353c2c40b4719c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49f9d799c171c7ae2ac546a33a353c2c40b4719c>`__
    `#6808 <https://pagure.io/freeipa/issue/6808>`__
 -  renew agent, restart scripts: connect to LDAP after kinit
-   `commit <https://pagure.io/freeipa/c/e9168e80ddb6066114f9438fa6a7a11b0eaa02cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9168e80ddb6066114f9438fa6a7a11b0eaa02cf>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  renew agent: revert to host keytab authentication
-   `commit <https://pagure.io/freeipa/c/1a7db624857c46a2c1c091ed4b8d7902a4486596>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a7db624857c46a2c1c091ed4b8d7902a4486596>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  install: request service certs after host keytab is set up
-   `commit <https://pagure.io/freeipa/c/cb141b0eb3950bcae1950e6190ba3573f348b1f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb141b0eb3950bcae1950e6190ba3573f348b1f2>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  dsinstance, httpinstance: consolidate certificate request code
-   `commit <https://pagure.io/freeipa/c/3317e172227fd72ad9049f7893d3018043201b3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3317e172227fd72ad9049f7893d3018043201b3c>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  httpinstance: avoid httpd restart during certificate request
-   `commit <https://pagure.io/freeipa/c/029da956be22c9e05a53c7c30e3afcb2c851ad86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/029da956be22c9e05a53c7c30e3afcb2c851ad86>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  dsinstance: reconnect ldap2 after DS is restarted by certmonger
-   `commit <https://pagure.io/freeipa/c/3a3cd01161b618dd6836fda7df935dd39adc117b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a3cd01161b618dd6836fda7df935dd39adc117b>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  httpinstance: make sure NSS database is backed up
-   `commit <https://pagure.io/freeipa/c/471dfcbe1cc3f319da788add3661cb6d63e3c0f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/471dfcbe1cc3f319da788add3661cb6d63e3c0f0>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  spec file: bump libsss_nss_idmap-devel BuildRequires
-   `commit <https://pagure.io/freeipa/c/127f7ce699677d8c689099eac350a54293a5009d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/127f7ce699677d8c689099eac350a54293a5009d>`__
    `#6828 <https://pagure.io/freeipa/issue/6828>`__
 -  spec file: bump krb5-devel BuildRequires for certauth
-   `commit <https://pagure.io/freeipa/c/2d246000ef2d715fab464b8ef71fdb3731da127e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d246000ef2d715fab464b8ef71fdb3731da127e>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  cert: do not limit internal searches in cert-find
-   `commit <https://pagure.io/freeipa/c/6382f9eee335907362a5ccb44b892f59de7d3751>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6382f9eee335907362a5ccb44b892f59de7d3751>`__
    `#6716 <https://pagure.io/freeipa/issue/6716>`__
 -  replica prepare: fix wrong IPA CA nickname in replica file
-   `commit <https://pagure.io/freeipa/c/df60e88e1bca6efd5ebf2a88e7825a5fd2631f08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df60e88e1bca6efd5ebf2a88e7825a5fd2631f08>`__
    `#6777 <https://pagure.io/freeipa/issue/6777>`__
 -  httpinstance: clean up /etc/httpd/alias on uninstall
-   `commit <https://pagure.io/freeipa/c/f788e3e36bcaefc7d94c92895916246681e64291>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f788e3e36bcaefc7d94c92895916246681e64291>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  certs: do not implicitly create DS pin.txt
-   `commit <https://pagure.io/freeipa/c/cf188c8513c6b36a0724866025ddc220683de8dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf188c8513c6b36a0724866025ddc220683de8dc>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  tasks: run \`systemctl daemon-reload\` after httpd.service.d updates
-   `commit <https://pagure.io/freeipa/c/62c41219acdd0e82201168aea5cb22879c655742>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62c41219acdd0e82201168aea5cb22879c655742>`__
    `#6773 <https://pagure.io/freeipa/issue/6773>`__
 
 
@@ -629,52 +629,52 @@ Martin Babinsky (16)
 ----------------------------------------------------------------------------------------------
 
 -  Travis CI: explicitly update pip before running the builds
-   `commit <https://pagure.io/freeipa/c/f2b58854bb8df46b7e0ac0a35bf473bc9d8ad607>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b58854bb8df46b7e0ac0a35bf473bc9d8ad607>`__
 -  Do not test anonymous PKINIT after install/upgrade
-   `commit <https://pagure.io/freeipa/c/d497c4589cc7506ef9a88b691b8b1d97ad1f1009>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d497c4589cc7506ef9a88b691b8b1d97ad1f1009>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Upgrade: configure local/full PKINIT depending on the master status
-   `commit <https://pagure.io/freeipa/c/2452e6e5f3a7e7a25eadf5243a28da75a47f9d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2452e6e5f3a7e7a25eadf5243a28da75a47f9d2c>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Use local anchor when armoring password requests
-   `commit <https://pagure.io/freeipa/c/5031929b6d710336f6308d7f46779c9e8e98103a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5031929b6d710336f6308d7f46779c9e8e98103a>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Stop requesting anonymous keytab and purge all references of it
-   `commit <https://pagure.io/freeipa/c/9fcc794dac6ffb1f1cc6c92a588ea0911be5ba14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fcc794dac6ffb1f1cc6c92a588ea0911be5ba14>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Use only anonymous PKINIT to fetch armor ccache
-   `commit <https://pagure.io/freeipa/c/fca378c9a65f582ac3dcda4b6201e8847ed9e512>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fca378c9a65f582ac3dcda4b6201e8847ed9e512>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  API for retrieval of master's PKINIT status and publishing it in LDAP
-   `commit <https://pagure.io/freeipa/c/a0e2a09292ffa2adbf97c2e7e4facc9693dbc311>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0e2a09292ffa2adbf97c2e7e4facc9693dbc311>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Allow for configuration of all three PKINIT variants when deploying
    KDC
-   `commit <https://pagure.io/freeipa/c/b49e075c90a7ab43e82f422aa11dc7540e2fb2c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b49e075c90a7ab43e82f422aa11dc7540e2fb2c0>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  separate function to set ipaConfigString values on service entry
-   `commit <https://pagure.io/freeipa/c/31a24436592304db6e84270e4a95df34d1e0af46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31a24436592304db6e84270e4a95df34d1e0af46>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Revert "Store GSSAPI session key in /var/run/ipa"
-   `commit <https://pagure.io/freeipa/c/a4e1ab6c893182b8b3610c0b45120194be4a0376>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4e1ab6c893182b8b3610c0b45120194be4a0376>`__
    `#6880 <https://pagure.io/freeipa/issue/6880>`__
 -  Remove duplicate functionality in upgrade
-   `commit <https://pagure.io/freeipa/c/0fcd56533a00c28f9f8f800c77b8c2c580cb3a8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fcd56533a00c28f9f8f800c77b8c2c580cb3a8f>`__
    `#6799 <https://pagure.io/freeipa/issue/6799>`__
 -  Always check and create anonymous principal during KDC install
-   `commit <https://pagure.io/freeipa/c/ce94f7fa7b4eca296d2f9692d35c2558bfeddb46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce94f7fa7b4eca296d2f9692d35c2558bfeddb46>`__
    `#6799 <https://pagure.io/freeipa/issue/6799>`__
 -  Ensure KDC is propery configured after upgrade
-   `commit <https://pagure.io/freeipa/c/89fc0a126be67755d4a687b427a6c67b3cbc4337>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89fc0a126be67755d4a687b427a6c67b3cbc4337>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Split out anonymous PKINIT test to a separate method
-   `commit <https://pagure.io/freeipa/c/c1393029b6a853cc2cb874f4f93706368627d7c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1393029b6a853cc2cb874f4f93706368627d7c4>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Remove unused variable from failed anonymous PKINIT handling
-   `commit <https://pagure.io/freeipa/c/4b2b1d33157963a8b3d8229d1edd573dcbb93fb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b2b1d33157963a8b3d8229d1edd573dcbb93fb5>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Upgrade: configure PKINIT after adding anonymous principal
-   `commit <https://pagure.io/freeipa/c/b9002bf6273151cb480dfba7ffa7480d037984ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9002bf6273151cb480dfba7ffa7480d037984ee>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 
 
@@ -683,40 +683,40 @@ Martin Basti (13)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.5.1
-   `commit <https://pagure.io/freeipa/c/9587efb317ac96d49457b16db2efa004924ad363>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9587efb317ac96d49457b16db2efa004924ad363>`__
 -  4.5.1 Translation update
-   `commit <https://pagure.io/freeipa/c/32e12477e88b5fa3c4ca5e6822d7556f389f896f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32e12477e88b5fa3c4ca5e6822d7556f389f896f>`__
 -  4.5.1 Contributors update
-   `commit <https://pagure.io/freeipa/c/a8f4938fe4e85cd344f966aa4d154368eb012e6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8f4938fe4e85cd344f966aa4d154368eb012e6b>`__
 -  ipasetup: fix dependencies handling based on python version
-   `commit <https://pagure.io/freeipa/c/c49e146a69a66cda894687f39f3d77ff3ad9c33b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c49e146a69a66cda894687f39f3d77ff3ad9c33b>`__
    `#6875 <https://pagure.io/freeipa/issue/6875>`__
 -  ipaclient: fix missing RPM ownership
-   `commit <https://pagure.io/freeipa/c/5d0975319daa34a16d4163669474af89e987457e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d0975319daa34a16d4163669474af89e987457e>`__
    `#6927 <https://pagure.io/freeipa/issue/6927>`__
 -  ca_status: add HTTP timeout 30 seconds
-   `commit <https://pagure.io/freeipa/c/68ce9aa2addb6048333e723f771132f5da7dd38f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68ce9aa2addb6048333e723f771132f5da7dd38f>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  http_request: add timeout option
-   `commit <https://pagure.io/freeipa/c/48bb3cb69c000cea3f28bd5b44072d0fe9caa7a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48bb3cb69c000cea3f28bd5b44072d0fe9caa7a2>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Use proper SELinux context with http.keytab
-   `commit <https://pagure.io/freeipa/c/bda733db9ede3307595963a8c086e1b700c41e25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bda733db9ede3307595963a8c086e1b700c41e25>`__
    `#6924 <https://pagure.io/freeipa/issue/6924>`__
 -  Store GSSAPI session key in /var/run/ipa
-   `commit <https://pagure.io/freeipa/c/b2aa3ed0bc9f5385ab6e8b1720d9f1d33136e5dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2aa3ed0bc9f5385ab6e8b1720d9f1d33136e5dc>`__
    `#6880 <https://pagure.io/freeipa/issue/6880>`__
 -  Fix PKCS11 helper
-   `commit <https://pagure.io/freeipa/c/e6b2ed6b68589ff7ee39b95559836af54f39e2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6b2ed6b68589ff7ee39b95559836af54f39e2de>`__
    `#6692 <https://pagure.io/freeipa/issue/6692>`__
 -  Remove surplus 'the' in output of ipa-adtrust-install
-   `commit <https://pagure.io/freeipa/c/e85795d4546847969ce8d0a38e6ac97c4366cfc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e85795d4546847969ce8d0a38e6ac97c4366cfc7>`__
    `#6864 <https://pagure.io/freeipa/issue/6864>`__
 -  Set "KDC:Disable Last Success" by default
-   `commit <https://pagure.io/freeipa/c/fdcd5f486839d9279dcba74b74f7756ace5812fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdcd5f486839d9279dcba74b74f7756ace5812fa>`__
    `#5313 <https://pagure.io/freeipa/issue/5313>`__
 -  Set zanata version to ipa-4-5
-   `commit <https://pagure.io/freeipa/c/a1f2754f18f93752f97d14168b74fb0f299d795d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1f2754f18f93752f97d14168b74fb0f299d795d>`__
 
 
 
@@ -724,10 +724,10 @@ Michal Reznik (2)
 ----------------------------------------------------------------------------------------------
 
 -  test_caless: mark TestCertinstall intermediate CA tests as xfail
-   `commit <https://pagure.io/freeipa/c/f9bf76e1f3b39495a9ad61513d842844b89201dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9bf76e1f3b39495a9ad61513d842844b89201dc>`__
    `#6959 <https://pagure.io/freeipa/issue/6959>`__
 -  test_caless: add pkinit option and test it
-   `commit <https://pagure.io/freeipa/c/cea42421bc17317f69143061173e8b9a5c0e153e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cea42421bc17317f69143061173e8b9a5c0e153e>`__
    `#6854 <https://pagure.io/freeipa/issue/6854>`__
 
 
@@ -736,7 +736,7 @@ Oliver Gutierrez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Added plugins directory to ipaclient subpackages
-   `commit <https://pagure.io/freeipa/c/3605f8ba9a2545680cd46ff02c282d03f84bb366>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3605f8ba9a2545680cd46ff02c282d03f84bb366>`__
    `#6927 <https://pagure.io/freeipa/issue/6927>`__
 
 
@@ -746,13 +746,13 @@ Petr Vobornik (3)
 
 -  kerberos session: use CA cert with full cert chain for obtaining
    cookie
-   `commit <https://pagure.io/freeipa/c/82679c11f1fc0701d753433d1f2d14c3ee0279af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82679c11f1fc0701d753433d1f2d14c3ee0279af>`__
    `#6876 <https://pagure.io/freeipa/issue/6876>`__
 -  restore: restart/reload gssproxy after restore
-   `commit <https://pagure.io/freeipa/c/04ed1fa3acdf002ecc37dde4f5d226c0fbe5aa30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04ed1fa3acdf002ecc37dde4f5d226c0fbe5aa30>`__
    `#6902 <https://pagure.io/freeipa/issue/6902>`__
 -  automount install: fix checking of SSSD functionality on uninstall
-   `commit <https://pagure.io/freeipa/c/ff513d6b20ee0a2ca90b06b8c114386f1e5751d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff513d6b20ee0a2ca90b06b8c114386f1e5751d9>`__
    `#6861 <https://pagure.io/freeipa/issue/6861>`__
 
 
@@ -761,28 +761,28 @@ Pavel Vomacka (8)
 ----------------------------------------------------------------------------------------------
 
 -  Turn on NSSOCSP check in mod_nss conf
-   `commit <https://pagure.io/freeipa/c/4aa7e70fcd1851394f943da669d6af4e11b60940>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4aa7e70fcd1851394f943da669d6af4e11b60940>`__
    `#6370 <https://pagure.io/freeipa/issue/6370>`__
 -  WebUI: Allow to add certs to certmapping with CERT LINES around
-   `commit <https://pagure.io/freeipa/c/eda23a9847197513555f6237b46c658365dfc12d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eda23a9847197513555f6237b46c658365dfc12d>`__
    `#6772 <https://pagure.io/freeipa/issue/6772>`__
 -  WebUI: Fix showing vault in selfservice view
-   `commit <https://pagure.io/freeipa/c/7b3cb1ccad28a1fd17803bdd7dd245bdfee9a046>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b3cb1ccad28a1fd17803bdd7dd245bdfee9a046>`__
    `#6812 <https://pagure.io/freeipa/issue/6812>`__
 -  WebUI: suppress truncation warning in select widget
-   `commit <https://pagure.io/freeipa/c/697a5779b377a5d76c1cb212514b6feb46326f71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/697a5779b377a5d76c1cb212514b6feb46326f71>`__
    `#6618 <https://pagure.io/freeipa/issue/6618>`__
 -  WebUI: Add support for suppressing warnings
-   `commit <https://pagure.io/freeipa/c/422c9058d9a6be69db4eab7db654b9184ae5eab6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/422c9058d9a6be69db4eab7db654b9184ae5eab6>`__
    `#6618 <https://pagure.io/freeipa/issue/6618>`__
 -  WebUI: Add support for login for AD users
-   `commit <https://pagure.io/freeipa/c/228e039e7d718ced7dce7c32cca3a89404c0a16e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/228e039e7d718ced7dce7c32cca3a89404c0a16e>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 -  WebUI: add method for disabling item in user dropdown menu
-   `commit <https://pagure.io/freeipa/c/01a0a38bdf53821bc420f01dc98fae577f83eabb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01a0a38bdf53821bc420f01dc98fae577f83eabb>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 -  WebUI: check principals in lowercase
-   `commit <https://pagure.io/freeipa/c/bee9c9f090e7808a2381054fa63c1d036743296c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bee9c9f090e7808a2381054fa63c1d036743296c>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 
 
@@ -792,7 +792,7 @@ Gabe (1)
 
 -  Update get_attr_filter in LDAPSearch to handle nsaccountlock user
    searches
-   `commit <https://pagure.io/freeipa/c/dc4d60c9665408666ab3dfab7023a578c34d65a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc4d60c9665408666ab3dfab7023a578c34d65a2>`__
    `#6896 <https://pagure.io/freeipa/issue/6896>`__
 
 
@@ -801,24 +801,24 @@ Sumit Bose (7)
 ----------------------------------------------------------------------------------------------
 
 -  IPA-KDB: use relative path in ipa-certmap config snippet
-   `commit <https://pagure.io/freeipa/c/fa46a01c37021e7b2b57fd3092383100e39792fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa46a01c37021e7b2b57fd3092383100e39792fb>`__
    `#6833 <https://pagure.io/freeipa/issue/6833>`__
 -  extdom: improve cert request
-   `commit <https://pagure.io/freeipa/c/a510a3d7e9f37e89acee84bed2363cb7f57fe88e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a510a3d7e9f37e89acee84bed2363cb7f57fe88e>`__
    `#6826 <https://pagure.io/freeipa/issue/6826>`__
 -  extdom: do reverse search for domain separator
-   `commit <https://pagure.io/freeipa/c/8046f9baab1e93b8b8e11d05088c8cdabdd47281>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8046f9baab1e93b8b8e11d05088c8cdabdd47281>`__
 -  ipa-kdb: do not depend on certauth_plugin.h
-   `commit <https://pagure.io/freeipa/c/8fde0b88d7c9360e16820d6086eba3e3ca0eee1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fde0b88d7c9360e16820d6086eba3e3ca0eee1e>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  configure: fix --disable-server with certauth plugin
-   `commit <https://pagure.io/freeipa/c/203d5416ce807f5cdcf9e2431feef84d49b3df61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/203d5416ce807f5cdcf9e2431feef84d49b3df61>`__
    `#6816 <https://pagure.io/freeipa/issue/6816>`__
 -  IPA certauth plugin
-   `commit <https://pagure.io/freeipa/c/5a1ce1fbaa6c7a85bd1bee2a70b8b22509ede7c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a1ce1fbaa6c7a85bd1bee2a70b8b22509ede7c7>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  ipa-kdb: add ipadb_fetch_principals_with_extra_filter()
-   `commit <https://pagure.io/freeipa/c/cfaaf4e821338dbc146dd49d3c22978165d2e329>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfaaf4e821338dbc146dd49d3c22978165d2e329>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 
 
@@ -827,25 +827,25 @@ Simo Sorce (7)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure remote hosts have our keys
-   `commit <https://pagure.io/freeipa/c/5f8d1119fe38807e86930af50d3680e28efe68eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f8d1119fe38807e86930af50d3680e28efe68eb>`__
    `#6838 <https://pagure.io/freeipa/issue/6838>`__
 -  Fix s4u2self with adtrust
-   `commit <https://pagure.io/freeipa/c/b5114070ae55bcc7ec1abe57b4c303cee4822930>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5114070ae55bcc7ec1abe57b4c303cee4822930>`__
    `#6862 <https://pagure.io/freeipa/issue/6862>`__
 -  Prevent churn on ccaches
-   `commit <https://pagure.io/freeipa/c/e94575f3466bbb8d4959ad0a1c436dcf745e3036>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e94575f3466bbb8d4959ad0a1c436dcf745e3036>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Work around issues fetching session data
-   `commit <https://pagure.io/freeipa/c/0912185b18599414e4f9302b1a80c6c7e9876821>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0912185b18599414e4f9302b1a80c6c7e9876821>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Handle failed authentication via cookie
-   `commit <https://pagure.io/freeipa/c/f41c9f476d678f9ecc4ca3338c7a58de0182f76f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f41c9f476d678f9ecc4ca3338c7a58de0182f76f>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Avoid growing FILE ccaches unnecessarily
-   `commit <https://pagure.io/freeipa/c/ba828a53a4736ed326d95e30856daba2c060439c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba828a53a4736ed326d95e30856daba2c060439c>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Add options to allow ticket caching
-   `commit <https://pagure.io/freeipa/c/62d39385e20b3e1b059466f37cc063833355551e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62d39385e20b3e1b059466f37cc063833355551e>`__
    `#6771 <https://pagure.io/freeipa/issue/6771>`__
 
 
@@ -854,104 +854,104 @@ Stanislav Laznicka (33)
 ----------------------------------------------------------------------------------------------
 
 -  cert-show: writable files does not mean dirs
-   `commit <https://pagure.io/freeipa/c/2410023ce6ef3255ddbaaf8939a928e733297d62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2410023ce6ef3255ddbaaf8939a928e733297d62>`__
    `#6883 <https://pagure.io/freeipa/issue/6883>`__
 -  Fix wrong message on Dogtag instances stop
-   `commit <https://pagure.io/freeipa/c/1b44c4caa1e7a1f90b3b3537de9cc1529f0891e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b44c4caa1e7a1f90b3b3537de9cc1529f0891e8>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Make CA/KRA fail when they don't start
-   `commit <https://pagure.io/freeipa/c/81f97cb89e17e63b3dcb8925a373970ac61764c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81f97cb89e17e63b3dcb8925a373970ac61764c2>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Remove the cachedproperty class
-   `commit <https://pagure.io/freeipa/c/9de343987e6d76d2edeba372c73c1060657aef59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9de343987e6d76d2edeba372c73c1060657aef59>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  Refresh Dogtag RestClient.ca_host property
-   `commit <https://pagure.io/freeipa/c/32981a0f9d0ff699e3d16da8f5a37c112871ba3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32981a0f9d0ff699e3d16da8f5a37c112871ba3a>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  Fix CA/server cert validation in FIPS
-   `commit <https://pagure.io/freeipa/c/651d132b701b773b2bbeb41496d6c5ddbf6d19b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/651d132b701b773b2bbeb41496d6c5ddbf6d19b3>`__
    `#6897 <https://pagure.io/freeipa/issue/6897>`__
 -  compat plugin: Update link to slapi-nis project
-   `commit <https://pagure.io/freeipa/c/efe096040aefdeea37afcf2671506982d8522f47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efe096040aefdeea37afcf2671506982d8522f47>`__
 -  compat: ignore cn=topology,cn=ipa,cn=etc subtree
-   `commit <https://pagure.io/freeipa/c/e691877c24e722d4fc91fed34cd31cc102879c1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e691877c24e722d4fc91fed34cd31cc102879c1a>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  Move the compat plugin setup at the end of install
-   `commit <https://pagure.io/freeipa/c/7364c1360c4e2271667f3a08d8d504b3cd813e2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7364c1360c4e2271667f3a08d8d504b3cd813e2f>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  compat-manage: behave the same for all users
-   `commit <https://pagure.io/freeipa/c/4fa7718c6ad03a7cf534313d5c50d78d4863fe6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fa7718c6ad03a7cf534313d5c50d78d4863fe6e>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  Fix CAInstance.import_ra_cert for empty passwords
-   `commit <https://pagure.io/freeipa/c/e3f2878909c1f92a0d92ed2a8ce00c96135e1346>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3f2878909c1f92a0d92ed2a8ce00c96135e1346>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  Fix RA cert import during DL0 replication
-   `commit <https://pagure.io/freeipa/c/3f70baf2a4811e3eee341aee6da99dfa80c092e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f70baf2a4811e3eee341aee6da99dfa80c092e6>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  ext. CA: correctly write the cert chain
-   `commit <https://pagure.io/freeipa/c/a6af0033a4d0af387eebdd6500eb1e74c5c29ce7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6af0033a4d0af387eebdd6500eb1e74c5c29ce7>`__
    `#6872 <https://pagure.io/freeipa/issue/6872>`__
 -  server-install: No double Kerberos install
-   `commit <https://pagure.io/freeipa/c/2144eaf25ef1148c9353dfb2680f8811fd8c21aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2144eaf25ef1148c9353dfb2680f8811fd8c21aa>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  Fix CA-less to CA-full upgrade
-   `commit <https://pagure.io/freeipa/c/7a6f78bab8f9f76bf37fb105ec2537676d889cc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a6f78bab8f9f76bf37fb105ec2537676d889cc2>`__
    `#6853 <https://pagure.io/freeipa/issue/6853>`__
 -  replicainstall: better client install exception handling
-   `commit <https://pagure.io/freeipa/c/534df55ea5ae736db832e0885520a6dfbd09299a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/534df55ea5ae736db832e0885520a6dfbd09299a>`__
    `#6183 <https://pagure.io/freeipa/issue/6183>`__
 -  Add the force-join option to replica install
-   `commit <https://pagure.io/freeipa/c/72f0ecde783be7d304044eff60c8c85e160d65d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72f0ecde783be7d304044eff60c8c85e160d65d8>`__
    `#6183 <https://pagure.io/freeipa/issue/6183>`__
 -  server-install: remove broken no-pkinit check
-   `commit <https://pagure.io/freeipa/c/1eb681ec7d4f6f42e733463f29374f0fecee4e68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1eb681ec7d4f6f42e733463f29374f0fecee4e68>`__
    `#6807 <https://pagure.io/freeipa/issue/6807>`__
 -  Add pki_pin only when needed
-   `commit <https://pagure.io/freeipa/c/f53c76b1055d4f7b26fc127852a66f942845cbae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f53c76b1055d4f7b26fc127852a66f942845cbae>`__
    `#6839 <https://pagure.io/freeipa/issue/6839>`__
 -  Remove publish_ca_cert() method from NSSDatabase
-   `commit <https://pagure.io/freeipa/c/99389748beb0158811505efa606c27e1e2e0bc7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99389748beb0158811505efa606c27e1e2e0bc7b>`__
    `#6806 <https://pagure.io/freeipa/issue/6806>`__
 -  Get correct CA cert nickname in CA-less
-   `commit <https://pagure.io/freeipa/c/ebf24e783604952e59e557b5537c6d0de6146ce4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebf24e783604952e59e557b5537c6d0de6146ce4>`__
    `#6806 <https://pagure.io/freeipa/issue/6806>`__
 -  Remove redundant option check for cert files
-   `commit <https://pagure.io/freeipa/c/8f7b6c349f4e81e88ef36f014e26de6b1f3f3e41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f7b6c349f4e81e88ef36f014e26de6b1f3f3e41>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  replica-prepare man: remove pkinit option refs
-   `commit <https://pagure.io/freeipa/c/85720b6bdc764b98dd471799ccc1045e1379709e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85720b6bdc764b98dd471799ccc1045e1379709e>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Don't allow setting pkinit-related options on DL0
-   `commit <https://pagure.io/freeipa/c/a1ad1ffa3540da4b5d5c1963b3818d9c9260e1a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1ad1ffa3540da4b5d5c1963b3818d9c9260e1a2>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Fix the order of cert-files check
-   `commit <https://pagure.io/freeipa/c/497e766427b3ced865ff88a51cd0c2c96e8b24f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/497e766427b3ced865ff88a51cd0c2c96e8b24f9>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Generate PIN for PKI to help Dogtag in FIPS
-   `commit <https://pagure.io/freeipa/c/39eac72faef5f44c9fb2cad943ad58d23fe60cf3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39eac72faef5f44c9fb2cad943ad58d23fe60cf3>`__
    `#6824 <https://pagure.io/freeipa/issue/6824>`__
 -  Backup CA cert from kerberos folder
-   `commit <https://pagure.io/freeipa/c/9fdc27ba3594e921d21d664fc5728292e52ac350>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fdc27ba3594e921d21d664fc5728292e52ac350>`__
    `#6748 <https://pagure.io/freeipa/issue/6748>`__
 -  Allow renaming of the sudorule objects
-   `commit <https://pagure.io/freeipa/c/7d3229bfb88f0fdc559245c8741563faba716106>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d3229bfb88f0fdc559245c8741563faba716106>`__
    `#2466 <https://pagure.io/freeipa/issue/2466>`__
 -  Allow renaming of the HBAC rule objects
-   `commit <https://pagure.io/freeipa/c/85f2a19f88eef94ff080a42246658f572b5275f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85f2a19f88eef94ff080a42246658f572b5275f4>`__
    `#6784 <https://pagure.io/freeipa/issue/6784>`__
 -  Reworked the renaming mechanism
-   `commit <https://pagure.io/freeipa/c/28db6cd40100c6301121e3f82c074624fe53729c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28db6cd40100c6301121e3f82c074624fe53729c>`__
    `#2466 <https://pagure.io/freeipa/issue/2466>`__,
    `#6784 <https://pagure.io/freeipa/issue/6784>`__
 -  Bump samba version for FIPS and priv. separation
-   `commit <https://pagure.io/freeipa/c/41ff57b81807f6747b098f1ed2c281031e22bbae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ff57b81807f6747b098f1ed2c281031e22bbae>`__
    `#6671 <https://pagure.io/freeipa/issue/6671>`__,
    `#6697 <https://pagure.io/freeipa/issue/6697>`__
 -  Backup ipa-specific httpd unit-file
-   `commit <https://pagure.io/freeipa/c/59342a7f6fffe2aaf0b8ce4e10bb41444d8fa25f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59342a7f6fffe2aaf0b8ce4e10bb41444d8fa25f>`__
    `#6748 <https://pagure.io/freeipa/issue/6748>`__
 -  Add debug log in case cookie retrieval went wrong
-   `commit <https://pagure.io/freeipa/c/c59729d783993f60582f5cc6ca018545231df22b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c59729d783993f60582f5cc6ca018545231df22b>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 
 
@@ -961,7 +961,7 @@ Timo Aaltonen (1)
 
 -  configure: Use ODS_USER and NAMED_GROUP in
    daemons/dnssec/\*.service.in
-   `commit <https://pagure.io/freeipa/c/57d8a722e3e2fb8ceae8270e1c453901cedd8745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57d8a722e3e2fb8ceae8270e1c453901cedd8745>`__
 
 
 
@@ -969,23 +969,23 @@ Tomas Krizek (7)
 ----------------------------------------------------------------------------------------------
 
 -  ca, kra install: validate DM password
-   `commit <https://pagure.io/freeipa/c/b8bcaa61ec6c9effcf029f82ca21685b692e0b7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8bcaa61ec6c9effcf029f82ca21685b692e0b7f>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  installutils: add DM password validator
-   `commit <https://pagure.io/freeipa/c/4c12b71717b2ca1d4af5018f77c07f8f4b4feca5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c12b71717b2ca1d4af5018f77c07f8f4b4feca5>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  ca install: merge duplicated code for DM password
-   `commit <https://pagure.io/freeipa/c/282fc0c86474bafcb28234eabbd807b99a98adec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/282fc0c86474bafcb28234eabbd807b99a98adec>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  upgrade: add missing suffix to http instance
-   `commit <https://pagure.io/freeipa/c/d10d5066aa60288703f2cf4b1a8dd7ed0aab8842>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d10d5066aa60288703f2cf4b1a8dd7ed0aab8842>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  installer service: fix typo in service entry
-   `commit <https://pagure.io/freeipa/c/1662b0ef2fff6ee002afd99f86b9075a603b6027>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1662b0ef2fff6ee002afd99f86b9075a603b6027>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  python2-ipalib: add missing python dependency
-   `commit <https://pagure.io/freeipa/c/cdefa3030fba0f9a79f65f91aec84a44795c17f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdefa3030fba0f9a79f65f91aec84a44795c17f5>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  kra install: update installation failure message
-   `commit <https://pagure.io/freeipa/c/a4410b41f8dc58b81f02ccc42483dcfe63ddede9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4410b41f8dc58b81f02ccc42483dcfe63ddede9>`__
    `#6923 <https://pagure.io/freeipa/issue/6923>`__

--- a/src/page/Releases/4.5.2.rst
+++ b/src/page/Releases/4.5.2.rst
@@ -120,17 +120,17 @@ Alexander Bokovoy (4)
 ----------------------------------------------------------------------------------------------
 
 -  trust-mod: allow modifying list of UPNs of a trusted forest
-   `commit <https://pagure.io/freeipa/c/9a31b21bff7c83219a4973adf815c900628ab620>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a31b21bff7c83219a4973adf815c900628ab620>`__
    `#7015 <https://pagure.io/freeipa/issue/7015>`__
 -  ipa-kdb: add pkinit authentication indicator in case of a successful
    certauth
-   `commit <https://pagure.io/freeipa/c/ca02cea8dfd63290e4821833fc2ac7d457290e9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca02cea8dfd63290e4821833fc2ac7d457290e9f>`__
    `#6736 <https://pagure.io/freeipa/issue/6736>`__
 -  Fix index definition for ipaAnchorUUID
-   `commit <https://pagure.io/freeipa/c/8410823e1811ac9e004cc79556334abd429d480d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8410823e1811ac9e004cc79556334abd429d480d>`__
    `#6975 <https://pagure.io/freeipa/issue/6975>`__
 -  krb5: make sure KDC certificate is readable
-   `commit <https://pagure.io/freeipa/c/db7967061b9b7d001c923ce3da9d6c6036627253>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db7967061b9b7d001c923ce3da9d6c6036627253>`__
    `#6973 <https://pagure.io/freeipa/issue/6973>`__
 
 
@@ -139,7 +139,7 @@ David Kupka (1)
 ----------------------------------------------------------------------------------------------
 
 -  kra: promote: Get ticket before calling custodia
-   `commit <https://pagure.io/freeipa/c/15076a1c2b0fb31dce3903e5f50cab9edf68ad07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15076a1c2b0fb31dce3903e5f50cab9edf68ad07>`__
    `#7020 <https://pagure.io/freeipa/issue/7020>`__
 
 
@@ -149,10 +149,10 @@ Felipe Volpone (2)
 
 -  Changing cert-find to go through the proxy instead of using the port
    8080
-   `commit <https://pagure.io/freeipa/c/960b9a3f1b1637c0ea5b11d6d7f671a09a3e89da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/960b9a3f1b1637c0ea5b11d6d7f671a09a3e89da>`__
    `#6966 <https://pagure.io/freeipa/issue/6966>`__
 -  Changing cert-find to do not use only primary key to search in LDAP.
-   `commit <https://pagure.io/freeipa/c/df1276e9daf9ee8db05538f47706855cb3d11e01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df1276e9daf9ee8db05538f47706855cb3d11e01>`__
    `#6948 <https://pagure.io/freeipa/issue/6948>`__
 
 
@@ -161,7 +161,7 @@ Florence Blanc-Renaud (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-replica-conncheck: handle ssh not installed
-   `commit <https://pagure.io/freeipa/c/bacccb70a2e91efa22ee19aec9cca75bac94bd95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bacccb70a2e91efa22ee19aec9cca75bac94bd95>`__
    `#6935 <https://pagure.io/freeipa/issue/6935>`__
 
 
@@ -170,16 +170,16 @@ Jan Cholasta (4)
 ----------------------------------------------------------------------------------------------
 
 -  server upgrade: do not enable PKINIT by default
-   `commit <https://pagure.io/freeipa/c/cb9353d6e0fbc0912dd20bf29e3835a7740d1af6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb9353d6e0fbc0912dd20bf29e3835a7740d1af6>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  pkinit manage: introduce ipa-pkinit-manage
-   `commit <https://pagure.io/freeipa/c/c072135340bc8e75f621e2b9163b1347b9eb528f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c072135340bc8e75f621e2b9163b1347b9eb528f>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  server certinstall: update KDC master entry
-   `commit <https://pagure.io/freeipa/c/1b62e5aac9d9668604e82879c020bff310fa549f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b62e5aac9d9668604e82879c020bff310fa549f>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  httpinstance: wait until the service entry is replicated
-   `commit <https://pagure.io/freeipa/c/9871bc08f8b8f51e2a05c4dfa18d844f9c141b8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9871bc08f8b8f51e2a05c4dfa18d844f9c141b8d>`__
    `#6867 <https://pagure.io/freeipa/issue/6867>`__
 
 
@@ -188,35 +188,35 @@ Martin Babinsky (10)
 ----------------------------------------------------------------------------------------------
 
 -  Prepare advise plugin for smart card auth configuration
-   `commit <https://pagure.io/freeipa/c/84ca9761bd47f28b72581d1fe6bd8cfa824b6df3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84ca9761bd47f28b72581d1fe6bd8cfa824b6df3>`__
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  Extend the advice printing code by some useful abstractions
-   `commit <https://pagure.io/freeipa/c/7ea7ee4326679c098d3e4e4d6a2bc743707708ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ea7ee4326679c098d3e4e4d6a2bc743707708ca>`__
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  fix incorrect suffix handling in topology checks
-   `commit <https://pagure.io/freeipa/c/d651a9877d0e2f9dd1b057630508b488678bb86e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d651a9877d0e2f9dd1b057630508b488678bb86e>`__
    `#6965 <https://pagure.io/freeipa/issue/6965>`__
 -  only stop/disable simple service if it is installed
-   `commit <https://pagure.io/freeipa/c/6114150de20a7d8371c7383f619cd0fefe339cbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6114150de20a7d8371c7383f619cd0fefe339cbf>`__
    `#6977 <https://pagure.io/freeipa/issue/6977>`__
 -  test_serverroles: Get rid of MockLDAP and use ldap2 instead
-   `commit <https://pagure.io/freeipa/c/4fa29a33765cb5d6ce86846f37766e5d3322f25f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fa29a33765cb5d6ce86846f37766e5d3322f25f>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add \`pkinit-status\` command
-   `commit <https://pagure.io/freeipa/c/6b815aae7174693b4952f2c60e7201d99e7b9684>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b815aae7174693b4952f2c60e7201d99e7b9684>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add the list of PKINIT servers as a virtual attribute to global
    config
-   `commit <https://pagure.io/freeipa/c/733cef9d5b0ae83127893ffff71689939902d257>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/733cef9d5b0ae83127893ffff71689939902d257>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add an attribute reporting client PKINIT-capable servers
-   `commit <https://pagure.io/freeipa/c/fbccb748a1c85b7ed67946ba7a11a960b839bcc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbccb748a1c85b7ed67946ba7a11a960b839bcc9>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Refactor the role/attribute member reporting code
-   `commit <https://pagure.io/freeipa/c/753f8cf3aff07d22b35005b973e8518665d1fe6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/753f8cf3aff07d22b35005b973e8518665d1fe6f>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Allow for multivalued server attributes
-   `commit <https://pagure.io/freeipa/c/c4aa3a17694b1ad8f9c60c98a95d217c01fc736c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4aa3a17694b1ad8f9c60c98a95d217c01fc736c>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 
 
@@ -225,17 +225,17 @@ Martin Basti (4)
 ----------------------------------------------------------------------------------------------
 
 -  Only warn when specified server IP addresses don't match intf
-   `commit <https://pagure.io/freeipa/c/6206ac8bd23250bda0f8eb628f422671b9b99ad1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6206ac8bd23250bda0f8eb628f422671b9b99ad1>`__
    `#2715 <https://pagure.io/freeipa/issue/2715>`__,
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Add remote_plugins subdirectories to RPM
-   `commit <https://pagure.io/freeipa/c/359e3f261705976229bace2d0a22546670181603>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/359e3f261705976229bace2d0a22546670181603>`__
    `#6927 <https://pagure.io/freeipa/issue/6927>`__
 -  custodia dep: require explictly python2 version
-   `commit <https://pagure.io/freeipa/c/444107a00bf995aca62aba74ea02b52e577ab791>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/444107a00bf995aca62aba74ea02b52e577ab791>`__
    `#6962 <https://pagure.io/freeipa/issue/6962>`__
 -  4.5 set back to git snapshot
-   `commit <https://pagure.io/freeipa/c/8a3d3e8b2358a536a5ef80e97a8605d7e334c750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a3d3e8b2358a536a5ef80e97a8605d7e334c750>`__
 
 
 
@@ -243,17 +243,17 @@ Pavel Vomacka (4)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: add support for changing trust UPN suffixes
-   `commit <https://pagure.io/freeipa/c/e22b61832bb5b52eb9daadcbc12ca41e0923503c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e22b61832bb5b52eb9daadcbc12ca41e0923503c>`__
    `#7015 <https://pagure.io/freeipa/issue/7015>`__
 -  Bump version of python-gssapi
-   `commit <https://pagure.io/freeipa/c/15d5ddd417d801a2356dcb043feef1aed8f76a25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15d5ddd417d801a2356dcb043feef1aed8f76a25>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  Turn off OCSP check
-   `commit <https://pagure.io/freeipa/c/51b361f475b3e25ace982873beb05cafcba95808>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51b361f475b3e25ace982873beb05cafcba95808>`__
    `#6981 <https://pagure.io/freeipa/issue/6981>`__,
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  Change python-cryptography to python2-cryptography
-   `commit <https://pagure.io/freeipa/c/14ff94a0d481051613338a512260b6a473671538>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14ff94a0d481051613338a512260b6a473671538>`__
    `#6749 <https://pagure.io/freeipa/issue/6749>`__
 
 
@@ -262,10 +262,10 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: use canonical principal in certauth plugin
-   `commit <https://pagure.io/freeipa/c/e8d8aab469ca634f4ec38b869767316806c739f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8d8aab469ca634f4ec38b869767316806c739f1>`__
    `#6993 <https://pagure.io/freeipa/issue/6993>`__
 -  ipa-kdb: reload certificate mapping rules periodically
-   `commit <https://pagure.io/freeipa/c/d59694a93c3a734915d4ac05bb4e02a40f9cb08a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d59694a93c3a734915d4ac05bb4e02a40f9cb08a>`__
    `#6963 <https://pagure.io/freeipa/issue/6963>`__
 
 
@@ -274,13 +274,13 @@ Simo Sorce (3)
 ----------------------------------------------------------------------------------------------
 
 -  Revert setting sessionMaxAge for old clients
-   `commit <https://pagure.io/freeipa/c/728e2f681a938f25d091a8480ec6db3961ebfc98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/728e2f681a938f25d091a8480ec6db3961ebfc98>`__
    `#7001 <https://pagure.io/freeipa/issue/7001>`__
 -  Add code to be able to set default kinit lifetime
-   `commit <https://pagure.io/freeipa/c/0def2ec653ac29210414aa09499b309dd1c3ac7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0def2ec653ac29210414aa09499b309dd1c3ac7d>`__
    `#7001 <https://pagure.io/freeipa/issue/7001>`__
 -  Fix rare race condition with missing ccache file
-   `commit <https://pagure.io/freeipa/c/90b432b93d71c795eaa4f92d3a9e1d322dce1802>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90b432b93d71c795eaa4f92d3a9e1d322dce1802>`__
 
 
 
@@ -288,22 +288,22 @@ Stanislav Laznicka (6)
 ----------------------------------------------------------------------------------------------
 
 -  rpc: avoid possible recursion in create_connection
-   `commit <https://pagure.io/freeipa/c/cb6c93dad044c724ba2cedbff49bf71aea939418>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb6c93dad044c724ba2cedbff49bf71aea939418>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  rpc: preparations for recursion fix
-   `commit <https://pagure.io/freeipa/c/d8aab383a39a22cc613cf64e5d66ce69111d97df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8aab383a39a22cc613cf64e5d66ce69111d97df>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  Avoid possible endless recursion in RPC call
-   `commit <https://pagure.io/freeipa/c/a5b413b72e224120acde09d1c877be11b3f61b6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5b413b72e224120acde09d1c877be11b3f61b6b>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  kdc.key should not be visible to all
-   `commit <https://pagure.io/freeipa/c/37be8e9ac3b46d6d31199227216b5a5a8d5d5614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37be8e9ac3b46d6d31199227216b5a5a8d5d5614>`__
    `#6973 <https://pagure.io/freeipa/issue/6973>`__
 -  Remove pkinit-anonymous command
-   `commit <https://pagure.io/freeipa/c/4e878c3dc6f72cae4e7b4cb2ef45f2f4e91ac287>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e878c3dc6f72cae4e7b4cb2ef45f2f4e91ac287>`__
    `#6936 <https://pagure.io/freeipa/issue/6936>`__
 -  ca/cert-show: check certificate_out in options
-   `commit <https://pagure.io/freeipa/c/9ce5d6bf36e669f40099a8468f3a664795df06b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ce5d6bf36e669f40099a8468f3a664795df06b4>`__
    `#6885 <https://pagure.io/freeipa/issue/6885>`__
 
 
@@ -312,13 +312,13 @@ Tibor Dudlák (3)
 ----------------------------------------------------------------------------------------------
 
 -  server.py: Removes dns-server configuration from ldap
-   `commit <https://pagure.io/freeipa/c/005c92868ce36770ce89e87ef3cdeae62d11ece4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/005c92868ce36770ce89e87ef3cdeae62d11ece4>`__
    `#6572 <https://pagure.io/freeipa/issue/6572>`__
 -  sssd.py: Deprecating no-sssd option.
-   `commit <https://pagure.io/freeipa/c/f984cef6ed49e04a4e3754d2f3214d64715d26df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f984cef6ed49e04a4e3754d2f3214d64715d26df>`__
    `#5860 <https://pagure.io/freeipa/issue/5860>`__
 -  client.py: Replace hardcoded 'admin' with options.principal
-   `commit <https://pagure.io/freeipa/c/7bef8c7ff16c95a43312a3d162ff354625ecd198>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bef8c7ff16c95a43312a3d162ff354625ecd198>`__
    `#5406 <https://pagure.io/freeipa/issue/5406>`__
 
 
@@ -327,7 +327,7 @@ Tibor Dudlák (1)
 ----------------------------------------------------------------------------------------------
 
 -  user.py: replace user_mod with ldap.update_entry()
-   `commit <https://pagure.io/freeipa/c/daeac31ba54d88159b46d61fc443ccd45902f8f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/daeac31ba54d88159b46d61fc443ccd45902f8f2>`__
    `#5788 <https://pagure.io/freeipa/issue/5788>`__
 
 
@@ -336,6 +336,6 @@ Tomas Krizek (2)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.5.2
-   `commit <https://pagure.io/freeipa/c/e89e825178741de042ca9ed9b603613a73113542>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e89e825178741de042ca9ed9b603613a73113542>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/ae5130988e602ca981cdac4f5ca8c606c4075d0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae5130988e602ca981cdac4f5ca8c606c4075d0e>`__

--- a/src/page/Releases/4.5.3.rst
+++ b/src/page/Releases/4.5.3.rst
@@ -85,10 +85,10 @@ Alexander Bokovoy (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-sam: use smbldap_set_bind_callback for Samba 4.7 or later
-   `commit <https://pagure.io/freeipa/c/933cfcb86417c8428d27c540d015288476cc87da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/933cfcb86417c8428d27c540d015288476cc87da>`__
    `#6877 <https://pagure.io/freeipa/issue/6877>`__
 -  ipa-sam: use own private structure, not ldapsam_privates
-   `commit <https://pagure.io/freeipa/c/dbc9c737fe99b542eb3799754612871a0c9b3263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbc9c737fe99b542eb3799754612871a0c9b3263>`__
    `#6877 <https://pagure.io/freeipa/issue/6877>`__
 
 
@@ -97,7 +97,7 @@ Fraser Tweedale (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add CommonNameToSANDefault to default cert profile
-   `commit <https://pagure.io/freeipa/c/33aa4c25a2c3d158e43978d8699c3776d0e06599>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33aa4c25a2c3d158e43978d8699c3776d0e06599>`__
    `#7007 <https://pagure.io/freeipa/issue/7007>`__
 
 
@@ -106,50 +106,50 @@ Martin Babinsky (15)
 ----------------------------------------------------------------------------------------------
 
 -  replica install: drop-in IPA specific config to tmpfiles.d
-   `commit <https://pagure.io/freeipa/c/76cc115c53c3a9c5f594083ff4c4452479070021>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76cc115c53c3a9c5f594083ff4c4452479070021>`__
    `#7053 <https://pagure.io/freeipa/issue/7053>`__
 -  Do not remove the old masters when setting the attribute fails
-   `commit <https://pagure.io/freeipa/c/03a30c0fb2748d5724112e702567c71cbd19d624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03a30c0fb2748d5724112e702567c71cbd19d624>`__
    `#7029 <https://pagure.io/freeipa/issue/7029>`__
 -  \*config-show: Do not show empty roles/attributes
-   `commit <https://pagure.io/freeipa/c/2431c76775a1e314a3a03f608bb7aa776d3c8bf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2431c76775a1e314a3a03f608bb7aa776d3c8bf2>`__
    `#7029 <https://pagure.io/freeipa/issue/7029>`__
 -  smart-card-advises: ensure that krb5-pkinit is installed on client
-   `commit <https://pagure.io/freeipa/c/1114e113d5cc558f13398af8bc5a179b33f9354b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1114e113d5cc558f13398af8bc5a179b33f9354b>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart card advise: use password when changing trust flags on HTTP
    cert
-   `commit <https://pagure.io/freeipa/c/e14194e171be82d43ad16b4a585502a9c28aace3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e14194e171be82d43ad16b4a585502a9c28aace3>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart card advises: use a wrapper around Bash \`for\` loops
-   `commit <https://pagure.io/freeipa/c/e5e4c0a484412e11cc414ca80dc230b0000c00d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5e4c0a484412e11cc414ca80dc230b0000c00d7>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Use the compound statement formatting API for configuring PKINIT
-   `commit <https://pagure.io/freeipa/c/08f56c3c8ccde61146baec16085b325726582752>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08f56c3c8ccde61146baec16085b325726582752>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Fix indentation of statements in Smart card advises
-   `commit <https://pagure.io/freeipa/c/61f6cb7e6fa632db08628534c512a22e35682dc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61f6cb7e6fa632db08628534c512a22e35682dc1>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  delegate formatting of compound Bash statements to dedicated classes
-   `commit <https://pagure.io/freeipa/c/2be45a1d95b7033ee25a643fdd74f5f30c41fea5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2be45a1d95b7033ee25a643fdd74f5f30c41fea5>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  advise: add an infrastructure for formatting Bash compound statements
-   `commit <https://pagure.io/freeipa/c/666c2da3afcc461870d423409db4298e7ead6493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/666c2da3afcc461870d423409db4298e7ead6493>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  delegate the indentation handling in advises to dedicated class
-   `commit <https://pagure.io/freeipa/c/9561e3f8a2be66c1c236ac7fe296a8c8cbbac5c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9561e3f8a2be66c1c236ac7fe296a8c8cbbac5c1>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  add a class that tracks the indentation in the generated advises
-   `commit <https://pagure.io/freeipa/c/e5f31e35d3d17b5871cb39ebe55b413ba0dca489>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5f31e35d3d17b5871cb39ebe55b413ba0dca489>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Allow to pass in multiple CA cert paths to the smart card advises
-   `commit <https://pagure.io/freeipa/c/3ebab27ded06a72d807c10b1ba521c6406df1ab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ebab27ded06a72d807c10b1ba521c6406df1ab4>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart-card advises: add steps to store smart card signing CA cert
-   `commit <https://pagure.io/freeipa/c/ef2ab942d2dee4a7a902f70a7eaf1c35cf88bee6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef2ab942d2dee4a7a902f70a7eaf1c35cf88bee6>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart-card advises: configure systemwide NSS DB also on master
-   `commit <https://pagure.io/freeipa/c/23917c71f72ba899054bc5dc72c36d5308ead94c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23917c71f72ba899054bc5dc72c36d5308ead94c>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 
 
@@ -158,28 +158,28 @@ Martin Basti (8)
 ----------------------------------------------------------------------------------------------
 
 -  python-netifaces: update to reflect upstream changes
-   `commit <https://pagure.io/freeipa/c/56d04b3dccc967630d869006dfbd0003fcfedabe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56d04b3dccc967630d869006dfbd0003fcfedabe>`__
    `#7021 <https://pagure.io/freeipa/issue/7021>`__
 -  Remove network and broadcast address warnings
-   `commit <https://pagure.io/freeipa/c/1c961161873c37cb29a51baeeed0e782cd4a1d4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c961161873c37cb29a51baeeed0e782cd4a1d4d>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  replica install: add missing check for non-local IP address
-   `commit <https://pagure.io/freeipa/c/93ef10292ca674842c79da0dab6de6fb63261881>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93ef10292ca674842c79da0dab6de6fb63261881>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Remove ip_netmask from option parser
-   `commit <https://pagure.io/freeipa/c/217905a20071b55b50568e8fbb36a8ecde974432>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/217905a20071b55b50568e8fbb36a8ecde974432>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  CheckedIPAddress: remove match_local param
-   `commit <https://pagure.io/freeipa/c/9a924dd8cc27507a70f4ec5020d97417e149e350>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a924dd8cc27507a70f4ec5020d97417e149e350>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  refactor CheckedIPAddress class
-   `commit <https://pagure.io/freeipa/c/0aa0041149f359f1954409baf886d4b31fdadc16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0aa0041149f359f1954409baf886d4b31fdadc16>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  ipa-dns-install: remove check for local ip address
-   `commit <https://pagure.io/freeipa/c/4d06f0c52200a4345db36dae3fdbc178f18f2f01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d06f0c52200a4345db36dae3fdbc178f18f2f01>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Fix local IP address validation
-   `commit <https://pagure.io/freeipa/c/d010191d170c0ebb5f46bac2fc528f788e8ffc41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d010191d170c0ebb5f46bac2fc528f788e8ffc41>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 
 
@@ -188,10 +188,10 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa_pwd_extop: do not generate NT hashes in FIPS mode
-   `commit <https://pagure.io/freeipa/c/79a5f3bf321f15e4c120d16b8988ed0cdb0ae64c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79a5f3bf321f15e4c120d16b8988ed0cdb0ae64c>`__
    `#7026 <https://pagure.io/freeipa/issue/7026>`__
 -  ipa-sam: replace encode_nt_key() with E_md4hash()
-   `commit <https://pagure.io/freeipa/c/b63b6790efc82c87398c39ba4f55330756b7b3cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b63b6790efc82c87398c39ba4f55330756b7b3cf>`__
    `#7026 <https://pagure.io/freeipa/issue/7026>`__
 
 
@@ -200,9 +200,9 @@ Simo Sorce (2)
 ----------------------------------------------------------------------------------------------
 
 -  Always check peer has keys before connecting
-   `commit <https://pagure.io/freeipa/c/2dccb91792f9369a5fe0248f8d2a3e95081737c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dccb91792f9369a5fe0248f8d2a3e95081737c3>`__
 -  Make sure we check ccaches in all rpcserver paths
-   `commit <https://pagure.io/freeipa/c/89463c0c527142c18b44f5b367fa8b2c683df011>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89463c0c527142c18b44f5b367fa8b2c683df011>`__
 
 
 
@@ -210,7 +210,7 @@ Stanislav Laznicka (1)
 ----------------------------------------------------------------------------------------------
 
 -  Ensure network is online prior to an upgrade
-   `commit <https://pagure.io/freeipa/c/6ca6942fda4cea7a78569eb83031e7e6032ace47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ca6942fda4cea7a78569eb83031e7e6032ace47>`__
    `#7039 <https://pagure.io/freeipa/issue/7039>`__
 
 
@@ -219,7 +219,7 @@ Tibor Dudlák (1)
 ----------------------------------------------------------------------------------------------
 
 -  topology.py: Removes error message from dictionary.
-   `commit <https://pagure.io/freeipa/c/0571e3840b0a5a70cf18ce5136acaf2235bab907>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0571e3840b0a5a70cf18ce5136acaf2235bab907>`__
    `#6533 <https://pagure.io/freeipa/issue/6533>`__
 
 
@@ -228,8 +228,8 @@ Tomas Krizek (3)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.5.3
-   `commit <https://pagure.io/freeipa/c/5083a97f88545b876e9e5fdada35b31b992f9dbe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5083a97f88545b876e9e5fdada35b31b992f9dbe>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/b3319b4e7e39fa69c519c353a1925ba8f390ab09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3319b4e7e39fa69c519c353a1925ba8f390ab09>`__
 -  4.5 set back to git snapshot
-   `commit <https://pagure.io/freeipa/c/b9a494f5e1d3c2ad5ea90091dfc24832c1937c44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9a494f5e1d3c2ad5ea90091dfc24832c1937c44>`__

--- a/src/page/Releases/4.5.4.rst
+++ b/src/page/Releases/4.5.4.rst
@@ -131,10 +131,10 @@ Alexander Bokovoy (2)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure upgrade also checks for IPv6 stack
-   `commit <https://pagure.io/freeipa/c/bdf9a34dffdf4d7925208e5df9f69e3927b88858>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdf9a34dffdf4d7925208e5df9f69e3927b88858>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 -  OTP import: support hash names with HMAC- prefix
-   `commit <https://pagure.io/freeipa/c/496936ed656c5dcb52f485476eb9adc27505228f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/496936ed656c5dcb52f485476eb9adc27505228f>`__
    `#7146 <https://pagure.io/freeipa/issue/7146>`__
 
 
@@ -143,7 +143,7 @@ Abhijeet Kasurde (1)
 ----------------------------------------------------------------------------------------------
 
 -  Vault testcase improvement
-   `commit <https://pagure.io/freeipa/c/f4b24692204ffa00be45cd7a15de86f4597c4231>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4b24692204ffa00be45cd7a15de86f4597c4231>`__
    `#7098 <https://pagure.io/freeipa/issue/7098>`__
 
 
@@ -152,7 +152,7 @@ Alexander Koksharov (1)
 ----------------------------------------------------------------------------------------------
 
 -  kra-install: better warning message
-   `commit <https://pagure.io/freeipa/c/7fb25bfffd9324021b3951a1418fa84d5ac20f00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fb25bfffd9324021b3951a1418fa84d5ac20f00>`__
    `#6952 <https://pagure.io/freeipa/issue/6952>`__
 
 
@@ -161,10 +161,10 @@ Aleksei Slaikovskii (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipaclient.plugins.dns: Cast DNS name to unicode.
-   `commit <https://pagure.io/freeipa/c/c3f390d2264f71cf4b87123fdcabd007075704ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3f390d2264f71cf4b87123fdcabd007075704ab>`__
    `#7185 <https://pagure.io/freeipa/issue/7185>`__
 -  Less confusing message for PKINIT configuration during install
-   `commit <https://pagure.io/freeipa/c/c79cdccfa2361f013fb51e8225b4630abab8b557>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c79cdccfa2361f013fb51e8225b4630abab8b557>`__
    `#7179 <https://pagure.io/freeipa/issue/7179>`__
 
 
@@ -173,7 +173,7 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Block PyOpenSSL to prevent SELinux execmem in wsgi
-   `commit <https://pagure.io/freeipa/c/e527dd17e89c0826d55d4a214c176fb00e383eef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e527dd17e89c0826d55d4a214c176fb00e383eef>`__
    `#5442 <https://pagure.io/freeipa/issue/5442>`__
 
 
@@ -182,9 +182,9 @@ David Kreitschmann (2)
 ----------------------------------------------------------------------------------------------
 
 -  Disable pylint in get_help function because of type confusion.
-   `commit <https://pagure.io/freeipa/c/7352b731169e4f995b3ffe254b9e0cae6b82a763>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7352b731169e4f995b3ffe254b9e0cae6b82a763>`__
 -  Store help in Schema before writing to disk
-   `commit <https://pagure.io/freeipa/c/9308e63fde736ea4274a280f18c83a4bc2935c81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9308e63fde736ea4274a280f18c83a4bc2935c81>`__
 
 
 
@@ -192,40 +192,40 @@ David Kupka (11)
 ----------------------------------------------------------------------------------------------
 
 -  tests: Add LDAP URI to ldappasswd explicitly
-   `commit <https://pagure.io/freeipa/c/d0a73195ced8c541712142482ff50d41af81a61d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0a73195ced8c541712142482ff50d41af81a61d>`__
    `#6622 <https://pagure.io/freeipa/issue/6622>`__
 -  tests: certmap: Add test for user-{add,remove}-certmap
-   `commit <https://pagure.io/freeipa/c/12f951b84164089c6f7390aeabac103d643ebd96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12f951b84164089c6f7390aeabac103d643ebd96>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapdataMixin tracker
-   `commit <https://pagure.io/freeipa/c/80f555179849e5799a87a837c0bf5cb8a53a7f1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80f555179849e5799a87a837c0bf5cb8a53a7f1c>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Add test for certmapconfig-{mod,show}
-   `commit <https://pagure.io/freeipa/c/9bad6526bca42db591f53d70b4f0fdf1d9847ffc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bad6526bca42db591f53d70b4f0fdf1d9847ffc>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapconfigTracker to tests certmapconfig-\*
    commands
-   `commit <https://pagure.io/freeipa/c/6d44657696545605162ccd480bdc867e8cd2d0d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d44657696545605162ccd480bdc867e8cd2d0d3>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Test permissions for certmap
-   `commit <https://pagure.io/freeipa/c/5d9ba56d0953690890dd6543fb23639a867b56d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d9ba56d0953690890dd6543fb23639a867b56d5>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Add basic tests for certmaprule commands
-   `commit <https://pagure.io/freeipa/c/bec002eefae7dd4acacb3f759970a0b6fa6fdd95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bec002eefae7dd4acacb3f759970a0b6fa6fdd95>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapTracker for testing certmap-\* commands
-   `commit <https://pagure.io/freeipa/c/7aac39b473f8a3e1de5682e17f3851b361e6c1ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7aac39b473f8a3e1de5682e17f3851b361e6c1ac>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add ConfigurationTracker to test \*config-{mod,show}
    commands
-   `commit <https://pagure.io/freeipa/c/62c9bf793b921ab2b193d398351437bc8ae8e70d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62c9bf793b921ab2b193d398351437bc8ae8e70d>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add EnableTracker to test \*-{enable,disable}
    commands
-   `commit <https://pagure.io/freeipa/c/d6ba6973ba507a5086bd6e6d4b817d4f276ceceb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6ba6973ba507a5086bd6e6d4b817d4f276ceceb>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Split Tracker into one-purpose Trackers
-   `commit <https://pagure.io/freeipa/c/0052a3312ccfa17d5c3f291e12c5b97d3922c18b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0052a3312ccfa17d5c3f291e12c5b97d3922c18b>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 
 
@@ -234,17 +234,17 @@ Felipe Volpone (4)
 ----------------------------------------------------------------------------------------------
 
 -  Changing idoverrideuser-\* to treat objectClass case insensitively
-   `commit <https://pagure.io/freeipa/c/61e8b4936f1fd73f8d4c359348cf83f37da35fef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61e8b4936f1fd73f8d4c359348cf83f37da35fef>`__
    `#7074 <https://pagure.io/freeipa/issue/7074>`__
 -  Fixing how sssd.conf is updated when promoting a client to replica
-   `commit <https://pagure.io/freeipa/c/79570804b0ffaae14b5db11b2d6e45dceff51aba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79570804b0ffaae14b5db11b2d6e45dceff51aba>`__
    `#7127 <https://pagure.io/freeipa/issue/7127>`__
 -  Removing part of circular dependency of ipalib in ipaplaform
-   `commit <https://pagure.io/freeipa/c/361566c5eae4716ca0c17796e116667852462123>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/361566c5eae4716ca0c17796e116667852462123>`__
    `#7108 <https://pagure.io/freeipa/issue/7108>`__
 -  Changing how commands handles error when it can't connect to IPA
    server
-   `commit <https://pagure.io/freeipa/c/73b381e21183dc2058c9a6ac4620928230a2dce8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73b381e21183dc2058c9a6ac4620928230a2dce8>`__
    `#6261 <https://pagure.io/freeipa/issue/6261>`__
 
 
@@ -253,20 +253,20 @@ Florence Blanc-Renaud (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-cacert-manage renew: switch from ext-signed CA to self-signed
-   `commit <https://pagure.io/freeipa/c/22e285fb6d17aad83caaa04674861bdea662f94d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22e285fb6d17aad83caaa04674861bdea662f94d>`__
    `#7173 <https://pagure.io/freeipa/issue/7173>`__
 -  Backport 4-5: Fix ipa-server-upgrade with server cert tracking
-   `commit <https://pagure.io/freeipa/c/52853875e298e38a1e5a9a56c02aac9e30916044>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52853875e298e38a1e5a9a56c02aac9e30916044>`__
    `#7141 <https://pagure.io/freeipa/issue/7141>`__
 -  Backport PR 1008 to ipa-4-5 Fix ipa-server-upgrade: This entry
    already exists
-   `commit <https://pagure.io/freeipa/c/d9035a045bece8c9a205c078a8cdd2e1f101590b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9035a045bece8c9a205c078a8cdd2e1f101590b>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Backport PR 988 to ipa-4-5 Fix Certificate renewal (with ext ca)
-   `commit <https://pagure.io/freeipa/c/85d5611119b9e3d616589d2a8e7447055184592b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85d5611119b9e3d616589d2a8e7447055184592b>`__
    `#7106 <https://pagure.io/freeipa/issue/7106>`__
 -  Fix ipa config-mod --ca-renewal-master
-   `commit <https://pagure.io/freeipa/c/770fb59637affc22c76256478b53bbe831b3ec88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/770fb59637affc22c76256478b53bbe831b3ec88>`__
    `#7120 <https://pagure.io/freeipa/issue/7120>`__
 
 
@@ -275,10 +275,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix external renewal for CA with non-default subject DN
-   `commit <https://pagure.io/freeipa/c/5b9f7c9ab593f7633da3e932e5583b3a93555347>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b9f7c9ab593f7633da3e932e5583b3a93555347>`__
    `#7123 <https://pagure.io/freeipa/issue/7123>`__
 -  Restore old version of caIPAserviceCert for upgrade only
-   `commit <https://pagure.io/freeipa/c/87393daba6b414e3afe6e22e77c9b20e561e5302>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87393daba6b414e3afe6e22e77c9b20e561e5302>`__
    `#7097 <https://pagure.io/freeipa/issue/7097>`__
 
 
@@ -287,7 +287,7 @@ Martin Basti (1)
 ----------------------------------------------------------------------------------------------
 
 -  DNS update: reduce timeout for CA records
-   `commit <https://pagure.io/freeipa/c/2b3b94f3c15aef57830bd81b9580d31d2e837612>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b3b94f3c15aef57830bd81b9580d31d2e837612>`__
    `#6176 <https://pagure.io/freeipa/issue/6176>`__
 
 
@@ -296,13 +296,13 @@ Michal Reznik (3)
 ----------------------------------------------------------------------------------------------
 
 -  test_caless: add replica ca-less to ca-full test (master caless)
-   `commit <https://pagure.io/freeipa/c/c4c9b751e2cd0cd9862ed6897341906b246d7c18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4c9b751e2cd0cd9862ed6897341906b246d7c18>`__
    `#7086 <https://pagure.io/freeipa/issue/7086>`__
 -  test_caless: add server_replica ca-less to ca-full test
-   `commit <https://pagure.io/freeipa/c/45db679fb5c8f387e16c36cef93bcfebf4aac9f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45db679fb5c8f387e16c36cef93bcfebf4aac9f7>`__
    `#7086 <https://pagure.io/freeipa/issue/7086>`__
 -  tests: fix external_ca test suite failing due to missing SKI
-   `commit <https://pagure.io/freeipa/c/870f430efc5f483096dfb70e248e9a747891615e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/870f430efc5f483096dfb70e248e9a747891615e>`__
    `#7099 <https://pagure.io/freeipa/issue/7099>`__
 
 
@@ -311,7 +311,7 @@ Nathaniel McCallum (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-otptoken-import: Make PBKDF2 refer to the pkcs5 namespace
-   `commit <https://pagure.io/freeipa/c/ade766abe5e60a90899e0df0d019fd9df0386864>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ade766abe5e60a90899e0df0d019fd9df0386864>`__
    `#7035 <https://pagure.io/freeipa/issue/7035>`__
 
 
@@ -320,7 +320,7 @@ Petr Čech (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fix on logs collection
-   `commit <https://pagure.io/freeipa/c/653ed4a00b90335153cea39378bf32685b1df8d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/653ed4a00b90335153cea39378bf32685b1df8d2>`__
    `#7214 <https://pagure.io/freeipa/issue/7214>`__
 
 
@@ -329,10 +329,10 @@ Petr Vobornik (2)
 ----------------------------------------------------------------------------------------------
 
 -  log progress of wait_for_open_ports
-   `commit <https://pagure.io/freeipa/c/756734351410077ab7b102a9a7a5264a62bcb0e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/756734351410077ab7b102a9a7a5264a62bcb0e0>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 -  control logging of host_port_open from caller
-   `commit <https://pagure.io/freeipa/c/b5970862a5b22c4272c00be1d31e1d50f3b7c14c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5970862a5b22c4272c00be1d31e1d50f3b7c14c>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 
 
@@ -341,30 +341,30 @@ Pavel Vomacka (9)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix calling undefined method during reset passwords
-   `commit <https://pagure.io/freeipa/c/f3615994c304c3157ddfb2a32bf0de3cc1a12598>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3615994c304c3157ddfb2a32bf0de3cc1a12598>`__
    `#7175 <https://pagure.io/freeipa/issue/7175>`__
 -  WebUI: remove unused parameter from get_whoami_command
-   `commit <https://pagure.io/freeipa/c/4be73033442276ea518d950e3df0531b418252d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4be73033442276ea518d950e3df0531b418252d8>`__
    `#7175 <https://pagure.io/freeipa/issue/7175>`__
 -  Adds whoami DS plugin in case that plugin is missing
-   `commit <https://pagure.io/freeipa/c/736a472222802dd0880063a3a4e288d1b40347b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/736a472222802dd0880063a3a4e288d1b40347b3>`__
    `#7126 <https://pagure.io/freeipa/issue/7126>`__
 -  WebUI: remove creating js/libs symlink from makefile
-   `commit <https://pagure.io/freeipa/c/3b0d696ba8d5dc430a6eadf14276bdb5163e05cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b0d696ba8d5dc430a6eadf14276bdb5163e05cf>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  WebUI: Remove plugins symlink as it is unused
-   `commit <https://pagure.io/freeipa/c/6c246375d5ca517f76248d0a36499e03ae39da0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c246375d5ca517f76248d0a36499e03ae39da0d>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  Remove all old JSON files
-   `commit <https://pagure.io/freeipa/c/16e14f29e60c93e80a1f395e65423864df4ba634>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16e14f29e60c93e80a1f395e65423864df4ba634>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  Revert "Web UI: Remove offline version of Web UI"
-   `commit <https://pagure.io/freeipa/c/331ad1fe8ec39c93cd11c6def910a55a410bc466>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/331ad1fe8ec39c93cd11c6def910a55a410bc466>`__
 -  WebUI: Add hyphenate versions of Host(Role) Based strings
-   `commit <https://pagure.io/freeipa/c/873cfe58f2445dc1af41ac0543811db0676bfd42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/873cfe58f2445dc1af41ac0543811db0676bfd42>`__
    `#6582 <https://pagure.io/freeipa/issue/6582>`__
 -  WebUI: fix incorrectly shown links in association tables
-   `commit <https://pagure.io/freeipa/c/705351c27092292d0ddc6c099bf060f68a3c8616>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/705351c27092292d0ddc6c099bf060f68a3c8616>`__
    `#7066 <https://pagure.io/freeipa/issue/7066>`__
 
 
@@ -373,7 +373,7 @@ Rob Crittenden (1)
 ----------------------------------------------------------------------------------------------
 
 -  Collect group membership without a size limit
-   `commit <https://pagure.io/freeipa/c/c27d015202be35b2ac04151a73a2179909127704>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c27d015202be35b2ac04151a73a2179909127704>`__
    `#7112 <https://pagure.io/freeipa/issue/7112>`__
 
 
@@ -382,7 +382,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: reinit trusted domain data for enterprise principals
-   `commit <https://pagure.io/freeipa/c/4e74685b1d6b465cd33aa5a8049db80da51de962>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e74685b1d6b465cd33aa5a8049db80da51de962>`__
    `#7172 <https://pagure.io/freeipa/issue/7172>`__
 
 
@@ -391,14 +391,14 @@ Stanislav Laznicka (4)
 ----------------------------------------------------------------------------------------------
 
 -  travis: make tests fail if pep8 does not pass
-   `commit <https://pagure.io/freeipa/c/5d4b4bbfc972eb2030a162e875fc26cbdb050ebc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d4b4bbfc972eb2030a162e875fc26cbdb050ebc>`__
 -  Use correct container for ipa-4-5 testing
-   `commit <https://pagure.io/freeipa/c/7544e71fdf5a250dc161c1a5755c0854360fdb35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7544e71fdf5a250dc161c1a5755c0854360fdb35>`__
 -  pkinit: don't fail when no pkinit servers found
-   `commit <https://pagure.io/freeipa/c/fee3adbdb56cdd8d5961e59d5f7600c6b6d0bda6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fee3adbdb56cdd8d5961e59d5f7600c6b6d0bda6>`__
    `#7144 <https://pagure.io/freeipa/issue/7144>`__
 -  travis: temporary workaround for Travis CI
-   `commit <https://pagure.io/freeipa/c/5f524ae5b5bc26ea33e5ae2abaa527f2384d09b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f524ae5b5bc26ea33e5ae2abaa527f2384d09b5>`__
 
 
 
@@ -406,7 +406,7 @@ Thierry Bordaz (1)
 ----------------------------------------------------------------------------------------------
 
 -  NULL LDAP context in call to ldap_search_ext_s during search
-   `commit <https://pagure.io/freeipa/c/1cb93edd5bbfbca51362ca8dd3bf7c40d2020218>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cb93edd5bbfbca51362ca8dd3bf7c40d2020218>`__
    `#7017 <https://pagure.io/freeipa/issue/7017>`__
 
 
@@ -415,7 +415,7 @@ Tibor Dudlák (1)
 ----------------------------------------------------------------------------------------------
 
 -  otptoken_yubikey.py: Removed traceback when package missing.
-   `commit <https://pagure.io/freeipa/c/1b33cdad14d7d5978266bac07c68dbe66cd298ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b33cdad14d7d5978266bac07c68dbe66cd298ce>`__
    `#6979 <https://pagure.io/freeipa/issue/6979>`__
 
 
@@ -424,27 +424,27 @@ Tomas Krizek (11)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.5.4
-   `commit <https://pagure.io/freeipa/c/73400c2b8fb267255952adb46cf5b1c6bd3ba640>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73400c2b8fb267255952adb46cf5b1c6bd3ba640>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/70c19cc19ce8bf89401dc8973241380b63b377f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70c19cc19ce8bf89401dc8973241380b63b377f0>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/22290d1878ea734e12c78fa2ddd2d83a09b358af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22290d1878ea734e12c78fa2ddd2d83a09b358af>`__
 -  prci: use f26 template for ipa-4-5
-   `commit <https://pagure.io/freeipa/c/d3c217f3a50cfb6ad8a9925e996e3480c2b1595c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3c217f3a50cfb6ad8a9925e996e3480c2b1595c>`__
 -  ipatests: collect log after ipa-ca-install
-   `commit <https://pagure.io/freeipa/c/be0f4787b5e7fb0992fb6e9dee81fa8b670f6ea8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be0f4787b5e7fb0992fb6e9dee81fa8b670f6ea8>`__
    `#7060 <https://pagure.io/freeipa/issue/7060>`__
 -  dnssec: fix localhsm.py utility script
-   `commit <https://pagure.io/freeipa/c/8e6c38096faa69c8e2ff847464d10bb504a3f63b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e6c38096faa69c8e2ff847464d10bb504a3f63b>`__
    `#7116 <https://pagure.io/freeipa/issue/7116>`__
 -  prci: rename template to ci-ipa-4-5-f25
-   `commit <https://pagure.io/freeipa/c/fe4b1547d700970ea27404aeff883b194f986f13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe4b1547d700970ea27404aeff883b194f986f13>`__
 -  prci: add caless tests
-   `commit <https://pagure.io/freeipa/c/af0dfc90cad34f548ec5a0e20687d52a6e320c0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af0dfc90cad34f548ec5a0e20687d52a6e320c0c>`__
 -  build: checkout \*.po files at the end of makerpms.sh
-   `commit <https://pagure.io/freeipa/c/f66360ebe01a23279b3e91e94634ce43aefea53f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f66360ebe01a23279b3e91e94634ce43aefea53f>`__
    `#6605 <https://pagure.io/freeipa/issue/6605>`__
 -  freeipa-pr-ci: enable pull-request CI
-   `commit <https://pagure.io/freeipa/c/3ca9b3de1b0ed8ae70c0fcc00e6f17091b1df088>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ca9b3de1b0ed8ae70c0fcc00e6f17091b1df088>`__
 -  4.5 set back to git snapshot
-   `commit <https://pagure.io/freeipa/c/91ba584eef5da36a6859892658df8429ff5baa92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91ba584eef5da36a6859892658df8429ff5baa92>`__

--- a/src/page/Releases/4.6.0.rst
+++ b/src/page/Releases/4.6.0.rst
@@ -177,45 +177,45 @@ Alexander Bokovoy (13)
 ----------------------------------------------------------------------------------------------
 
 -  csrgen: support openssl 1.0 and 1.1
-   `commit <https://pagure.io/freeipa/c/79378c90512a1cdd5f3d5ec6482e434caea06e01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79378c90512a1cdd5f3d5ec6482e434caea06e01>`__
    `#7110 <https://pagure.io/freeipa/issue/7110>`__
 -  dcerpc: support Python 3
-   `commit <https://pagure.io/freeipa/c/928374ca7de5c0bec54e848a35b6bacda9f55343>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/928374ca7de5c0bec54e848a35b6bacda9f55343>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ipa-sam: use smbldap_set_bind_callback for Samba 4.7 or later
-   `commit <https://pagure.io/freeipa/c/3ab6a68e91a4fad5af037a910fd4f6b6d8f7611f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ab6a68e91a4fad5af037a910fd4f6b6d8f7611f>`__
    `#6877 <https://pagure.io/freeipa/issue/6877>`__
 -  ipa-sam: use own private structure, not ldapsam_privates
-   `commit <https://pagure.io/freeipa/c/11d43a16035d9ce7970ddf757f17025289ec4854>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11d43a16035d9ce7970ddf757f17025289ec4854>`__
    `#6877 <https://pagure.io/freeipa/issue/6877>`__
 -  trust-mod: allow modifying list of UPNs of a trusted forest
-   `commit <https://pagure.io/freeipa/c/abb638487580af99882b4751b64939d0aff0d38b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abb638487580af99882b4751b64939d0aff0d38b>`__
    `#7015 <https://pagure.io/freeipa/issue/7015>`__
 -  ipa-kdb: add pkinit authentication indicator in case of a successful
    certauth
-   `commit <https://pagure.io/freeipa/c/e8a7e2e38ad7cea2964305247430e964d2b785b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8a7e2e38ad7cea2964305247430e964d2b785b1>`__
    `#6736 <https://pagure.io/freeipa/issue/6736>`__
 -  Fix index definition for ipaAnchorUUID
-   `commit <https://pagure.io/freeipa/c/49ce395b90ea64eda3f9362b05936a3e4d43234a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49ce395b90ea64eda3f9362b05936a3e4d43234a>`__
    `#6975 <https://pagure.io/freeipa/issue/6975>`__
 -  krb5: make sure KDC certificate is readable
-   `commit <https://pagure.io/freeipa/c/9c3fad9cef7785a65c795f1b4fc3f94e50af9db2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c3fad9cef7785a65c795f1b4fc3f94e50af9db2>`__
    `#6973 <https://pagure.io/freeipa/issue/6973>`__
 -  trust: always use oddjobd helper for fetching trust information
-   `commit <https://pagure.io/freeipa/c/e560899cce20ca7773a5ce46a1c29db1349e8ec7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e560899cce20ca7773a5ce46a1c29db1349e8ec7>`__
 -  ipaserver/dcerpc: unify error processing
-   `commit <https://pagure.io/freeipa/c/aef77b3529540ad12939a2cc54996c341c5d49d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aef77b3529540ad12939a2cc54996c341c5d49d3>`__
    `#6859 <https://pagure.io/freeipa/issue/6859>`__
 -  adtrust: make sure that runtime hostname result is consistent with
    the configuration
-   `commit <https://pagure.io/freeipa/c/0d817ae63a4ad8ba7a29910a9342a78e15e89593>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d817ae63a4ad8ba7a29910a9342a78e15e89593>`__
    `#6786 <https://pagure.io/freeipa/issue/6786>`__
 -  server: make sure we test for sss_nss_getlistbycert
-   `commit <https://pagure.io/freeipa/c/67e5244cad72bef76de1c4df47a0c77a672fa861>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67e5244cad72bef76de1c4df47a0c77a672fa861>`__
    `#6828 <https://pagure.io/freeipa/issue/6828>`__
 -  ldap2: use LDAP whoami operation to retrieve bind DN for current
    connection
-   `commit <https://pagure.io/freeipa/c/7324451834ec03786fda947679f750fe2a72f29c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7324451834ec03786fda947679f750fe2a72f29c>`__
    `#6797 <https://pagure.io/freeipa/issue/6797>`__
 
 
@@ -224,22 +224,22 @@ Abhijeet Kasurde (6)
 ----------------------------------------------------------------------------------------------
 
 -  Vault testcase improvement
-   `commit <https://pagure.io/freeipa/c/8d3924dc98ba5a3873ae21c3c60de97510eebc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d3924dc98ba5a3873ae21c3c60de97510eebc88>`__
    `#7098 <https://pagure.io/freeipa/issue/7098>`__
 -  Minor typo fixes
-   `commit <https://pagure.io/freeipa/c/cb869314729022d4c16339bb08b79c5c30fe29df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb869314729022d4c16339bb08b79c5c30fe29df>`__
    `#6865 <https://pagure.io/freeipa/issue/6865>`__
 -  Minor typo in details.js
-   `commit <https://pagure.io/freeipa/c/0f20eca3f58b59ed15a5acd69b3d763bf19f26f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f20eca3f58b59ed15a5acd69b3d763bf19f26f1>`__
    `#6863 <https://pagure.io/freeipa/issue/6863>`__
 -  Hide request_type doc string in cert-request help
-   `commit <https://pagure.io/freeipa/c/a1bb442054936113369a88b49483e914664712e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1bb442054936113369a88b49483e914664712e7>`__
    `#5734 <https://pagure.io/freeipa/issue/5734>`__,
    `#6494 <https://pagure.io/freeipa/issue/6494>`__
 -  Hide PKI Client database password in log file
-   `commit <https://pagure.io/freeipa/c/7fddc1df573cb56949b1bc8ad83a041e97523df1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fddc1df573cb56949b1bc8ad83a041e97523df1>`__
 -  Use with statement for opening file
-   `commit <https://pagure.io/freeipa/c/6d4c917440793e988b907a62f2f56f5dc82b53dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d4c917440793e988b907a62f2f56f5dc82b53dd>`__
 
 
 
@@ -247,7 +247,7 @@ Alex Zeleznikov (1)
 ----------------------------------------------------------------------------------------------
 
 -  Sort SRV records by priority
-   `commit <https://pagure.io/freeipa/c/8ec8e24015df29bae97fa58d1a7ae12d28639d25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ec8e24015df29bae97fa58d1a7ae12d28639d25>`__
 
 
 
@@ -255,11 +255,11 @@ Aleksei Slaikovskii (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipapython/graph.py redundant variable fix
-   `commit <https://pagure.io/freeipa/c/c39da523adbcc1b2e0d7ca702971c69dc40135ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c39da523adbcc1b2e0d7ca702971c69dc40135ba>`__
 -  ipapython/graph.py String formatting
-   `commit <https://pagure.io/freeipa/c/fe913b9c9f8ce6e481f8f1f78bc082b55390fbea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe913b9c9f8ce6e481f8f1f78bc082b55390fbea>`__
 -  ipapython/graph.py complexity optimization
-   `commit <https://pagure.io/freeipa/c/52a435978b367fb94834f7c02debd06327c5e930>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52a435978b367fb94834f7c02debd06327c5e930>`__
    `#7051 <https://pagure.io/freeipa/issue/7051>`__
 
 
@@ -268,17 +268,17 @@ Ben Lipton (4)
 ----------------------------------------------------------------------------------------------
 
 -  csrgen: Beginnings of NSS database support
-   `commit <https://pagure.io/freeipa/c/a53e17830c3d4fd59a62248d4447491675c6a80e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a53e17830c3d4fd59a62248d4447491675c6a80e>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Modify cert_get_requestdata to return a
    CertificationRequestInfo
-   `commit <https://pagure.io/freeipa/c/e7588ab2dc73e7f66ebc6cdcfb99470540e37731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7588ab2dc73e7f66ebc6cdcfb99470540e37731>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Change to pure openssl config format (no script)
-   `commit <https://pagure.io/freeipa/c/136c6c3e2a4f77a27f435efd4a1cd95c9e089314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/136c6c3e2a4f77a27f435efd4a1cd95c9e089314>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 -  csrgen: Remove helper abstraction
-   `commit <https://pagure.io/freeipa/c/5420e9cfbe7803808b6e26d2dae64f2a6a50149a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5420e9cfbe7803808b6e26d2dae64f2a6a50149a>`__
    `#4899 <https://pagure.io/freeipa/issue/4899>`__
 
 
@@ -287,110 +287,110 @@ Christian Heimes (40)
 ----------------------------------------------------------------------------------------------
 
 -  Misc Python 3 fixes for ipaserver.secrets
-   `commit <https://pagure.io/freeipa/c/5f0332905132b7c8fa65d6ed16cd2c028e5a0ed5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f0332905132b7c8fa65d6ed16cd2c028e5a0ed5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Reimplement yield tests are parametrized tests
-   `commit <https://pagure.io/freeipa/c/090eadbe4e4d0ab9fe387c1966b51cdf28ed9b17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/090eadbe4e4d0ab9fe387c1966b51cdf28ed9b17>`__
    `#6591 <https://pagure.io/freeipa/issue/6591>`__
 -  Silence pytest.yield_fixture deprecation warning
-   `commit <https://pagure.io/freeipa/c/af140b0bc15cf4c27c63cc88bc6eec792f29422a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af140b0bc15cf4c27c63cc88bc6eec792f29422a>`__
    `#6591 <https://pagure.io/freeipa/issue/6591>`__
 -  Slim down dependencies
-   `commit <https://pagure.io/freeipa/c/bd5a5012d24820b54cdca2955f5405b84de1178c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd5a5012d24820b54cdca2955f5405b84de1178c>`__
 -  Vault: Explicitly default to 3DES CBC
-   `commit <https://pagure.io/freeipa/c/5197422ef65e7239fc56c562ab87d99388a38a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5197422ef65e7239fc56c562ab87d99388a38a8d>`__
    `#6899 <https://pagure.io/freeipa/issue/6899>`__
 -  Band-aid for pip dependency bug
-   `commit <https://pagure.io/freeipa/c/994d24d288080e924e039ca0a7b0b0dfc2355ac1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/994d24d288080e924e039ca0a7b0b0dfc2355ac1>`__
 -  Correct PyPI package dependencies
-   `commit <https://pagure.io/freeipa/c/26ab51ddf47f421f3404709052db89f08c05adaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26ab51ddf47f421f3404709052db89f08c05adaa>`__
    `#6875 <https://pagure.io/freeipa/issue/6875>`__
 -  tox: use pylint 1.6.x for now
-   `commit <https://pagure.io/freeipa/c/b64ec757883284a765745ef4fbd78fb55bf0e228>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b64ec757883284a765745ef4fbd78fb55bf0e228>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Replace \_BSD_SOURCE with \_DEFAULT_SOURCE
-   `commit <https://pagure.io/freeipa/c/9b443b908fe6fb9c11f9b76552bf4fef2c3b2be5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b443b908fe6fb9c11f9b76552bf4fef2c3b2be5>`__
    `#6818 <https://pagure.io/freeipa/issue/6818>`__
 -  Regenerate ASN.1 code with asn1c 0.9.28
-   `commit <https://pagure.io/freeipa/c/ad0843047779b55848425eaba0385034d6893446>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad0843047779b55848425eaba0385034d6893446>`__
    `#6818 <https://pagure.io/freeipa/issue/6818>`__
 -  tox testing support for client wheel packages
-   `commit <https://pagure.io/freeipa/c/3a5b3be8b92a509d207d814c9fe294ee7b4e81c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a5b3be8b92a509d207d814c9fe294ee7b4e81c4>`__
 -  Stabilize make pypi_packages
-   `commit <https://pagure.io/freeipa/c/d0c36b9c2eae1298604ec8ad4597e19e20365e11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0c36b9c2eae1298604ec8ad4597e19e20365e11>`__
 -  Replace hard-coded kdcproxy path with WSGI script
-   `commit <https://pagure.io/freeipa/c/2cd6788c3f52a9b87f24b9b3e57d66a864397966>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2cd6788c3f52a9b87f24b9b3e57d66a864397966>`__
    `#6834 <https://pagure.io/freeipa/issue/6834>`__
 -  Use entry_points for ipa CLI
-   `commit <https://pagure.io/freeipa/c/bf67974459f093487a1c5a49234769803780ecbe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf67974459f093487a1c5a49234769803780ecbe>`__
    `#6653 <https://pagure.io/freeipa/issue/6653>`__,
    `#6850 <https://pagure.io/freeipa/issue/6850>`__
 -  Don't hard-code with_wheels
-   `commit <https://pagure.io/freeipa/c/40a60675f3feb118af70562582399afefe97214d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40a60675f3feb118af70562582399afefe97214d>`__
 -  Add an option to build ipaserver wheels
-   `commit <https://pagure.io/freeipa/c/ae1c2086db3efb51341025ae25f9b39060868ac1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae1c2086db3efb51341025ae25f9b39060868ac1>`__
 -  Add extra_requires for additional dependencies
-   `commit <https://pagure.io/freeipa/c/7c9df35d3dd812543cf537c0762c6db728379919>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c9df35d3dd812543cf537c0762c6db728379919>`__
 -  Conditionally import pyhbac
-   `commit <https://pagure.io/freeipa/c/3064b890e24a5056c77f19c3951cfb59d49366f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3064b890e24a5056c77f19c3951cfb59d49366f8>`__
 -  Skip test_session_storage in ipaclient unittest mode
-   `commit <https://pagure.io/freeipa/c/6c092c24b2bfbba0a3f263d88f7a0dbf83f24869>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c092c24b2bfbba0a3f263d88f7a0dbf83f24869>`__
 -  Add make devcheck for developers
-   `commit <https://pagure.io/freeipa/c/e357133fd7b276ccabfe1896ee948f2bb3541d94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e357133fd7b276ccabfe1896ee948f2bb3541d94>`__
    `#6604 <https://pagure.io/freeipa/issue/6604>`__
 -  session storage parameters must be bytes
-   `commit <https://pagure.io/freeipa/c/d06315de6b1e951d6cce7d7d6495a32b44216274>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d06315de6b1e951d6cce7d7d6495a32b44216274>`__
 -  Fix ipatests.util doc tests
-   `commit <https://pagure.io/freeipa/c/397e6716974f90168792ec0a6ad0b7b37c02eb87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/397e6716974f90168792ec0a6ad0b7b37c02eb87>`__
 -  Use Custodia 0.3.1 features
-   `commit <https://pagure.io/freeipa/c/f5bf5466eda0de2a211b4f2682e5c50b82577701>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5bf5466eda0de2a211b4f2682e5c50b82577701>`__
 -  Simplify KRA transport cert cache
-   `commit <https://pagure.io/freeipa/c/abefb64bea8ea1b8487ad87716e4a335555d19dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abefb64bea8ea1b8487ad87716e4a335555d19dc>`__
    `#6787 <https://pagure.io/freeipa/issue/6787>`__
 -  pytest 3.x compatibility
-   `commit <https://pagure.io/freeipa/c/dd6b72e418eba01cc9eb9a7305291bf141b9eadf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd6b72e418eba01cc9eb9a7305291bf141b9eadf>`__
 -  Constrain wheel package versions
-   `commit <https://pagure.io/freeipa/c/fe17d187f9f2cbac28fe369cbcdd697d85105481>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe17d187f9f2cbac28fe369cbcdd697d85105481>`__
    `#6468 <https://pagure.io/freeipa/issue/6468>`__
 -  Move remaining util functions to tasks module
-   `commit <https://pagure.io/freeipa/c/24161a619049e0fb3b954592f64ee6d561320d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24161a619049e0fb3b954592f64ee6d561320d2c>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Ship ipatests.pytest_plugins.integration
-   `commit <https://pagure.io/freeipa/c/5587a37e2345de4e76813e00f4b2751d24c618fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5587a37e2345de4e76813e00f4b2751d24c618fc>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move function run_repeatedly to tasks module
-   `commit <https://pagure.io/freeipa/c/8aadd55c93a627e88e007d2df864a5fb72fba0a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8aadd55c93a627e88e007d2df864a5fb72fba0a2>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move hosts module to ipatests.pytest_plugins.integration.hosts
-   `commit <https://pagure.io/freeipa/c/8867412adc0ffd0cacf555a5c3693e04074fed5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8867412adc0ffd0cacf555a5c3693e04074fed5b>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move tasks module to ipatests.pytest_plugins.integration.tasks
-   `commit <https://pagure.io/freeipa/c/313ae46b573b4cac1075dc1b5bd7294424fabfdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/313ae46b573b4cac1075dc1b5bd7294424fabfdb>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move env_config module to
    ipatests.pytest_plugins.integration.env_config
-   `commit <https://pagure.io/freeipa/c/1406dbc8c223ac0894088146bfe2a8ef0688097a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1406dbc8c223ac0894088146bfe2a8ef0688097a>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move config module to ipatests.pytest_plugins.integration.config
-   `commit <https://pagure.io/freeipa/c/2895e3931d0b4a9e20e1b211ef5a76f79fc73c9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2895e3931d0b4a9e20e1b211ef5a76f79fc73c9d>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Move helper code for integration plugin
-   `commit <https://pagure.io/freeipa/c/dde71ec4a9669a155456a8e8912ed3a0503b8704>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dde71ec4a9669a155456a8e8912ed3a0503b8704>`__
    `#6798 <https://pagure.io/freeipa/issue/6798>`__
 -  Increase Apache HTTPD's default keep alive timeout
-   `commit <https://pagure.io/freeipa/c/7f567286f6b89f3e981af02913e833d3e8ed5064>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f567286f6b89f3e981af02913e833d3e8ed5064>`__
 -  Add debug logging for keep-alive
-   `commit <https://pagure.io/freeipa/c/b2bdd2e1a912573ae4a3e8e5f40831a800d972f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2bdd2e1a912573ae4a3e8e5f40831a800d972f7>`__
 -  Use connection keep-alive
-   `commit <https://pagure.io/freeipa/c/7beb6d1cad7e2200208cb14be6c823a89abf0dc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7beb6d1cad7e2200208cb14be6c823a89abf0dc3>`__
    `#6641 <https://pagure.io/freeipa/issue/6641>`__
 -  Add options to run only ipaclient unittests
-   `commit <https://pagure.io/freeipa/c/fd1b4f6ec9a349196d5df510008c4745f0b1fb84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd1b4f6ec9a349196d5df510008c4745f0b1fb84>`__
    `#6517 <https://pagure.io/freeipa/issue/6517>`__
 -  Python 3: Fix session storage
-   `commit <https://pagure.io/freeipa/c/42bc778c0c1de91f0d8dc695dfee4e5aea4cc1f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42bc778c0c1de91f0d8dc695dfee4e5aea4cc1f0>`__
 -  Fix Python 3 pylint errors
-   `commit <https://pagure.io/freeipa/c/602b395cf19b0ae0b8ade1c13ddaf09175ed7291>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/602b395cf19b0ae0b8ade1c13ddaf09175ed7291>`__
 
 
 
@@ -398,14 +398,14 @@ David Kreitschmann (4)
 ----------------------------------------------------------------------------------------------
 
 -  Disable pylint in get_help function because of type confusion.
-   `commit <https://pagure.io/freeipa/c/bf0ba9b36e95f2e2b14bb27059280027d8354c13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf0ba9b36e95f2e2b14bb27059280027d8354c13>`__
 -  Store help in Schema before writing to disk
-   `commit <https://pagure.io/freeipa/c/d5bb541061e6c0952d2075a24d0a58c87455f233>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5bb541061e6c0952d2075a24d0a58c87455f233>`__
 -  Use os.fsync instead of os.fdatasync because macOS doesn't support
    fdatasync
-   `commit <https://pagure.io/freeipa/c/f1c6a5d8de6dbf470805e479899b1a60909a2b92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1c6a5d8de6dbf470805e479899b1a60909a2b92>`__
 -  Fix libkrb5 filename for macOS
-   `commit <https://pagure.io/freeipa/c/b8b28c3d098ae00b451802f0ecc287010128ce93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8b28c3d098ae00b451802f0ecc287010128ce93>`__
 
 
 
@@ -413,75 +413,75 @@ David Kupka (22)
 ----------------------------------------------------------------------------------------------
 
 -  tests: certmap: Add test for user-{add,remove}-certmap
-   `commit <https://pagure.io/freeipa/c/bda3dd722b87aea3e852284775b15af67b15359d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bda3dd722b87aea3e852284775b15af67b15359d>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapdataMixin tracker
-   `commit <https://pagure.io/freeipa/c/7bce62d5d4a93bdce4cefd673289caeec1668093>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bce62d5d4a93bdce4cefd673289caeec1668093>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Add test for certmapconfig-{mod,show}
-   `commit <https://pagure.io/freeipa/c/e574f5d65e51a0a368f0efe3117d3c26d889bd2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e574f5d65e51a0a368f0efe3117d3c26d889bd2a>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapconfigTracker to tests certmapconfig-\*
    commands
-   `commit <https://pagure.io/freeipa/c/0ccde4450198270ff191f1320f80d3c0e4b5d487>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ccde4450198270ff191f1320f80d3c0e4b5d487>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Test permissions for certmap
-   `commit <https://pagure.io/freeipa/c/eabd3971548b313e1905f7025c40fac643786e1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eabd3971548b313e1905f7025c40fac643786e1b>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: certmap: Add basic tests for certmaprule commands
-   `commit <https://pagure.io/freeipa/c/c6a43ffcad5b3860cbb0587b4f823a4b6e9a607f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6a43ffcad5b3860cbb0587b4f823a4b6e9a607f>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add CertmapTracker for testing certmap-\* commands
-   `commit <https://pagure.io/freeipa/c/aee200816e68d1eba1e635538dfb64dbb51e1fc4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aee200816e68d1eba1e635538dfb64dbb51e1fc4>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add ConfigurationTracker to test \*config-{mod,show}
    commands
-   `commit <https://pagure.io/freeipa/c/3113bfb0cfdca14569303137beb2f2fb4f0c4099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3113bfb0cfdca14569303137beb2f2fb4f0c4099>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Add EnableTracker to test \*-{enable,disable}
    commands
-   `commit <https://pagure.io/freeipa/c/7b015a2e761258039f0f2e9ff3c7daafecf97b3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b015a2e761258039f0f2e9ff3c7daafecf97b3d>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  tests: tracker: Split Tracker into one-purpose Trackers
-   `commit <https://pagure.io/freeipa/c/ac7712c93e2080d298e9e0a909aae40238dee305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac7712c93e2080d298e9e0a909aae40238dee305>`__
    `#7105 <https://pagure.io/freeipa/issue/7105>`__
 -  install: replica: Show message about key synchronization
-   `commit <https://pagure.io/freeipa/c/d6787eea4899af6bd7075a3311a45cb8eda571e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6787eea4899af6bd7075a3311a45cb8eda571e5>`__
    `#6940 <https://pagure.io/freeipa/issue/6940>`__
 -  kra: promote: Get ticket before calling custodia
-   `commit <https://pagure.io/freeipa/c/342f72140f9bd8b8db19f469ae4c56cac7492901>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/342f72140f9bd8b8db19f469ae4c56cac7492901>`__
    `#7020 <https://pagure.io/freeipa/issue/7020>`__
 -  ipapython.ipautil.run: Add option to set umask before executing
    command
-   `commit <https://pagure.io/freeipa/c/b9fd123d61fa7adda090c05216906ba0cf4779a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9fd123d61fa7adda090c05216906ba0cf4779a9>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  otptoken-add-yubikey: When --digits not provided use default value
-   `commit <https://pagure.io/freeipa/c/e415da22f350fbda5b8b341bf2dc5f969cecb84a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e415da22f350fbda5b8b341bf2dc5f969cecb84a>`__
    `#6900 <https://pagure.io/freeipa/issue/6900>`__
 -  Bump version of ipa.conf file
-   `commit <https://pagure.io/freeipa/c/9d32e61ba548e7e940f165c0ec8df0b4bfd210bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d32e61ba548e7e940f165c0ec8df0b4bfd210bd>`__
    `#6860 <https://pagure.io/freeipa/issue/6860>`__
 -  Create system users for FreeIPA services during package installation
-   `commit <https://pagure.io/freeipa/c/a726e98f034347227765d7303a033a0538f5d8a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a726e98f034347227765d7303a033a0538f5d8a1>`__
    `#6743 <https://pagure.io/freeipa/issue/6743>`__
 -  WebUI: cert login: Configure name of parameter used to pass username
-   `commit <https://pagure.io/freeipa/c/157831a287c64106eed4da4ace5228d7e369ae2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/157831a287c64106eed4da4ace5228d7e369ae2f>`__
    `#6860 <https://pagure.io/freeipa/issue/6860>`__
 -  httpinstance.disable_system_trust: Don't fail if module 'Root Certs'
    is not available
-   `commit <https://pagure.io/freeipa/c/0128e805e591bc8ca5cea99739ad4cd7478df0b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0128e805e591bc8ca5cea99739ad4cd7478df0b4>`__
    `#6803 <https://pagure.io/freeipa/issue/6803>`__
 -  spec file: Bump requires to make Certificate Login in WebUI work
-   `commit <https://pagure.io/freeipa/c/27d13d90fe9b06618c88bc20b7d6540e6b4d367f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27d13d90fe9b06618c88bc20b7d6540e6b4d367f>`__
    `#6823 <https://pagure.io/freeipa/issue/6823>`__
 -  rpcserver.login_x509: Actually return reply from \__call_\_ method
-   `commit <https://pagure.io/freeipa/c/7e1fdd2c5881893fd9540689045a11f9e88beef9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e1fdd2c5881893fd9540689045a11f9e88beef9>`__
    `#6819 <https://pagure.io/freeipa/issue/6819>`__
 -  Create temporaty directories at the begining of uninstall
-   `commit <https://pagure.io/freeipa/c/3dcd3426310ccacdb1564ad7fe83358110a044f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dcd3426310ccacdb1564ad7fe83358110a044f6>`__
    `#6715 <https://pagure.io/freeipa/issue/6715>`__
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
-   `commit <https://pagure.io/freeipa/c/4297ad6db0d4f39d82fd155323163df92b2b7894>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4297ad6db0d4f39d82fd155323163df92b2b7894>`__
    `#6738 <https://pagure.io/freeipa/issue/6738>`__
 
 
@@ -490,7 +490,7 @@ felipe (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixing replica install: fix ldap connection in domlvl 0
-   `commit <https://pagure.io/freeipa/c/772d4e3d4e9a2756e6a34e265a1219599688cde3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/772d4e3d4e9a2756e6a34e265a1219599688cde3>`__
    `#6549 <https://pagure.io/freeipa/issue/6549>`__
 
 
@@ -499,14 +499,14 @@ Felipe Volpone (3)
 ----------------------------------------------------------------------------------------------
 
 -  Removing part of circular dependency of ipalib in ipaplaform
-   `commit <https://pagure.io/freeipa/c/0b7d9c5a7b271f0e8b296dac86525b9ce948084a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b7d9c5a7b271f0e8b296dac86525b9ce948084a>`__
    `#7108 <https://pagure.io/freeipa/issue/7108>`__
 -  Changing how commands handles error when it can't connect to IPA
    server
-   `commit <https://pagure.io/freeipa/c/cac3475a0454b730d6e5b2093c2e63d395acd387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cac3475a0454b730d6e5b2093c2e63d395acd387>`__
    `#6261 <https://pagure.io/freeipa/issue/6261>`__
 -  py3: fixing zonemgr_callback
-   `commit <https://pagure.io/freeipa/c/75d26e1f0121f875bdb017b0636c02a6f5660e8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75d26e1f0121f875bdb017b0636c02a6f5660e8a>`__
    `#5990 <https://pagure.io/freeipa/issue/5990>`__
 
 
@@ -515,21 +515,21 @@ Felipe Volpone (5)
 ----------------------------------------------------------------------------------------------
 
 -  Adding section "Building FreeIPA from source" on README
-   `commit <https://pagure.io/freeipa/c/be2fba08ce3d89448d4a87f9d0dd15f605cf6dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be2fba08ce3d89448d4a87f9d0dd15f605cf6dd1>`__
    `#6725 <https://pagure.io/freeipa/issue/6725>`__
 -  Changing cert-find to go through the proxy instead of using the port
    8080
-   `commit <https://pagure.io/freeipa/c/36532031cfef893aa2f95d709efd807729de79f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36532031cfef893aa2f95d709efd807729de79f7>`__
    `#6966 <https://pagure.io/freeipa/issue/6966>`__
 -  Changing cert-find to do not use only primary key to search in LDAP.
-   `commit <https://pagure.io/freeipa/c/44bd5e358b027f8956b730f250854efb5087f05e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44bd5e358b027f8956b730f250854efb5087f05e>`__
    `#6948 <https://pagure.io/freeipa/issue/6948>`__
 -  Fixing adding authenticator indicators to host
-   `commit <https://pagure.io/freeipa/c/d51af28bdbef8386b6d3bde683be2fc5f73b904e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d51af28bdbef8386b6d3bde683be2fc5f73b904e>`__
    `#6911 <https://pagure.io/freeipa/issue/6911>`__
 -  Fixing the cert-request comparing whole email address
    case-sensitively.
-   `commit <https://pagure.io/freeipa/c/d973168e89c7fb5e8c36919b3adb685371e1a3ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d973168e89c7fb5e8c36919b3adb685371e1a3ab>`__
    `#5919 <https://pagure.io/freeipa/issue/5919>`__
 
 
@@ -538,7 +538,7 @@ Fabiano Fidêncio (1)
 ----------------------------------------------------------------------------------------------
 
 -  Allow erasing ipaDomainResolutionOrder attribute
-   `commit <https://pagure.io/freeipa/c/e03056cf34de5ba0100d62f008d76e8c851c3ba7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e03056cf34de5ba0100d62f008d76e8c851c3ba7>`__
    `#6825 <https://pagure.io/freeipa/issue/6825>`__
 
 
@@ -547,73 +547,73 @@ Florence Blanc-Renaud (22)
 ----------------------------------------------------------------------------------------------
 
 -  Fix Certificate renewal (with ext ca)
-   `commit <https://pagure.io/freeipa/c/ee5345ac05fd1e133243ffb61c25615840f7bd87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee5345ac05fd1e133243ffb61c25615840f7bd87>`__
    `#7106 <https://pagure.io/freeipa/issue/7106>`__
 -  Fix ipa-server-upgrade: This entry already exists
-   `commit <https://pagure.io/freeipa/c/69bda6b440d6b84f042ff74b9ce708d963616eda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69bda6b440d6b84f042ff74b9ce708d963616eda>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  ipa-replica-conncheck: handle ssh not installed
-   `commit <https://pagure.io/freeipa/c/f960450820c13284b52b4c5f420f0f1191a45619>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f960450820c13284b52b4c5f420f0f1191a45619>`__
    `#6935 <https://pagure.io/freeipa/issue/6935>`__
 -  ipa-ca-install: append CA cert chain into /etc/ipa/ca.crt
-   `commit <https://pagure.io/freeipa/c/d93264247563937d6d8e3f030a2bffac10572612>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d93264247563937d6d8e3f030a2bffac10572612>`__
    `#6925 <https://pagure.io/freeipa/issue/6925>`__
 -  ipa-replica-manage del (dl 0): remove server from defaultServerList
-   `commit <https://pagure.io/freeipa/c/319a079f6decc81c7f0912ee5aef239768db554b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/319a079f6decc81c7f0912ee5aef239768db554b>`__
    `#6946 <https://pagure.io/freeipa/issue/6946>`__
 -  server-del: update defaultServerList in cn=default,ou=profile,$BASE
-   `commit <https://pagure.io/freeipa/c/a02a0a95f24c07357147e44147194c296b16d24a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a02a0a95f24c07357147e44147194c296b16d24a>`__
    `#6943 <https://pagure.io/freeipa/issue/6943>`__
 -  ipa-kra-install: fix pkispawn setting for
    pki_security_domain_hostname
-   `commit <https://pagure.io/freeipa/c/c26038d24cc11ab2dc1e6839a160fcf1bce48f69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c26038d24cc11ab2dc1e6839a160fcf1bce48f69>`__
    `#6895 <https://pagure.io/freeipa/issue/6895>`__
 -  ipa-server-install: fix uninstall
-   `commit <https://pagure.io/freeipa/c/d9ed2573fd5b4dcdc8ea865f16d81325707e0f9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9ed2573fd5b4dcdc8ea865f16d81325707e0f9d>`__
    `#6950 <https://pagure.io/freeipa/issue/6950>`__
 -  ipa-kra-install manpage: document domain-level 1
-   `commit <https://pagure.io/freeipa/c/f3e1efdcf5db5da2c3c42d3d58be172943f20bce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3e1efdcf5db5da2c3c42d3d58be172943f20bce>`__
    `#6922 <https://pagure.io/freeipa/issue/6922>`__
 -  ipa-kra-install: fix check_host_keys
-   `commit <https://pagure.io/freeipa/c/8983ce53e3fdee98926f81f3012146e33bb92d30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8983ce53e3fdee98926f81f3012146e33bb92d30>`__
    `#6934 <https://pagure.io/freeipa/issue/6934>`__
 -  ipa-server-install with external CA: fix pkinit cert issuance
-   `commit <https://pagure.io/freeipa/c/a24923066dd95a88ded329f1a558d46fbb9d8f81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a24923066dd95a88ded329f1a558d46fbb9d8f81>`__
    `#6921 <https://pagure.io/freeipa/issue/6921>`__
 -  ipa-client-install: remove extra space in pkinit_anchors definition
-   `commit <https://pagure.io/freeipa/c/26dbab1fd4384b8f3999b153c2d94220cf541ad2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26dbab1fd4384b8f3999b153c2d94220cf541ad2>`__
    `#6916 <https://pagure.io/freeipa/issue/6916>`__
 -  vault: piped input for ipa vault-add fails
-   `commit <https://pagure.io/freeipa/c/d5c41ed4ad370c7d74296a830993a5bd3fd32e5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5c41ed4ad370c7d74296a830993a5bd3fd32e5f>`__
    `#6907 <https://pagure.io/freeipa/issue/6907>`__
 -  upgrade: adtrust update_tdo_gidnumber plugin must check if adtrust is
    installed
-   `commit <https://pagure.io/freeipa/c/434d9e539d24fe0110c5d6bf4a4342daf40d15d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/434d9e539d24fe0110c5d6bf4a4342daf40d15d5>`__
    `#6881 <https://pagure.io/freeipa/issue/6881>`__
 -  tests: add non-reg for idrange-add
-   `commit <https://pagure.io/freeipa/c/342dccea47f6cb14cda63f75789eab51070fb3f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/342dccea47f6cb14cda63f75789eab51070fb3f6>`__
    `#6404 <https://pagure.io/freeipa/issue/6404>`__
 -  Upgrade: add gidnumber to trusted domain entry
-   `commit <https://pagure.io/freeipa/c/5405de5bc15941d71137af10aa66a6cf922d9e6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5405de5bc15941d71137af10aa66a6cf922d9e6d>`__
    `#6827 <https://pagure.io/freeipa/issue/6827>`__
 -  ipa-sam: create the gidNumber attribute in the trusted domain entry
-   `commit <https://pagure.io/freeipa/c/e052c2dce04f5ce147dc2b6804f44705fa4d69df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e052c2dce04f5ce147dc2b6804f44705fa4d69df>`__
    `#6827 <https://pagure.io/freeipa/issue/6827>`__
 -  idrange-add: properly handle empty --dom-name option
-   `commit <https://pagure.io/freeipa/c/70743c8c48db54309a09d510b3a5d8ae86c29e58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70743c8c48db54309a09d510b3a5d8ae86c29e58>`__
    `#6404 <https://pagure.io/freeipa/issue/6404>`__
 -  ipa-ca-install man page: Add domain level 1 help
-   `commit <https://pagure.io/freeipa/c/b96a942cdca09496be9f911499036bee60084aee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b96a942cdca09496be9f911499036bee60084aee>`__
    `#5831 <https://pagure.io/freeipa/issue/5831>`__
 -  git-commit-template: update ticket url to use pagure.io instead of
    fedorahosted.org
-   `commit <https://pagure.io/freeipa/c/f17460a34ce452b46d431850aa565efd6c7b23ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f17460a34ce452b46d431850aa565efd6c7b23ba>`__
    `#6822 <https://pagure.io/freeipa/issue/6822>`__
 -  dogtag-ipa-ca-renew-agent-submit: fix the is_replicated() function
-   `commit <https://pagure.io/freeipa/c/e934da09d5e738c735f874931dd1b54d79b3150b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e934da09d5e738c735f874931dd1b54d79b3150b>`__
    `#6813 <https://pagure.io/freeipa/issue/6813>`__
 -  man ipa-cacert-manage install needs clarification
-   `commit <https://pagure.io/freeipa/c/3ea2834b76a72c97186b01487e885800754c0fbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ea2834b76a72c97186b01487e885800754c0fbc>`__
    `#6795 <https://pagure.io/freeipa/issue/6795>`__
 
 
@@ -622,46 +622,46 @@ Fraser Tweedale (14)
 ----------------------------------------------------------------------------------------------
 
 -  Fix external renewal for CA with non-default subject DN
-   `commit <https://pagure.io/freeipa/c/504c303ec448d5adce2f12416c9ee1719ee1de3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/504c303ec448d5adce2f12416c9ee1719ee1de3b>`__
    `#7123 <https://pagure.io/freeipa/issue/7123>`__
 -  py3: handle bytes in schema response
-   `commit <https://pagure.io/freeipa/c/947ac4bc1f6f4016cf5baf2ecb4577e893bc3948>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/947ac4bc1f6f4016cf5baf2ecb4577e893bc3948>`__
    `#6809 <https://pagure.io/freeipa/issue/6809>`__
 -  py3: fix vault public key decoding
-   `commit <https://pagure.io/freeipa/c/9cead4da2ee4a1b1abbb60e28dee1a78cda83bf5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cead4da2ee4a1b1abbb60e28dee1a78cda83bf5>`__
    `#7033 <https://pagure.io/freeipa/issue/7033>`__
 -  cert: fix application of 'str' to bytes when formatting otherName
-   `commit <https://pagure.io/freeipa/c/cac7357ebdd7c7218f1d847ca7374735d7e411cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cac7357ebdd7c7218f1d847ca7374735d7e411cd>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: fix schema response for py2 server with py3 client
-   `commit <https://pagure.io/freeipa/c/b1e1109679c0a95aadbd63ce2587561b58d7a050>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1e1109679c0a95aadbd63ce2587561b58d7a050>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Fix incorrect 'with' statement in CA-less installation
-   `commit <https://pagure.io/freeipa/c/477b3dca802349ac4e8d60cfcabc7fe31d0ab9ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/477b3dca802349ac4e8d60cfcabc7fe31d0ab9ef>`__
    `#7118 <https://pagure.io/freeipa/issue/7118>`__
 -  Restore old version of caIPAserviceCert for upgrade only
-   `commit <https://pagure.io/freeipa/c/79955189217fec328f2d561a4a1a23ddb29eac44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79955189217fec328f2d561a4a1a23ddb29eac44>`__
    `#7097 <https://pagure.io/freeipa/issue/7097>`__
 -  cert-request: simplify request processing
-   `commit <https://pagure.io/freeipa/c/227cf8d4e98178212386eca0a1ac21459436e63f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/227cf8d4e98178212386eca0a1ac21459436e63f>`__
    `#6531 <https://pagure.io/freeipa/issue/6531>`__
 -  Add CommonNameToSANDefault to default cert profile
-   `commit <https://pagure.io/freeipa/c/1a35a2e213b46f3c5bb91d0f1b7fa05e8f051d4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a35a2e213b46f3c5bb91d0f1b7fa05e8f051d4a>`__
    `#7007 <https://pagure.io/freeipa/issue/7007>`__
 -  Add a README to certificate profile templates directory
-   `commit <https://pagure.io/freeipa/c/d7e1ab8438b02db9250b0985be29ac3325c2d2dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7e1ab8438b02db9250b0985be29ac3325c2d2dc>`__
    `#7014 <https://pagure.io/freeipa/issue/7014>`__
 -  py3: fix regression in schemaupdate
-   `commit <https://pagure.io/freeipa/c/89eb162fcd60861ed4c628dab4e1aaf10c6160bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89eb162fcd60861ed4c628dab4e1aaf10c6160bb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ca-add: validate Subject DN name attributes
-   `commit <https://pagure.io/freeipa/c/5f0e13ce9c3d1ead02de61a148de973fc6787b96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f0e13ce9c3d1ead02de61a148de973fc6787b96>`__
    `#6987 <https://pagure.io/freeipa/issue/6987>`__
 -  Add Subject Key Identifier to CA cert validity check
-   `commit <https://pagure.io/freeipa/c/bc6d4995144505c45a62320c71f503b54f68a962>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc6d4995144505c45a62320c71f503b54f68a962>`__
    `#6976 <https://pagure.io/freeipa/issue/6976>`__
 -  Support 8192-bit RSA keys in default cert profile
-   `commit <https://pagure.io/freeipa/c/1530758475c2e21dd732581ff6816e03ca74dede>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1530758475c2e21dd732581ff6816e03ca74dede>`__
    `#6319 <https://pagure.io/freeipa/issue/6319>`__
 
 
@@ -670,174 +670,174 @@ Jan Cholasta (61)
 ----------------------------------------------------------------------------------------------
 
 -  pylint: enable logging checks
-   `commit <https://pagure.io/freeipa/c/7f10a5145c2f68c3b268bda2356b9d23b7a8c500>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f10a5145c2f68c3b268bda2356b9d23b7a8c500>`__
 -  logging: do not use \`ipa_log_manager\` to create module-level
    loggers
-   `commit <https://pagure.io/freeipa/c/07229c8ff66669ba87b7d6599c3ec0d362ef2be4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07229c8ff66669ba87b7d6599c3ec0d362ef2be4>`__
 -  logging: do not log into the root logger
-   `commit <https://pagure.io/freeipa/c/7a482b7c7286f738f10e43ca70c94c35029398bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a482b7c7286f738f10e43ca70c94c35029398bc>`__
 -  logging: do not reference loggers in arguments and attributes
-   `commit <https://pagure.io/freeipa/c/ab9d1e75fc69830f9ee79f62501701f3a7a82c52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab9d1e75fc69830f9ee79f62501701f3a7a82c52>`__
 -  doc: sync guide.org with cli.py
-   `commit <https://pagure.io/freeipa/c/bccb243b05f13cc4a99ac3504d5e8f8039b853e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bccb243b05f13cc4a99ac3504d5e8f8039b853e3>`__
 -  logging: remove object-specific loggers
-   `commit <https://pagure.io/freeipa/c/ffadcb0414e31117921660ca1b2526323afac56f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffadcb0414e31117921660ca1b2526323afac56f>`__
 -  logging: use the actual root logger as the root logger
-   `commit <https://pagure.io/freeipa/c/9d19654cbd99c2133bfb86253c63da33621ea110>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d19654cbd99c2133bfb86253c63da33621ea110>`__
 -  logging: port to standard Python logging
-   `commit <https://pagure.io/freeipa/c/f62a0fdb904d2a4bb1961847e240dbb6df3b0b67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f62a0fdb904d2a4bb1961847e240dbb6df3b0b67>`__
 -  logging: do not configure any handlers by default
-   `commit <https://pagure.io/freeipa/c/464516489ff029a39446138b16e858e96d157841>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/464516489ff029a39446138b16e858e96d157841>`__
 -  wsgi, oddjob: remove needless uses of Env
-   `commit <https://pagure.io/freeipa/c/0562359f3102357310fd385c9188ea14680e5302>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0562359f3102357310fd385c9188ea14680e5302>`__
 -  config: provide defaults for \`xmlrpc_uri`, \`ldap_uri\` and
    \`basedn\`
-   `commit <https://pagure.io/freeipa/c/ba3963b4dc445fe6979bf321617e8c397107bd02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba3963b4dc445fe6979bf321617e8c397107bd02>`__
 -  ldap2: remove URI argument from ldap2 constructor
-   `commit <https://pagure.io/freeipa/c/4736fef6bb30bc07592dc5acaac05d193d660d5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4736fef6bb30bc07592dc5acaac05d193d660d5e>`__
 -  test_ldap: drop redundant URI argument
-   `commit <https://pagure.io/freeipa/c/8f849a77f5b26e087a078376c2fb17db49d9cdcf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f849a77f5b26e087a078376c2fb17db49d9cdcf>`__
 -  {ca,kra}instance: drop redundant URI argument from ad-hoc ldap2
    connections
-   `commit <https://pagure.io/freeipa/c/935fcaea2edc6bb189a6fe4f9aefc2998695b74d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/935fcaea2edc6bb189a6fe4f9aefc2998695b74d>`__
 -  user, migration: use LDAPClient for ad-hoc LDAP connections
-   `commit <https://pagure.io/freeipa/c/e9cb74fd27f4015ad980781785d95bd4107b6f40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9cb74fd27f4015ad980781785d95bd4107b6f40>`__
 -  install: do not assume /etc/krb5.conf.d exists
-   `commit <https://pagure.io/freeipa/c/d5fc0ddd874f6289c0fcf60a6a4147ca5b280700>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5fc0ddd874f6289c0fcf60a6a4147ca5b280700>`__
    `#6589 <https://pagure.io/freeipa/issue/6589>`__
 -  server upgrade: do not enable PKINIT by default
-   `commit <https://pagure.io/freeipa/c/0772ef20b39b11950fddc913a350534988294c89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0772ef20b39b11950fddc913a350534988294c89>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  pkinit manage: introduce ipa-pkinit-manage
-   `commit <https://pagure.io/freeipa/c/92276c1e8809f3ff6b59bd6124869f816627bac7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92276c1e8809f3ff6b59bd6124869f816627bac7>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  server certinstall: update KDC master entry
-   `commit <https://pagure.io/freeipa/c/e131905f3e0fe9179c5f4a09da4e7a204012603a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e131905f3e0fe9179c5f4a09da4e7a204012603a>`__
    `#7000 <https://pagure.io/freeipa/issue/7000>`__
 -  httpinstance: wait until the service entry is replicated
-   `commit <https://pagure.io/freeipa/c/ab71cd5a1693c221950bdfa9ffdfb99b9c317004>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab71cd5a1693c221950bdfa9ffdfb99b9c317004>`__
    `#6867 <https://pagure.io/freeipa/issue/6867>`__
 -  server certinstall: support PKINIT
-   `commit <https://pagure.io/freeipa/c/96ca62f81d3505b050eb9b9d71d4fc4c18e1535e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96ca62f81d3505b050eb9b9d71d4fc4c18e1535e>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  cacert manage: support PKINIT
-   `commit <https://pagure.io/freeipa/c/9ea764ecf5c3118df0917d94c4940b4ee38b3a31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ea764ecf5c3118df0917d94c4940b4ee38b3a31>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  replica install: respect --pkinit-cert-file
-   `commit <https://pagure.io/freeipa/c/b3855704f479eaf122139189b762b943b2dcc0fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3855704f479eaf122139189b762b943b2dcc0fc>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  server install: fix KDC certificate validation in CA-less
-   `commit <https://pagure.io/freeipa/c/3b5dbf7cdb4c03260057c8f7a2abd5c5712eca41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b5dbf7cdb4c03260057c8f7a2abd5c5712eca41>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__,
    `#6869 <https://pagure.io/freeipa/issue/6869>`__
 -  certs: do not export CA certs in install_pem_from_p12
-   `commit <https://pagure.io/freeipa/c/cc572378a69a7e4d18b7297b7fa54e2fe8e33b2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc572378a69a7e4d18b7297b7fa54e2fe8e33b2f>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__,
    `#6869 <https://pagure.io/freeipa/issue/6869>`__
 -  certs: do not export keys world-readable in install_key_from_p12
-   `commit <https://pagure.io/freeipa/c/0c5b2c42bf52dc75ecf9d95036ca8517670877d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c5b2c42bf52dc75ecf9d95036ca8517670877d6>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  server install: fix KDC PKINIT configuration
-   `commit <https://pagure.io/freeipa/c/f769045f0ae9c5fdc651e03c0c96af9cdec8f298>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f769045f0ae9c5fdc651e03c0c96af9cdec8f298>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  install: introduce generic Kerberos Augeas lens
-   `commit <https://pagure.io/freeipa/c/4d36cbf6ad412822b8fb029f517f9228e2c8d4ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d36cbf6ad412822b8fb029f517f9228e2c8d4ee>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  client install: fix client PKINIT configuration
-   `commit <https://pagure.io/freeipa/c/11b8a3434655932fa73f05d4bd864bed0194035c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11b8a3434655932fa73f05d4bd864bed0194035c>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  install: trust IPA CA for PKINIT
-   `commit <https://pagure.io/freeipa/c/01a7416d305ddb11d5b83c99afbacf8ba854c148>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01a7416d305ddb11d5b83c99afbacf8ba854c148>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb: use custom object for trust flags
-   `commit <https://pagure.io/freeipa/c/52730c786f6bb11aa7992b11fa0f5c94c90f9eb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52730c786f6bb11aa7992b11fa0f5c94c90f9eb8>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb, certs: make trust flags argument mandatory
-   `commit <https://pagure.io/freeipa/c/f0442a2d0ed54abe6567fce6d99fd31f7c6c7883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0442a2d0ed54abe6567fce6d99fd31f7c6c7883>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  certdb: add named trust flag constants
-   `commit <https://pagure.io/freeipa/c/235265a5f5436148dd8d7e63b7e3928689796560>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/235265a5f5436148dd8d7e63b7e3928689796560>`__
    `#6831 <https://pagure.io/freeipa/issue/6831>`__
 -  ipa-cacert-manage: add --external-ca-type
-   `commit <https://pagure.io/freeipa/c/b03ede87963bc5933691c9e3f88768e1bf92736f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b03ede87963bc5933691c9e3f88768e1bf92736f>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: get rid of virtual profiles
-   `commit <https://pagure.io/freeipa/c/21f4cbf8da8091b898fc8032fff65e821223d042>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21f4cbf8da8091b898fc8032fff65e821223d042>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: always export CSR on IPA CA certificate renewal
-   `commit <https://pagure.io/freeipa/c/0bf41e804e89937fc72502cfbe1363dd7591675e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0bf41e804e89937fc72502cfbe1363dd7591675e>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: allow reusing existing certs
-   `commit <https://pagure.io/freeipa/c/25aeeaf46dd92e06f14de83459ab9be8ab846922>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25aeeaf46dd92e06f14de83459ab9be8ab846922>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  cainstance: use correct profile for lightweight CA certificates
-   `commit <https://pagure.io/freeipa/c/09a49ad45846e3c2e76c5a035a27d0fa95b347b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09a49ad45846e3c2e76c5a035a27d0fa95b347b9>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  server upgrade: always fix certmonger tracking request
-   `commit <https://pagure.io/freeipa/c/5abd9bb99680df45b6cd87de3b08466d612344bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5abd9bb99680df45b6cd87de3b08466d612344bb>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  renew agent: respect CA renewal master setting
-   `commit <https://pagure.io/freeipa/c/ce9eefe53b398b73f956df420ea8694b90e24f76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce9eefe53b398b73f956df420ea8694b90e24f76>`__
    `#5799 <https://pagure.io/freeipa/issue/5799>`__
 -  spec file: bump krb5 Requires for certauth fixes
-   `commit <https://pagure.io/freeipa/c/0f42670afa935801c25bc66f733a8d1b90ea5a0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f42670afa935801c25bc66f733a8d1b90ea5a0b>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  spec file: bump python-netaddr Requires
-   `commit <https://pagure.io/freeipa/c/0784e53f7f8a323acafbbff26a9d1c0276a229b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0784e53f7f8a323acafbbff26a9d1c0276a229b0>`__
    `#6894 <https://pagure.io/freeipa/issue/6894>`__
 -  configure: fix AC_CHECK_LIB usage
-   `commit <https://pagure.io/freeipa/c/4322b57e313105611df39e99097993ba4161ab42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4322b57e313105611df39e99097993ba4161ab42>`__
    `#6846 <https://pagure.io/freeipa/issue/6846>`__
 -  cert: defer cert-find result post-processing
-   `commit <https://pagure.io/freeipa/c/eb6d4c3037d0cc269a7924745f1cbd8f647e6e1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb6d4c3037d0cc269a7924745f1cbd8f647e6e1a>`__
    `#6808 <https://pagure.io/freeipa/issue/6808>`__
 -  renew agent, restart scripts: connect to LDAP after kinit
-   `commit <https://pagure.io/freeipa/c/a6a89e24147d8542fd09cf64e04982599b79e3cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6a89e24147d8542fd09cf64e04982599b79e3cc>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  renew agent: revert to host keytab authentication
-   `commit <https://pagure.io/freeipa/c/3884a671cb59c360fae67884755fa5779053107a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3884a671cb59c360fae67884755fa5779053107a>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  install: request service certs after host keytab is set up
-   `commit <https://pagure.io/freeipa/c/181cb94e744c380a823b94d0d5ca088ab3dcca1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/181cb94e744c380a823b94d0d5ca088ab3dcca1c>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  dsinstance, httpinstance: consolidate certificate request code
-   `commit <https://pagure.io/freeipa/c/ec52332229672f35af8db5aaf1ed2827a8dd5467>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec52332229672f35af8db5aaf1ed2827a8dd5467>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  httpinstance: avoid httpd restart during certificate request
-   `commit <https://pagure.io/freeipa/c/8a8558637946d7dac1d85642baaf9ba7c1be98f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a8558637946d7dac1d85642baaf9ba7c1be98f8>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  dsinstance: reconnect ldap2 after DS is restarted by certmonger
-   `commit <https://pagure.io/freeipa/c/b189be12ecd1ba9efa35daf41e7e04a9362c6a5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b189be12ecd1ba9efa35daf41e7e04a9362c6a5e>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  httpinstance: make sure NSS database is backed up
-   `commit <https://pagure.io/freeipa/c/5f5a3b29dba7cc736ba334aefb55484baeefeb76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f5a3b29dba7cc736ba334aefb55484baeefeb76>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  certdb: fix \`AttributeError\` in \`verify_ca_cert_validity\`
-   `commit <https://pagure.io/freeipa/c/720034f1b440135671d03596368ed5e9e5a0f3c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/720034f1b440135671d03596368ed5e9e5a0f3c3>`__
 -  setup, pylint, spec file: drop python-nss dependency
-   `commit <https://pagure.io/freeipa/c/2b33230f669ca22d6948a4a351b4c92ba15222ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b33230f669ca22d6948a4a351b4c92ba15222ab>`__
 -  certdb: use certutil and match_hostname for cert verification
-   `commit <https://pagure.io/freeipa/c/9183cf2a7505624235b255b1406702cdaa65bb38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9183cf2a7505624235b255b1406702cdaa65bb38>`__
 -  spec file: bump libsss_nss_idmap-devel BuildRequires
-   `commit <https://pagure.io/freeipa/c/b18ee8b9dd3b1d0cfdc45373a7a56747e1f993a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b18ee8b9dd3b1d0cfdc45373a7a56747e1f993a3>`__
    `#6828 <https://pagure.io/freeipa/issue/6828>`__
 -  spec file: bump krb5-devel BuildRequires for certauth
-   `commit <https://pagure.io/freeipa/c/2dda1acf44dc96e660e81baadee9c3a54bf05eb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dda1acf44dc96e660e81baadee9c3a54bf05eb0>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  cert: do not limit internal searches in cert-find
-   `commit <https://pagure.io/freeipa/c/6de507c2cad255975665eca6dd6ef7c8f2458d51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6de507c2cad255975665eca6dd6ef7c8f2458d51>`__
    `#6716 <https://pagure.io/freeipa/issue/6716>`__
 -  replica prepare: fix wrong IPA CA nickname in replica file
-   `commit <https://pagure.io/freeipa/c/9939aa53630a9c6a66e83140e64ec56539891c13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9939aa53630a9c6a66e83140e64ec56539891c13>`__
    `#6777 <https://pagure.io/freeipa/issue/6777>`__
 -  httpinstance: clean up /etc/httpd/alias on uninstall
-   `commit <https://pagure.io/freeipa/c/e263cb46cba604421d5ed2e1dbf5dd1d66ce0221>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e263cb46cba604421d5ed2e1dbf5dd1d66ce0221>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  certs: do not implicitly create DS pin.txt
-   `commit <https://pagure.io/freeipa/c/bbd18cf10f2e67e5205a3a3bee883272e89c0042>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbd18cf10f2e67e5205a3a3bee883272e89c0042>`__
    `#4639 <https://pagure.io/freeipa/issue/4639>`__
 -  tasks: run \`systemctl daemon-reload\` after httpd.service.d updates
-   `commit <https://pagure.io/freeipa/c/3de09709cc33f1d26f2d605bac82110fe73dde03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3de09709cc33f1d26f2d605bac82110fe73dde03>`__
    `#6773 <https://pagure.io/freeipa/issue/6773>`__
 
 
@@ -846,11 +846,11 @@ René Genz (3)
 ----------------------------------------------------------------------------------------------
 
 -  fix minor spelling mistakes
-   `commit <https://pagure.io/freeipa/c/a0566ed9ce7c777309693ca9a34b9eeb4f74932f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0566ed9ce7c777309693ca9a34b9eeb4f74932f>`__
 -  fix spelling mistake; minor rewording
-   `commit <https://pagure.io/freeipa/c/bdd88a3eabd8b58f7f388520b899e74e49978ab5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdd88a3eabd8b58f7f388520b899e74e49978ab5>`__
 -  fix minor typos in ipa-adtrust-install.1
-   `commit <https://pagure.io/freeipa/c/298f725e5b2f820369c337dd1ab4bfd9ad3cd01f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/298f725e5b2f820369c337dd1ab4bfd9ad3cd01f>`__
 
 
 
@@ -858,142 +858,142 @@ Martin Babinsky (45)
 ----------------------------------------------------------------------------------------------
 
 -  Move tmpfiles.d configuration handling back to spec file
-   `commit <https://pagure.io/freeipa/c/a2de6a17c56ab86b0f4f22f63406bfff131155cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2de6a17c56ab86b0f4f22f63406bfff131155cf>`__
    `#7053 <https://pagure.io/freeipa/issue/7053>`__
 -  Do not remove the old masters when setting the attribute fails
-   `commit <https://pagure.io/freeipa/c/e2e380e83be8bafd8cf23e0a395edf065b1ae961>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2e380e83be8bafd8cf23e0a395edf065b1ae961>`__
    `#7029 <https://pagure.io/freeipa/issue/7029>`__
 -  \*config-show: Do not show empty roles/attributes
-   `commit <https://pagure.io/freeipa/c/f4d77533f5e0cb306da2aeb9548d891c5264c088>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4d77533f5e0cb306da2aeb9548d891c5264c088>`__
    `#7029 <https://pagure.io/freeipa/issue/7029>`__
 -  smart-card-advises: ensure that krb5-pkinit is installed on client
-   `commit <https://pagure.io/freeipa/c/53c5c0ad7bde137b1123504f6a52c2b22e2a3868>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53c5c0ad7bde137b1123504f6a52c2b22e2a3868>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart card advise: use password when changing trust flags on HTTP
    cert
-   `commit <https://pagure.io/freeipa/c/e0cf7090f3869bc3d4673242f64d63011dc8d1a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0cf7090f3869bc3d4673242f64d63011dc8d1a5>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart card advises: use a wrapper around Bash \`for\` loops
-   `commit <https://pagure.io/freeipa/c/4d57aef7a50eeae04bbd117531808ac616c675eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d57aef7a50eeae04bbd117531808ac616c675eb>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Use the compound statement formatting API for configuring PKINIT
-   `commit <https://pagure.io/freeipa/c/a9fec090f7a50e6f53394cab1cc5929c18934ac0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9fec090f7a50e6f53394cab1cc5929c18934ac0>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Fix indentation of statements in Smart card advises
-   `commit <https://pagure.io/freeipa/c/85a79b5ccd29a532f7e3f0f17b9ba08153bf9717>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85a79b5ccd29a532f7e3f0f17b9ba08153bf9717>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  delegate formatting of compound Bash statements to dedicated classes
-   `commit <https://pagure.io/freeipa/c/9808395c17388d69b51e562bc7f2b1d7d172a7fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9808395c17388d69b51e562bc7f2b1d7d172a7fb>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  advise: add an infrastructure for formatting Bash compound statements
-   `commit <https://pagure.io/freeipa/c/dea4b4ca1bebf128a9a2e26dbbe9ffd3d6f360e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dea4b4ca1bebf128a9a2e26dbbe9ffd3d6f360e1>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  delegate the indentation handling in advises to dedicated class
-   `commit <https://pagure.io/freeipa/c/0181334c4c8e4b73b9b1c634d9837857e5e388b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0181334c4c8e4b73b9b1c634d9837857e5e388b8>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  add a class that tracks the indentation in the generated advises
-   `commit <https://pagure.io/freeipa/c/36e0d2d65cf19033b1022737cd24a1120bc0f85f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36e0d2d65cf19033b1022737cd24a1120bc0f85f>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Allow to pass in multiple CA cert paths to the smart card advises
-   `commit <https://pagure.io/freeipa/c/e0c2e0f26cc264dccc51295cdd595109b4e46392>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0c2e0f26cc264dccc51295cdd595109b4e46392>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart-card advises: add steps to store smart card signing CA cert
-   `commit <https://pagure.io/freeipa/c/584abe5b68b74d6a4721525328d5dfadd0e092c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/584abe5b68b74d6a4721525328d5dfadd0e092c0>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  smart-card advises: configure systemwide NSS DB also on master
-   `commit <https://pagure.io/freeipa/c/69ba5f942284d17f32650638965c21dcf907a579>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ba5f942284d17f32650638965c21dcf907a579>`__
    `#7036 <https://pagure.io/freeipa/issue/7036>`__
 -  Prepare advise plugin for smart card auth configuration
-   `commit <https://pagure.io/freeipa/c/e418e9a4ca747886c53d05ae80597834f1d3d021>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e418e9a4ca747886c53d05ae80597834f1d3d021>`__
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  Extend the advice printing code by some useful abstractions
-   `commit <https://pagure.io/freeipa/c/0569c02f17f853d97280f52f4a7fefecc72cf45d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0569c02f17f853d97280f52f4a7fefecc72cf45d>`__
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  fix incorrect suffix handling in topology checks
-   `commit <https://pagure.io/freeipa/c/8ef4888af77f8e6fd8324297d26287b575b18163>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ef4888af77f8e6fd8324297d26287b575b18163>`__
    `#6965 <https://pagure.io/freeipa/issue/6965>`__
 -  Do not delete DS and PKI users during backup/restore tests
-   `commit <https://pagure.io/freeipa/c/1e5f55e791ac3665d4db0f6d14995491f11ef887>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e5f55e791ac3665d4db0f6d14995491f11ef887>`__
    `#6956 <https://pagure.io/freeipa/issue/6956>`__
 -  test_backup_restore: do not fail on missing KrbLastSuccessfulAuth
-   `commit <https://pagure.io/freeipa/c/2624cf2e4cc4b4b560fe64688ee55160f9d8fb80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2624cf2e4cc4b4b560fe64688ee55160f9d8fb80>`__
    `#6956 <https://pagure.io/freeipa/issue/6956>`__
 -  only stop/disable simple service if it is installed
-   `commit <https://pagure.io/freeipa/c/8b6f8ed7d47542b9bd8b7453a8a0e202ed1db97d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b6f8ed7d47542b9bd8b7453a8a0e202ed1db97d>`__
    `#6977 <https://pagure.io/freeipa/issue/6977>`__
 -  test_serverroles: Get rid of MockLDAP and use ldap2 instead
-   `commit <https://pagure.io/freeipa/c/58fd229a1dbb3f00a591de9417f36197141e26d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58fd229a1dbb3f00a591de9417f36197141e26d7>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add \`pkinit-status\` command
-   `commit <https://pagure.io/freeipa/c/99352731b4b4bdcedfe6668ce71c1d67720ac4af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99352731b4b4bdcedfe6668ce71c1d67720ac4af>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add the list of PKINIT servers as a virtual attribute to global
    config
-   `commit <https://pagure.io/freeipa/c/f80553208e8d9f3df422f5be8e1cafa511e1b2c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f80553208e8d9f3df422f5be8e1cafa511e1b2c4>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Add an attribute reporting client PKINIT-capable servers
-   `commit <https://pagure.io/freeipa/c/d8bb23ac389929f28c584602e592b821e4c6ef9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8bb23ac389929f28c584602e592b821e4c6ef9a>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Refactor the role/attribute member reporting code
-   `commit <https://pagure.io/freeipa/c/cac7e49daa04e838650548cc9162b8f117dc55b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cac7e49daa04e838650548cc9162b8f117dc55b3>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Allow for multivalued server attributes
-   `commit <https://pagure.io/freeipa/c/bddb90f38a3505a2768862d2f814c5e749a7dcde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddb90f38a3505a2768862d2f814c5e749a7dcde>`__
    `#6937 <https://pagure.io/freeipa/issue/6937>`__
 -  Travis CI: Add the server uninstaller as a last step of tests
-   `commit <https://pagure.io/freeipa/c/89a5bb2c6becae8d3463731f39234d54ced7bbca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89a5bb2c6becae8d3463731f39234d54ced7bbca>`__
    `#6950 <https://pagure.io/freeipa/issue/6950>`__
 -  Travis CI: explicitly update pip before running the builds
-   `commit <https://pagure.io/freeipa/c/afe85c37981d2846c26010f22f652c60d9cd0941>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afe85c37981d2846c26010f22f652c60d9cd0941>`__
 -  Do not test anonymous PKINIT after install/upgrade
-   `commit <https://pagure.io/freeipa/c/960e361f68a3d7acd9bcf16ec6fe8f6d5376c4ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/960e361f68a3d7acd9bcf16ec6fe8f6d5376c4ae>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Upgrade: configure local/full PKINIT depending on the master status
-   `commit <https://pagure.io/freeipa/c/a194055c92c7ca4eba29323f990ec3b92026221b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a194055c92c7ca4eba29323f990ec3b92026221b>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Use local anchor when armoring password requests
-   `commit <https://pagure.io/freeipa/c/2374b648d0dfd08ec4cfbcc35f7987fa8b8a6ffa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2374b648d0dfd08ec4cfbcc35f7987fa8b8a6ffa>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Stop requesting anonymous keytab and purge all references of it
-   `commit <https://pagure.io/freeipa/c/68c6a4d4e1340ce01bdc7ec5dd394604a3da7688>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c6a4d4e1340ce01bdc7ec5dd394604a3da7688>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Use only anonymous PKINIT to fetch armor ccache
-   `commit <https://pagure.io/freeipa/c/3adb9ca875f8eb99e99a29e17a471a2b6f408a4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3adb9ca875f8eb99e99a29e17a471a2b6f408a4a>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  API for retrieval of master's PKINIT status and publishing it in LDAP
-   `commit <https://pagure.io/freeipa/c/86972299d937960bcb713fc73b447cddb4ea44bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86972299d937960bcb713fc73b447cddb4ea44bd>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Allow for configuration of all three PKINIT variants when deploying
    KDC
-   `commit <https://pagure.io/freeipa/c/fb52f7a1f328b126626525179d5250692daca2cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb52f7a1f328b126626525179d5250692daca2cd>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  separate function to set ipaConfigString values on service entry
-   `commit <https://pagure.io/freeipa/c/b1a1e104391c84cb9af7b0a7c8748c8652442ddb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1a1e104391c84cb9af7b0a7c8748c8652442ddb>`__
    `#6830 <https://pagure.io/freeipa/issue/6830>`__
 -  Revert "Store GSSAPI session key in /var/run/ipa"
-   `commit <https://pagure.io/freeipa/c/50f6883662e258b0335c8b3cb69946d6dcbf206c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50f6883662e258b0335c8b3cb69946d6dcbf206c>`__
    `#6880 <https://pagure.io/freeipa/issue/6880>`__
 -  Remove duplicate functionality in upgrade
-   `commit <https://pagure.io/freeipa/c/2eabb0dab7b4dab1c45395f3e02d43676d91f4a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2eabb0dab7b4dab1c45395f3e02d43676d91f4a2>`__
    `#6799 <https://pagure.io/freeipa/issue/6799>`__
 -  Always check and create anonymous principal during KDC install
-   `commit <https://pagure.io/freeipa/c/191668e85be0b53020a56df409731812e528d101>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/191668e85be0b53020a56df409731812e528d101>`__
    `#6799 <https://pagure.io/freeipa/issue/6799>`__
 -  Ensure KDC is propery configured after upgrade
-   `commit <https://pagure.io/freeipa/c/5c22f905d48d3d8dd50e394290e1feb8f6dedcaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c22f905d48d3d8dd50e394290e1feb8f6dedcaa>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Split out anonymous PKINIT test to a separate method
-   `commit <https://pagure.io/freeipa/c/17aa51ef0291b9c6174509f52913076ae599357f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17aa51ef0291b9c6174509f52913076ae599357f>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Remove unused variable from failed anonymous PKINIT handling
-   `commit <https://pagure.io/freeipa/c/1fc48cd0af3b19272fcfe25235e55eae249bb6c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fc48cd0af3b19272fcfe25235e55eae249bb6c9>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Upgrade: configure PKINIT after adding anonymous principal
-   `commit <https://pagure.io/freeipa/c/c2d95d3962d525017732618e66b39b099235d43e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2d95d3962d525017732618e66b39b099235d43e>`__
    `#6792 <https://pagure.io/freeipa/issue/6792>`__
 -  Travis CI: invoke integration test helper scripts before test
    execution
-   `commit <https://pagure.io/freeipa/c/b6624594bedce75849248469305ae964ce5ea2ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6624594bedce75849248469305ae964ce5ea2ef>`__
 
 
 
@@ -1001,184 +1001,184 @@ Martin Basti (63)
 ----------------------------------------------------------------------------------------------
 
 -  DNS update: reduce timeout for CA records
-   `commit <https://pagure.io/freeipa/c/dffddbd2c0dae7d646bdb2be23ac5ebe46f19d7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dffddbd2c0dae7d646bdb2be23ac5ebe46f19d7a>`__
    `#6176 <https://pagure.io/freeipa/issue/6176>`__
 -  baseldap: fix format string
-   `commit <https://pagure.io/freeipa/c/041982f07392f117c5acf252cc5faacf0e127712>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/041982f07392f117c5acf252cc5faacf0e127712>`__
 -  IPAOptionParser: fix dict comprehension
-   `commit <https://pagure.io/freeipa/c/f18ce013556c5bafe7e9c35e361deb149eef37a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f18ce013556c5bafe7e9c35e361deb149eef37a4>`__
 -  py3: run already ported scripts under py3 by default
-   `commit <https://pagure.io/freeipa/c/aa1c0cf3e8f2a77e27d548f73694d99aa0497459>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa1c0cf3e8f2a77e27d548f73694d99aa0497459>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: temporary set dependencies to both py2 and py3 packages
-   `commit <https://pagure.io/freeipa/c/17103e53cbbf6d4cfb42d727d3f2edb7b56c8e9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17103e53cbbf6d4cfb42d727d3f2edb7b56c8e9c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: test_otptoken_import: fix bytes usage
-   `commit <https://pagure.io/freeipa/c/902f736a2b288fac5d080b7f146f6a8b16f882f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/902f736a2b288fac5d080b7f146f6a8b16f882f1>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipa_otptoken_import: fix hex decoding
-   `commit <https://pagure.io/freeipa/c/637d259361306bcbc4af86bbedf17a7ff6875716>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/637d259361306bcbc4af86bbedf17a7ff6875716>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipa_otptoken_import: fix calling unicode on bytes
-   `commit <https://pagure.io/freeipa/c/e53674e741fa8a2268e4a663c3ffbc00d891123c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e53674e741fa8a2268e4a663c3ffbc00d891123c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipa_otptoken_import: fix lamba code inspection
-   `commit <https://pagure.io/freeipa/c/24eadd3a39f472669585355c5db00fc430acac1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24eadd3a39f472669585355c5db00fc430acac1b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: Remove comparison >=2 of debnug log level
-   `commit <https://pagure.io/freeipa/c/8416d5772d5e14829df58dabb24b30721c302c07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8416d5772d5e14829df58dabb24b30721c302c07>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: vault: data must be bytes
-   `commit <https://pagure.io/freeipa/c/3f59721c5548a62ec63a72bad0c08021e0dd536e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f59721c5548a62ec63a72bad0c08021e0dd536e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: test_location_plugin: fix iteration over changed dict
-   `commit <https://pagure.io/freeipa/c/10d4fb7ea859cb07240b09acdb805f23782b3dc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10d4fb7ea859cb07240b09acdb805f23782b3dc9>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: test_kerberos_principal_aliases: fix code scope
-   `commit <https://pagure.io/freeipa/c/8116a7b450581cc2bc6e0e9a58b511f43addde42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8116a7b450581cc2bc6e0e9a58b511f43addde42>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: dogtag.py: fix bytes warnings
-   `commit <https://pagure.io/freeipa/c/c422206cc7e5de9cd94c30811489e78817290c59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c422206cc7e5de9cd94c30811489e78817290c59>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: travis: enable tests for plugins that are aleready working
-   `commit <https://pagure.io/freeipa/c/b35db9152c12f8029086fc5c3720b63c4b2b58d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b35db9152c12f8029086fc5c3720b63c4b2b58d7>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: secrets: remove iteritems usage
-   `commit <https://pagure.io/freeipa/c/b0e51688417ee422196006b700499ef7b8bb5737>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0e51688417ee422196006b700499ef7b8bb5737>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Travis: check for BytesWarnings in httpd error_log
-   `commit <https://pagure.io/freeipa/c/b43dab83880b8ed99ffab3ed8b4b69e5da80177c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b43dab83880b8ed99ffab3ed8b4b69e5da80177c>`__
 -  py3: ipaldap: fix encoding of datetime objects
-   `commit <https://pagure.io/freeipa/c/0487f993fdba5487bd622ffcc9c64e516077e745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0487f993fdba5487bd622ffcc9c64e516077e745>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: LDAPClient: remove \__del_\_ method
-   `commit <https://pagure.io/freeipa/c/db01767acf4cb002995a3609061a45ca90cde573>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db01767acf4cb002995a3609061a45ca90cde573>`__
 -  LDAPEntry: rename \_orig to \_orig_raw
-   `commit <https://pagure.io/freeipa/c/7c163c90b8445fe441612f6857174b5fd5d505f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c163c90b8445fe441612f6857174b5fd5d505f4>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  python-netifaces: update to reflect upstream changes
-   `commit <https://pagure.io/freeipa/c/52b43c7168d02e84865e31faa478d8a93be7a913>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52b43c7168d02e84865e31faa478d8a93be7a913>`__
    `#7021 <https://pagure.io/freeipa/issue/7021>`__
 -  Travis: enable temporary Py3 testing
-   `commit <https://pagure.io/freeipa/c/172a2e7456fe3f702dd6d4da51a92ad030824294>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/172a2e7456fe3f702dd6d4da51a92ad030824294>`__
 -  Travis: build only py2 packages for py2 testing
-   `commit <https://pagure.io/freeipa/c/5fdd0a3f60d5786ca429cf2827dc41312aac1358>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fdd0a3f60d5786ca429cf2827dc41312aac1358>`__
 -  Build: allow to build only py2 rpms for fedora
-   `commit <https://pagure.io/freeipa/c/4eec2f5e572a9ec77b4eb3ef66470f0f9813bfbb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4eec2f5e572a9ec77b4eb3ef66470f0f9813bfbb>`__
 -  Remove network and broadcast address warnings
-   `commit <https://pagure.io/freeipa/c/f3537297bee2890c6b839750bb7a0a2cf904cdf9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3537297bee2890c6b839750bb7a0a2cf904cdf9>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  replica install: add missing check for non-local IP address
-   `commit <https://pagure.io/freeipa/c/1b8dc1131c9ca7218efb8fe16dcce97f9f960be9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b8dc1131c9ca7218efb8fe16dcce97f9f960be9>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Remove ip_netmask from option parser
-   `commit <https://pagure.io/freeipa/c/f9cba7d161f788c32336b66ff7c641f4a1ed2754>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9cba7d161f788c32336b66ff7c641f4a1ed2754>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  CheckedIPAddress: remove match_local param
-   `commit <https://pagure.io/freeipa/c/6024165101677c844dc3bbb337e290df2e66eaf1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6024165101677c844dc3bbb337e290df2e66eaf1>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  refactor CheckedIPAddress class
-   `commit <https://pagure.io/freeipa/c/0b69e44f16fbba6ab7ddef5a3e55bdabcfd6a8a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b69e44f16fbba6ab7ddef5a3e55bdabcfd6a8a6>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  ipa-dns-install: remove check for local ip address
-   `commit <https://pagure.io/freeipa/c/cb48a49c80f4a11d2d16511e0f1366867320f153>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb48a49c80f4a11d2d16511e0f1366867320f153>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Fix local IP address validation
-   `commit <https://pagure.io/freeipa/c/82ad586f6cbf6e707add3c866ed4e37ade69b045>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82ad586f6cbf6e707add3c866ed4e37ade69b045>`__
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  Explicitly ask for py2 dependencies in py2 packages
-   `commit <https://pagure.io/freeipa/c/a2147de6e2eb217163d6f106d3220c7b1e7570b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2147de6e2eb217163d6f106d3220c7b1e7570b5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Only warn when specified server IP addresses don't match intf
-   `commit <https://pagure.io/freeipa/c/6637980af6069623d944d9d592cbadba20b610a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6637980af6069623d944d9d592cbadba20b610a2>`__
    `#2715 <https://pagure.io/freeipa/issue/2715>`__,
    `#4317 <https://pagure.io/freeipa/issue/4317>`__
 -  pylint: explicitly depends on python2-pylint
-   `commit <https://pagure.io/freeipa/c/be1415b6cc8f5dadc1ac3766305a33f370fdf9bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be1415b6cc8f5dadc1ac3766305a33f370fdf9bb>`__
    `#6986 <https://pagure.io/freeipa/issue/6986>`__
 -  py3: update_mod_nss_cipher_suite: ordering doesn't work with None
-   `commit <https://pagure.io/freeipa/c/99771ceb9ffcf21d0364bf57994716322b24551e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99771ceb9ffcf21d0364bf57994716322b24551e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: urlfetch: use "file://" prefix with filenames
-   `commit <https://pagure.io/freeipa/c/c6a57d8091aeefb6067711189ee0ce11411dee57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6a57d8091aeefb6067711189ee0ce11411dee57>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: cainstance: fix BytesWarning
-   `commit <https://pagure.io/freeipa/c/b09a941f34507cfce682d8c5a3acf6dfe7fa624e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b09a941f34507cfce682d8c5a3acf6dfe7fa624e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: schemaupdate: fix BytesWarning
-   `commit <https://pagure.io/freeipa/c/d89de4219d0e8ee33e81d6b6d1bc6c22ac9ffbaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d89de4219d0e8ee33e81d6b6d1bc6c22ac9ffbaa>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: LDAP updates: use only bytes/raw values
-   `commit <https://pagure.io/freeipa/c/bc9addac30d69d88f5040e194be1e32a881cfba9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc9addac30d69d88f5040e194be1e32a881cfba9>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: softhsm key_id must be bytes
-   `commit <https://pagure.io/freeipa/c/d7a9e81fbd7a339dddd41a8c5ae9f29252522944>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7a9e81fbd7a339dddd41a8c5ae9f29252522944>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ipaldap: encode Boolean as bytes
-   `commit <https://pagure.io/freeipa/c/27f8f9f03d69276f9ee410169b76574da2461794>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27f8f9f03d69276f9ee410169b76574da2461794>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: ConfigParser: replace deprecated readfd with read
-   `commit <https://pagure.io/freeipa/c/6e7071d6add24e8923d705d35a362761f356d56d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e7071d6add24e8923d705d35a362761f356d56d>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: use ConfigParser instead of SafeConfigParser
-   `commit <https://pagure.io/freeipa/c/2e63ec42d0f879f2d129c4f81f88a1712ce86b8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e63ec42d0f879f2d129c4f81f88a1712ce86b8c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Add remote_plugins subdirectories to RPM
-   `commit <https://pagure.io/freeipa/c/71adc8cd3ff6d6e54f332e94bfda3ed59396de90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71adc8cd3ff6d6e54f332e94bfda3ed59396de90>`__
    `#6927 <https://pagure.io/freeipa/issue/6927>`__
 -  custodia dep: require explictly python2 version
-   `commit <https://pagure.io/freeipa/c/a90a113b66fca620b04635442b135a5136ece7ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a90a113b66fca620b04635442b135a5136ece7ba>`__
    `#6962 <https://pagure.io/freeipa/issue/6962>`__
 -  pylint: ignore new checks added in 1.7
-   `commit <https://pagure.io/freeipa/c/7eb02a49ed86c0640266af47d11c9efa91bc54cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7eb02a49ed86c0640266af47d11c9efa91bc54cb>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Pylint: fix ipa_forbidden_import checker
-   `commit <https://pagure.io/freeipa/c/5f640de76e57272d7b7707e710bbee19a8eda79a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f640de76e57272d7b7707e710bbee19a8eda79a>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  travis: fix pylint execution with py3
-   `commit <https://pagure.io/freeipa/c/cba678d846056606e8d1c2d29177baaa345fdbdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cba678d846056606e8d1c2d29177baaa345fdbdb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: add missing py3 pylint depedencies
-   `commit <https://pagure.io/freeipa/c/6e679783561eaa755691f6d193481e998efb7617>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e679783561eaa755691f6d193481e998efb7617>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__,
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  adtrust: move SELinux settings to constants
-   `commit <https://pagure.io/freeipa/c/663f227a5cd8ee4eb2b365d2765b330a9aa60685>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/663f227a5cd8ee4eb2b365d2765b330a9aa60685>`__
 -  httpd: move SELinux settings to constants
-   `commit <https://pagure.io/freeipa/c/1a6de32c9e74493ca677353a0c7f14aa45977b6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a6de32c9e74493ca677353a0c7f14aa45977b6b>`__
 -  ipasetup: fix dependencies handling based on python version
-   `commit <https://pagure.io/freeipa/c/bea7236b9c5a82db5d945a88103c0524a793a8a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bea7236b9c5a82db5d945a88103c0524a793a8a2>`__
    `#6875 <https://pagure.io/freeipa/issue/6875>`__
 -  ipaclient: fix missing RPM ownership
-   `commit <https://pagure.io/freeipa/c/374a58fa49adc715d50996571631af37ae16bd64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/374a58fa49adc715d50996571631af37ae16bd64>`__
    `#6927 <https://pagure.io/freeipa/issue/6927>`__
 -  tests: add missing dependency iptables
-   `commit <https://pagure.io/freeipa/c/6c061b6836c13bf63553c6143b19e89658937e7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c061b6836c13bf63553c6143b19e89658937e7e>`__
 -  ca_status: add HTTP timeout 30 seconds
-   `commit <https://pagure.io/freeipa/c/05984f171b0b41681254c95380a0598e4208a201>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05984f171b0b41681254c95380a0598e4208a201>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  http_request: add timeout option
-   `commit <https://pagure.io/freeipa/c/20f7689079328aeef42b62a359b303f531db5666>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20f7689079328aeef42b62a359b303f531db5666>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Use proper SELinux context with http.keytab
-   `commit <https://pagure.io/freeipa/c/7f4c2fbd975d09c01e6898a4eb70d7dfea1171b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f4c2fbd975d09c01e6898a4eb70d7dfea1171b4>`__
    `#6924 <https://pagure.io/freeipa/issue/6924>`__
 -  Store GSSAPI session key in /var/run/ipa
-   `commit <https://pagure.io/freeipa/c/2bab2d4963daa99742875f3633a99966bc56f5a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bab2d4963daa99742875f3633a99966bc56f5a3>`__
    `#6880 <https://pagure.io/freeipa/issue/6880>`__
 -  Fix PKCS11 helper
-   `commit <https://pagure.io/freeipa/c/e8f2a415b3dcba30b0c39cd542acd6b459f46957>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8f2a415b3dcba30b0c39cd542acd6b459f46957>`__
    `#6692 <https://pagure.io/freeipa/issue/6692>`__
 -  Remove surplus 'the' in output of ipa-adtrust-install
-   `commit <https://pagure.io/freeipa/c/bad0f608c4f44cb36556f305f1290020d37439c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bad0f608c4f44cb36556f305f1290020d37439c6>`__
    `#6864 <https://pagure.io/freeipa/issue/6864>`__
 -  collect audit.log for easier selinux investigation
-   `commit <https://pagure.io/freeipa/c/fd597f83aed53bf3281ce9ec6b94f601868cfc75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd597f83aed53bf3281ce9ec6b94f601868cfc75>`__
 -  Set "KDC:Disable Last Success" by default
-   `commit <https://pagure.io/freeipa/c/eeaf428b1befc37489ed5ee14ae193b46cbd1db7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eeaf428b1befc37489ed5ee14ae193b46cbd1db7>`__
    `#5313 <https://pagure.io/freeipa/issue/5313>`__
 -  Set development version to 4.5.90
-   `commit <https://pagure.io/freeipa/c/9ac62bec44b642838cbb175d94efd90acb417ecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ac62bec44b642838cbb175d94efd90acb417ecc>`__
 
 
 
@@ -1186,7 +1186,7 @@ Lewis Eason (1)
 ----------------------------------------------------------------------------------------------
 
 -  Correct typo estabilish->establish in the install scripts
-   `commit <https://pagure.io/freeipa/c/bcfa6b533d8a683ba15101a260c6ba4a62f09af2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcfa6b533d8a683ba15101a260c6ba4a62f09af2>`__
 
 
 
@@ -1194,32 +1194,32 @@ Michal Reznik (9)
 ----------------------------------------------------------------------------------------------
 
 -  test_caless: add SAN dNSName extensions for wildcard tests
-   `commit <https://pagure.io/freeipa/c/a3c99367bfe1071073cd93237660d783459b25e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c99367bfe1071073cd93237660d783459b25e2>`__
    `#7100 <https://pagure.io/freeipa/issue/7100>`__
 -  test_caless: add replica ca-less to ca-full test (master caless)
-   `commit <https://pagure.io/freeipa/c/1ff356241c890e7021e64530a6e4a8c17ca99bdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ff356241c890e7021e64530a6e4a8c17ca99bdb>`__
    `#6226 <https://pagure.io/freeipa/issue/6226>`__,
    `#7086 <https://pagure.io/freeipa/issue/7086>`__
 -  test_caless: add server_replica ca-less to ca-full test
-   `commit <https://pagure.io/freeipa/c/7a5b1cc1402d739a9804eebe1a9d2be13bf454ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a5b1cc1402d739a9804eebe1a9d2be13bf454ec>`__
    `#7086 <https://pagure.io/freeipa/issue/7086>`__
 -  tests: fix external_ca test suite failing due to missing SKI
-   `commit <https://pagure.io/freeipa/c/4caabb140e31218c72846877da0c985c6a178d7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4caabb140e31218c72846877da0c985c6a178d7a>`__
    `#7099 <https://pagure.io/freeipa/issue/7099>`__
 -  test_caless: remove xfail in wildcard certificate tests
-   `commit <https://pagure.io/freeipa/c/284658e08ef88ae2796ace0a4f172e7b8464a5e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/284658e08ef88ae2796ace0a4f172e7b8464a5e9>`__
    `#5603 <https://pagure.io/freeipa/issue/5603>`__
 -  test_caless: introduce new python makepki + fix SKI extension issue
-   `commit <https://pagure.io/freeipa/c/64375ba65bfc56694a425b1e39bd2081e604f777>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64375ba65bfc56694a425b1e39bd2081e604f777>`__
    `#7030 <https://pagure.io/freeipa/issue/7030>`__
 -  test_caless: mark TestCertinstall intermediate CA tests as xfail
-   `commit <https://pagure.io/freeipa/c/d5e84d70650a8b3430c11583876e5f604560c74e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5e84d70650a8b3430c11583876e5f604560c74e>`__
    `#6959 <https://pagure.io/freeipa/issue/6959>`__
 -  test_caless: add pkinit option and test it
-   `commit <https://pagure.io/freeipa/c/f7c4039e415af2db51ae132ec15456f57eed161a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7c4039e415af2db51ae132ec15456f57eed161a>`__
    `#6854 <https://pagure.io/freeipa/issue/6854>`__
 -  added krb5kdc.log to pytest logging
-   `commit <https://pagure.io/freeipa/c/2493f812048f191225eefc07abd91090dee47653>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2493f812048f191225eefc07abd91090dee47653>`__
 
 
 
@@ -1227,7 +1227,7 @@ Nathaniel McCallum (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-otptoken-import: Make PBKDF2 refer to the pkcs5 namespace
-   `commit <https://pagure.io/freeipa/c/bc05ab992226febb54e47e3963b694fe96ca4167>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc05ab992226febb54e47e3963b694fe96ca4167>`__
    `#7035 <https://pagure.io/freeipa/issue/7035>`__
 
 
@@ -1236,7 +1236,7 @@ Oliver Gutierrez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Added plugins directory to paclient subpackages
-   `commit <https://pagure.io/freeipa/c/548014f03eeababfd1b49e4bc9ac608633cb9b98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/548014f03eeababfd1b49e4bc9ac608633cb9b98>`__
 
 
 
@@ -1245,7 +1245,7 @@ Petr Spacek (1)
 
 -  ipalib.constants: Remove default domain, realm, basedn, xmlrpc_uri,
    ldap_uri
-   `commit <https://pagure.io/freeipa/c/3f6411a49c49da7013341ff8feae3a63e75e0fbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f6411a49c49da7013341ff8feae3a63e75e0fbf>`__
 
 
 
@@ -1253,20 +1253,20 @@ Petr Vobornik (5)
 ----------------------------------------------------------------------------------------------
 
 -  log progress of wait_for_open_ports
-   `commit <https://pagure.io/freeipa/c/038d1920657c6fd349f8414ed173a9c97681a602>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/038d1920657c6fd349f8414ed173a9c97681a602>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 -  control logging of host_port_open from caller
-   `commit <https://pagure.io/freeipa/c/cc72db67e2eaede577c3129d572b85e9c2ba593c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc72db67e2eaede577c3129d572b85e9c2ba593c>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 -  kerberos session: use CA cert with full cert chain for obtaining
    cookie
-   `commit <https://pagure.io/freeipa/c/c19196a0d3fc0a38c4c83cb8a7fde56e6bc310af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c19196a0d3fc0a38c4c83cb8a7fde56e6bc310af>`__
    `#6876 <https://pagure.io/freeipa/issue/6876>`__
 -  restore: restart/reload gssproxy after restore
-   `commit <https://pagure.io/freeipa/c/3a4c8e39c3e38ec651cfcbb3cac59e0e92e04fe0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a4c8e39c3e38ec651cfcbb3cac59e0e92e04fe0>`__
    `#6902 <https://pagure.io/freeipa/issue/6902>`__
 -  automount install: fix checking of SSSD functionality on uninstall
-   `commit <https://pagure.io/freeipa/c/b4e447fa6fc7d659ae6a3b6285d4ddda0baa0be4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4e447fa6fc7d659ae6a3b6285d4ddda0baa0be4>`__
    `#6861 <https://pagure.io/freeipa/issue/6861>`__
 
 
@@ -1275,102 +1275,102 @@ Pavel Vomacka (34)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes bug in actions creating for search facet
-   `commit <https://pagure.io/freeipa/c/76f217b2893b0604ed0adf372422c685c2febbe8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76f217b2893b0604ed0adf372422c685c2febbe8>`__
    `#7052 <https://pagure.io/freeipa/issue/7052>`__
 -  WebUI: fix showing required asterisk '*'
-   `commit <https://pagure.io/freeipa/c/d5ef1a7fd0863b52d91fc44f0e9dbdb9d76a7bb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5ef1a7fd0863b52d91fc44f0e9dbdb9d76a7bb1>`__
    `#6849 <https://pagure.io/freeipa/issue/6849>`__
 -  WebUI: Update unit test README
-   `commit <https://pagure.io/freeipa/c/8c2dbece59b9ff1ee8d247e940e2e776a660fec8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c2dbece59b9ff1ee8d247e940e2e776a660fec8>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Fixes details_test.js
-   `commit <https://pagure.io/freeipa/c/6b70b91de4d241b999d62cc56051c8af364d3630>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b70b91de4d241b999d62cc56051c8af364d3630>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Fixes for widget_tests.js
-   `commit <https://pagure.io/freeipa/c/bb5582d52bc7ce80e6cfc691cc4bb10a9beb307b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb5582d52bc7ce80e6cfc691cc4bb10a9beb307b>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Fixes for aci_tests.js
-   `commit <https://pagure.io/freeipa/c/63f7575cb38982575342a6856b7d322c14fc83f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63f7575cb38982575342a6856b7d322c14fc83f6>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Fixes for entity_tests.js
-   `commit <https://pagure.io/freeipa/c/11e19cd5d5e475350d6de29d9cb2920c3ab99110>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11e19cd5d5e475350d6de29d9cb2920c3ab99110>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Fixes for ipa_test.js
-   `commit <https://pagure.io/freeipa/c/4fb52371f27f4013a8e30c09ccaed75da5a08404>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fb52371f27f4013a8e30c09ccaed75da5a08404>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Add up to date JSON files
-   `commit <https://pagure.io/freeipa/c/9e0db0759abe35d786f6570234afb04d353ae6df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e0db0759abe35d786f6570234afb04d353ae6df>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  Add loader.js into requirements of all HTML unit test files
-   `commit <https://pagure.io/freeipa/c/46fba2128fb42c5c2cbea60ff288f3180d729042>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46fba2128fb42c5c2cbea60ff288f3180d729042>`__
    `#6974 <https://pagure.io/freeipa/issue/6974>`__
 -  WebUI: remove creating js/libs symlink from makefile
-   `commit <https://pagure.io/freeipa/c/4eb37d7436bcb90991f56cd7e1cf75fa2d34fa22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4eb37d7436bcb90991f56cd7e1cf75fa2d34fa22>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  WebUI: Remove plugins symlink as it is unused
-   `commit <https://pagure.io/freeipa/c/0ee7db75e45573a8f16a3776c3e0d862b685c15c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ee7db75e45573a8f16a3776c3e0d862b685c15c>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  Remove all old JSON files
-   `commit <https://pagure.io/freeipa/c/41a18bbbc8793335daa0583bddb2f8c775d2b6a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41a18bbbc8793335daa0583bddb2f8c775d2b6a2>`__
    `#6447 <https://pagure.io/freeipa/issue/6447>`__
 -  Revert "Web UI: Remove offline version of Web UI"
-   `commit <https://pagure.io/freeipa/c/6ad92d3a4f0a4e9af0124fe457d2a3c646f15710>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ad92d3a4f0a4e9af0124fe457d2a3c646f15710>`__
 -  WebUI: Add hyphenate versions of Host(Role) Based strings
-   `commit <https://pagure.io/freeipa/c/2a73b5d7399e21b2ea074ddcb915a74adb4f0f48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a73b5d7399e21b2ea074ddcb915a74adb4f0f48>`__
    `#6582 <https://pagure.io/freeipa/issue/6582>`__
 -  WebUI: fix incorrectly shown links in association tables
-   `commit <https://pagure.io/freeipa/c/ed7de96648daf95868f34107890700124836b69d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed7de96648daf95868f34107890700124836b69d>`__
    `#7066 <https://pagure.io/freeipa/issue/7066>`__
 -  WebUI: fix jslint error
-   `commit <https://pagure.io/freeipa/c/0b8d46019172e83bdbacf7200759de640c19a2d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b8d46019172e83bdbacf7200759de640c19a2d4>`__
 -  WebUI: change validator of page size settings
-   `commit <https://pagure.io/freeipa/c/cfa157c1e554e0cd113a6fb9fd3af9fbad4529ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfa157c1e554e0cd113a6fb9fd3af9fbad4529ef>`__
    `#6980 <https://pagure.io/freeipa/issue/6980>`__
 -  WebUI: Add positive number validator
-   `commit <https://pagure.io/freeipa/c/3cac851498ab85e6b0abf74bc3ff4eea2f960983>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cac851498ab85e6b0abf74bc3ff4eea2f960983>`__
    `#6980 <https://pagure.io/freeipa/issue/6980>`__
 -  WebUI: add support for changing trust UPN suffixes
-   `commit <https://pagure.io/freeipa/c/b25412f9889f3523974e7aeb43920d4e2347fcfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b25412f9889f3523974e7aeb43920d4e2347fcfa>`__
    `#7015 <https://pagure.io/freeipa/issue/7015>`__
 -  Bump version of python-gssapi
-   `commit <https://pagure.io/freeipa/c/2485c3377abe7628c5f657233e65b1df6b3ce290>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2485c3377abe7628c5f657233e65b1df6b3ce290>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  Turn off OCSP check
-   `commit <https://pagure.io/freeipa/c/566361e63d4a670460df3dbb28b9d19f38eaea2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/566361e63d4a670460df3dbb28b9d19f38eaea2d>`__
    `#6981 <https://pagure.io/freeipa/issue/6981>`__,
    `#6982 <https://pagure.io/freeipa/issue/6982>`__
 -  Change python-cryptography to python2-cryptography
-   `commit <https://pagure.io/freeipa/c/9149f2d9c6e90f6dd974ea4317f71d17db3c869c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9149f2d9c6e90f6dd974ea4317f71d17db3c869c>`__
    `#6749 <https://pagure.io/freeipa/issue/6749>`__
 -  Turn on NSSOCSP check in mod_nss conf
-   `commit <https://pagure.io/freeipa/c/e0b32dac5462164869ab19c3d56c36e80cde4b7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0b32dac5462164869ab19c3d56c36e80cde4b7b>`__
    `#6370 <https://pagure.io/freeipa/issue/6370>`__
 -  WebUI - Coverity: fix identical branches of if statement
-   `commit <https://pagure.io/freeipa/c/01516e58c8fc71985c538136b2286198765da296>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01516e58c8fc71985c538136b2286198765da296>`__
 -  WebUI - Coverity: fixed null pointer exception
-   `commit <https://pagure.io/freeipa/c/5ba7957450ebe78c67cf675855f4f4c3a34fab54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ba7957450ebe78c67cf675855f4f4c3a34fab54>`__
 -  WebUI: Coverity - add explicit window object to alert methods
-   `commit <https://pagure.io/freeipa/c/b54ceae9616b733c35ce7928309b8ab93527110b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b54ceae9616b733c35ce7928309b8ab93527110b>`__
 -  WebUI: Allow to add certs to certmapping with CERT LINES around
-   `commit <https://pagure.io/freeipa/c/84b38b6793cbc45d36c39abf79893e22e90baac6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84b38b6793cbc45d36c39abf79893e22e90baac6>`__
    `#6772 <https://pagure.io/freeipa/issue/6772>`__
 -  WebUI: Fix showing vault in selfservice view
-   `commit <https://pagure.io/freeipa/c/ab6d7ac50a93efa6a9e3566dbe07b34a23c41cce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab6d7ac50a93efa6a9e3566dbe07b34a23c41cce>`__
    `#6812 <https://pagure.io/freeipa/issue/6812>`__
 -  WebUI: suppress truncation warning in select widget
-   `commit <https://pagure.io/freeipa/c/b9e6ad1967ba24c7ebe5181da1ebe32d30e7b28f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9e6ad1967ba24c7ebe5181da1ebe32d30e7b28f>`__
    `#6618 <https://pagure.io/freeipa/issue/6618>`__
 -  WebUI: Add support for suppressing warnings
-   `commit <https://pagure.io/freeipa/c/7b3a10da7001d7ee394cd891d926def66d0f2546>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b3a10da7001d7ee394cd891d926def66d0f2546>`__
    `#6618 <https://pagure.io/freeipa/issue/6618>`__
 -  WebUI: Add support for login for AD users
-   `commit <https://pagure.io/freeipa/c/ceedc3f7ecb1300ed5bfaf5db8ef1b1450c6288e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ceedc3f7ecb1300ed5bfaf5db8ef1b1450c6288e>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 -  WebUI: add method for disabling item in user dropdown menu
-   `commit <https://pagure.io/freeipa/c/2992e3c5d480567cfdc71b38365d5d74f009b4d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2992e3c5d480567cfdc71b38365d5d74f009b4d2>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 -  WebUI: check principals in lowercase
-   `commit <https://pagure.io/freeipa/c/1dcdcd12f4336c98e7507fe0e7f0c0da2bc69eba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1dcdcd12f4336c98e7507fe0e7f0c0da2bc69eba>`__
    `#3242 <https://pagure.io/freeipa/issue/3242>`__
 
 
@@ -1379,10 +1379,10 @@ Rob Crittenden (2)
 ----------------------------------------------------------------------------------------------
 
 -  Include the CA basic constraint in CSRs when renewing a CA
-   `commit <https://pagure.io/freeipa/c/a37e90530fd205604d30213c3410bd5cb9e063cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a37e90530fd205604d30213c3410bd5cb9e063cf>`__
    `#7088 <https://pagure.io/freeipa/issue/7088>`__
 -  Pass ipa-ca-agent credentials as PEM files
-   `commit <https://pagure.io/freeipa/c/9c1ab3ca5015317091f40ac8c352823a75849cef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c1ab3ca5015317091f40ac8c352823a75849cef>`__
    `#7076 <https://pagure.io/freeipa/issue/7076>`__
 
 
@@ -1392,11 +1392,11 @@ Gabe (2)
 
 -  Update get_attr_filter in LDAPSearch to handle nsaccountlock user
    searches
-   `commit <https://pagure.io/freeipa/c/38276d3473ecf2a4cc5b5e2a107347f046625626>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38276d3473ecf2a4cc5b5e2a107347f046625626>`__
    `#6896 <https://pagure.io/freeipa/issue/6896>`__
 -  Add --password-expiration to allow admin to force user password
    expiration
-   `commit <https://pagure.io/freeipa/c/274b0bcf5ff2408739d94ba1b1b4bca69f310dfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/274b0bcf5ff2408739d94ba1b1b4bca69f310dfc>`__
 
 
 
@@ -1404,36 +1404,36 @@ Sumit Bose (11)
 ----------------------------------------------------------------------------------------------
 
 -  ipa_pwd_extop: do not generate NT hashes in FIPS mode
-   `commit <https://pagure.io/freeipa/c/1f0ca6aafd966e086692007a0df76e3c3276915f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f0ca6aafd966e086692007a0df76e3c3276915f>`__
    `#7026 <https://pagure.io/freeipa/issue/7026>`__
 -  ipa-sam: replace encode_nt_key() with E_md4hash()
-   `commit <https://pagure.io/freeipa/c/f169481b558bd7ec9102e02e40eb38df7867a694>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f169481b558bd7ec9102e02e40eb38df7867a694>`__
    `#7026 <https://pagure.io/freeipa/issue/7026>`__
 -  ipa-kdb: use canonical principal in certauth plugin
-   `commit <https://pagure.io/freeipa/c/117d6e9be0c386f134bd27eee3377e70df77f0f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/117d6e9be0c386f134bd27eee3377e70df77f0f0>`__
    `#6993 <https://pagure.io/freeipa/issue/6993>`__
 -  ipa-kdb: reload certificate mapping rules periodically
-   `commit <https://pagure.io/freeipa/c/e8aed2524846f1cff3d09d676675f3b426178f60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8aed2524846f1cff3d09d676675f3b426178f60>`__
    `#6963 <https://pagure.io/freeipa/issue/6963>`__
 -  IPA-KDB: use relative path in ipa-certmap config snippet
-   `commit <https://pagure.io/freeipa/c/6c2772dde52c84024d32533b29e6cbd04c69924a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c2772dde52c84024d32533b29e6cbd04c69924a>`__
    `#6833 <https://pagure.io/freeipa/issue/6833>`__
 -  extdom: improve cert request
-   `commit <https://pagure.io/freeipa/c/8960398a57f69c124ec3105289dc355baa0d5b09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8960398a57f69c124ec3105289dc355baa0d5b09>`__
    `#6826 <https://pagure.io/freeipa/issue/6826>`__
 -  extdom: do reverse search for domain separator
-   `commit <https://pagure.io/freeipa/c/ee455f163d756a6b71db8e999365139cad46c6ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee455f163d756a6b71db8e999365139cad46c6ad>`__
 -  ipa-kdb: do not depend on certauth_plugin.h
-   `commit <https://pagure.io/freeipa/c/0ba0c0781367d8e2d4affca29e3cf5ab93c4c33a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ba0c0781367d8e2d4affca29e3cf5ab93c4c33a>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  configure: fix --disable-server with certauth plugin
-   `commit <https://pagure.io/freeipa/c/054f1bd78b04a79f765f524f829b34c0ee252a1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/054f1bd78b04a79f765f524f829b34c0ee252a1b>`__
    `#6816 <https://pagure.io/freeipa/issue/6816>`__
 -  IPA certauth plugin
-   `commit <https://pagure.io/freeipa/c/c4156041feb9c48598427ad59e43313b9c7327bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4156041feb9c48598427ad59e43313b9c7327bb>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 -  ipa-kdb: add ipadb_fetch_principals_with_extra_filter()
-   `commit <https://pagure.io/freeipa/c/da880decfedc66f9d0d2734dcb86c23a8866f603>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da880decfedc66f9d0d2734dcb86c23a8866f603>`__
    `#4905 <https://pagure.io/freeipa/issue/4905>`__
 
 
@@ -1442,37 +1442,37 @@ Simo Sorce (12)
 ----------------------------------------------------------------------------------------------
 
 -  Always check peer has keys before connecting
-   `commit <https://pagure.io/freeipa/c/c565fa1781121cf284886e1f2d0691cfe10760d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c565fa1781121cf284886e1f2d0691cfe10760d2>`__
 -  Make sure we check ccaches in all rpcserver paths
-   `commit <https://pagure.io/freeipa/c/0537ab07bad852381357df3b93d5ca7d30b1b5ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0537ab07bad852381357df3b93d5ca7d30b1b5ec>`__
 -  Revert setting sessionMaxAge for old clients
-   `commit <https://pagure.io/freeipa/c/c52ca92cdabf07da5b3b27344b8eaa8b161ea49b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c52ca92cdabf07da5b3b27344b8eaa8b161ea49b>`__
    `#7001 <https://pagure.io/freeipa/issue/7001>`__
 -  Add code to be able to set default kinit lifetime
-   `commit <https://pagure.io/freeipa/c/77db574cca900eb03d8e0ab577568c2058ae4a86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77db574cca900eb03d8e0ab577568c2058ae4a86>`__
    `#7001 <https://pagure.io/freeipa/issue/7001>`__
 -  Fix rare race condition with missing ccache file
-   `commit <https://pagure.io/freeipa/c/83619e804b53f2bfb8b0d94882c01abed23c4a9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83619e804b53f2bfb8b0d94882c01abed23c4a9f>`__
 -  Make sure remote hosts have our keys
-   `commit <https://pagure.io/freeipa/c/1f9f84a66d6cf9391b91ee4a13ac0f1119212578>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f9f84a66d6cf9391b91ee4a13ac0f1119212578>`__
    `#6838 <https://pagure.io/freeipa/issue/6838>`__
 -  Fix s4u2self with adtrust
-   `commit <https://pagure.io/freeipa/c/e88d5e815ea440bcef4acdc5f8fcb3a29e6eaec9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e88d5e815ea440bcef4acdc5f8fcb3a29e6eaec9>`__
    `#6862 <https://pagure.io/freeipa/issue/6862>`__
 -  Prevent churn on ccaches
-   `commit <https://pagure.io/freeipa/c/d63326632b796a5ec9c6468c5ffe0c5a846501e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d63326632b796a5ec9c6468c5ffe0c5a846501e1>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Work around issues fetching session data
-   `commit <https://pagure.io/freeipa/c/e07aefb886096a7d419a4f1a2dec287e5ecd1626>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e07aefb886096a7d419a4f1a2dec287e5ecd1626>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Handle failed authentication via cookie
-   `commit <https://pagure.io/freeipa/c/fbbeb132bf37f8a03ef2f2184adb11796ab13d8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbbeb132bf37f8a03ef2f2184adb11796ab13d8b>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Avoid growing FILE ccaches unnecessarily
-   `commit <https://pagure.io/freeipa/c/9a6ac74eb4421b9ffa831dc6fed067d2ddc0618e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a6ac74eb4421b9ffa831dc6fed067d2ddc0618e>`__
    `#6775 <https://pagure.io/freeipa/issue/6775>`__
 -  Add options to allow ticket caching
-   `commit <https://pagure.io/freeipa/c/4ee7e4ee6d6500d8b8935c9033388adc4cdbe672>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ee7e4ee6d6500d8b8935c9033388adc4cdbe672>`__
    `#6771 <https://pagure.io/freeipa/issue/6771>`__
 
 
@@ -1481,291 +1481,291 @@ Stanislav Laznicka (97)
 ----------------------------------------------------------------------------------------------
 
 -  spec: remove strict options from shebangs
-   `commit <https://pagure.io/freeipa/c/aa969da461a2bbdfc2fc2de49c3f21b6de23e9e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa969da461a2bbdfc2fc2de49c3f21b6de23e9e1>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  spec: have the scripts depend on py3 packages
-   `commit <https://pagure.io/freeipa/c/263217ff46f7ec260629c2ace5640bd281be9914>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/263217ff46f7ec260629c2ace5640bd281be9914>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  spec: remove python3 workaround
-   `commit <https://pagure.io/freeipa/c/3aff58c804145716a34b38a0d7009df62be17d0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3aff58c804145716a34b38a0d7009df62be17d0d>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Remove unused variable
-   `commit <https://pagure.io/freeipa/c/c14aa6cdac5795bd2a05606c51e4b9d9f26755a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c14aa6cdac5795bd2a05606c51e4b9d9f26755a4>`__
 -  certmonger: remove temporary workaround
-   `commit <https://pagure.io/freeipa/c/170f7a778bf62d11c0ba910f1e6d7924614b68c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/170f7a778bf62d11c0ba910f1e6d7924614b68c5>`__
 -  cert: fix wrong assumption of cert-show result type
-   `commit <https://pagure.io/freeipa/c/1b78f79283e633abc5dd901ca4db99cea36aca1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b78f79283e633abc5dd901ca4db99cea36aca1a>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  rpc: don't encode bytes
-   `commit <https://pagure.io/freeipa/c/e09b6c260288b955c1f7d63209ff6b932f363ad1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e09b6c260288b955c1f7d63209ff6b932f363ad1>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: Fix searching for yubikeys
-   `commit <https://pagure.io/freeipa/c/0be9a1721133ad512a7420f6508249d4e8453d90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be9a1721133ad512a7420f6508249d4e8453d90>`__
    `#7121 <https://pagure.io/freeipa/issue/7121>`__
 -  py3: remove relative import
-   `commit <https://pagure.io/freeipa/c/2bc5b7f044435921b9fa1d5728731a843919102e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bc5b7f044435921b9fa1d5728731a843919102e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__,
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  py3: remove Exception.message appearances
-   `commit <https://pagure.io/freeipa/c/e6a9de8a2ea453843e71ff717bee7dd74383db64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6a9de8a2ea453843e71ff717bee7dd74383db64>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__,
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Fix cert file creation during CA-less installation
-   `commit <https://pagure.io/freeipa/c/7a86ff5d9bf5d9bf0f5970298addcd5b0f21d728>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a86ff5d9bf5d9bf0f5970298addcd5b0f21d728>`__
    `#7118 <https://pagure.io/freeipa/issue/7118>`__
 -  Uninstall: fix BytesWarning exception
-   `commit <https://pagure.io/freeipa/c/6ca8787cc7f4865cfce20241440f17d3a41bef78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ca8787cc7f4865cfce20241440f17d3a41bef78>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Unify storing certificates in LDAP
-   `commit <https://pagure.io/freeipa/c/31142ead830b441c81ee1439e81210426792cac5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31142ead830b441c81ee1439e81210426792cac5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: fix caless to CA promotion on replica
-   `commit <https://pagure.io/freeipa/c/2151ab02c19d0a74d90d3784a1ac1b14877a7b96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2151ab02c19d0a74d90d3784a1ac1b14877a7b96>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  cacert_manage: fix CA cert renewal
-   `commit <https://pagure.io/freeipa/c/6fc7a96e11b3f5de88f971478dc9365bf91c069e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fc7a96e11b3f5de88f971478dc9365bf91c069e>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  python3: port certmonger requests script
-   `commit <https://pagure.io/freeipa/c/7ef6de931bf2dda4be022c912012974d9e494fac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ef6de931bf2dda4be022c912012974d9e494fac>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  crtmgr: fix bug if CERTMONGER_CERTIFICATE not set
-   `commit <https://pagure.io/freeipa/c/a3c11b01afa4d0f33a507c03bfdd4299fdf987dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c11b01afa4d0f33a507c03bfdd4299fdf987dc>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  certmonger: finish refactoring for request script
-   `commit <https://pagure.io/freeipa/c/0412625a2bfc20b9f9b85ba6cb4b1e087e4630e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0412625a2bfc20b9f9b85ba6cb4b1e087e4630e9>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  certmonger: fix storing retrieved certificates
-   `commit <https://pagure.io/freeipa/c/32be3ef62210d77dc07f94837be739c82be17661>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32be3ef62210d77dc07f94837be739c82be17661>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Make the IPA server run under Python 3 by default
-   `commit <https://pagure.io/freeipa/c/9869d52bab70bb144d51835dc4e70a61a5788ffa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9869d52bab70bb144d51835dc4e70a61a5788ffa>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Turn IPA scripts to python3 -bb for testing
-   `commit <https://pagure.io/freeipa/c/5965e27b304dd21482228e4b9134549bdc9dd1ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5965e27b304dd21482228e4b9134549bdc9dd1ab>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  py3: Depend on newer pyldap for server-upgrade
-   `commit <https://pagure.io/freeipa/c/7bf6eb7e19ecdb24be185ab2a4d0a549029b9cf0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bf6eb7e19ecdb24be185ab2a4d0a549029b9cf0>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ipautil: port host_port_open() to python 3
-   `commit <https://pagure.io/freeipa/c/b1fbdbefdb201fc036e41e84a25e3e0725d8e3d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1fbdbefdb201fc036e41e84a25e3e0725d8e3d2>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  conncheck: fix progression on failure
-   `commit <https://pagure.io/freeipa/c/31a5cf588e1171bcfd58d6a08a76867552dfe811>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31a5cf588e1171bcfd58d6a08a76867552dfe811>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  kerberos: fix sorting Principal objects
-   `commit <https://pagure.io/freeipa/c/dbeb41efd6ad2067f24a099f27c02cab88a8d84b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbeb41efd6ad2067f24a099f27c02cab88a8d84b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  host, service: fix adding host/svc with a cert
-   `commit <https://pagure.io/freeipa/c/7d217c8c9b6f9703b46a42ecbd55b4ca32868795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d217c8c9b6f9703b46a42ecbd55b4ca32868795>`__
    `#7077 <https://pagure.io/freeipa/issue/7077>`__
 -  server plugin: pass bytes to ldap.modify_s
-   `commit <https://pagure.io/freeipa/c/d147948fccd7fda1909a809a691f86722cb6de6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d147948fccd7fda1909a809a691f86722cb6de6b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  replica: fix SetuptoolsVersion comparison
-   `commit <https://pagure.io/freeipa/c/76904ba84dce182ea003d0f88e66fc09778f51eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76904ba84dce182ea003d0f88e66fc09778f51eb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  replica-prepare: run the script in py3 by default
-   `commit <https://pagure.io/freeipa/c/1124eee2ffc8fed933c2f061f4c65a0a17b519cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1124eee2ffc8fed933c2f061f4c65a0a17b519cb>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  certs: write and read bytes as such
-   `commit <https://pagure.io/freeipa/c/9fc2cab972c3506b96d49b8d341259360b486eb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fc2cab972c3506b96d49b8d341259360b486eb1>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  client: make ipa-client-install py3 compatible
-   `commit <https://pagure.io/freeipa/c/6f8d90d97a5f3751252f2ab99f13a5d012247f22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f8d90d97a5f3751252f2ab99f13a5d012247f22>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  cainstance: read cert file as bytes
-   `commit <https://pagure.io/freeipa/c/c95617e71495fff4bf2352fdeb5089e3e02bd79b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c95617e71495fff4bf2352fdeb5089e3e02bd79b>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ca: TypeError fix
-   `commit <https://pagure.io/freeipa/c/0c848b791df7368a32434b3ac87a45728abc2d0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c848b791df7368a32434b3ac87a45728abc2d0f>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  krainstance: fix writing str to file
-   `commit <https://pagure.io/freeipa/c/276bef101b9fa0f83e5de353bc733270d958ee41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/276bef101b9fa0f83e5de353bc733270d958ee41>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  replica-conncheck: log when failed to RPC connect
-   `commit <https://pagure.io/freeipa/c/06fbf4b312777751085f3dcfeff456b037ee2737>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06fbf4b312777751085f3dcfeff456b037ee2737>`__
 -  Fixup of not-so-good PEM certs
-   `commit <https://pagure.io/freeipa/c/e1f88c844e704246e4a948dc74489513f66633d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1f88c844e704246e4a948dc74489513f66633d5>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  x509,certdb: handle certificates as bytes
-   `commit <https://pagure.io/freeipa/c/1521296297d99ea9f6e8f67b30d8e11c6bd56426>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1521296297d99ea9f6e8f67b30d8e11c6bd56426>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Create a Certificate parameter
-   `commit <https://pagure.io/freeipa/c/5a44ca638310913ab6b0c239374f4b0ddeeedeb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a44ca638310913ab6b0c239374f4b0ddeeedeb3>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  parameters: relax type checks
-   `commit <https://pagure.io/freeipa/c/5ff1de84909dd65c44b9aa48000b9e73a7a93716>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ff1de84909dd65c44b9aa48000b9e73a7a93716>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  tests: fix failing HTTPS connection
-   `commit <https://pagure.io/freeipa/c/bf4dae70e0d163f4d485771d7d163169748fa6b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf4dae70e0d163f4d485771d7d163169748fa6b3>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Introduce load_unknown_x509_certificate()
-   `commit <https://pagure.io/freeipa/c/43c74d33337d4c65947816ba31de5eaa53e001ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43c74d33337d4c65947816ba31de5eaa53e001ff>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  x509: Make certificates represented as objects
-   `commit <https://pagure.io/freeipa/c/b5732efda6d27f588adbc3f41259bc4511716f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5732efda6d27f588adbc3f41259bc4511716f43>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  Split x509.load_certificate() into PEM/DER functions
-   `commit <https://pagure.io/freeipa/c/4375ef860fdd8221baeff23e88f9217b0cddc5ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4375ef860fdd8221baeff23e88f9217b0cddc5ac>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  README: Fix trailing whitespace
-   `commit <https://pagure.io/freeipa/c/62f19fc082a7d7d41fb732e9fcb726f6b4591f57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62f19fc082a7d7d41fb732e9fcb726f6b4591f57>`__
 -  Ensure network is online prior to an upgrade
-   `commit <https://pagure.io/freeipa/c/a36f2aed637dad5bac6f2063c05a5ed64eb922ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a36f2aed637dad5bac6f2063c05a5ed64eb922ce>`__
    `#7039 <https://pagure.io/freeipa/issue/7039>`__
 -  rpcserver: remove addition of str and bytes
-   `commit <https://pagure.io/freeipa/c/d308abac2e6758014ebb39bcbd0fc3bd61a57db2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d308abac2e6758014ebb39bcbd0fc3bd61a57db2>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  wsgi plugins: mod_wsgi expects bytes as an output
-   `commit <https://pagure.io/freeipa/c/db4d0998fdd37422ed9dcb0d88ea5adf6ac98412>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db4d0998fdd37422ed9dcb0d88ea5adf6ac98412>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  adtrustinstance: write the conf as a string
-   `commit <https://pagure.io/freeipa/c/8311069d1890d6b742b5aac17dfaaf79a6e1bf62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8311069d1890d6b742b5aac17dfaaf79a6e1bf62>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  adtrustinstance: pep8 fix
-   `commit <https://pagure.io/freeipa/c/a83b2583ab9eaeffc1b37ceb9009bdc7d5de084c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a83b2583ab9eaeffc1b37ceb9009bdc7d5de084c>`__
 -  More verbose error message on kdc cert validation
-   `commit <https://pagure.io/freeipa/c/bee3c1eccd44f7671a1455d12235bcbb910494b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bee3c1eccd44f7671a1455d12235bcbb910494b3>`__
    `#6945 <https://pagure.io/freeipa/issue/6945>`__
 -  cert-validate: keep all messages in cert validation
-   `commit <https://pagure.io/freeipa/c/f827fe0f19596d29f9354368077fb43be2e16e8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f827fe0f19596d29f9354368077fb43be2e16e8e>`__
    `#6945 <https://pagure.io/freeipa/issue/6945>`__
 -  adtrustinstance: fix ID range comparison
-   `commit <https://pagure.io/freeipa/c/440c61dc40353833cad3a5fc509821ce1f23757f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/440c61dc40353833cad3a5fc509821ce1f23757f>`__
    `#7002 <https://pagure.io/freeipa/issue/7002>`__
 -  Docstring+refactor of IPADiscovery.ipadnssearchkrbrealm()
-   `commit <https://pagure.io/freeipa/c/c8cc62564b09959c451522b1d7eb122566594867>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8cc62564b09959c451522b1d7eb122566594867>`__
 -  ipadiscovery: Return realm as a string
-   `commit <https://pagure.io/freeipa/c/1cab1e980c7cad65943e2984158a458a6472c9d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cab1e980c7cad65943e2984158a458a6472c9d2>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  session_storage: Correctly handle string/byte types
-   `commit <https://pagure.io/freeipa/c/d665224a85610cccbe7d291e9ed41d2ce7e5b61c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d665224a85610cccbe7d291e9ed41d2ce7e5b61c>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  rpc: avoid possible recursion in create_connection
-   `commit <https://pagure.io/freeipa/c/e1f8684e858b4ae47b54acd0d76a844bc20ce443>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1f8684e858b4ae47b54acd0d76a844bc20ce443>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  rpc: preparations for recursion fix
-   `commit <https://pagure.io/freeipa/c/79d1752577e8fcb568b701509fe5b52f949d5e4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79d1752577e8fcb568b701509fe5b52f949d5e4b>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  Avoid possible endless recursion in RPC call
-   `commit <https://pagure.io/freeipa/c/81a808caeb5676427610e113b5a259511c2835d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81a808caeb5676427610e113b5a259511c2835d6>`__
    `#6796 <https://pagure.io/freeipa/issue/6796>`__
 -  kdc.key should not be visible to all
-   `commit <https://pagure.io/freeipa/c/3b6892783ee6ed6dac9c4f328cc89ae030ce10a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b6892783ee6ed6dac9c4f328cc89ae030ce10a7>`__
    `#6973 <https://pagure.io/freeipa/issue/6973>`__
 -  Change ConfigParser to RawConfigParser
-   `commit <https://pagure.io/freeipa/c/35675ca2bbe9c044f115764a2daac45f7468be00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35675ca2bbe9c044f115764a2daac45f7468be00>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ca/cert-show: check certificate_out in options
-   `commit <https://pagure.io/freeipa/c/1ed1717e9956ba5a3baa9d0992e14fd2d4a2dd6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ed1717e9956ba5a3baa9d0992e14fd2d4a2dd6a>`__
    `#6885 <https://pagure.io/freeipa/issue/6885>`__
 -  Remove pkinit-anonymous command
-   `commit <https://pagure.io/freeipa/c/24099d0f806103d8ec57d69fc97e9b4ae061bfdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24099d0f806103d8ec57d69fc97e9b4ae061bfdd>`__
    `#6936 <https://pagure.io/freeipa/issue/6936>`__
 -  Make a doctext more clear
-   `commit <https://pagure.io/freeipa/c/df8205b55c67cfbe2abfe0f68e8747c0d09a44b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df8205b55c67cfbe2abfe0f68e8747c0d09a44b8>`__
 -  Provide useful messages during cert validation
-   `commit <https://pagure.io/freeipa/c/3d969d7bad06e4f9527c88106806c28b68bfcc20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d969d7bad06e4f9527c88106806c28b68bfcc20>`__
    `#6945 <https://pagure.io/freeipa/issue/6945>`__
 -  cert-show: writable files does not mean dirs
-   `commit <https://pagure.io/freeipa/c/33b3d7ad7ada45edbd178fe99f1257c40f39dcaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33b3d7ad7ada45edbd178fe99f1257c40f39dcaa>`__
    `#6883 <https://pagure.io/freeipa/issue/6883>`__
 -  fix managed-entries printing IPA not installed
-   `commit <https://pagure.io/freeipa/c/6522c4a8378a22ffe82e8e845698ab104f611888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6522c4a8378a22ffe82e8e845698ab104f611888>`__
    `#6928 <https://pagure.io/freeipa/issue/6928>`__
 -  Fix wrong message on Dogtag instances stop
-   `commit <https://pagure.io/freeipa/c/aba384ddb535e81f81a518fa468a8ed095250ca1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aba384ddb535e81f81a518fa468a8ed095250ca1>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Make CA/KRA fail when they don't start
-   `commit <https://pagure.io/freeipa/c/1a7a1f955e327bf1a06faa53c517bdbffff22eba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a7a1f955e327bf1a06faa53c517bdbffff22eba>`__
    `#6766 <https://pagure.io/freeipa/issue/6766>`__
 -  Remove the cachedproperty class
-   `commit <https://pagure.io/freeipa/c/92313c9e9d37733feb79d1b1c825178f48d6c69c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92313c9e9d37733feb79d1b1c825178f48d6c69c>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  Refresh Dogtag RestClient.ca_host property
-   `commit <https://pagure.io/freeipa/c/0d406fcb784924bfe685729f3156efb8c902b947>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d406fcb784924bfe685729f3156efb8c902b947>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  compat plugin: Update link to slapi-nis project
-   `commit <https://pagure.io/freeipa/c/68c8ddf1871efe7ef78ce153573d522aefecfdfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c8ddf1871efe7ef78ce153573d522aefecfdfa>`__
 -  compat: ignore cn=topology,cn=ipa,cn=etc subtree
-   `commit <https://pagure.io/freeipa/c/645615958d4b0f9e6dd8a5ff2541952abb588d55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/645615958d4b0f9e6dd8a5ff2541952abb588d55>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  Move the compat plugin setup at the end of install
-   `commit <https://pagure.io/freeipa/c/ddbbb1c58e8a4fec8129e7d1e941c54660af6a69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddbbb1c58e8a4fec8129e7d1e941c54660af6a69>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  compat-manage: behave the same for all users
-   `commit <https://pagure.io/freeipa/c/0c0af8cf7adf61ef03ba1240ecbdecef7fa15275>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c0af8cf7adf61ef03ba1240ecbdecef7fa15275>`__
    `#6821 <https://pagure.io/freeipa/issue/6821>`__
 -  Fix CAInstance.import_ra_cert for empty passwords
-   `commit <https://pagure.io/freeipa/c/b38750eaa82025aad56f8eca849f47775b2cbc75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b38750eaa82025aad56f8eca849f47775b2cbc75>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  Fix RA cert import during DL0 replication
-   `commit <https://pagure.io/freeipa/c/6f0a622d83ee22ce712a380d1701cb1f383689e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f0a622d83ee22ce712a380d1701cb1f383689e4>`__
    `#6878 <https://pagure.io/freeipa/issue/6878>`__
 -  ext. CA: correctly write the cert chain
-   `commit <https://pagure.io/freeipa/c/7b8503173b253860c1059bd40858f2fdffb4ae33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b8503173b253860c1059bd40858f2fdffb4ae33>`__
    `#6872 <https://pagure.io/freeipa/issue/6872>`__
 -  server-install: No double Kerberos install
-   `commit <https://pagure.io/freeipa/c/25a33ce8b1c77b0d957772143affd7085757bccb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25a33ce8b1c77b0d957772143affd7085757bccb>`__
    `#6757 <https://pagure.io/freeipa/issue/6757>`__
 -  Fix CA-less to CA-full upgrade
-   `commit <https://pagure.io/freeipa/c/9ac56e47d78582fbc2911f67a7344bcce321842f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ac56e47d78582fbc2911f67a7344bcce321842f>`__
    `#6853 <https://pagure.io/freeipa/issue/6853>`__
 -  replicainstall: better client install exception handling
-   `commit <https://pagure.io/freeipa/c/db84516d23d3a6e53e95881828d494fb80647602>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db84516d23d3a6e53e95881828d494fb80647602>`__
    `#6183 <https://pagure.io/freeipa/issue/6183>`__
 -  Add the force-join option to replica install
-   `commit <https://pagure.io/freeipa/c/87051f51c695afa3e9ba072da7005cf1a4194668>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87051f51c695afa3e9ba072da7005cf1a4194668>`__
    `#6183 <https://pagure.io/freeipa/issue/6183>`__
 -  server-install: remove broken no-pkinit check
-   `commit <https://pagure.io/freeipa/c/1160dc5d8bacea42a7ada45a10bf1019a3af5aca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1160dc5d8bacea42a7ada45a10bf1019a3af5aca>`__
    `#6807 <https://pagure.io/freeipa/issue/6807>`__
 -  Add pki_pin only when needed
-   `commit <https://pagure.io/freeipa/c/1aa77fe389e957a652c530ec0456ee05467754b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1aa77fe389e957a652c530ec0456ee05467754b3>`__
    `#6839 <https://pagure.io/freeipa/issue/6839>`__
 -  Remove publish_ca_cert() method from NSSDatabase
-   `commit <https://pagure.io/freeipa/c/aae9a918b68dc4f9a7b4fb9abf1bb4d26673109d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aae9a918b68dc4f9a7b4fb9abf1bb4d26673109d>`__
    `#6806 <https://pagure.io/freeipa/issue/6806>`__
 -  Get correct CA cert nickname in CA-less
-   `commit <https://pagure.io/freeipa/c/8c87014e199b3dbe885c69d40a01d2723f813c3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c87014e199b3dbe885c69d40a01d2723f813c3e>`__
    `#6806 <https://pagure.io/freeipa/issue/6806>`__
 -  Remove redundant option check for cert files
-   `commit <https://pagure.io/freeipa/c/fe7cf1e854b7dc28861455011091df3cbe45abe9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe7cf1e854b7dc28861455011091df3cbe45abe9>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  replica-prepare man: remove pkinit option refs
-   `commit <https://pagure.io/freeipa/c/8af884d0489d5d57895959d27ca6eb8815c6c922>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8af884d0489d5d57895959d27ca6eb8815c6c922>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Don't allow setting pkinit-related options on DL0
-   `commit <https://pagure.io/freeipa/c/9e3ae785ac9b62b8e0809a4aa56363c458316135>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e3ae785ac9b62b8e0809a4aa56363c458316135>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Fix the order of cert-files check
-   `commit <https://pagure.io/freeipa/c/6cda1509a68d7a21578280d381a6b9e994fd4f49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cda1509a68d7a21578280d381a6b9e994fd4f49>`__
    `#6801 <https://pagure.io/freeipa/issue/6801>`__
 -  Generate PIN for PKI to help Dogtag in FIPS
-   `commit <https://pagure.io/freeipa/c/e204d030fc4154800acb0b2b312188e72dd80f80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e204d030fc4154800acb0b2b312188e72dd80f80>`__
    `#6824 <https://pagure.io/freeipa/issue/6824>`__
 -  Backup CA cert from kerberos folder
-   `commit <https://pagure.io/freeipa/c/dc13703e75997e0c9539b326acb13458dae00202>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc13703e75997e0c9539b326acb13458dae00202>`__
    `#6748 <https://pagure.io/freeipa/issue/6748>`__
 -  Allow renaming of the sudorule objects
-   `commit <https://pagure.io/freeipa/c/8c1409155e9a9a978d3d763045a84d1eac585dfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c1409155e9a9a978d3d763045a84d1eac585dfd>`__
    `#2466 <https://pagure.io/freeipa/issue/2466>`__
 -  Allow renaming of the HBAC rule objects
-   `commit <https://pagure.io/freeipa/c/55424c8677ba7de464c820afd31260aa4a7678d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55424c8677ba7de464c820afd31260aa4a7678d0>`__
    `#6784 <https://pagure.io/freeipa/issue/6784>`__
 -  Reworked the renaming mechanism
-   `commit <https://pagure.io/freeipa/c/8e4408e6784f929b4c3d861f0dd509335238e951>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e4408e6784f929b4c3d861f0dd509335238e951>`__
    `#2466 <https://pagure.io/freeipa/issue/2466>`__,
    `#6784 <https://pagure.io/freeipa/issue/6784>`__
 -  Bump samba version for FIPS and priv. separation
-   `commit <https://pagure.io/freeipa/c/b7ae3363fd5bb1bf3b3175395d5bd3d26c9b48f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7ae3363fd5bb1bf3b3175395d5bd3d26c9b48f0>`__
    `#6671 <https://pagure.io/freeipa/issue/6671>`__,
    `#6697 <https://pagure.io/freeipa/issue/6697>`__
 -  Backup ipa-specific httpd unit-file
-   `commit <https://pagure.io/freeipa/c/2612c092dd797c9c8f772c785aae1f152f06847d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2612c092dd797c9c8f772c785aae1f152f06847d>`__
    `#6748 <https://pagure.io/freeipa/issue/6748>`__
 -  Add debug log in case cookie retrieval went wrong
-   `commit <https://pagure.io/freeipa/c/0bb858ea770e081817dc243579d08ad1f113e825>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0bb858ea770e081817dc243579d08ad1f113e825>`__
    `#6774 <https://pagure.io/freeipa/issue/6774>`__
 
 
@@ -1774,7 +1774,7 @@ Thierry Bordaz (1)
 ----------------------------------------------------------------------------------------------
 
 -  NULL LDAP context in call to ldap_search_ext_s during search
-   `commit <https://pagure.io/freeipa/c/0f0423cf531d5fab73516323750af6b5106ba070>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f0423cf531d5fab73516323750af6b5106ba070>`__
    `#7017 <https://pagure.io/freeipa/issue/7017>`__
 
 
@@ -1783,37 +1783,37 @@ Tibor Dudlák (11)
 ----------------------------------------------------------------------------------------------
 
 -  otptoken_yubikey.py: Removed traceback when package missing.
-   `commit <https://pagure.io/freeipa/c/76357283ec522aef8aaf3d3b8eea7155263e3517>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76357283ec522aef8aaf3d3b8eea7155263e3517>`__
    `#6979 <https://pagure.io/freeipa/issue/6979>`__
 -  topology.py: Removes error message from dictionary.
-   `commit <https://pagure.io/freeipa/c/69d05b86b76461880bc316120b95fbf6fcf35159>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69d05b86b76461880bc316120b95fbf6fcf35159>`__
    `#6533 <https://pagure.io/freeipa/issue/6533>`__
 -  Add test: test_xmlrpc/test_whoami_plugin.py
-   `commit <https://pagure.io/freeipa/c/19f3eda7900207a4a0c77b1781a9cdb3483ea234>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19f3eda7900207a4a0c77b1781a9cdb3483ea234>`__
    `#6745 <https://pagure.io/freeipa/issue/6745>`__
 -  whoami.py: Type error when running tests
-   `commit <https://pagure.io/freeipa/c/17f03a7952ff444a36c40dd6aaf5c27ef087d41d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17f03a7952ff444a36c40dd6aaf5c27ef087d41d>`__
    `#7050 <https://pagure.io/freeipa/issue/7050>`__
 -  Create indexes for 'serverhostname' attribute
-   `commit <https://pagure.io/freeipa/c/22b0ae440a34dc8f18475f79c656f67584d4ad3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22b0ae440a34dc8f18475f79c656f67584d4ad3b>`__
    `#6939 <https://pagure.io/freeipa/issue/6939>`__
 -  Add --force-join into ipa-replica-install manpage
-   `commit <https://pagure.io/freeipa/c/7fd2102a78f2e008f2cd5fe68e9be58ead914b35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fd2102a78f2e008f2cd5fe68e9be58ead914b35>`__
    `#7011 <https://pagure.io/freeipa/issue/7011>`__
 -  dnsserver.py: dnsserver-find no longer returns internal server error
-   `commit <https://pagure.io/freeipa/c/74d36a8af69a2946007ebd4d57c7bf0891d561db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74d36a8af69a2946007ebd4d57c7bf0891d561db>`__
    `#6571 <https://pagure.io/freeipa/issue/6571>`__
 -  Add Role 'Enrollment Administrator'
-   `commit <https://pagure.io/freeipa/c/468eb3c712140399ed2ec346ff4356bffd590e09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/468eb3c712140399ed2ec346ff4356bffd590e09>`__
    `#6852 <https://pagure.io/freeipa/issue/6852>`__
 -  server.py: Removes dns-server configuration from ldap
-   `commit <https://pagure.io/freeipa/c/063211d665d02fc343952f5b158fd8d89223fbc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/063211d665d02fc343952f5b158fd8d89223fbc9>`__
    `#6572 <https://pagure.io/freeipa/issue/6572>`__
 -  sssd.py: Deprecating no-sssd option.
-   `commit <https://pagure.io/freeipa/c/dfc271fdf4514481c11c342fabda135feeb44de6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfc271fdf4514481c11c342fabda135feeb44de6>`__
    `#5860 <https://pagure.io/freeipa/issue/5860>`__
 -  client.py: Replace hardcoded 'admin' with options.principal
-   `commit <https://pagure.io/freeipa/c/eae8714026339e1e7926d01412916ad08be737b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eae8714026339e1e7926d01412916ad08be737b9>`__
    `#5406 <https://pagure.io/freeipa/issue/5406>`__
 
 
@@ -1822,10 +1822,10 @@ Tibor Dudlák (2)
 ----------------------------------------------------------------------------------------------
 
 -  user.py: replace user_mod with ldap.update_entry()
-   `commit <https://pagure.io/freeipa/c/d73ec06cb3c8042f90d1520485aa9b0f2e7c8fbe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d73ec06cb3c8042f90d1520485aa9b0f2e7c8fbe>`__
    `#5788 <https://pagure.io/freeipa/issue/5788>`__
 -  Add 'TIP' to enable copr repo.
-   `commit <https://pagure.io/freeipa/c/a2f4a94925b24cc22aa3c3e046935671750daa2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2f4a94925b24cc22aa3c3e046935671750daa2f>`__
 
 
 
@@ -1834,11 +1834,11 @@ Timo Aaltonen (2)
 
 -  ipa-otpd.socket.in: Use a platform specific value for KDC service
    file
-   `commit <https://pagure.io/freeipa/c/076eb409a032cbd689f1d5e298c1009e80168e34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/076eb409a032cbd689f1d5e298c1009e80168e34>`__
    `#6845 <https://pagure.io/freeipa/issue/6845>`__
 -  configure: Use ODS_USER and NAMED_GROUP in
    daemons/dnssec/\*.service.in
-   `commit <https://pagure.io/freeipa/c/44a3e0fe1d168ad87182654976a26e352287b1e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44a3e0fe1d168ad87182654976a26e352287b1e0>`__
 
 
 
@@ -1846,70 +1846,70 @@ Tomas Krizek (25)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.6.0
-   `commit <https://pagure.io/freeipa/c/59e4bc285390886422d5e15314fa8e2fac1cc4bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59e4bc285390886422d5e15314fa8e2fac1cc4bd>`__
 -  Contributors.txt: update
-   `commit <https://pagure.io/freeipa/c/8aabe9d337280e1a116c6acc5e57159fb048d1ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8aabe9d337280e1a116c6acc5e57159fb048d1ee>`__
 -  zanata: update translations for ipa-4-6
-   `commit <https://pagure.io/freeipa/c/062ee46e3ab71d330cf69cc14401d492d12927ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/062ee46e3ab71d330cf69cc14401d492d12927ca>`__
 -  zanata: set project version to ipa-4-6
-   `commit <https://pagure.io/freeipa/c/7ca68e42680a3f130f694ab8e337e8c0898c983e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ca68e42680a3f130f694ab8e337e8c0898c983e>`__
 -  dnssec: keep dnssec daemons in Python2
-   `commit <https://pagure.io/freeipa/c/5dcb0e6fc772f459a29693867f9b73f1ac811b9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5dcb0e6fc772f459a29693867f9b73f1ac811b9a>`__
    `#4985 <https://pagure.io/freeipa/issue/4985>`__
 -  ipatests: collect log after ipa-ca-install
-   `commit <https://pagure.io/freeipa/c/4028f1aebb460eb4f81eabd31e7621b026c4aa9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4028f1aebb460eb4f81eabd31e7621b026c4aa9d>`__
    `#7060 <https://pagure.io/freeipa/issue/7060>`__
 -  dnssec: fix localhsm.py utility script
-   `commit <https://pagure.io/freeipa/c/661e611d14ac744154c9b493876d373826e6b24a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/661e611d14ac744154c9b493876d373826e6b24a>`__
    `#7116 <https://pagure.io/freeipa/issue/7116>`__
 -  prci: add caless tests
-   `commit <https://pagure.io/freeipa/c/3091938c0b2df192fb0fddf24ec885e6e20cf697>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3091938c0b2df192fb0fddf24ec885e6e20cf697>`__
 -  makerpms.sh: make git checkout optional
-   `commit <https://pagure.io/freeipa/c/f7d1a10f22548fb2c1eba99a3001c6da49605edd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7d1a10f22548fb2c1eba99a3001c6da49605edd>`__
    `#6605 <https://pagure.io/freeipa/issue/6605>`__
 -  build: checkout \*.po files at the end of makerpms.sh
-   `commit <https://pagure.io/freeipa/c/f32784f4cb0c89ceae95f5bbc7c7224ed139aeb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f32784f4cb0c89ceae95f5bbc7c7224ed139aeb0>`__
    `#6605 <https://pagure.io/freeipa/issue/6605>`__
 -  freeipa-pr-ci: enable pull-request CI
-   `commit <https://pagure.io/freeipa/c/8f92a9bdc16129d506d4c46388f16c9d12ec3b65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f92a9bdc16129d506d4c46388f16c9d12ec3b65>`__
 -  ipactl: log check_version exception
-   `commit <https://pagure.io/freeipa/c/fc7e2565bdb2b2a40380ffb343d8a7295ac21cd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc7e2565bdb2b2a40380ffb343d8a7295ac21cd7>`__
 -  logging: make sure logging level is set to proper value
-   `commit <https://pagure.io/freeipa/c/ba5f7afedca282e79fdfde0dd359028fc4111f90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba5f7afedca282e79fdfde0dd359028fc4111f90>`__
 -  ipatests: do not finalize api when IPA is not configured
-   `commit <https://pagure.io/freeipa/c/7f8d79f637825c61922aba8952acb5eccf6956bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f8d79f637825c61922aba8952acb5eccf6956bb>`__
    `#7046 <https://pagure.io/freeipa/issue/7046>`__
 -  ipatests: do not collect systemd journal when logfile_dir is missing
-   `commit <https://pagure.io/freeipa/c/44e3496bd1a3004bc7a6497cbd212bba7910b2e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44e3496bd1a3004bc7a6497cbd212bba7910b2e3>`__
    `#6971 <https://pagure.io/freeipa/issue/6971>`__
 -  ipatests: add systemd journal collection for multihost tests
-   `commit <https://pagure.io/freeipa/c/48b7e83511b80b3a1e0416134496ac37244f1073>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48b7e83511b80b3a1e0416134496ac37244f1073>`__
    `#6971 <https://pagure.io/freeipa/issue/6971>`__
 -  ipatests: change logdir naming pattern for multihost tests
-   `commit <https://pagure.io/freeipa/c/906c4c94590455c41603e5eca869b64c8d86d4f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/906c4c94590455c41603e5eca869b64c8d86d4f5>`__
    `#6971 <https://pagure.io/freeipa/issue/6971>`__
 -  named.conf template: add modification warning
-   `commit <https://pagure.io/freeipa/c/a924efe847e725d6a4dde209f57521a9a899ef23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a924efe847e725d6a4dde209f57521a9a899ef23>`__
 -  ca, kra install: validate DM password
-   `commit <https://pagure.io/freeipa/c/1b1bace75095cf7a26a56156ff537479ef4b9619>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b1bace75095cf7a26a56156ff537479ef4b9619>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  installutils: add DM password validator
-   `commit <https://pagure.io/freeipa/c/7a4a368c5387569f6802b5b3ca0686ea20f1de7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a4a368c5387569f6802b5b3ca0686ea20f1de7e>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  ca install: merge duplicated code for DM password
-   `commit <https://pagure.io/freeipa/c/80d61c2e01bdce0ab805037bfc1ce8e9543d2b10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80d61c2e01bdce0ab805037bfc1ce8e9543d2b10>`__
    `#6892 <https://pagure.io/freeipa/issue/6892>`__
 -  upgrade: add missing suffix to http instance
-   `commit <https://pagure.io/freeipa/c/ebefb281775d5bd5f32459ac597af78781d7dbf5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebefb281775d5bd5f32459ac597af78781d7dbf5>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  installer service: fix typo in service entry
-   `commit <https://pagure.io/freeipa/c/4b8ab77dd4800bd9c6b822502462ee649c88c663>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b8ab77dd4800bd9c6b822502462ee649c88c663>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  python2-ipalib: add missing python dependency
-   `commit <https://pagure.io/freeipa/c/999706fcdfa7fd4206a2399aa578fb00753d9978>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999706fcdfa7fd4206a2399aa578fb00753d9978>`__
    `#6920 <https://pagure.io/freeipa/issue/6920>`__
 -  kra install: update installation failure message
-   `commit <https://pagure.io/freeipa/c/0fa6c4d96ef2a55f853eedf3fb89433863e29ddf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa6c4d96ef2a55f853eedf3fb89433863e29ddf>`__
    `#6923 <https://pagure.io/freeipa/issue/6923>`__
 
 
@@ -1918,7 +1918,7 @@ Thorsten Scherf (2)
 ----------------------------------------------------------------------------------------------
 
 -  Changed ownership of ldiffile to DS_USER
-   `commit <https://pagure.io/freeipa/c/e8358eaea9ccf05c5c5ac0bf5c970663c611e333>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8358eaea9ccf05c5c5ac0bf5c970663c611e333>`__
    `#7010 <https://pagure.io/freeipa/issue/7010>`__
 -  Fixed typo in ipa-client-install output
-   `commit <https://pagure.io/freeipa/c/e3f849d541e8d054b0932d8ec1bd4c836e53c6f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3f849d541e8d054b0932d8ec1bd4c836e53c6f0>`__

--- a/src/page/Releases/4.6.1.rst
+++ b/src/page/Releases/4.6.1.rst
@@ -85,13 +85,13 @@ Alexander Bokovoy (3)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure upgrade also checks for IPv6 stack
-   `commit <https://pagure.io/freeipa/c/f05afa4813f425e9fc9960f63100431a78310638>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f05afa4813f425e9fc9960f63100431a78310638>`__
    `#7083 <https://pagure.io/freeipa/issue/7083>`__
 -  OTP import: support hash names with HMAC- prefix
-   `commit <https://pagure.io/freeipa/c/68c079d9d55ae63f318c8ead1e17d4966bfe4378>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c079d9d55ae63f318c8ead1e17d4966bfe4378>`__
    `#7146 <https://pagure.io/freeipa/issue/7146>`__
 -  dsinstance: Restore context after changing dse.ldif
-   `commit <https://pagure.io/freeipa/c/715e78654158fbebce7da5f0f35bca7807502162>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/715e78654158fbebce7da5f0f35bca7807502162>`__
    `#7150 <https://pagure.io/freeipa/issue/7150>`__
 
 
@@ -100,10 +100,10 @@ Felipe Volpone (2)
 ----------------------------------------------------------------------------------------------
 
 -  Changing idoverrideuser-\* to treat objectClass case insensitively
-   `commit <https://pagure.io/freeipa/c/a5e8f52801f5f6c59ac9bfcf2a14b002584c560a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5e8f52801f5f6c59ac9bfcf2a14b002584c560a>`__
    `#7074 <https://pagure.io/freeipa/issue/7074>`__
 -  Fixing how sssd.conf is updated when promoting a client to replica
-   `commit <https://pagure.io/freeipa/c/dc6ae8f2d868cdf846c017b8307dd12bab1b3768>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc6ae8f2d868cdf846c017b8307dd12bab1b3768>`__
    `#7127 <https://pagure.io/freeipa/issue/7127>`__
 
 
@@ -112,13 +112,13 @@ Florence Blanc-Renaud (3)
 ----------------------------------------------------------------------------------------------
 
 -  Fix ipa-server-upgrade with server cert tracking
-   `commit <https://pagure.io/freeipa/c/726a8b269c8843e495168deea3a4951c61de0e72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/726a8b269c8843e495168deea3a4951c61de0e72>`__
    `#7141 <https://pagure.io/freeipa/issue/7141>`__
 -  Python3: Fix winsync replication agreement
-   `commit <https://pagure.io/freeipa/c/3dea5b5d960674e5fb13ac60bb704495ba39b374>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dea5b5d960674e5fb13ac60bb704495ba39b374>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  Fix ipa config-mod --ca-renewal-master
-   `commit <https://pagure.io/freeipa/c/5f79504d3dc29891802c6d7eeaa465c298b7e417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f79504d3dc29891802c6d7eeaa465c298b7e417>`__
    `#7120 <https://pagure.io/freeipa/issue/7120>`__
 
 
@@ -127,10 +127,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-pki-retrieve-key: ensure we do not crash
-   `commit <https://pagure.io/freeipa/c/f9074dcc9c025594d6961dcbb03805b9a20bb220>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9074dcc9c025594d6961dcbb03805b9a20bb220>`__
    `#7115 <https://pagure.io/freeipa/issue/7115>`__
 -  issue_server_cert: avoid application of str to bytes
-   `commit <https://pagure.io/freeipa/c/a5a1bb1b93094e192ced394b7a51c3e50c0f04ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5a1bb1b93094e192ced394b7a51c3e50c0f04ef>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 
 
@@ -139,7 +139,7 @@ Martin Basti (1)
 ----------------------------------------------------------------------------------------------
 
 -  py3: set samba dependencies
-   `commit <https://pagure.io/freeipa/c/4b4fb990a5cdbf1b9a550005e3051a9ec51595d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b4fb990a5cdbf1b9a550005e3051a9ec51595d1>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 
 
@@ -148,7 +148,7 @@ Petr Vobornik (1)
 ----------------------------------------------------------------------------------------------
 
 -  browser config: cleanup after removal of Firefox extension
-   `commit <https://pagure.io/freeipa/c/0e8e94aa69dff9ac14490ae07dda61fccf1544b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e8e94aa69dff9ac14490ae07dda61fccf1544b0>`__
    `#7135 <https://pagure.io/freeipa/issue/7135>`__
 
 
@@ -157,13 +157,13 @@ Pavel Vomacka (3)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix calling undefined method during reset passwords
-   `commit <https://pagure.io/freeipa/c/44b012cc01cd6a543ba460cdc723eb469f22ffd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44b012cc01cd6a543ba460cdc723eb469f22ffd4>`__
    `#7143 <https://pagure.io/freeipa/issue/7143>`__
 -  WebUI: remove unused parameter from get_whoami_command
-   `commit <https://pagure.io/freeipa/c/47c7a192a6a96e89bd714854ed35466e48299cfe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47c7a192a6a96e89bd714854ed35466e48299cfe>`__
    `#7143 <https://pagure.io/freeipa/issue/7143>`__
 -  Adds whoami DS plugin in case that plugin is missing
-   `commit <https://pagure.io/freeipa/c/59ef33d2a20bb6ea1b19a40f049490a14fffd3c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59ef33d2a20bb6ea1b19a40f049490a14fffd3c8>`__
    `#7126 <https://pagure.io/freeipa/issue/7126>`__
 
 
@@ -172,10 +172,10 @@ Rob Crittenden (2)
 ----------------------------------------------------------------------------------------------
 
 -  Add exec to /var/lib/ipa/sysrestore for install status inquiries
-   `commit <https://pagure.io/freeipa/c/1b642245b96ed4afc26ac9e499bf1c87c02524c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b642245b96ed4afc26ac9e499bf1c87c02524c0>`__
    `#7081 <https://pagure.io/freeipa/issue/7081>`__
 -  Use TLS for the cert-find operation
-   `commit <https://pagure.io/freeipa/c/52a18de613458f8cabc81742ddf2e1311d772eb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52a18de613458f8cabc81742ddf2e1311d772eb9>`__
    `#7027 <https://pagure.io/freeipa/issue/7027>`__
 
 
@@ -184,86 +184,86 @@ Stanislav Laznicka (28)
 ----------------------------------------------------------------------------------------------
 
 -  Don't write p11-kit EKU extension object if no EKU
-   `commit <https://pagure.io/freeipa/c/7da5187987799210b596fe638e98ed26a8563b11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7da5187987799210b596fe638e98ed26a8563b11>`__
    `#7119 <https://pagure.io/freeipa/issue/7119>`__
 -  pylint: fix missing module
-   `commit <https://pagure.io/freeipa/c/1ff94501cc8bd6af302997eaafe706de91d78271>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ff94501cc8bd6af302997eaafe706de91d78271>`__
 -  travis: run the same tests in python2/3
-   `commit <https://pagure.io/freeipa/c/b3d07e5c42937bf55f7abdef828b9384168bfac5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3d07e5c42937bf55f7abdef828b9384168bfac5>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  certmap testing: fix wrong cert construction
-   `commit <https://pagure.io/freeipa/c/5c21a8d01d3041382df94145524879a7d6d96a7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c21a8d01d3041382df94145524879a7d6d96a7c>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  ldap2: don't use decode() on str instance
-   `commit <https://pagure.io/freeipa/c/3b255b22fd4473d191179c40f066a181e427d1ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b255b22fd4473d191179c40f066a181e427d1ac>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  client: fix retrieving certs from HTTP
-   `commit <https://pagure.io/freeipa/c/ba4386599331cf81d222687d658f5ce54e923478>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba4386599331cf81d222687d658f5ce54e923478>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  uninstall: remove deprecation warning
-   `commit <https://pagure.io/freeipa/c/f57ab91d1e7af3cd1d0b358895036722d62ae834>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f57ab91d1e7af3cd1d0b358895036722d62ae834>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  ldif: handle attribute names as strings
-   `commit <https://pagure.io/freeipa/c/1bb28b8a0f9b5d5c7c54964d8d93a81e3defb907>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bb28b8a0f9b5d5c7c54964d8d93a81e3defb907>`__
    `#7129 <https://pagure.io/freeipa/issue/7129>`__
 -  pkinit: fix sorting dictionaries
-   `commit <https://pagure.io/freeipa/c/ecee99c4c13f1fa5b57dff0162c258bcc227b77c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecee99c4c13f1fa5b57dff0162c258bcc227b77c>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  pkinit: don't fail when no pkinit servers found
-   `commit <https://pagure.io/freeipa/c/a0bbe68c133a18c61443d60aae1d2b9261fd0662>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0bbe68c133a18c61443d60aae1d2b9261fd0662>`__
    `#7144 <https://pagure.io/freeipa/issue/7144>`__
 -  travis: remove "fast" from "makecache fast"
-   `commit <https://pagure.io/freeipa/c/4f4b0ef61b9c9beb5d07db3e89a40d391fbaeaa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f4b0ef61b9c9beb5d07db3e89a40d391fbaeaa3>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Change Travis CI container to FreeIPA-owned
-   `commit <https://pagure.io/freeipa/c/79d9bdcec388b5b21b46fcb5a35d93d5b246ace2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79d9bdcec388b5b21b46fcb5a35d93d5b246ace2>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Change the requirements for pylint in wheel
-   `commit <https://pagure.io/freeipa/c/0449a4c8113719004297db3466fd189f22544875>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0449a4c8113719004297db3466fd189f22544875>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  rpcserver: don't call xmlserver.Command
-   `commit <https://pagure.io/freeipa/c/dfeadfed2c6fe1540933c46b540c657344a6a264>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfeadfed2c6fe1540933c46b540c657344a6a264>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  secrets: disable relative-imports for custodia
-   `commit <https://pagure.io/freeipa/c/388bc9459216183deda2336220ca1f5d6f9d0698>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/388bc9459216183deda2336220ca1f5d6f9d0698>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  pylint: disable \__hash_\_ for some classes
-   `commit <https://pagure.io/freeipa/c/2952af4dc450363ae6c6a466812ae4ef32d087f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2952af4dc450363ae6c6a466812ae4ef32d087f4>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  install.util: disable no-value-for-parameter
-   `commit <https://pagure.io/freeipa/c/e67cdb01c40f9eaec4518b327bd72fdd3100253c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e67cdb01c40f9eaec4518b327bd72fdd3100253c>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  pylint: make unsupported-assignment-operation check local
-   `commit <https://pagure.io/freeipa/c/9cf1f1d4cbe38730dff7f35476fd1a5ad09ca605>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cf1f1d4cbe38730dff7f35476fd1a5ad09ca605>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  sudocmd: fix unsupported assignment
-   `commit <https://pagure.io/freeipa/c/568926fd74f395be5c3b6a2d3bc811732c470fcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/568926fd74f395be5c3b6a2d3bc811732c470fcc>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  pylint: Iterate through dictionaries
-   `commit <https://pagure.io/freeipa/c/06f3aad5cf26b36e40abd0dd5fc547690c5c5b3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06f3aad5cf26b36e40abd0dd5fc547690c5c5b3d>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  parameters: convert Decimal.precision to int
-   `commit <https://pagure.io/freeipa/c/25d8229bf9843b857b1918026dc45da92771fa7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25d8229bf9843b857b1918026dc45da92771fa7c>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  dcerpc: disable unbalanced-tuple-unpacking
-   `commit <https://pagure.io/freeipa/c/f80af622810afc05675eaf7d0b91217ca41a05ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f80af622810afc05675eaf7d0b91217ca41a05ab>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  dcerpc: refactor assess_dcerpc_exception
-   `commit <https://pagure.io/freeipa/c/0b8207df865b28288519a1b6bcfea52f3c693096>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b8207df865b28288519a1b6bcfea52f3c693096>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  pylint: fix no-member in schema plugin
-   `commit <https://pagure.io/freeipa/c/7c64aca2d08fdc40901f4b5bf04a9d093944086a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c64aca2d08fdc40901f4b5bf04a9d093944086a>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  csrgen: fix incorrect codec for pyasn BitString
-   `commit <https://pagure.io/freeipa/c/47352fb19df83675863167601d57a6d28c278eb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47352fb19df83675863167601d57a6d28c278eb2>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  pylint: fix not-context-manager false positives
-   `commit <https://pagure.io/freeipa/c/ce148ed700b354b4324e65fe5a6097b80bdfc442>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce148ed700b354b4324e65fe5a6097b80bdfc442>`__
    `#6874 <https://pagure.io/freeipa/issue/6874>`__
 -  Travis: archive logs of py3 jobs
-   `commit <https://pagure.io/freeipa/c/0565600635777b71a96e63ed421820e0a0891ae5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0565600635777b71a96e63ed421820e0a0891ae5>`__
 -  travis: temporary workaround for Travis CI
-   `commit <https://pagure.io/freeipa/c/c8db7962e8ad24333d2210ae674c1cdb0c14c2f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8db7962e8ad24333d2210ae674c1cdb0c14c2f2>`__
 
 
 
@@ -271,15 +271,15 @@ Tomas Krizek (6)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.6.1
-   `commit <https://pagure.io/freeipa/c/152881ed191b6d26eff99a8d344822b3f4c90065>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/152881ed191b6d26eff99a8d344822b3f4c90065>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/7a99a538fe1aa62454c22c9f5d25cbf4c817273c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a99a538fe1aa62454c22c9f5d25cbf4c817273c>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/65cc71c2f35114e676a80aea99b310a42c2471f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65cc71c2f35114e676a80aea99b310a42c2471f1>`__
 -  spec: bump python-pyasn1 to 0.3.2-2
-   `commit <https://pagure.io/freeipa/c/f982a8aa93c5cf41090889273d00c3b9769a2c76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f982a8aa93c5cf41090889273d00c3b9769a2c76>`__
    `#7157 <https://pagure.io/freeipa/issue/7157>`__
 -  prci: use f26 template for master
-   `commit <https://pagure.io/freeipa/c/659f9d111de6dcfd084aab41940d69b050b27251>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/659f9d111de6dcfd084aab41940d69b050b27251>`__
 -  VERSION: set back to git snapshot
-   `commit <https://pagure.io/freeipa/c/404ce01b0402784bb163f9519666db5c55c47f37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/404ce01b0402784bb163f9519666db5c55c47f37>`__

--- a/src/page/Releases/4.6.2.rst
+++ b/src/page/Releases/4.6.2.rst
@@ -112,30 +112,30 @@ Alexander Bokovoy (10)
 ----------------------------------------------------------------------------------------------
 
 -  ipaserver/plugins/trust.py: pep8 compliance
-   `commit <https://pagure.io/freeipa/c/31c2b1dea8a34f6551f0b556afc0f0928eacaf8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31c2b1dea8a34f6551f0b556afc0f0928eacaf8b>`__
 -  trust: detect and error out when non-AD trust with IPA domain name
    exists
-   `commit <https://pagure.io/freeipa/c/c34c1da3291b722e21fec0875e0bf9c771423f96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c34c1da3291b722e21fec0875e0bf9c771423f96>`__
    `#7264 <https://pagure.io/freeipa/issue/7264>`__
 -  ipaserver/plugins/trust.py; fix some indenting issues
-   `commit <https://pagure.io/freeipa/c/0ea2e7e314cbabb155cb130051945e67a638bc24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ea2e7e314cbabb155cb130051945e67a638bc24>`__
 -  ipa-extdom-extop: refactor nsswitch operations
-   `commit <https://pagure.io/freeipa/c/d1dd79423ecf664f3a3bb7b9fa919f56d0bd32e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1dd79423ecf664f3a3bb7b9fa919f56d0bd32e5>`__
    `#5464 <https://pagure.io/freeipa/issue/5464>`__
 -  test_dns_plugin: cope with missing IPv6 in Travis
-   `commit <https://pagure.io/freeipa/c/c380e42a307c6e63762b79d1f0a51e73d10998cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c380e42a307c6e63762b79d1f0a51e73d10998cd>`__
 -  travis-ci: collect logs from cmocka tests
-   `commit <https://pagure.io/freeipa/c/993eb744d856bb1279b0a0bb2af69ea6ca244128>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/993eb744d856bb1279b0a0bb2af69ea6ca244128>`__
 -  ipa-kdb: override krb5.conf when testing KDC code in cmocka
-   `commit <https://pagure.io/freeipa/c/abcbb4501e79906f766b16ac9c3555ee88755a93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abcbb4501e79906f766b16ac9c3555ee88755a93>`__
 -  adtrust: filter out subdomains when defining our topology to AD
-   `commit <https://pagure.io/freeipa/c/1490e9c8277bd5bd996a532c498430485d423050>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1490e9c8277bd5bd996a532c498430485d423050>`__
    `#6666 <https://pagure.io/freeipa/issue/6666>`__
 -  ipa-replica-manage: implicitly ignore initial time skew in force-sync
-   `commit <https://pagure.io/freeipa/c/a3b0af387f8e3c67f1b223869d3f540989eb2f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3b0af387f8e3c67f1b223869d3f540989eb2f43>`__
    `#7211 <https://pagure.io/freeipa/issue/7211>`__
 -  ds: ignore time skew during initial replication step
-   `commit <https://pagure.io/freeipa/c/eaacfed3d9ae82b92897ddeb298d1baa295bed8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eaacfed3d9ae82b92897ddeb298d1baa295bed8e>`__
    `#7211 <https://pagure.io/freeipa/issue/7211>`__
 
 
@@ -144,12 +144,12 @@ Abhijeet Kasurde (3)
 ----------------------------------------------------------------------------------------------
 
 -  Trivial typo fix.
-   `commit <https://pagure.io/freeipa/c/62ada1290e07f292b207f9afcc1bec1a137f93fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62ada1290e07f292b207f9afcc1bec1a137f93fe>`__
 -  ipatests: Fix interactive prompt in ca_less tests
-   `commit <https://pagure.io/freeipa/c/467c065deee1613b3be82b4d2b2365eb9976e602>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/467c065deee1613b3be82b4d2b2365eb9976e602>`__
    `#7182 <https://pagure.io/freeipa/issue/7182>`__
 -  tests: correct usage of hostname in logger in tasks
-   `commit <https://pagure.io/freeipa/c/4116812a3ec9934fa9172f4e997467f10fbb807a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4116812a3ec9934fa9172f4e997467f10fbb807a>`__
    `#7190 <https://pagure.io/freeipa/issue/7190>`__
 
 
@@ -158,7 +158,7 @@ Alexander Koksharov (1)
 ----------------------------------------------------------------------------------------------
 
 -  kra-install: better warning message
-   `commit <https://pagure.io/freeipa/c/ca09c180a0d751e0e995b83434062bd164021267>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca09c180a0d751e0e995b83434062bd164021267>`__
    `#6952 <https://pagure.io/freeipa/issue/6952>`__
 
 
@@ -167,22 +167,22 @@ Aleksei Slaikovskii (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-restore: Set umask to 0022 while restoring
-   `commit <https://pagure.io/freeipa/c/74fcdefd22bbe47d9e5dd19fab829beb28c77743>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74fcdefd22bbe47d9e5dd19fab829beb28c77743>`__
    `#6844 <https://pagure.io/freeipa/issue/6844>`__
 -  View plugin/command help in pager
-   `commit <https://pagure.io/freeipa/c/36ccc8facea3150e4c96ce789d1fb115685c50cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36ccc8facea3150e4c96ce789d1fb115685c50cf>`__
    `#7225 <https://pagure.io/freeipa/issue/7225>`__
 -  Add a notice to restart ipa services after certs are installed
-   `commit <https://pagure.io/freeipa/c/9175b9c12d9e488c38281f91a961db4083565281>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9175b9c12d9e488c38281f91a961db4083565281>`__
    `#7016 <https://pagure.io/freeipa/issue/7016>`__
 -  Fix TypeError while ipa-restore is restoring a backup
-   `commit <https://pagure.io/freeipa/c/8fc40ae5ee741b8df94a74c67752bd323dc68e07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fc40ae5ee741b8df94a74c67752bd323dc68e07>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  ipaclient.plugins.dns: Cast DNS name to unicode
-   `commit <https://pagure.io/freeipa/c/9dc4ddf9cd05b50d25abdd1b11406f48ce58e3d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dc4ddf9cd05b50d25abdd1b11406f48ce58e3d5>`__
    `#7185 <https://pagure.io/freeipa/issue/7185>`__
 -  Less confusing message for PKINIT configuration during install
-   `commit <https://pagure.io/freeipa/c/f8e6c997b54564533250e536fbe250f460035235>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8e6c997b54564533250e536fbe250f460035235>`__
    `#7179 <https://pagure.io/freeipa/issue/7179>`__
 
 
@@ -191,62 +191,62 @@ Christian Heimes (23)
 ----------------------------------------------------------------------------------------------
 
 -  Update IPA_GIT_BRANCH to ipa-4-6
-   `commit <https://pagure.io/freeipa/c/219ee2fa40d7d325c1b2fa67c6b0d6b892342888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/219ee2fa40d7d325c1b2fa67c6b0d6b892342888>`__
 -  Add make targets for fast linting and testing
-   `commit <https://pagure.io/freeipa/c/f1fcbe6b546632904bdf63f9f636c28e22a666e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1fcbe6b546632904bdf63f9f636c28e22a666e7>`__
 -  Add marker needs_ipaapi and option to skip tests
-   `commit <https://pagure.io/freeipa/c/cc389e9fe69f9f145d7b36837168a7886a44b501>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc389e9fe69f9f145d7b36837168a7886a44b501>`__
 -  Add python_requires to Python package metadata
-   `commit <https://pagure.io/freeipa/c/e88e2b0cde4a5d81aad84a4b76a8bb0dc7079d21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e88e2b0cde4a5d81aad84a4b76a8bb0dc7079d21>`__
    `#7294 <https://pagure.io/freeipa/issue/7294>`__
 -  Remove Custodia keys on uninstall
-   `commit <https://pagure.io/freeipa/c/fef419bc6562c83ca84cf2b477e1cd81da0e789f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fef419bc6562c83ca84cf2b477e1cd81da0e789f>`__
    `#7253 <https://pagure.io/freeipa/issue/7253>`__
 -  Update to python-ldap 3.0.0
-   `commit <https://pagure.io/freeipa/c/e8536f5084cbaf6712c98287bd0d0bb20740b91e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8536f5084cbaf6712c98287bd0d0bb20740b91e>`__
 -  Update builddep command to install Python 3 and tox deps
-   `commit <https://pagure.io/freeipa/c/8c2cad6c9ccf9e74d1caf54932aa6f2c990fd361>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c2cad6c9ccf9e74d1caf54932aa6f2c990fd361>`__
 -  Add workaround for pytest 3.3.0 bug
-   `commit <https://pagure.io/freeipa/c/4c92b6dabc40d886560bf178790fb9e738ac5060>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c92b6dabc40d886560bf178790fb9e738ac5060>`__
 -  Fix dict iteration bug in dnsrecord_show
-   `commit <https://pagure.io/freeipa/c/a090225cb5e7ab8f0dccc4804182294bde386290>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a090225cb5e7ab8f0dccc4804182294bde386290>`__
    `#7275 <https://pagure.io/freeipa/issue/7275>`__
 -  Reproducer for bug in structured dnsrecord_show
-   `commit <https://pagure.io/freeipa/c/4de5bf3789bda5c808cf0fbfd03ef5f2a4c1f565>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4de5bf3789bda5c808cf0fbfd03ef5f2a4c1f565>`__
    `#7275 <https://pagure.io/freeipa/issue/7275>`__
 -  Use Python 3 on Travis
-   `commit <https://pagure.io/freeipa/c/dcb1f9d48ca282eacddebf6a69ed360f6462d1d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcb1f9d48ca282eacddebf6a69ed360f6462d1d1>`__
 -  Prevent installation of Py2 and Py3 mod_wsgi
-   `commit <https://pagure.io/freeipa/c/66e38e917f6517a86cd08839018e14d03aad4a5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66e38e917f6517a86cd08839018e14d03aad4a5b>`__
    `#7161 <https://pagure.io/freeipa/issue/7161>`__
 -  libotp: add libraries after objects
-   `commit <https://pagure.io/freeipa/c/40c98383aa374eee6598972c2fa40edebbc77f39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40c98383aa374eee6598972c2fa40edebbc77f39>`__
    `#7189 <https://pagure.io/freeipa/issue/7189>`__
 -  Require UTF-8 fs encoding
-   `commit <https://pagure.io/freeipa/c/1ea1fdd7421bcf288ed82939e84352af3cd6a6b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ea1fdd7421bcf288ed82939e84352af3cd6a6b4>`__
    `#5887 <https://pagure.io/freeipa/issue/5887>`__
 -  Run tox tests for PyPI packages on Travis
-   `commit <https://pagure.io/freeipa/c/29d0c211b8051b2b91f9b610a9c04d9afd17818b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29d0c211b8051b2b91f9b610a9c04d9afd17818b>`__
 -  Py3: Fix vault tests
-   `commit <https://pagure.io/freeipa/c/7b446f03a26e42165b0d855acd1e2044304d9423>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b446f03a26e42165b0d855acd1e2044304d9423>`__
    `#7033 <https://pagure.io/freeipa/issue/7033>`__
 -  Use namespace-aware meta importer for ipaplatform
-   `commit <https://pagure.io/freeipa/c/dbc9c01d055f16bb513258a6e49f632a144d856f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbc9c01d055f16bb513258a6e49f632a144d856f>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__
 -  Test script for ipa-custodia
-   `commit <https://pagure.io/freeipa/c/4ffe4847e94561814263ad8a5130b292fda54077>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ffe4847e94561814263ad8a5130b292fda54077>`__
 -  Remove ignore_import_errors
-   `commit <https://pagure.io/freeipa/c/bb5b8b1e4af3768f105f76cf01a041c8b31ffe25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb5b8b1e4af3768f105f76cf01a041c8b31ffe25>`__
 -  Backup ipa-custodia conf and keys
-   `commit <https://pagure.io/freeipa/c/a926a002d65d5980df8b6f6f5fe6a4aa811ec41e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a926a002d65d5980df8b6f6f5fe6a4aa811ec41e>`__
    `#7247 <https://pagure.io/freeipa/issue/7247>`__
 -  Py3: fix fetching of tar files
-   `commit <https://pagure.io/freeipa/c/5de813b4e4da0953d78183eaf4252da39e33466c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5de813b4e4da0953d78183eaf4252da39e33466c>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  Use os.path.isfile() and isdir()
-   `commit <https://pagure.io/freeipa/c/f044643fa6a83f47ac06de444dca39da69946ee0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f044643fa6a83f47ac06de444dca39da69946ee0>`__
 -  Block PyOpenSSL to prevent SELinux execmem in wsgi
-   `commit <https://pagure.io/freeipa/c/52dd5e138b7ebec68c7280122b1284648bd4117b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52dd5e138b7ebec68c7280122b1284648bd4117b>`__
    `#5442 <https://pagure.io/freeipa/issue/5442>`__
 
 
@@ -256,9 +256,9 @@ David Kupka (2)
 
 -  schema: Fix internal error in param-{find,show} with nonexistent
    object
-   `commit <https://pagure.io/freeipa/c/41de9cc381e8227225e6628109b80e065be18ad8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41de9cc381e8227225e6628109b80e065be18ad8>`__
 -  tests: Add LDAP URI to ldappasswd explicitly
-   `commit <https://pagure.io/freeipa/c/f0f38d5563fd460369238b564f875ee645d6090b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0f38d5563fd460369238b564f875ee645d6090b>`__
    `#6622 <https://pagure.io/freeipa/issue/6622>`__
 
 
@@ -267,22 +267,22 @@ Felipe Barreto (6)
 ----------------------------------------------------------------------------------------------
 
 -  Warning the user when using a loopback IP as forwarder
-   `commit <https://pagure.io/freeipa/c/29e1f264740d9f0eee47441f1a9b61f2a6abfb7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29e1f264740d9f0eee47441f1a9b61f2a6abfb7a>`__
    `#5801 <https://pagure.io/freeipa/issue/5801>`__
 -  Removing replica-s4u2proxy.ldif since it's not used anymore
-   `commit <https://pagure.io/freeipa/c/bff8cb6e8db67790539936360d139ec7d0e52823>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bff8cb6e8db67790539936360d139ec7d0e52823>`__
    `#7174 <https://pagure.io/freeipa/issue/7174>`__
 -  Fix log capture when running pytests_multihosts commands
-   `commit <https://pagure.io/freeipa/c/d9737c0fe49711e148cc5c417d293d2dcdaf3c7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9737c0fe49711e148cc5c417d293d2dcdaf3c7c>`__
    `#7186 <https://pagure.io/freeipa/issue/7186>`__
 -  Checks if replica-s4u2proxy.ldif should be applied
-   `commit <https://pagure.io/freeipa/c/b3dfc13f36de365b78bfbf6ac0fda2549d134739>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3dfc13f36de365b78bfbf6ac0fda2549d134739>`__
    `#7174 <https://pagure.io/freeipa/issue/7174>`__
 -  Fixing tox and pylint errors
-   `commit <https://pagure.io/freeipa/c/90aa4d6b9379ec02873c7cfa20364eb64721f5af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90aa4d6b9379ec02873c7cfa20364eb64721f5af>`__
    `#7132 <https://pagure.io/freeipa/issue/7132>`__
 -  Fixing param-{find,show} and output-{find,show} commands
-   `commit <https://pagure.io/freeipa/c/68178a45523ecdfb11216261cd62f7a68ee87426>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68178a45523ecdfb11216261cd62f7a68ee87426>`__
    `#7134 <https://pagure.io/freeipa/issue/7134>`__
 
 
@@ -291,34 +291,34 @@ Florence Blanc-Renaud (10)
 ----------------------------------------------------------------------------------------------
 
 -  Improve help message for ipa trust-add --range-type
-   `commit <https://pagure.io/freeipa/c/131ac7c8900ecf29499893869316759a3142412c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/131ac7c8900ecf29499893869316759a3142412c>`__
    `#7308 <https://pagure.io/freeipa/issue/7308>`__
 -  Fix ca less IPA install on fips mode
-   `commit <https://pagure.io/freeipa/c/ba25408d997ec064038ee815e970b4b39a633f16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba25408d997ec064038ee815e970b4b39a633f16>`__
    `#7280 <https://pagure.io/freeipa/issue/7280>`__
 -  Fix ipa-restore (python2)
-   `commit <https://pagure.io/freeipa/c/71c54ef03cabd598ff1c0032529793dbbcd59a9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71c54ef03cabd598ff1c0032529793dbbcd59a9e>`__
    `#7231 <https://pagure.io/freeipa/issue/7231>`__
 -  ipa-getkeytab man page: add more details about the -r option
-   `commit <https://pagure.io/freeipa/c/e76ab3e8b08a4b4d08f05208117be38e383fa0a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e76ab3e8b08a4b4d08f05208117be38e383fa0a6>`__
    `#7237 <https://pagure.io/freeipa/issue/7237>`__
 -  Py3: fix ipa-replica-conncheck
-   `commit <https://pagure.io/freeipa/c/50fb9b6272dbedd64d8f200ab72f70648e78b380>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50fb9b6272dbedd64d8f200ab72f70648e78b380>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  Fix ipa-replica-conncheck when called with --principal
-   `commit <https://pagure.io/freeipa/c/cd09db2042a38cc4026dfd5591e38275ca602d93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd09db2042a38cc4026dfd5591e38275ca602d93>`__
    `#7221 <https://pagure.io/freeipa/issue/7221>`__
 -  py3: fix ipa cert-request --database ...
-   `commit <https://pagure.io/freeipa/c/d00a2c75413d392c60e47e89652ea18fab5ccd02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d00a2c75413d392c60e47e89652ea18fab5ccd02>`__
    `#7148 <https://pagure.io/freeipa/issue/7148>`__
 -  ipa-cacert-manage renew: switch from ext-signed CA to self-signed
-   `commit <https://pagure.io/freeipa/c/b1eee1155ddcfe86cb1651e2e476ce49ef854e11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1eee1155ddcfe86cb1651e2e476ce49ef854e11>`__
    `#7173 <https://pagure.io/freeipa/issue/7173>`__
 -  ipa-server-upgrade: do not add untracked certs to the request list
-   `commit <https://pagure.io/freeipa/c/ef6aa6759bfc7e0a46e1dafefb3a1b9d15b5f553>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef6aa6759bfc7e0a46e1dafefb3a1b9d15b5f553>`__
    `#7151 <https://pagure.io/freeipa/issue/7151>`__
 -  ipa-server-upgrade: fix the logic for tracking certs
-   `commit <https://pagure.io/freeipa/c/b70e1f59c54d68e8e318db396b777efd0e340e8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b70e1f59c54d68e8e318db396b777efd0e340e8d>`__
    `#7151 <https://pagure.io/freeipa/issue/7151>`__
 
 
@@ -327,70 +327,70 @@ Fraser Tweedale (22)
 ----------------------------------------------------------------------------------------------
 
 -  ipa_certupdate: avoid classmethod and staticmethod
-   `commit <https://pagure.io/freeipa/c/5eab20e3e8c9a9e9a2fe1d91de65045705637ccd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5eab20e3e8c9a9e9a2fe1d91de65045705637ccd>`__
    `#6577 <https://pagure.io/freeipa/issue/6577>`__
 -  Run certupdate after promoting to CA-ful deployment
-   `commit <https://pagure.io/freeipa/c/cd4d9cc46d7d4b3bb9ed7a69976b0986b083abfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd4d9cc46d7d4b3bb9ed7a69976b0986b083abfa>`__
    `#7230 <https://pagure.io/freeipa/issue/7230>`__
 -  ipa-ca-install: run certupdate as initial step
-   `commit <https://pagure.io/freeipa/c/75a3ede7107c07521a668bcfeb268a5024132731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75a3ede7107c07521a668bcfeb268a5024132731>`__
    `#6577 <https://pagure.io/freeipa/issue/6577>`__
 -  CertUpdate: make it easy to invoke from other programs
-   `commit <https://pagure.io/freeipa/c/75e4cf1d2a4de9323b95437b6097059014d21ac3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75e4cf1d2a4de9323b95437b6097059014d21ac3>`__
    `#6577 <https://pagure.io/freeipa/issue/6577>`__
 -  renew_ra_cert: fix update of IPA RA user entry
-   `commit <https://pagure.io/freeipa/c/9d5e3d199d8a05102805f8550f6fc649f29a985c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d5e3d199d8a05102805f8550f6fc649f29a985c>`__
    `#7282 <https://pagure.io/freeipa/issue/7282>`__
 -  Use correct version of Python in RPM scripts
-   `commit <https://pagure.io/freeipa/c/74ec1f934ecfb01f2c2dff3146cca28d67b4e2a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74ec1f934ecfb01f2c2dff3146cca28d67b4e2a6>`__
    `#7299 <https://pagure.io/freeipa/issue/7299>`__
 -  Re-enable some KRA installation tests
-   `commit <https://pagure.io/freeipa/c/17b4fa7832517879baa8964500451b8e83319a13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17b4fa7832517879baa8964500451b8e83319a13>`__
    `#7220 <https://pagure.io/freeipa/issue/7220>`__
 -  Remove caJarSigningCert profile and related code
-   `commit <https://pagure.io/freeipa/c/ea116544db19554efd7389ef436bf8c97a2518b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea116544db19554efd7389ef436bf8c97a2518b6>`__
    `#7226 <https://pagure.io/freeipa/issue/7226>`__
 -  CertDB: remove unused method issue_signing_cert
-   `commit <https://pagure.io/freeipa/c/6441185b789cd693cfdc22020e647ceecdc4e2af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6441185b789cd693cfdc22020e647ceecdc4e2af>`__
    `#7226 <https://pagure.io/freeipa/issue/7226>`__
 -  Remove XPI and JAR MIME types from httpd config
-   `commit <https://pagure.io/freeipa/c/3e62dd1686b66557e158a12dff923c88ecadbd6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e62dd1686b66557e158a12dff923c88ecadbd6f>`__
    `#7226 <https://pagure.io/freeipa/issue/7226>`__
 -  Remove mention of firefox plugin after CA-less install
-   `commit <https://pagure.io/freeipa/c/a9b168665901615e2fd89ad6f4957b008b7534eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9b168665901615e2fd89ad6f4957b008b7534eb>`__
    `#7226 <https://pagure.io/freeipa/issue/7226>`__
 -  ipa-cacert-manage: avoid some duplicate string definitions
-   `commit <https://pagure.io/freeipa/c/78d0122c938cc31d288116370ec1a14d5bddd7f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78d0122c938cc31d288116370ec1a14d5bddd7f8>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  ipa-cacert-manage: handle alternative tracking request CA name
-   `commit <https://pagure.io/freeipa/c/d07563b744060a4c4d02cb44de20d5589800f38e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d07563b744060a4c4d02cb44de20d5589800f38e>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  Add tests for external CA profile specifiers
-   `commit <https://pagure.io/freeipa/c/05be8398572fc517e4adc48b2454a68bc402ce26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05be8398572fc517e4adc48b2454a68bc402ce26>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  ipa-cacert-manage: support MS V2 template extension
-   `commit <https://pagure.io/freeipa/c/562f114aad4dc674f87f6264ff123b9f0cf403f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/562f114aad4dc674f87f6264ff123b9f0cf403f9>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  certmonger: add support for MS V2 template
-   `commit <https://pagure.io/freeipa/c/9d8c2fcf2407487a2273e980ef78268369b39cbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d8c2fcf2407487a2273e980ef78268369b39cbd>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  certmonger: refactor 'resubmit_request' and 'modify'
-   `commit <https://pagure.io/freeipa/c/9774af3dc7c1ddf0b8f4386ce599c64dbcf38120>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9774af3dc7c1ddf0b8f4386ce599c64dbcf38120>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  ipa-ca-install: add --external-ca-profile option
-   `commit <https://pagure.io/freeipa/c/0054cfb7ebd41fb39a92d71e623cf2cbf8365de3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0054cfb7ebd41fb39a92d71e623cf2cbf8365de3>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  install: allow specifying external CA template
-   `commit <https://pagure.io/freeipa/c/f612678ad6af006bd3bb949db119d126c0ba1822>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f612678ad6af006bd3bb949db119d126c0ba1822>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  Remove duplicate references to external CA type
-   `commit <https://pagure.io/freeipa/c/6de5432d25723b5ae4af88bf126fb48862abc8ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6de5432d25723b5ae4af88bf126fb48862abc8ce>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  cli: simplify parsing of arbitrary types
-   `commit <https://pagure.io/freeipa/c/61303c73a20f45499c70add171478c96eb24305e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61303c73a20f45499c70add171478c96eb24305e>`__
    `#6858 <https://pagure.io/freeipa/issue/6858>`__
 -  py3: fix pkcs7 file processing
-   `commit <https://pagure.io/freeipa/c/3f21e70786a3ed352b51265c67a27a4e49859d5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f21e70786a3ed352b51265c67a27a4e49859d5b>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 
 
@@ -399,7 +399,7 @@ John Morris (1)
 ----------------------------------------------------------------------------------------------
 
 -  Increase dbus client timeouts during CA install
-   `commit <https://pagure.io/freeipa/c/7881d6db3e1795be280fe3ce77533a787f0d1e46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7881d6db3e1795be280fe3ce77533a787f0d1e46>`__
 
 
 
@@ -407,40 +407,40 @@ Michal Reznik (12)
 ----------------------------------------------------------------------------------------------
 
 -  test_batch_plugin: fix py2/3 failing assertion
-   `commit <https://pagure.io/freeipa/c/72ff10b230b8d3fc9d921c8b4c8ab4cad51b89c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72ff10b230b8d3fc9d921c8b4c8ab4cad51b89c5>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  test_vault: increase WAIT_AFTER_ARCHIVE
-   `commit <https://pagure.io/freeipa/c/2b8f6121090cda022db160b40f618699ef604ae5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b8f6121090cda022db160b40f618699ef604ae5>`__
    `#7265 <https://pagure.io/freeipa/issue/7265>`__
 -  test_caless: fix http.p12 is not valid
-   `commit <https://pagure.io/freeipa/c/d94ffdb795e150d39302d0f6d361257350a5aaad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d94ffdb795e150d39302d0f6d361257350a5aaad>`__
    `#7254 <https://pagure.io/freeipa/issue/7254>`__
 -  test_caless: fix TypeError on domain_level compare
-   `commit <https://pagure.io/freeipa/c/3cd3f224096bfcb571b55693b3a3ecfa69931095>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cd3f224096bfcb571b55693b3a3ecfa69931095>`__
    `#7254 <https://pagure.io/freeipa/issue/7254>`__
 -  manpage: ipa-replica-conncheck - fix minor typo
-   `commit <https://pagure.io/freeipa/c/ec153949d703ec36444af3594433261fd82127f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec153949d703ec36444af3594433261fd82127f6>`__
    `#7250 <https://pagure.io/freeipa/issue/7250>`__
 -  test_forced_client: decode get_file_contents() result
-   `commit <https://pagure.io/freeipa/c/0cdf5ffa6fe62002c242893b4d50b1fb505d4947>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cdf5ffa6fe62002c242893b4d50b1fb505d4947>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  test_external_dns: add missing test cases
-   `commit <https://pagure.io/freeipa/c/c11395685bf667810dee07a71554bc9ec31be371>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c11395685bf667810dee07a71554bc9ec31be371>`__
    `#6091 <https://pagure.io/freeipa/issue/6091>`__
 -  test_caless: open CA cert in binary mode
-   `commit <https://pagure.io/freeipa/c/f2a1766cacf0ecdce0b408131c88d0b50f435786>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2a1766cacf0ecdce0b408131c88d0b50f435786>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  tests: add host zone with overlap
-   `commit <https://pagure.io/freeipa/c/c6bedd7e8fe512db60a03f963d6c844f37030cc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6bedd7e8fe512db60a03f963d6c844f37030cc9>`__
    `#7124 <https://pagure.io/freeipa/issue/7124>`__
 -  tests_py3: decode get_file_contents() result
-   `commit <https://pagure.io/freeipa/c/1bee023caf908ee1256c2c12722de9e44e84a582>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bee023caf908ee1256c2c12722de9e44e84a582>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  test_caless: add caless to external CA test
-   `commit <https://pagure.io/freeipa/c/5d954986166b51a7ed5895fd5d5c686b1f3dfe4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d954986166b51a7ed5895fd5d5c686b1f3dfe4f>`__
    `#7155 <https://pagure.io/freeipa/issue/7155>`__
 -  test_external_ca: switch to python-cryptography
-   `commit <https://pagure.io/freeipa/c/353a4910897976471630639fc445a7c66f71b1a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/353a4910897976471630639fc445a7c66f71b1a5>`__
    `#7154 <https://pagure.io/freeipa/issue/7154>`__
 
 
@@ -449,7 +449,7 @@ Mohammad Rizwan Yusuf (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: replica install with existing entry on master
-   `commit <https://pagure.io/freeipa/c/05acc9c1f5b39c2fae27f53a2b1d1e3dca72b29b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05acc9c1f5b39c2fae27f53a2b1d1e3dca72b29b>`__
    `#7174 <https://pagure.io/freeipa/issue/7174>`__,
    `#7276 <https://pagure.io/freeipa/issue/7276>`__
 
@@ -459,11 +459,11 @@ Petr Čech (2)
 ----------------------------------------------------------------------------------------------
 
 -  tests: Mark failing tests as failing
-   `commit <https://pagure.io/freeipa/c/e8a3c0e768ae2b46912d7b501f21d45072a15b6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8a3c0e768ae2b46912d7b501f21d45072a15b6f>`__
    `#7008 <https://pagure.io/freeipa/issue/7008>`__,
    `#7220 <https://pagure.io/freeipa/issue/7220>`__
 -  ipatests: Fix on logs collection
-   `commit <https://pagure.io/freeipa/c/085ec3ee21351d83a3e00041c475a58dd6f44d86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/085ec3ee21351d83a3e00041c475a58dd6f44d86>`__
    `#7214 <https://pagure.io/freeipa/issue/7214>`__
 
 
@@ -472,7 +472,7 @@ Pavel Vomacka (1)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: make Domain Resolution Order writable
-   `commit <https://pagure.io/freeipa/c/94a645939628666d57537ce24f85b07ce80db2a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94a645939628666d57537ce24f85b07ce80db2a4>`__
    `#7169 <https://pagure.io/freeipa/issue/7169>`__
 
 
@@ -481,24 +481,24 @@ Rob Crittenden (7)
 ----------------------------------------------------------------------------------------------
 
 -  Run server upgrade in ipactl start/restart
-   `commit <https://pagure.io/freeipa/c/b2d3b568ce2e1163e67dc633ea84c418baa0b553>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2d3b568ce2e1163e67dc633ea84c418baa0b553>`__
    `#6968 <https://pagure.io/freeipa/issue/6968>`__
 -  If the cafile is not present or readable then raise an exception
-   `commit <https://pagure.io/freeipa/c/6273ec612b1318fbab2208b39d5855909c38e983>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6273ec612b1318fbab2208b39d5855909c38e983>`__
    `#7145 <https://pagure.io/freeipa/issue/7145>`__
 -  Add test to ensure that properties are being set in rpcclient
-   `commit <https://pagure.io/freeipa/c/cd0066a5de7bb58e0169917ec4eeb6d4b96055cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd0066a5de7bb58e0169917ec4eeb6d4b96055cf>`__
 -  Use the CA chain file from the RPC context
-   `commit <https://pagure.io/freeipa/c/806b76b650da1d2b7c2fe135dfe3691355e1e849>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/806b76b650da1d2b7c2fe135dfe3691355e1e849>`__
    `#7145 <https://pagure.io/freeipa/issue/7145>`__
 -  Fix cert-find for CA-less installations
-   `commit <https://pagure.io/freeipa/c/bbb781a73aed67efe2f7c25f9f95f57acfaef7f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbb781a73aed67efe2f7c25f9f95f57acfaef7f7>`__
    `#7202 <https://pagure.io/freeipa/issue/7202>`__
 -  Use 389-ds provided method for file limits tuning
-   `commit <https://pagure.io/freeipa/c/669e84b85c16fd47a0a832de89062611ddf8fad2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/669e84b85c16fd47a0a832de89062611ddf8fad2>`__
    `#6994 <https://pagure.io/freeipa/issue/6994>`__
 -  Collect group membership without a size limit
-   `commit <https://pagure.io/freeipa/c/b516ad8af484a12a0a88375cef7da12569d6ae01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b516ad8af484a12a0a88375cef7da12569d6ae01>`__
    `#7112 <https://pagure.io/freeipa/issue/7112>`__
 
 
@@ -507,7 +507,7 @@ Rishabh Dave (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-ca-install: mention REPLICA_FILE as optional in help
-   `commit <https://pagure.io/freeipa/c/411f5bebd84ada977ed554cc72bf0288401ba7f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/411f5bebd84ada977ed554cc72bf0288401ba7f2>`__
    `#7223 <https://pagure.io/freeipa/issue/7223>`__
 
 
@@ -516,7 +516,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: reinit trusted domain data for enterprise principals
-   `commit <https://pagure.io/freeipa/c/f7da70183d0d15e4ee5f8f1023bf5b1697f2d67f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7da70183d0d15e4ee5f8f1023bf5b1697f2d67f>`__
    `#7172 <https://pagure.io/freeipa/issue/7172>`__
 
 
@@ -525,63 +525,63 @@ Stanislav Laznicka (22)
 ----------------------------------------------------------------------------------------------
 
 -  Don't allow OTP or RADIUS in FIPS mode
-   `commit <https://pagure.io/freeipa/c/61e7c41bb8e87a9304f422343a1453974e528ce9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61e7c41bb8e87a9304f422343a1453974e528ce9>`__
    `#7168 <https://pagure.io/freeipa/issue/7168>`__
 -  caless tests: decode cert bytes in debug log
-   `commit <https://pagure.io/freeipa/c/59a5b245ca55f1abfd169ae9b9422c94d3f780b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59a5b245ca55f1abfd169ae9b9422c94d3f780b3>`__
 -  caless tests: make debug log of certificates sensible
-   `commit <https://pagure.io/freeipa/c/fa23cdc70feba90ca595d37dec28002b4633afc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa23cdc70feba90ca595d37dec28002b4633afc9>`__
 -  Add indexing to improve host-find performance
-   `commit <https://pagure.io/freeipa/c/b5735dd3d62f30507cc5d7348edb325cedcf6122>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5735dd3d62f30507cc5d7348edb325cedcf6122>`__
    `#6371 <https://pagure.io/freeipa/issue/6371>`__
 -  Add the sub operation for fqdn index config
-   `commit <https://pagure.io/freeipa/c/47f426a2d31ae3224e355af4de573e4f8c8ccd03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47f426a2d31ae3224e355af4de573e4f8c8ccd03>`__
    `#6371 <https://pagure.io/freeipa/issue/6371>`__
 -  x509: remove subject_base() function
-   `commit <https://pagure.io/freeipa/c/e2bcf42bba0aa3ccc81ce5659ba4eb99c1072c1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2bcf42bba0aa3ccc81ce5659ba4eb99c1072c1c>`__
 -  x509: remove the strip_header() function
-   `commit <https://pagure.io/freeipa/c/ffc162468e5ddaa9c0e4b8fced1a7d3ef15beb64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffc162468e5ddaa9c0e4b8fced1a7d3ef15beb64>`__
 -  py3: pass raw entries to LDIFWriter
-   `commit <https://pagure.io/freeipa/c/5a2b42839bc130078a4058c5065df9ebda059508>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a2b42839bc130078a4058c5065df9ebda059508>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  ipatests: use python3 if built with python3
-   `commit <https://pagure.io/freeipa/c/9baa3f6101cb81cf1bb0dd02749024e40f762c61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9baa3f6101cb81cf1bb0dd02749024e40f762c61>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  PRCI: use a new template for py3 testing
-   `commit <https://pagure.io/freeipa/c/c16679222f213015b5345e6ff5717dd95892cac7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c16679222f213015b5345e6ff5717dd95892cac7>`__
 -  csrgen_ffi: cast the DN value to unsigned char \*
-   `commit <https://pagure.io/freeipa/c/3ea9a0d9fe0ab982230878764d0f9abc71dae475>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ea9a0d9fe0ab982230878764d0f9abc71dae475>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  Remove pkcs10 module contents
-   `commit <https://pagure.io/freeipa/c/c73a1800263e17b61d4bd2f114c7d876cac04bcd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c73a1800263e17b61d4bd2f114c7d876cac04bcd>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  Add tests for CertificateSigningRequest
-   `commit <https://pagure.io/freeipa/c/eb657e0b63eedd9eebebcc02acb202edf7884f1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb657e0b63eedd9eebebcc02acb202edf7884f1f>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  parameters: introduce CertificateSigningRequest
-   `commit <https://pagure.io/freeipa/c/4fe53145c9bc6fadbedbf81e8fa734b7354ea910>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fe53145c9bc6fadbedbf81e8fa734b7354ea910>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  parameters: relax type checks
-   `commit <https://pagure.io/freeipa/c/db19ecc9696ea0de2632cd1ae7d204d0b3e228ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db19ecc9696ea0de2632cd1ae7d204d0b3e228ef>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  csrgen: update docstring for py3
-   `commit <https://pagure.io/freeipa/c/72536fdd33b57a60974422acabe5b83003993786>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72536fdd33b57a60974422acabe5b83003993786>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  csrgen: accept public key info as Bytes
-   `commit <https://pagure.io/freeipa/c/8495683d99692c893a5cdcc5133dec33d6733925>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8495683d99692c893a5cdcc5133dec33d6733925>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  csrgen_ffi: pass bytes where "char \*" is required
-   `commit <https://pagure.io/freeipa/c/f860d0f50ec295da998c406bd967f35a1b42f979>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f860d0f50ec295da998c406bd967f35a1b42f979>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  travis: pep8 changes to pycodestyle
-   `commit <https://pagure.io/freeipa/c/ba1064ee3e1d9ab50596a4451f3ad69b3f9e5fdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba1064ee3e1d9ab50596a4451f3ad69b3f9e5fdd>`__
 -  p11-kit: add serial number in DER format
-   `commit <https://pagure.io/freeipa/c/07630799b65721f2d3543d33a8ede4cf9064be71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07630799b65721f2d3543d33a8ede4cf9064be71>`__
    `#7210 <https://pagure.io/freeipa/issue/7210>`__
 -  travis: make tests fail if pep8 does not pass
-   `commit <https://pagure.io/freeipa/c/39239fea14af08293c7e0f3b503dd218b3b590d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39239fea14af08293c7e0f3b503dd218b3b590d8>`__
 -  Remove the \`message\` attribute from exceptions
-   `commit <https://pagure.io/freeipa/c/9b34869271dc0e5518a2f25903f2d3875cff9492>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b34869271dc0e5518a2f25903f2d3875cff9492>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 
 
@@ -590,7 +590,7 @@ Thierry Bordaz (1)
 ----------------------------------------------------------------------------------------------
 
 -  389-ds-base crashed as part of ipa-server-intall in ipa-uuid
-   `commit <https://pagure.io/freeipa/c/cb6ac16fcd58f0ca18bba93ef5714d6efdc98abf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb6ac16fcd58f0ca18bba93ef5714d6efdc98abf>`__
    `#7227 <https://pagure.io/freeipa/issue/7227>`__
 
 
@@ -599,11 +599,11 @@ Tibor Dudlák (3)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.6.2
-   `commit <https://pagure.io/freeipa/c/f5703563fb4f3591840b12f502c768de759373af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5703563fb4f3591840b12f502c768de759373af>`__
 -  Update Contributors.txt
-   `commit <https://pagure.io/freeipa/c/808187a6019345a6329ddd056989fef45ddcb9fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/808187a6019345a6329ddd056989fef45ddcb9fb>`__
 -  Update zanata translations
-   `commit <https://pagure.io/freeipa/c/ffa6fa9b7079fe666d20ca42e925d20c98fdf7aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffa6fa9b7079fe666d20ca42e925d20c98fdf7aa>`__
 
 
 
@@ -611,36 +611,36 @@ Tomas Krizek (13)
 ----------------------------------------------------------------------------------------------
 
 -  prci: define testing topologies
-   `commit <https://pagure.io/freeipa/c/2ab056a8e05ea5bdf91c056d3cf8452899f1280d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ab056a8e05ea5bdf91c056d3cf8452899f1280d>`__
 -  prci: start testing PRs on fedora 27
-   `commit <https://pagure.io/freeipa/c/ed460f1bfe58e6153fcd54861eb99e6f2a78ed25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed460f1bfe58e6153fcd54861eb99e6f2a78ed25>`__
 -  py3 spec: remove python2 dependencies from server-trust-ad
-   `commit <https://pagure.io/freeipa/c/aaf2621e84243ab8978054cad14164ae50b539b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aaf2621e84243ab8978054cad14164ae50b539b8>`__
    `#7208 <https://pagure.io/freeipa/issue/7208>`__
 -  py3 spec: remove python2 dependencies from freeipa-server
-   `commit <https://pagure.io/freeipa/c/d4f47d17f1077f3c839c325fd3d86b363772434b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4f47d17f1077f3c839c325fd3d86b363772434b>`__
    `#7208 <https://pagure.io/freeipa/issue/7208>`__
 -  py3 spec: use proper python2 package names
-   `commit <https://pagure.io/freeipa/c/b03d51555e22cf138fc93c85584493eb64aba0cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b03d51555e22cf138fc93c85584493eb64aba0cd>`__
    `#7131 <https://pagure.io/freeipa/issue/7131>`__
 -  ipatests: fix circular import for collect_logs
-   `commit <https://pagure.io/freeipa/c/768e18b419dc23c15329a1b212f33f1de0a4df86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/768e18b419dc23c15329a1b212f33f1de0a4df86>`__
 -  ipatests: collect logs for external_ca test suite
-   `commit <https://pagure.io/freeipa/c/3b0ede658a363de8d623cbb63b19d4f47d6828fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b0ede658a363de8d623cbb63b19d4f47d6828fc>`__
 -  prci: add external_ca test
-   `commit <https://pagure.io/freeipa/c/efcbe1b415e6be413d27448f6714bb345e48df8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efcbe1b415e6be413d27448f6714bb345e48df8f>`__
 -  ldap: limit the retro changelog to dns subtree
-   `commit <https://pagure.io/freeipa/c/68a7e478d4b44a96a6b2684e60203f622e719dd9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68a7e478d4b44a96a6b2684e60203f622e719dd9>`__
    `#6515 <https://pagure.io/freeipa/issue/6515>`__
 -  spec: bump 389-ds-base to 1.3.7.6-1
-   `commit <https://pagure.io/freeipa/c/fb131796300b5ccc511c3176888fc01ee846b981>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb131796300b5ccc511c3176888fc01ee846b981>`__
 -  ipatests: set default 389-ds log level to 0
-   `commit <https://pagure.io/freeipa/c/e9d058f9afa69f8f89bbd67316070bd01e28ac2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9d058f9afa69f8f89bbd67316070bd01e28ac2c>`__
    `#7162 <https://pagure.io/freeipa/issue/7162>`__
 -  prci: update F26 template
-   `commit <https://pagure.io/freeipa/c/d7d952dba01d30d5c681056627d0e25561df6254>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7d952dba01d30d5c681056627d0e25561df6254>`__
 -  4.6 set back to git snapshot
-   `commit <https://pagure.io/freeipa/c/9de5b35f9452280a719f88bec126e1f8644ac8c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9de5b35f9452280a719f88bec126e1f8644ac8c8>`__
 
 
 
@@ -649,5 +649,5 @@ Thorsten Scherf (1)
 
 -  Add debug option to ipa-replica-manage and remove references to
    api_env var.
-   `commit <https://pagure.io/freeipa/c/40fc14769128b0bad80257676f6295917020fe75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40fc14769128b0bad80257676f6295917020fe75>`__
    `#7187 <https://pagure.io/freeipa/issue/7187>`__

--- a/src/page/Releases/4.6.8.rst
+++ b/src/page/Releases/4.6.8.rst
@@ -263,10 +263,10 @@ Armando Neto (2)
 ----------------------------------------------------------------------------------------------
 
 -  Travis: Enable IPv6 support for Docker
-   `commit <https://pagure.io/freeipa/c/423a052700889d075d5dba3711679375e8990437>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/423a052700889d075d5dba3711679375e8990437>`__
    `#8213 <https://pagure.io/freeipa/issue/8213>`__
 -  prci: Update box used in branch ipa-4-6
-   `commit <https://pagure.io/freeipa/c/b93258d004ccd5da8b526ea554031315d756b57b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b93258d004ccd5da8b526ea554031315d756b57b>`__
 
 
 
@@ -274,72 +274,72 @@ Alexander Bokovoy (24)
 ----------------------------------------------------------------------------------------------
 
 -  Return to development snapshots
-   `commit <https://pagure.io/freeipa/c/33088c027424573209367ee6531910da30501519>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33088c027424573209367ee6531910da30501519>`__
 -  Become FreeIPA 4.6.8
-   `commit <https://pagure.io/freeipa/c/a718e4a4ab11ab1949bb45c8f15054bd7f2427ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a718e4a4ab11ab1949bb45c8f15054bd7f2427ab>`__
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/1c0749a3c12c3799fd772da17dd864896fc6f908>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c0749a3c12c3799fd772da17dd864896fc6f908>`__
 -  Allow rename of a host group
-   `commit <https://pagure.io/freeipa/c/4c0a2a113d707166cca8cba857937fd624426745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c0a2a113d707166cca8cba857937fd624426745>`__
    `#6783 <https://pagure.io/freeipa/issue/6783>`__
 -  Add 'api' and 'aci' targets to make
-   `commit <https://pagure.io/freeipa/c/7ce5e79dae8cae2790717f68adacd039dc913ab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ce5e79dae8cae2790717f68adacd039dc913ab4>`__
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
-   `commit <https://pagure.io/freeipa/c/3d41453138c0d730a94acd8c22ef345d910a4e42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d41453138c0d730a94acd8c22ef345d910a4e42>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
-   `commit <https://pagure.io/freeipa/c/d038fc70f8e904a492c5ec0874e0fd0be254ead6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d038fc70f8e904a492c5ec0874e0fd0be254ead6>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
-   `commit <https://pagure.io/freeipa/c/41fc40a6b18d26d92869f278b2b8436378653b38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41fc40a6b18d26d92869f278b2b8436378653b38>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
-   `commit <https://pagure.io/freeipa/c/e4f3cd0f26efda56db44bf55aa0bb65d8470b160>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4f3cd0f26efda56db44bf55aa0bb65d8470b160>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  Fix indentation levels
-   `commit <https://pagure.io/freeipa/c/aaa79c872aad2a5458acefdc16203b9efd62c6c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aaa79c872aad2a5458acefdc16203b9efd62c6c9>`__
 -  Prevent adding IPA objects as external members of external groups
-   `commit <https://pagure.io/freeipa/c/c14e385141ea05f2709364b6f0fca844578a7652>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c14e385141ea05f2709364b6f0fca844578a7652>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
-   `commit <https://pagure.io/freeipa/c/901d0eca7d462c74c1664aae9b3415ede7ba3dfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/901d0eca7d462c74c1664aae9b3415ede7ba3dfc>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Tighten permissions on PKI proxy configuration
-   `commit <https://pagure.io/freeipa/c/af2dca13d0cc24e0cf32bc23e4edb86fbbf60d03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af2dca13d0cc24e0cf32bc23e4edb86fbbf60d03>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  install/updates: move external members past schema compat update
-   `commit <https://pagure.io/freeipa/c/a5a201fc008b19841f98bb70d44ede7d04ef1126>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5a201fc008b19841f98bb70d44ede7d04ef1126>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
-   `commit <https://pagure.io/freeipa/c/830466c0489466d385a333cb829fe8cd5e59644c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/830466c0489466d385a333cb829fe8cd5e59644c>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  covscan: free encryption types in case there is an error
-   `commit <https://pagure.io/freeipa/c/e8983f69ce1788144b2b348a65f709412c68e47e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8983f69ce1788144b2b348a65f709412c68e47e>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  Become FreeIPA 4.6.7
-   `commit <https://pagure.io/freeipa/c/71c4dd1f0ba5bd4ddee841d69821398bec35cef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71c4dd1f0ba5bd4ddee841d69821398bec35cef8>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
-   `commit <https://pagure.io/freeipa/c/fa23f5a13a326b4cedf6705be7d14da8bc813763>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa23f5a13a326b4cedf6705be7d14da8bc813763>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  adtrust: add default read_keys permission for TDO objects
-   `commit <https://pagure.io/freeipa/c/b764b386f66fdf813f3914362985b4944c13090f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b764b386f66fdf813f3914362985b4944c13090f>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  add default access control when migrating trust objects
-   `commit <https://pagure.io/freeipa/c/5741e031318267b28f5812154fa34ff2ff6c3483>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5741e031318267b28f5812154fa34ff2ff6c3483>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  ipasam: use SID formatting calls to libsss_idmap
-   `commit <https://pagure.io/freeipa/c/95c91b5709d0c7fec20eef5ef69a084a74868c2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95c91b5709d0c7fec20eef5ef69a084a74868c2d>`__
    `#7893 <https://pagure.io/freeipa/issue/7893>`__
 -  Use unicode strings for Python 2 version
-   `commit <https://pagure.io/freeipa/c/37fa917fa2630dd90dd3a12bab213aeb6adfe182>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37fa917fa2630dd90dd3a12bab213aeb6adfe182>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
-   `commit <https://pagure.io/freeipa/c/387ed98e59ba4df8d3fd435cfc84f055970c064e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/387ed98e59ba4df8d3fd435cfc84f055970c064e>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 -  Revert back to git snapshots
-   `commit <https://pagure.io/freeipa/c/ca00a83c79677c22aed5ff77044cb09c59182448>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca00a83c79677c22aed5ff77044cb09c59182448>`__
 
 
 
@@ -347,33 +347,33 @@ Anuja More (13)
 ----------------------------------------------------------------------------------------------
 
 -  Mark test to skip sssd-1.16.3 [sssd/issue/4073]
-   `commit <https://pagure.io/freeipa/c/edbf8f78019709d4af396ba6ad3724a11dd2b576>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edbf8f78019709d4af396ba6ad3724a11dd2b576>`__
 -  ipatests: User and group with same name should not break reading AD
    user data.
-   `commit <https://pagure.io/freeipa/c/4ca75cf610335cfc2be43aeb8c0ddc1fde2e0c08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ca75cf610335cfc2be43aeb8c0ddc1fde2e0c08>`__
 -  Mark xfail for tests using sssd-1.16.3
-   `commit <https://pagure.io/freeipa/c/734121fa1497ef2e074d2879ab9fc54c0ace95b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/734121fa1497ef2e074d2879ab9fc54c0ace95b8>`__
 -  ipatests: Added test when 2FA prompting configurations is set.
-   `commit <https://pagure.io/freeipa/c/b36c4a70fc0e577265bb587de1e1b7bd739a8709>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36c4a70fc0e577265bb587de1e1b7bd739a8709>`__
 -  Mark xfail for sssd-version 1.16.3
-   `commit <https://pagure.io/freeipa/c/0c828dad4cfd3df9db8056b2497543c022c7680a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c828dad4cfd3df9db8056b2497543c022c7680a>`__
 -  ipatests: SSSD should fetch external groups without any limit.
-   `commit <https://pagure.io/freeipa/c/fd74fcf75606ded2987753337161c163e8ae9a44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd74fcf75606ded2987753337161c163e8ae9a44>`__
 -  Add sssd.py in nightly ipa-4-6.yaml
-   `commit <https://pagure.io/freeipa/c/2e4e1b37a71d7a9d8bd834fefcc241eaac19e1e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e4e1b37a71d7a9d8bd834fefcc241eaac19e1e7>`__
 -  ipatests: Add test for ipa-extdom-extop plugin should allow @ in
    group name
-   `commit <https://pagure.io/freeipa/c/a736449a217dc38e98054e8018fe7c7fd11f54be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a736449a217dc38e98054e8018fe7c7fd11f54be>`__
 -  Mark xfail for test_is_user_filtered
-   `commit <https://pagure.io/freeipa/c/d3b740e3df70c37bb3b7aa1fcd77acf5d68dc2bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3b740e3df70c37bb3b7aa1fcd77acf5d68dc2bc>`__
 -  ipatests: filter_users should be applied correctly.
-   `commit <https://pagure.io/freeipa/c/4b70132c83f417b83aa4905de73f720336a90128>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b70132c83f417b83aa4905de73f720336a90128>`__
 -  Mark xfail for test_sss_ssh_authorizedkeys()
-   `commit <https://pagure.io/freeipa/c/3ddddad50d98274a065781f2238c102badc8cea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ddddad50d98274a065781f2238c102badc8cea7>`__
 -  ipatests: 'sss_ssh_authorizedkeys user' should return ssh key
-   `commit <https://pagure.io/freeipa/c/0c452369f753116496f3a170d1bb7fde4cdfb12f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c452369f753116496f3a170d1bb7fde4cdfb12f>`__
 -  Extdom plugin should not return error (32)/'No such object'
-   `commit <https://pagure.io/freeipa/c/17536af58b5a2d1ae1adf7e741dade7b3f84179a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17536af58b5a2d1ae1adf7e741dade7b3f84179a>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -382,23 +382,23 @@ Christian Heimes (7)
 ----------------------------------------------------------------------------------------------
 
 -  Add test case for OTP login
-   `commit <https://pagure.io/freeipa/c/cabb7abfc07b093a9912b20ee712baaa40d16d19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cabb7abfc07b093a9912b20ee712baaa40d16d19>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Cherry-picked only ldapmodify_dm()
-   `commit <https://pagure.io/freeipa/c/48ecb92afdbd577fbb4fe05ea15cfaf44e504f89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48ecb92afdbd577fbb4fe05ea15cfaf44e504f89>`__
 -  Use default ssh host key algorithms
-   `commit <https://pagure.io/freeipa/c/7cd1d565ac2b240eda697dbebb043a1a2885d23a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cd1d565ac2b240eda697dbebb043a1a2885d23a>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 -  Log stderr in run_command
-   `commit <https://pagure.io/freeipa/c/c5ff32870d22f7c42edec63c686a730d7bcf21cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5ff32870d22f7c42edec63c686a730d7bcf21cc>`__
 -  Fix CustodiaClient ccache handling
-   `commit <https://pagure.io/freeipa/c/436214aea7fd5893525292cb03b3c28cdbc249f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/436214aea7fd5893525292cb03b3c28cdbc249f2>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 -  Don't configure KEYRING ccache in containers
-   `commit <https://pagure.io/freeipa/c/91e54057f130f0c2d9da8506e34c3cadc9cd9c6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91e54057f130f0c2d9da8506e34c3cadc9cd9c6e>`__
    `#7807 <https://pagure.io/freeipa/issue/7807>`__
 -  Remove ZERO_STRUCT() call
-   `commit <https://pagure.io/freeipa/c/910e56333d4631244053b5c506ba2bec905d1c27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/910e56333d4631244053b5c506ba2bec905d1c27>`__
 
 
 
@@ -406,10 +406,10 @@ François Cami (2)
 ----------------------------------------------------------------------------------------------
 
 -  adtrust.py: mention restarting sssd when adding trust agents
-   `commit <https://pagure.io/freeipa/c/5bc4218bf8716d28339a3f30d1be8471d04cb4b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bc4218bf8716d28339a3f30d1be8471d04cb4b4>`__
    `#8148 <https://pagure.io/freeipa/issue/8148>`__
 -  prci_definitions: add master_3client topology
-   `commit <https://pagure.io/freeipa/c/663163cbcf0bb12236a675b60784fdf36f917343>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/663163cbcf0bb12236a675b60784fdf36f917343>`__
    `#8026 <https://pagure.io/freeipa/issue/8026>`__
 
 
@@ -418,87 +418,87 @@ Florence Blanc-Renaud (28)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix group-add-member in test_sssd
-   `commit <https://pagure.io/freeipa/c/7b9cdfb2556bd290d5f18b0680a1cf907b4dff0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b9cdfb2556bd290d5f18b0680a1cf907b4dff0c>`__
    `#8238 <https://pagure.io/freeipa/issue/8238>`__
 -  ipatests: fix KeyError in test_sssd
-   `commit <https://pagure.io/freeipa/c/bce50976ca5363e2097171b36a0d9a5df652a988>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bce50976ca5363e2097171b36a0d9a5df652a988>`__
    `#8238 <https://pagure.io/freeipa/issue/8238>`__
 -  xmlrpc tests: add a test for idview-apply on a master
-   `commit <https://pagure.io/freeipa/c/e946b879750d0b316b25902f15b7f5a0a078012e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e946b879750d0b316b25902f15b7f5a0a078012e>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  idviews: prevent applying to a master
-   `commit <https://pagure.io/freeipa/c/0d62f3de06520282c9656e13ca07e503f1d48c59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d62f3de06520282c9656e13ca07e503f1d48c59>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
-   `commit <https://pagure.io/freeipa/c/79f9ba5557d14e74ab29b85407c5de5622d7ea35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79f9ba5557d14e74ab29b85407c5de5622d7ea35>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
-   `commit <https://pagure.io/freeipa/c/796c86ac701d23d1dd281d0d5c5331b9a66c2888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/796c86ac701d23d1dd281d0d5c5331b9a66c2888>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
-   `commit <https://pagure.io/freeipa/c/f9fcd2c7fb7823becb3a6b68da4b0bf2c1db229f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9fcd2c7fb7823becb3a6b68da4b0bf2c1db229f>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
-   `commit <https://pagure.io/freeipa/c/d051d2d47a36c79fd2c20733437fda95f443f053>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d051d2d47a36c79fd2c20733437fda95f443f053>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/ed71305be9e236d8f49e3298516c6f6bfadb958c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed71305be9e236d8f49e3298516c6f6bfadb958c>`__
 -  ipatests: fix modify_sssd_conf()
-   `commit <https://pagure.io/freeipa/c/f605f21cc092300640a27dfc4652c2748407664f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f605f21cc092300640a27dfc4652c2748407664f>`__
 -  test: add non-reg test checking pkinit after server install
-   `commit <https://pagure.io/freeipa/c/18ed56acc58bb379d5187fbcaafc6d7f16178cdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18ed56acc58bb379d5187fbcaafc6d7f16178cdb>`__
    `#7795 <https://pagure.io/freeipa/issue/7795>`__
 -  pkinit setup: fix regression on master install
-   `commit <https://pagure.io/freeipa/c/50e8c5d652bc2b6c937a3def52621f0c60e085f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50e8c5d652bc2b6c937a3def52621f0c60e085f1>`__
    `#7795 <https://pagure.io/freeipa/issue/7795>`__
 -  ipatests: add integration test for pkinit enable on replica
-   `commit <https://pagure.io/freeipa/c/95cbf7003ff7b391311a1da6f1065aa1d2c6addf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95cbf7003ff7b391311a1da6f1065aa1d2c6addf>`__
    `#7795 <https://pagure.io/freeipa/issue/7795>`__
 -  pkinit enable: use local dogtag only if host has CA
-   `commit <https://pagure.io/freeipa/c/f7c47341c217312b4b4265fcbea80088bc06381f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7c47341c217312b4b4265fcbea80088bc06381f>`__
    `#7795 <https://pagure.io/freeipa/issue/7795>`__
 -  ipatests: fix backup and restore
-   `commit <https://pagure.io/freeipa/c/4bd5da1417f12e9f1f22d20b09ed58dcbcfca5cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4bd5da1417f12e9f1f22d20b09ed58dcbcfca5cc>`__
    `#8170 <https://pagure.io/freeipa/issue/8170>`__
 -  ipa-cacert-manage man page: fix indentation
-   `commit <https://pagure.io/freeipa/c/3d8b16b9457a3a4d7eceb326b3c53be13bb6543c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d8b16b9457a3a4d7eceb326b3c53be13bb6543c>`__
    `#8138 <https://pagure.io/freeipa/issue/8138>`__
 -  trust upgrade: ensure that host is member of adtrust agents
-   `commit <https://pagure.io/freeipa/c/bb4ec6fcb4547bc624cde93e16a9201dfa8d4426>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb4ec6fcb4547bc624cde93e16a9201dfa8d4426>`__
 -  ipatests: fix test_ca_custom_sdn
-   `commit <https://pagure.io/freeipa/c/526c184a8729c36a54a81eeff73bac3428ed6e5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/526c184a8729c36a54a81eeff73bac3428ed6e5a>`__
    `#8126 <https://pagure.io/freeipa/issue/8126>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
-   `commit <https://pagure.io/freeipa/c/7a19c0d730ae3d16a9763f4769a37bf19680622a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a19c0d730ae3d16a9763f4769a37bf19680622a>`__
    `#8113 <https://pagure.io/freeipa/issue/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
-   `commit <https://pagure.io/freeipa/c/11921266df6e2600afc207b3a721f00bc7e63e99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11921266df6e2600afc207b3a721f00bc7e63e99>`__
    `#8099 <https://pagure.io/freeipa/issue/8099>`__
 -  ipa-server-certinstall manpage: add missing options
-   `commit <https://pagure.io/freeipa/c/ddc00468b74b170721c1769029f771e163621c70>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddc00468b74b170721c1769029f771e163621c70>`__
    `#8086 <https://pagure.io/freeipa/issue/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
-   `commit <https://pagure.io/freeipa/c/a5228a7fb94fdcb16ec4571677af5b5ec33979d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5228a7fb94fdcb16ec4571677af5b5ec33979d2>`__
    `#8070 <https://pagure.io/freeipa/issue/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
-   `commit <https://pagure.io/freeipa/c/317c111b830fbeb4cd907a6812ce35b7fbf1c174>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/317c111b830fbeb4cd907a6812ce35b7fbf1c174>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
-   `commit <https://pagure.io/freeipa/c/0b574c130a1d28a6c7d085f795a9fdd3ef91f016>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b574c130a1d28a6c7d085f795a9fdd3ef91f016>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  replica install: enforce --server arg
-   `commit <https://pagure.io/freeipa/c/22e4eef6cb54c74fc9907db1385549db670094fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22e4eef6cb54c74fc9907db1385549db670094fa>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  check for single-label domains only during server install
-   `commit <https://pagure.io/freeipa/c/8ae6c1af1e6ef25fdfbbf7e72265372366e6b106>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ae6c1af1e6ef25fdfbbf7e72265372366e6b106>`__
    `#8058 <https://pagure.io/freeipa/issue/8058>`__
 -  xmlrpc test: add test for preserved > stage user
-   `commit <https://pagure.io/freeipa/c/5ab31a9c3b16536b02416c6b996aec2c1f3ba962>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ab31a9c3b16536b02416c6b996aec2c1f3ba962>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
-   `commit <https://pagure.io/freeipa/c/6a9f1c802bb28fde8e1d9f38673e554ef23e5620>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a9f1c802bb28fde8e1d9f38673e554ef23e5620>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 
 
@@ -507,27 +507,27 @@ Fraser Tweedale (8)
 ----------------------------------------------------------------------------------------------
 
 -  Do not renew externally-signed CA as self-signed
-   `commit <https://pagure.io/freeipa/c/c30af44b8a55ebf85f4657ee13eb1554e3b2a2ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c30af44b8a55ebf85f4657ee13eb1554e3b2a2ad>`__
    `#8176 <https://pagure.io/freeipa/issue/8176>`__
 -  test_integration: add tests for custom CA subject DN
-   `commit <https://pagure.io/freeipa/c/0a0e802bd47188fe31d6bf02b28ef0ea51567194>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a0e802bd47188fe31d6bf02b28ef0ea51567194>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
-   `commit <https://pagure.io/freeipa/c/2fa8c6903405294f0e11e373db321172663d6cfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fa8c6903405294f0e11e373db321172663d6cfd>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
-   `commit <https://pagure.io/freeipa/c/946d96f6c3fd5766d60222da940c27d5d4e41158>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/946d96f6c3fd5766d60222da940c27d5d4e41158>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  Bump krb5 min version
-   `commit <https://pagure.io/freeipa/c/e686949dcdc46486061d23d5e18f21e2a2038f58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e686949dcdc46486061d23d5e18f21e2a2038f58>`__
 -  CustodiaClient: fix IPASecStore config on ipa-4-7
-   `commit <https://pagure.io/freeipa/c/c9d0ba0c355c433ae883cafa3c1e99fea1a85220>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9d0ba0c355c433ae883cafa3c1e99fea1a85220>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 -  CustodiaClient: use ldapi when ldap_uri not specified
-   `commit <https://pagure.io/freeipa/c/1f455867f82407c0dfab0b9f123c75ca0d1a0090>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f455867f82407c0dfab0b9f123c75ca0d1a0090>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 -  Handle missing LWCA certificate or chain
-   `commit <https://pagure.io/freeipa/c/82a9fe7e655115befbdde10907a5aa7669c35fde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82a9fe7e655115befbdde10907a5aa7669c35fde>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 
 
@@ -536,7 +536,7 @@ Gaurav Talreja (1)
 ----------------------------------------------------------------------------------------------
 
 -  Normalize test definations titles
-   `commit <https://pagure.io/freeipa/c/636ea489bb59ed0b26951299053db5651c78a20f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/636ea489bb59ed0b26951299053db5651c78a20f>`__
 
 
 
@@ -544,7 +544,7 @@ Ganna Kaihorodova (1)
 ----------------------------------------------------------------------------------------------
 
 -  TestBasicADTrust.test_ipauser_authentication
-   `commit <https://pagure.io/freeipa/c/2b6638becbfbae746cef35176890ae3f4a8b01a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b6638becbfbae746cef35176890ae3f4a8b01a6>`__
    `#7470 <https://pagure.io/freeipa/issue/7470>`__
 
 
@@ -553,9 +553,9 @@ Jayesh Garg (2)
 ----------------------------------------------------------------------------------------------
 
 -  Test if ipactl starts services stopped by systemctl
-   `commit <https://pagure.io/freeipa/c/c1099f7298a7e175bb90bc65f3dd1af58995bc07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1099f7298a7e175bb90bc65f3dd1af58995bc07>`__
 -  Test for ipa-ca-install on replica
-   `commit <https://pagure.io/freeipa/c/c559e41e8ce87f2a16958113ef08effe5b5e8875>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c559e41e8ce87f2a16958113ef08effe5b5e8875>`__
 
 
 
@@ -563,7 +563,7 @@ Kaleemullah Siddiqui (1)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for autounmembership feature
-   `commit <https://pagure.io/freeipa/c/4a8316d308a34a4a3e590ab1d3c4bb1de2b9d89b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a8316d308a34a4a3e590ab1d3c4bb1de2b9d89b>`__
 
 
 
@@ -571,24 +571,24 @@ Mohammad Rizwan Yusuf (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test if slew mode is not set while configuring ntpd
-   `commit <https://pagure.io/freeipa/c/81b859795c72f6c96b27137cc24d6df327ca8471>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81b859795c72f6c96b27137cc24d6df327ca8471>`__
    `#8242 <https://pagure.io/freeipa/issue/8242>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/b739bc2089774cea0437347283c821ac86f8251d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b739bc2089774cea0437347283c821ac86f8251d>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/e6960b7af2e8d8e4746245d8ba82a46225174529>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6960b7af2e8d8e4746245d8ba82a46225174529>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Add promote option to install_replica() method
-   `commit <https://pagure.io/freeipa/c/0d91a78ee409e66f96e7b2555ca33fb2128fdfa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d91a78ee409e66f96e7b2555ca33fb2128fdfa3>`__
    `#8152 <https://pagure.io/freeipa/issue/8152>`__
 -  Add test to nightly.yaml
-   `commit <https://pagure.io/freeipa/c/9b3855ec486990ecd08a9f3a0ca408425ee7fbf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b3855ec486990ecd08a9f3a0ca408425ee7fbf7>`__
 -  Installation of replica against a specific server
-   `commit <https://pagure.io/freeipa/c/f4dc0ee169689974020a4a77b8bb58b26f360369>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4dc0ee169689974020a4a77b8bb58b26f360369>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  Check file ownership and permission for dirsrv log instance
-   `commit <https://pagure.io/freeipa/c/de0afeaf5e07028af8ec7247ce37efc789add2ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de0afeaf5e07028af8ec7247ce37efc789add2ae>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 
 
@@ -597,7 +597,7 @@ ndehadra (1)
 ----------------------------------------------------------------------------------------------
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
-   `commit <https://pagure.io/freeipa/c/ad3ddbb80d9f1dd3556afdc9cf506f3bae7f6783>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3ddbb80d9f1dd3556afdc9cf506f3bae7f6783>`__
    `#7307 <https://pagure.io/freeipa/issue/7307>`__
 
 
@@ -606,33 +606,33 @@ Rob Crittenden (11)
 ----------------------------------------------------------------------------------------------
 
 -  Don't configure ntpd with -x
-   `commit <https://pagure.io/freeipa/c/2c1495460fcb0d58d27579bfbd6aba63b91bf985>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c1495460fcb0d58d27579bfbd6aba63b91bf985>`__
    `#8242 <https://pagure.io/freeipa/issue/8242>`__
 -  Test that pwpolicy only applied on Kerberos entries
-   `commit <https://pagure.io/freeipa/c/5a98670e4abfac2b7de2f604f8fe19fbea988b16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a98670e4abfac2b7de2f604f8fe19fbea988b16>`__
 -  Add ability to change a user password as the Directory Manager
-   `commit <https://pagure.io/freeipa/c/19e872e653705bb178457ebe39c90d4f550f438b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19e872e653705bb178457ebe39c90d4f550f438b>`__
 -  Don't save password history on non-Kerberos accounts
-   `commit <https://pagure.io/freeipa/c/dc833948006fac6920581e56ec69763bde3f1d4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc833948006fac6920581e56ec69763bde3f1d4a>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/73d415b72da8a57a2369a55b1533b45f36daf544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73d415b72da8a57a2369a55b1533b45f36daf544>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
-   `commit <https://pagure.io/freeipa/c/5913826a4654a115cd5ff2dbf4a2b3ad38a93081>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5913826a4654a115cd5ff2dbf4a2b3ad38a93081>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
-   `commit <https://pagure.io/freeipa/c/8cd2052c3cb6d8a2569903593762d64669303ff6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cd2052c3cb6d8a2569903593762d64669303ff6>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 -  Report if a certmonger CA is missing
-   `commit <https://pagure.io/freeipa/c/9eb7763b76c7f4f3d78c76fa324560a8af9342ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9eb7763b76c7f4f3d78c76fa324560a8af9342ae>`__
    `#7870 <https://pagure.io/freeipa/issue/7870>`__
 -  Don't log host passwords when they are set/modified
-   `commit <https://pagure.io/freeipa/c/86529f5e21a5b09f026b9787178426a8b8b96bb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86529f5e21a5b09f026b9787178426a8b8b96bb4>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  Disable deprecated-lambda check in adtrust upgrade code
-   `commit <https://pagure.io/freeipa/c/582e7a35121e0f5ff331699d29a485408f5e17ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/582e7a35121e0f5ff331699d29a485408f5e17ff>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
-   `commit <https://pagure.io/freeipa/c/643a1d6747e523ac456aefc4707772aebde5573a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/643a1d6747e523ac456aefc4707772aebde5573a>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 
 
@@ -641,11 +641,11 @@ Robbie Harwood (3)
 ----------------------------------------------------------------------------------------------
 
 -  Fix NULL pointer dereference in maybe_require_preauth()
-   `commit <https://pagure.io/freeipa/c/95f50d7f51fe6b2bca29daa45b795de2517469a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95f50d7f51fe6b2bca29daa45b795de2517469a7>`__
 -  Log INFO message when LDAP connection fails on startup
-   `commit <https://pagure.io/freeipa/c/f132def4812a5b9bb1d14672f8e33e66bc778229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f132def4812a5b9bb1d14672f8e33e66bc778229>`__
 -  Fix segfault in ipadb_parse_ldap_entry()
-   `commit <https://pagure.io/freeipa/c/ed0d7561a148e23519a1097b3bdf99abf5edcc6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed0d7561a148e23519a1097b3bdf99abf5edcc6d>`__
 
 
 
@@ -653,9 +653,9 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa_sam: remove dependency to talloc_strackframe.h
-   `commit <https://pagure.io/freeipa/c/fa0b273874760503c7f57f279721e97aaf007ca5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa0b273874760503c7f57f279721e97aaf007ca5>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
-   `commit <https://pagure.io/freeipa/c/574a615e61ca74b08e2bd7e1e820757f88150418>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/574a615e61ca74b08e2bd7e1e820757f88150418>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -664,10 +664,10 @@ Stanislav Levin (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix errors found by Pylint-2.4.3
-   `commit <https://pagure.io/freeipa/c/f0f839326c8c0de83cb875a473b3fb5d4a014296>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0f839326c8c0de83cb875a473b3fb5d4a014296>`__
    `#8102 <https://pagure.io/freeipa/issue/8102>`__
 -  Fixed errors newly exposed by pylint 2.4.0
-   `commit <https://pagure.io/freeipa/c/700a6c9313188a0448e46cca17a08146deb21c2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/700a6c9313188a0448e46cca17a08146deb21c2a>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 
 
@@ -676,64 +676,64 @@ Sergey Orlov (24)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: remove test_ordering
-   `commit <https://pagure.io/freeipa/c/3a2244ce7fd8be03f7340afa18971cbfa306a196>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a2244ce7fd8be03f7340afa18971cbfa306a196>`__
 -  ipatests: add test_trust suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/d44374e761a1e7f5aaca22399631f77fccc45f94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d44374e761a1e7f5aaca22399631f77fccc45f94>`__
 -  ipatests: add workaround for unfixed sssd bug in Fedora 27
-   `commit <https://pagure.io/freeipa/c/37e383aae94b0450c06f0e78354245e4b14d70f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37e383aae94b0450c06f0e78354245e4b14d70f5>`__
 -  ipatests: use less strict check for error message
-   `commit <https://pagure.io/freeipa/c/941c231b692216f3dc4b66944dd170b5380fe981>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/941c231b692216f3dc4b66944dd170b5380fe981>`__
 -  ipatests: provide AD admin password when trying to establish trust
-   `commit <https://pagure.io/freeipa/c/795a973c00c2fe862b1eff8bd851d8eafe9d970a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/795a973c00c2fe862b1eff8bd851d8eafe9d970a>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  ipatests: remove workaround for pylint error no-name-in-module
-   `commit <https://pagure.io/freeipa/c/46b9139ac9ecbbd89495239e380982514db3a5f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46b9139ac9ecbbd89495239e380982514db3a5f4>`__
    `#8220 <https://pagure.io/freeipa/issue/8220>`__
 -  ipatests: temporary disable pylint check no-name-in-module
-   `commit <https://pagure.io/freeipa/c/044748b5724f408643fe9f95c3a63d29ca646002>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/044748b5724f408643fe9f95c3a63d29ca646002>`__
    `#8220 <https://pagure.io/freeipa/issue/8220>`__
 -  ipatests: remove invalid parameter from sssd.conf
-   `commit <https://pagure.io/freeipa/c/551dabe5f933475e4609b6b23eb1200dec90945b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/551dabe5f933475e4609b6b23eb1200dec90945b>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
-   `commit <https://pagure.io/freeipa/c/aff397b9ef09b1f2dc6c02a6bb85b96fb16b9ded>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aff397b9ef09b1f2dc6c02a6bb85b96fb16b9ded>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: replace utility for editing sssd.conf
-   `commit <https://pagure.io/freeipa/c/7f18f08ca607fdf3b730a6b5e66dc97535007259>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f18f08ca607fdf3b730a6b5e66dc97535007259>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
-   `commit <https://pagure.io/freeipa/c/e25b10ef3a4da973300cd7d888f1506291fa882d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e25b10ef3a4da973300cd7d888f1506291fa882d>`__
 -  ipatests: refactor FileBackup helper
-   `commit <https://pagure.io/freeipa/c/714b61f3605f53ecde73dd7e3d23ae92d219f926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/714b61f3605f53ecde73dd7e3d23ae92d219f926>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: fix collection of tests from test_trust suite
-   `commit <https://pagure.io/freeipa/c/d12e4bdeef92415c081b99c5b3235997bb086529>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d12e4bdeef92415c081b99c5b3235997bb086529>`__
 -  Add convenient template for temp commits
-   `commit <https://pagure.io/freeipa/c/3d0ffe2ca8b67715328596b18c8603ff55ecc4fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d0ffe2ca8b67715328596b18c8603ff55ecc4fc>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/28df8cef01de0c7adac348774e243e72df7e8f96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28df8cef01de0c7adac348774e243e72df7e8f96>`__
 -  ipatests: fix compatibility with python2 (import ConfigParser)
-   `commit <https://pagure.io/freeipa/c/0ad66fc17db76187fb869983ded2b2c60e40d4a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ad66fc17db76187fb869983ded2b2c60e40d4a3>`__
 -  ipatests: add new utilities for file management
-   `commit <https://pagure.io/freeipa/c/ba4aaa73f19035433bbd98b536540c86b87f87c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba4aaa73f19035433bbd98b536540c86b87f87c8>`__
 -  ipatests: add utility functions related to using and managing user
    accounts
-   `commit <https://pagure.io/freeipa/c/ee3d998599bf96c4f0ddb1ab0abf049e3e0e892c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee3d998599bf96c4f0ddb1ab0abf049e3e0e892c>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
-   `commit <https://pagure.io/freeipa/c/a8fbbb1d3528952685d7b3259329313cc112080e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8fbbb1d3528952685d7b3259329313cc112080e>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
-   `commit <https://pagure.io/freeipa/c/4487fc43d036481a315574bfe719b10a57c54a64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4487fc43d036481a315574bfe719b10a57c54a64>`__
    `#7995 <https://pagure.io/freeipa/issue/7995>`__
 -  ipatests: modify run_command to allow specify successful return codes
-   `commit <https://pagure.io/freeipa/c/aa0ecc93ff0faad6663add73d5e013775ce4a68f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa0ecc93ff0faad6663add73d5e013775ce4a68f>`__
 -  ipatests: in DNS zone file add A record for name server
-   `commit <https://pagure.io/freeipa/c/cf61f74a2e67c03000ecd1020eb692f1d7364c28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf61f74a2e67c03000ecd1020eb692f1d7364c28>`__
 -  ipatests: strip newline character when getting name of temp file
-   `commit <https://pagure.io/freeipa/c/99e8d80bc5bc43cf84dd0b403b8a318d3353c936>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99e8d80bc5bc43cf84dd0b403b8a318d3353c936>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
-   `commit <https://pagure.io/freeipa/c/f803c2c935c03d4bf7bb328a0ee62463f209c487>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f803c2c935c03d4bf7bb328a0ee62463f209c487>`__
 
 
 
@@ -742,11 +742,11 @@ Sumedh Sidhaye (2)
 
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
-   `commit <https://pagure.io/freeipa/c/189fc03a52c80dc675ea1015d97a4e4c357549b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/189fc03a52c80dc675ea1015d97a4e4c357549b5>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
-   `commit <https://pagure.io/freeipa/c/5d8936c44aaf1531a8f6de1ec747cd28db266fc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d8936c44aaf1531a8f6de1ec747cd28db266fc6>`__
 
 
 
@@ -754,7 +754,7 @@ Simo Sorce (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure to have storage space for tag
-   `commit <https://pagure.io/freeipa/c/cc45a3970cf7a9735a80df5342844339fc66faa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc45a3970cf7a9735a80df5342844339fc66faa3>`__
 
 
 
@@ -762,10 +762,10 @@ Serhii Tsymbaliuk (2)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix notification area layout
-   `commit <https://pagure.io/freeipa/c/6e6223419de9a50f1357fc7478a95cf623bf5a10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e6223419de9a50f1357fc7478a95cf623bf5a10>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/927e339cae309226b654997871c9f8b5cdf32b0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/927e339cae309226b654997871c9f8b5cdf32b0b>`__
    `#8239 <https://pagure.io/freeipa/issue/8239>`__
 
 
@@ -774,7 +774,7 @@ Tibor Dudlák (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add container environment check to replicainstall
-   `commit <https://pagure.io/freeipa/c/a016ed75ecbe7e2698530036043ef19df1bd718f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a016ed75ecbe7e2698530036043ef19df1bd718f>`__
    `#6210 <https://pagure.io/freeipa/issue/6210>`__
 
 
@@ -783,10 +783,10 @@ Tomas Halman (4)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: add extdom protocol documentation
-   `commit <https://pagure.io/freeipa/c/9a140cdc269bbde9e9ebb99d9cd8c643a94afb6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a140cdc269bbde9e9ebb99d9cd8c643a94afb6c>`__
 -  extdom: use sss_nss_*_timeout calls
-   `commit <https://pagure.io/freeipa/c/0a1ad84adfedc141fbbaece3a7dee1ade69c1fdc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a1ad84adfedc141fbbaece3a7dee1ade69c1fdc>`__
 -  extdom: plugin doesn't use timeout in blocking call
-   `commit <https://pagure.io/freeipa/c/20612db06516ec59922827e16f5226d21815751a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20612db06516ec59922827e16f5226d21815751a>`__
 -  extdom: plugin doesn't allow @ in group name
-   `commit <https://pagure.io/freeipa/c/b182a96226de46b6d194fb924b7374d923c14733>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b182a96226de46b6d194fb924b7374d923c14733>`__

--- a/src/page/Releases/4.6.9.rst
+++ b/src/page/Releases/4.6.9.rst
@@ -106,7 +106,7 @@ Alexander Bokovoy (1)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.6.9
-   `commit <https://pagure.io/freeipa/c/4f1f8754742d55263a7da89575c5d94b5ea4c7e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f1f8754742d55263a7da89575c5d94b5ea4c7e3>`__
 
 
 
@@ -114,5 +114,5 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Prevent local account takeover
-   `commit <https://pagure.io/freeipa/c/316ac7cd62ac130f88b374c1f9f47b41806187c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/316ac7cd62ac130f88b374c1f9f47b41806187c1>`__
    `#8326 <https://pagure.io/freeipa/issue/8326>`__

--- a/src/page/Releases/4.7.5.rst
+++ b/src/page/Releases/4.7.5.rst
@@ -238,19 +238,19 @@ Armando Neto (6)
 ----------------------------------------------------------------------------------------------
 
 -  Travis: Enable IPv6 support for Docker
-   `commit <https://pagure.io/freeipa/c/4cddbfd8cc7b46b78cb8e27200a12941a3781e3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cddbfd8cc7b46b78cb8e27200a12941a3781e3e>`__
    `#8213 <https://pagure.io/freeipa/issue/8213>`__
 -  prci: Bump template version
-   `commit <https://pagure.io/freeipa/c/529d571d505e83e764596496db5d2dfc9a43960f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/529d571d505e83e764596496db5d2dfc9a43960f>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
-   `commit <https://pagure.io/freeipa/c/54b14f4cb3e65571be54b94ab5f42d471b92a23d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54b14f4cb3e65571be54b94ab5f42d471b92a23d>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  prci: bump template version
-   `commit <https://pagure.io/freeipa/c/4fec68611059069205086b88829d9dddbd7f78c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fec68611059069205086b88829d9dddbd7f78c7>`__
 -  prci: increase timeout argument for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/51a531ddbfacec75abe2c4d16b16baf0cd323798>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51a531ddbfacec75abe2c4d16b16baf0cd323798>`__
 -  prci: Update box used in branch ipa-4-7
-   `commit <https://pagure.io/freeipa/c/db305621fcaf46606cd8a9078f96dd19048140d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db305621fcaf46606cd8a9078f96dd19048140d1>`__
 
 
 
@@ -259,63 +259,63 @@ Alexander Bokovoy (20)
 
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
-   `commit <https://pagure.io/freeipa/c/eaec7584195ce173a6de5101d745be35b7c4cb5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eaec7584195ce173a6de5101d745be35b7c4cb5f>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
-   `commit <https://pagure.io/freeipa/c/79fab655ceca9d1ea0791d3a0fb584ea51a9849d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79fab655ceca9d1ea0791d3a0fb584ea51a9849d>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
-   `commit <https://pagure.io/freeipa/c/74c5a96b8441f0d6b5a64ede2e9de95b4f3fcc4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74c5a96b8441f0d6b5a64ede2e9de95b4f3fcc4b>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
-   `commit <https://pagure.io/freeipa/c/d91c4d638c6db3183bd0c5e3f18f25ed229a1f3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d91c4d638c6db3183bd0c5e3f18f25ed229a1f3f>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  Fix indentation levels
-   `commit <https://pagure.io/freeipa/c/57e30f88242d926c9487e7ca26dc5ded40700192>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57e30f88242d926c9487e7ca26dc5ded40700192>`__
 -  ipatests: always skip additional input for group-add-member
    --external
-   `commit <https://pagure.io/freeipa/c/935c356dace23a60be8a0fba4ac482eeccb95948>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/935c356dace23a60be8a0fba4ac482eeccb95948>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  Prevent adding IPA objects as external members of external groups
-   `commit <https://pagure.io/freeipa/c/5a2f27fe036d61415a128b650d6750e2c2048b4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a2f27fe036d61415a128b650d6750e2c2048b4b>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
-   `commit <https://pagure.io/freeipa/c/fc82b966c054b8a6a98441f08d9ccf2f5737e623>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc82b966c054b8a6a98441f08d9ccf2f5737e623>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Tighten permissions on PKI proxy configuration
-   `commit <https://pagure.io/freeipa/c/d4ad2c24df2477a5b4ced14a592d99547a0c029e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ad2c24df2477a5b4ced14a592d99547a0c029e>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  install/updates: move external members past schema compat update
-   `commit <https://pagure.io/freeipa/c/9db61a51f4cfcaae5e51d10c9ce2ed751cce4c49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9db61a51f4cfcaae5e51d10c9ce2ed751cce4c49>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
-   `commit <https://pagure.io/freeipa/c/c37081576d2f282e702b42652c04e053886c47cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c37081576d2f282e702b42652c04e053886c47cf>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  covscan: free encryption types in case there is an error
-   `commit <https://pagure.io/freeipa/c/212e86eee15e883bffd01f969219ce644c3e45c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/212e86eee15e883bffd01f969219ce644c3e45c6>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  Become FreeIPA 4.7.4
-   `commit <https://pagure.io/freeipa/c/f5e60ffe9e0b909075071511ffa041390a9a87b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5e60ffe9e0b909075071511ffa041390a9a87b6>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
-   `commit <https://pagure.io/freeipa/c/2f8f257d9a9c076bf1a2d28aee06fbac0532aa72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f8f257d9a9c076bf1a2d28aee06fbac0532aa72>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  adtrust: add default read_keys permission for TDO objects
-   `commit <https://pagure.io/freeipa/c/df19bf51730e1762f3c1e8a1fe196ec5c5381b98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df19bf51730e1762f3c1e8a1fe196ec5c5381b98>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  add default access control when migrating trust objects
-   `commit <https://pagure.io/freeipa/c/cf23e732f521f6b6dca8a3b7043cabb161dcbca9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf23e732f521f6b6dca8a3b7043cabb161dcbca9>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
-   `commit <https://pagure.io/freeipa/c/f87ee14da5c734e6c6d2455da6272712c567c091>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f87ee14da5c734e6c6d2455da6272712c567c091>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 -  Update sudo test as SSSD 2.2.0 is available in the test image
-   `commit <https://pagure.io/freeipa/c/ce2dcd7b6188416c5c7024786e258a524eb98288>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce2dcd7b6188416c5c7024786e258a524eb98288>`__
 -  Restore SELinux context for p11-kit config overrides
-   `commit <https://pagure.io/freeipa/c/e16099a6097ed73d647e5a20d969bd15b5f4df0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e16099a6097ed73d647e5a20d969bd15b5f4df0f>`__
    `#7810 <https://pagure.io/freeipa/issue/7810>`__
 -  Back to git builds
-   `commit <https://pagure.io/freeipa/c/f4c55e144e7e73a3ed5f2875f5bddc271d4cbb38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4c55e144e7e73a3ed5f2875f5bddc271d4cbb38>`__
 
 
 
@@ -323,29 +323,29 @@ Anuja More (11)
 ----------------------------------------------------------------------------------------------
 
 -  Mark test to skip sssd-2.2.0 [sssd/issue/4073]
-   `commit <https://pagure.io/freeipa/c/2ea0a1dd3cf5bacf8599ecbe2f3f2b97b524895d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ea0a1dd3cf5bacf8599ecbe2f3f2b97b524895d>`__
 -  ipatests: User and group with same name should not break reading AD
    user data.
-   `commit <https://pagure.io/freeipa/c/7c452d70ab7b2223770592e11299574284cfaa05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c452d70ab7b2223770592e11299574284cfaa05>`__
 -  ipatests: Added test when 2FA prompting configurations is set.
-   `commit <https://pagure.io/freeipa/c/40359d2e1a1c4038ac9fc1afa2841e55b11073d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40359d2e1a1c4038ac9fc1afa2841e55b11073d8>`__
 -  Mark xfail for sssd-version < 2.2.2
-   `commit <https://pagure.io/freeipa/c/bd350690c6e984697b767279c1ec930c028f8a4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd350690c6e984697b767279c1ec930c028f8a4f>`__
 -  ipatests: SSSD should fetch external groups without any limit.
-   `commit <https://pagure.io/freeipa/c/6d65406e2baf751415c29c331b95580b70ac1706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d65406e2baf751415c29c331b95580b70ac1706>`__
 -  ipatests: Add test for ipa-extdom-extop plugin should allow @ in
    group name
-   `commit <https://pagure.io/freeipa/c/b0ad2c432362e88764bb11e14cc852c2616fd952>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0ad2c432362e88764bb11e14cc852c2616fd952>`__
 -  Update topology for test_integration/test_sssd.py
-   `commit <https://pagure.io/freeipa/c/9a0f6cb2582e265a5d1bb87aaff6049ccd5a5b35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a0f6cb2582e265a5d1bb87aaff6049ccd5a5b35>`__
 -  Fix fedora version for xfail for sssd test
-   `commit <https://pagure.io/freeipa/c/62777234a45627ff6e9b3417ce77a81194d15193>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62777234a45627ff6e9b3417ce77a81194d15193>`__
 -  ipatests: filter_users should be applied correctly.
-   `commit <https://pagure.io/freeipa/c/e8a629d2ae59566593c9855e4050f53773b325fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8a629d2ae59566593c9855e4050f53773b325fa>`__
 -  ipatests: 'sss_ssh_authorizedkeys user' should return ssh key
-   `commit <https://pagure.io/freeipa/c/480ac797439e24609f7154a168b2ddcfa32575a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/480ac797439e24609f7154a168b2ddcfa32575a4>`__
 -  Extdom plugin should not return error (32)/'No such object'
-   `commit <https://pagure.io/freeipa/c/83e3f5d105a8d52328fbd966bf82404760c51668>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83e3f5d105a8d52328fbd966bf82404760c51668>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -354,14 +354,14 @@ Christian Heimes (4)
 ----------------------------------------------------------------------------------------------
 
 -  Add test case for OTP login
-   `commit <https://pagure.io/freeipa/c/85b595aefacd8a52ca9cadf53bdd74184aeb2ba8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85b595aefacd8a52ca9cadf53bdd74184aeb2ba8>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Cherry-picked only ldapmodify_dm()
-   `commit <https://pagure.io/freeipa/c/f66df362c31f1bed322d891568d888b2e2e48bfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f66df362c31f1bed322d891568d888b2e2e48bfa>`__
 -  Print LDAP diagnostic messages on error
-   `commit <https://pagure.io/freeipa/c/1ffe826caa0283b2b2a15e341e178bac7a748fe5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ffe826caa0283b2b2a15e341e178bac7a748fe5>`__
 -  Use default ssh host key algorithms
-   `commit <https://pagure.io/freeipa/c/fb313d83adf04bc52f047c9167ade9be4c28e946>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb313d83adf04bc52f047c9167ade9be4c28e946>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 
 
@@ -370,22 +370,22 @@ François Cami (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-restore: restart services at the end
-   `commit <https://pagure.io/freeipa/c/e7fcffcc7209428f2775c97f76db3ecff8499689>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7fcffcc7209428f2775c97f76db3ecff8499689>`__
    `#8226 <https://pagure.io/freeipa/issue/8226>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
-   `commit <https://pagure.io/freeipa/c/14de3644ea1e8ce3954b1da6a0e99f6e27d4db03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14de3644ea1e8ce3954b1da6a0e99f6e27d4db03>`__
    `#8148 <https://pagure.io/freeipa/issue/8148>`__
 -  test_nfs.py: switch to master_3repl
-   `commit <https://pagure.io/freeipa/c/98d3b63ca95aafbba3075b5d38fb0bc0ee6d559e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98d3b63ca95aafbba3075b5d38fb0bc0ee6d559e>`__
    `#8027 <https://pagure.io/freeipa/issue/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/912c38a661874274206948f8bc1befa827b2d959>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/912c38a661874274206948f8bc1befa827b2d959>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/b79f8d8d38860097bfad98bd29a60a7511f02a4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b79f8d8d38860097bfad98bd29a60a7511f02a4b>`__
    `#7949 <https://pagure.io/freeipa/issue/7949>`__
 -  prci_definitions: add master_3client topology
-   `commit <https://pagure.io/freeipa/c/f5b11567488ac2c6a6abd242ef3bf37eb8781234>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5b11567488ac2c6a6abd242ef3bf37eb8781234>`__
    `#8026 <https://pagure.io/freeipa/issue/8026>`__
 
 
@@ -394,70 +394,70 @@ Florence Blanc-Renaud (22)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: wait for SSSD to become online in backup/restore tests
-   `commit <https://pagure.io/freeipa/c/dcdab7b8f8f82077943b5842368e5797a141dbb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcdab7b8f8f82077943b5842368e5797a141dbb3>`__
    `#8228 <https://pagure.io/freeipa/issue/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
-   `commit <https://pagure.io/freeipa/c/454168fadd19e0b613e76266ca62157bf2befe67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/454168fadd19e0b613e76266ca62157bf2befe67>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  idviews: prevent applying to a master
-   `commit <https://pagure.io/freeipa/c/e9bf4edbee28ea28d9d0a0ead834773c46861c4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9bf4edbee28ea28d9d0a0ead834773c46861c4c>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
-   `commit <https://pagure.io/freeipa/c/1fccdd00d53bc71e87ab5a4b1c68ab6e3efcce8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fccdd00d53bc71e87ab5a4b1c68ab6e3efcce8c>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
-   `commit <https://pagure.io/freeipa/c/59b09f154b9d85d937da64d6fe271d09c5b61bc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59b09f154b9d85d937da64d6fe271d09c5b61bc1>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
-   `commit <https://pagure.io/freeipa/c/3a880ff64d44156fa274ef13ea726fe78cd37f2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a880ff64d44156fa274ef13ea726fe78cd37f2e>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
-   `commit <https://pagure.io/freeipa/c/2b5c409c3031696a358d57def4dc2e98142ef643>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b5c409c3031696a358d57def4dc2e98142ef643>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/15ab3a21dcfca6d11de0179455a09f3816f30bf3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15ab3a21dcfca6d11de0179455a09f3816f30bf3>`__
 -  ipatests: fix modify_sssd_conf()
-   `commit <https://pagure.io/freeipa/c/6b25791f791e716f566dc945b58f241c71312cb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b25791f791e716f566dc945b58f241c71312cb6>`__
 -  ipatests: fix backup and restore
-   `commit <https://pagure.io/freeipa/c/aa0bcb1380198fee4028eeb327c6541828779391>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa0bcb1380198fee4028eeb327c6541828779391>`__
    `#8170 <https://pagure.io/freeipa/issue/8170>`__
 -  AD user without override receive InternalServerError with API
-   `commit <https://pagure.io/freeipa/c/f9f822ac10c0a5fffca906d5f5412c8d35adcc18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9f822ac10c0a5fffca906d5f5412c8d35adcc18>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 -  ipa-cacert-manage man page: fix indentation
-   `commit <https://pagure.io/freeipa/c/a281a42ed89c1e901c7f4676423998c6764ec765>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a281a42ed89c1e901c7f4676423998c6764ec765>`__
    `#8138 <https://pagure.io/freeipa/issue/8138>`__
 -  trust upgrade: ensure that host is member of adtrust agents
-   `commit <https://pagure.io/freeipa/c/206e1f94efda11dd773860c9bbf9609d797688d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/206e1f94efda11dd773860c9bbf9609d797688d4>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
-   `commit <https://pagure.io/freeipa/c/134c6bd1243329ec41f7a6648e78af57955bc6a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/134c6bd1243329ec41f7a6648e78af57955bc6a6>`__
    `#8113 <https://pagure.io/freeipa/issue/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
-   `commit <https://pagure.io/freeipa/c/3a399e1dfa4d64ad1a1030f86dbdb13486aa69f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a399e1dfa4d64ad1a1030f86dbdb13486aa69f7>`__
    `#8099 <https://pagure.io/freeipa/issue/8099>`__
 -  ipa-server-certinstall manpage: add missing options
-   `commit <https://pagure.io/freeipa/c/5448797ee8a0d1e83599a58bb1b0b8257a9ff35a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5448797ee8a0d1e83599a58bb1b0b8257a9ff35a>`__
    `#8086 <https://pagure.io/freeipa/issue/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
-   `commit <https://pagure.io/freeipa/c/548b697fbdc9a851ce22745a477f938c5816bf43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/548b697fbdc9a851ce22745a477f938c5816bf43>`__
    `#8070 <https://pagure.io/freeipa/issue/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
-   `commit <https://pagure.io/freeipa/c/6f512b00ee4b5cce9e5b8a658cb7388e2aa3a52a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f512b00ee4b5cce9e5b8a658cb7388e2aa3a52a>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
-   `commit <https://pagure.io/freeipa/c/ee0b0f66c15b4062c214f6993bc0b1e0da9a8a6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee0b0f66c15b4062c214f6993bc0b1e0da9a8a6d>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  replica install: enforce --server arg
-   `commit <https://pagure.io/freeipa/c/6c5e72aee4dffb353b79b99324858bf2a1ec7314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c5e72aee4dffb353b79b99324858bf2a1ec7314>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
-   `commit <https://pagure.io/freeipa/c/a7168658210c85e746c6bb2d1a0be9b546702677>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7168658210c85e746c6bb2d1a0be9b546702677>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
-   `commit <https://pagure.io/freeipa/c/5bf6a39ceab02e0dca0626a556eadfe6a853a61a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bf6a39ceab02e0dca0626a556eadfe6a853a61a>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 
 
@@ -466,16 +466,16 @@ Fraser Tweedale (4)
 ----------------------------------------------------------------------------------------------
 
 -  Do not renew externally-signed CA as self-signed
-   `commit <https://pagure.io/freeipa/c/3afd13a0b45de7349e2cb27cb45e7b3a02edf1c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3afd13a0b45de7349e2cb27cb45e7b3a02edf1c6>`__
    `#8176 <https://pagure.io/freeipa/issue/8176>`__
 -  test_integration: add tests for custom CA subject DN
-   `commit <https://pagure.io/freeipa/c/4767add057353280274b884b1bd15f7f63408970>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4767add057353280274b884b1bd15f7f63408970>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
-   `commit <https://pagure.io/freeipa/c/4aad2c9b5ed7c7f4b6cba1e0328cf2ff88175d1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4aad2c9b5ed7c7f4b6cba1e0328cf2ff88175d1c>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
-   `commit <https://pagure.io/freeipa/c/1071eb2c64ef94fde13ba7a146d75635b4d56244>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1071eb2c64ef94fde13ba7a146d75635b4d56244>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 
 
@@ -484,7 +484,7 @@ Gaurav Talreja (1)
 ----------------------------------------------------------------------------------------------
 
 -  Normalize test definations titles
-   `commit <https://pagure.io/freeipa/c/c22da325586eff18b1bb732d7e18b7161ea06fd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c22da325586eff18b1bb732d7e18b7161ea06fd3>`__
 
 
 
@@ -492,9 +492,9 @@ Jayesh Garg (2)
 ----------------------------------------------------------------------------------------------
 
 -  Test if ipactl starts services stopped by systemctl
-   `commit <https://pagure.io/freeipa/c/db6d0a6563644a003a6842ea712d9d6af99ee28c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db6d0a6563644a003a6842ea712d9d6af99ee28c>`__
 -  Test for ipa-ca-install on replica
-   `commit <https://pagure.io/freeipa/c/1cd2ff5577af1043389e9bf59cb741b184ca31a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1cd2ff5577af1043389e9bf59cb741b184ca31a1>`__
 
 
 
@@ -503,15 +503,15 @@ Michal Polovka (3)
 
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
-   `commit <https://pagure.io/freeipa/c/353062abc635d6fd310680461618d1cc32d5e07a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/353062abc635d6fd310680461618d1cc32d5e07a>`__
    `#2018 <https://pagure.io/freeipa/issue/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
-   `commit <https://pagure.io/freeipa/c/465706ac98cd7608916090610418a15943e791e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/465706ac98cd7608916090610418a15943e791e0>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__,
    `#8055 <https://pagure.io/freeipa/issue/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
-   `commit <https://pagure.io/freeipa/c/b384b297f44e3fb96b1509affabcd9f0011592a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b384b297f44e3fb96b1509affabcd9f0011592a7>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__
 
 
@@ -520,18 +520,18 @@ Mohammad Rizwan Yusuf (5)
 ----------------------------------------------------------------------------------------------
 
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/651d97a47d1f60875648ae72c2c0e6fe6ffabe04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/651d97a47d1f60875648ae72c2c0e6fe6ffabe04>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/405363baa62c7a2e875aae516abc8080031094f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/405363baa62c7a2e875aae516abc8080031094f2>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  add test to nightly yaml
-   `commit <https://pagure.io/freeipa/c/16c794d8a3d7d690883da5b29c5c04a203a2b8db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16c794d8a3d7d690883da5b29c5c04a203a2b8db>`__
 -  Installation of replica against a specific server
-   `commit <https://pagure.io/freeipa/c/e12fa0b88371962e3684c6b932980c3ac0ab8e1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e12fa0b88371962e3684c6b932980c3ac0ab8e1d>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  Check file ownership and permission for dirsrv log instance
-   `commit <https://pagure.io/freeipa/c/140111cd53803194a6c41a576cab9b3c282ed54f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/140111cd53803194a6c41a576cab9b3c282ed54f>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 
 
@@ -540,7 +540,7 @@ ndehadra (1)
 ----------------------------------------------------------------------------------------------
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
-   `commit <https://pagure.io/freeipa/c/90c22dbc46910739b1ed43c5a1e94afdc464fe75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90c22dbc46910739b1ed43c5a1e94afdc464fe75>`__
    `#7307 <https://pagure.io/freeipa/issue/7307>`__
 
 
@@ -549,31 +549,31 @@ Rob Crittenden (10)
 ----------------------------------------------------------------------------------------------
 
 -  Test that pwpolicy only applied on Kerberos entries
-   `commit <https://pagure.io/freeipa/c/1e6f6f590342fd5c3cf90dee8f23ca1d2651c551>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e6f6f590342fd5c3cf90dee8f23ca1d2651c551>`__
 -  Add ability to change a user password as the Directory Manager
-   `commit <https://pagure.io/freeipa/c/6d28e82b2616ccc8b67cbe1b60d5e914e02636ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d28e82b2616ccc8b67cbe1b60d5e914e02636ca>`__
 -  Don't save password history on non-Kerberos accounts
-   `commit <https://pagure.io/freeipa/c/82585849cfbad0c7cf2225d2766cb0aed0dce898>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82585849cfbad0c7cf2225d2766cb0aed0dce898>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/e5983600bfc0f143c3a6732be6532e48d9faaf15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5983600bfc0f143c3a6732be6532e48d9faaf15>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
-   `commit <https://pagure.io/freeipa/c/e8ed8b0b242e3c8e4107090f56a4771b53b777e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8ed8b0b242e3c8e4107090f56a4771b53b777e5>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
-   `commit <https://pagure.io/freeipa/c/05b173c1a7fb0b18b371771bafe01c0083547c79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05b173c1a7fb0b18b371771bafe01c0083547c79>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 -  Report if a certmonger CA is missing
-   `commit <https://pagure.io/freeipa/c/eda9a51110a645de2ffe459a5101631af4d7772b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eda9a51110a645de2ffe459a5101631af4d7772b>`__
    `#7870 <https://pagure.io/freeipa/issue/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
-   `commit <https://pagure.io/freeipa/c/a62e3c011992ca8d4d9dbd0a8d97b036820a5cd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a62e3c011992ca8d4d9dbd0a8d97b036820a5cd2>`__
    `#8034 <https://pagure.io/freeipa/issue/8034>`__
 -  Don't log host passwords when they are set/modified
-   `commit <https://pagure.io/freeipa/c/2d58e3bcaa8732f448e01e75448092fe53fd6d13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d58e3bcaa8732f448e01e75448092fe53fd6d13>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
-   `commit <https://pagure.io/freeipa/c/bdbc918724275e19c81e2e8fa6edfa1972e63f95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdbc918724275e19c81e2e8fa6edfa1972e63f95>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 
 
@@ -582,11 +582,11 @@ Robbie Harwood (3)
 ----------------------------------------------------------------------------------------------
 
 -  Fix segfault in ipadb_parse_ldap_entry()
-   `commit <https://pagure.io/freeipa/c/6b4a80e889a2603a65e869f4fd492c9c4fe5c896>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b4a80e889a2603a65e869f4fd492c9c4fe5c896>`__
 -  Fix NULL pointer dereference in maybe_require_preauth()
-   `commit <https://pagure.io/freeipa/c/47aa96e7ff0bf31edefaa8cbe76c0acb360a7fb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47aa96e7ff0bf31edefaa8cbe76c0acb360a7fb3>`__
 -  Log INFO message when LDAP connection fails on startup
-   `commit <https://pagure.io/freeipa/c/dbdd15966b035c657517a373e6b91c35e0ac1cb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbdd15966b035c657517a373e6b91c35e0ac1cb8>`__
 
 
 
@@ -594,7 +594,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
-   `commit <https://pagure.io/freeipa/c/a0a16df8a9a171c6508a04970ba3b5321d43ddfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0a16df8a9a171c6508a04970ba3b5321d43ddfa>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -603,13 +603,13 @@ Stanislav Levin (3)
 ----------------------------------------------------------------------------------------------
 
 -  pki-proxy: Don't rely on running apache until it's configured
-   `commit <https://pagure.io/freeipa/c/0db996906bbc0fcfd02c81dd468276aae67f0e53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0db996906bbc0fcfd02c81dd468276aae67f0e53>`__
    `#8233 <https://pagure.io/freeipa/issue/8233>`__
 -  Fix errors found by Pylint-2.4.3
-   `commit <https://pagure.io/freeipa/c/20548ef82f470e11c11722b549f4aac21e8ca5a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20548ef82f470e11c11722b549f4aac21e8ca5a7>`__
    `#8102 <https://pagure.io/freeipa/issue/8102>`__
 -  Fixed errors newly exposed by pylint 2.4.0
-   `commit <https://pagure.io/freeipa/c/1248050e19fef3aa39a95fecd2257f841ef6392e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1248050e19fef3aa39a95fecd2257f841ef6392e>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 
 
@@ -618,52 +618,52 @@ Sergey Orlov (19)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: provide AD admin password when trying to establish trust
-   `commit <https://pagure.io/freeipa/c/db1b9fc428d8932f4fa9da79501ff2be8e4e7cc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db1b9fc428d8932f4fa9da79501ff2be8e4e7cc2>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  ipatests: remove test_ordering
-   `commit <https://pagure.io/freeipa/c/ca8cd6ad722590eec545bfb2a68208a0ba8557f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca8cd6ad722590eec545bfb2a68208a0ba8557f0>`__
 -  ipatests: remove invalid parameter from sssd.conf
-   `commit <https://pagure.io/freeipa/c/c89dbf2440ef0da37b1f766f7a424408b3202966>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c89dbf2440ef0da37b1f766f7a424408b3202966>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
-   `commit <https://pagure.io/freeipa/c/90d88634ef0b05fdfe6879e03c7c44cd2246668d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90d88634ef0b05fdfe6879e03c7c44cd2246668d>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: replace utility for editing sssd.conf
-   `commit <https://pagure.io/freeipa/c/7a4d30717e1d4a65e0e9277e6a52e369df3989bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a4d30717e1d4a65e0e9277e6a52e369df3989bf>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
-   `commit <https://pagure.io/freeipa/c/aa722083cea3d3d238d80699de21201242888116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa722083cea3d3d238d80699de21201242888116>`__
 -  ipatests: add test_trust suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/5ed1b87c384ce4df6dfeb34424295280cf92dde8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ed1b87c384ce4df6dfeb34424295280cf92dde8>`__
 -  ipatests: fix collection of tests from test_trust suite
-   `commit <https://pagure.io/freeipa/c/39a0b12fca2ea4b760f6c1aad99f1fa6614c159b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39a0b12fca2ea4b760f6c1aad99f1fa6614c159b>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/a60c057310db5ad11f4358890fc9e3784681e663>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a60c057310db5ad11f4358890fc9e3784681e663>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
-   `commit <https://pagure.io/freeipa/c/e2a7e73f86d66740f8e6c8e64929bcad6793b6f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2a7e73f86d66740f8e6c8e64929bcad6793b6f6>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 -  ipatests: refactor FileBackup helper
-   `commit <https://pagure.io/freeipa/c/f92c28da7bbc03c2ef47f0617e8dabbdfd0bf65e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f92c28da7bbc03c2ef47f0617e8dabbdfd0bf65e>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: in DNS zone file add A record for name server
-   `commit <https://pagure.io/freeipa/c/13fbe2c8642906711c660ab7edc1b7b883b295a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13fbe2c8642906711c660ab7edc1b7b883b295a7>`__
 -  ipatests: strip newline character when getting name of temp file
-   `commit <https://pagure.io/freeipa/c/6b59ceeb37f4c94fe2903fdd7ff81149147f7bd9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b59ceeb37f4c94fe2903fdd7ff81149147f7bd9>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
-   `commit <https://pagure.io/freeipa/c/f9566100a512656b98b72baf708becc7870750c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9566100a512656b98b72baf708becc7870750c4>`__
    `#7995 <https://pagure.io/freeipa/issue/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
-   `commit <https://pagure.io/freeipa/c/180259f20c4170b96b3a0433d4db0950eda6cd20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/180259f20c4170b96b3a0433d4db0950eda6cd20>`__
 -  ipatests: add tests for cached_auth_timeout in sssd.conf
-   `commit <https://pagure.io/freeipa/c/72dc394614300ee4dac25b4509eb216d5104c224>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72dc394614300ee4dac25b4509eb216d5104c224>`__
 -  ipatests: add new utilities for file management
-   `commit <https://pagure.io/freeipa/c/f44dc80c52d0357fb582a0999958221dab33b952>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f44dc80c52d0357fb582a0999958221dab33b952>`__
 -  ipatests: add utility functions related to using and managing user
    accounts
-   `commit <https://pagure.io/freeipa/c/62fe597a68a218eebf106ca7dc5d107b14ea4e3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62fe597a68a218eebf106ca7dc5d107b14ea4e3d>`__
 -  ipatests: modify run_command to allow specify successful return codes
-   `commit <https://pagure.io/freeipa/c/a092198a0bd9ac6fa37635a21163061cc186d0fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a092198a0bd9ac6fa37635a21163061cc186d0fb>`__
 
 
 
@@ -672,11 +672,11 @@ Sumedh Sidhaye (2)
 
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
-   `commit <https://pagure.io/freeipa/c/f4fdfaac3bea3b1301222f6362275f34b1b710e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4fdfaac3bea3b1301222f6362275f34b1b710e9>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
-   `commit <https://pagure.io/freeipa/c/4c421ec4d5dbfa63027c8c41b8b699a2b938e3de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c421ec4d5dbfa63027c8c41b8b699a2b938e3de>`__
 
 
 
@@ -684,7 +684,7 @@ Simo Sorce (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure to have storage space for tag
-   `commit <https://pagure.io/freeipa/c/975c1a3d6c48bf5d71fbe12373603298a5573754>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/975c1a3d6c48bf5d71fbe12373603298a5573754>`__
 
 
 
@@ -692,26 +692,26 @@ Serhii Tsymbaliuk (7)
 ----------------------------------------------------------------------------------------------
 
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/5e122aa20594e8f34ffa175401d6ada4c05bbb5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e122aa20594e8f34ffa175401d6ada4c05bbb5e>`__
    `#8239 <https://pagure.io/freeipa/issue/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
-   `commit <https://pagure.io/freeipa/c/a45679047f82a3fbb98422a023a782766df0ca25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a45679047f82a3fbb98422a023a782766df0ca25>`__
    `#8157 <https://pagure.io/freeipa/issue/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
-   `commit <https://pagure.io/freeipa/c/220aba3119c2243e890540a95404f14cfffc6ca5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/220aba3119c2243e890540a95404f14cfffc6ca5>`__
    `#8169 <https://pagure.io/freeipa/issue/8169>`__
 -  Fix occasional 'whoami.data is undefined' error in FreeIPA web UI
-   `commit <https://pagure.io/freeipa/c/74e66ba3aac2fcf751f58a89879e2031078c7960>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74e66ba3aac2fcf751f58a89879e2031078c7960>`__
    `#7917 <https://pagure.io/freeipa/issue/7917>`__
 -  Fix certificate revocation tests for Web UI
-   `commit <https://pagure.io/freeipa/c/e054f681a301bdde2ed92334957fe906229b3bcf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e054f681a301bdde2ed92334957fe906229b3bcf>`__
    `#7834 <https://pagure.io/freeipa/issue/7834>`__
 -  WebUI: Fix notification area layout
-   `commit <https://pagure.io/freeipa/c/128a8bcf7b18a7e295ac8cb811021cf462282877>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/128a8bcf7b18a7e295ac8cb811021cf462282877>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
-   `commit <https://pagure.io/freeipa/c/ad006f7008cf6d97c0ff435b5bcb6d17a450a94b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad006f7008cf6d97c0ff435b5bcb6d17a450a94b>`__
    `#5062 <https://pagure.io/freeipa/issue/5062>`__
 
 
@@ -720,17 +720,17 @@ Tibor Dudlák (5)
 ----------------------------------------------------------------------------------------------
 
 -  Add container environment check to replicainstall
-   `commit <https://pagure.io/freeipa/c/82351f1e09e9d592e3b0bef521c2c94b0d222cce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82351f1e09e9d592e3b0bef521c2c94b0d222cce>`__
    `#6210 <https://pagure.io/freeipa/issue/6210>`__
 -  Increase ntp_options test timeout
-   `commit <https://pagure.io/freeipa/c/0f40193c6301174f54865fd867ad279456fe3ddd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f40193c6301174f54865fd867ad279456fe3ddd>`__
 -  ipatests: refactor TestNTPoptions
-   `commit <https://pagure.io/freeipa/c/6a046c525d61f5962c02a7ede808080089420604>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a046c525d61f5962c02a7ede808080089420604>`__
 -  ipatests: Add tests for interactive chronyd config
-   `commit <https://pagure.io/freeipa/c/b2c79ecbc1e47e36cbc7e65a575a398bd005f95c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2c79ecbc1e47e36cbc7e65a575a398bd005f95c>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 -  ipatests: Update test tasks for client to be interactive
-   `commit <https://pagure.io/freeipa/c/4e08b90bb785416582f4e993206b9342b1f0dbf9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e08b90bb785416582f4e993206b9342b1f0dbf9>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 
 
@@ -739,13 +739,13 @@ Tomas Halman (4)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: add extdom protocol documentation
-   `commit <https://pagure.io/freeipa/c/f8b070587c5c2779b6b76237d1c712a0947f9438>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8b070587c5c2779b6b76237d1c712a0947f9438>`__
 -  extdom: use sss_nss_*_timeout calls
-   `commit <https://pagure.io/freeipa/c/5340a03e30d37015777eafb58d7f36fc3d81c5eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5340a03e30d37015777eafb58d7f36fc3d81c5eb>`__
 -  extdom: plugin doesn't use timeout in blocking call
-   `commit <https://pagure.io/freeipa/c/b442b82b4a4c80b9e7992b33eb008f4f0dea44e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b442b82b4a4c80b9e7992b33eb008f4f0dea44e2>`__
 -  extdom: plugin doesn't allow @ in group name
-   `commit <https://pagure.io/freeipa/c/2e8a2a564a46a2a4f04236e08dda26d6126135ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e8a2a564a46a2a4f04236e08dda26d6126135ea>`__
 
 
 
@@ -753,4 +753,4 @@ Theodor van Nahl (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix UnboundLocalError in ipa-replica-manage on errors
-   `commit <https://pagure.io/freeipa/c/635c4db608e0dcb8fa2bfd88fe291e9f3ce838db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/635c4db608e0dcb8fa2bfd88fe291e9f3ce838db>`__

--- a/src/page/Releases/4.8.0.rst
+++ b/src/page/Releases/4.8.0.rst
@@ -427,103 +427,103 @@ Alexander Bokovoy (35)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.8.0
-   `commit <https://pagure.io/freeipa/c/15db87855109d8ffea2c5b12f092180eb2d4c852>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15db87855109d8ffea2c5b12f092180eb2d4c852>`__
 -  translations: update from Zanata Spanish and Ukrainian translations
-   `commit <https://pagure.io/freeipa/c/e6b2894795f04fde15048be0acacedaf4ce52030>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6b2894795f04fde15048be0acacedaf4ce52030>`__
 -  Set up CI with Azure Pipelines
-   `commit <https://pagure.io/freeipa/c/58fe6fac619200873c299b158c639d88f9b9b7ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58fe6fac619200873c299b158c639d88f9b9b7ce>`__
 -  prci: add test_integration/test_smb to the gating set
-   `commit <https://pagure.io/freeipa/c/e25392e976bcbc34e53fafa5eb68014ff3ceb5e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e25392e976bcbc34e53fafa5eb68014ff3ceb5e5>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipa-client-samba: a tool to configure Samba domain member on IPA
    client
-   `commit <https://pagure.io/freeipa/c/814592cf2218956893baa2272101fffa93abb465>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/814592cf2218956893baa2272101fffa93abb465>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipaserver.plugins.service: add service-add-smb to set up an SMB
    service
-   `commit <https://pagure.io/freeipa/c/afb8305ada944293f978a20f3829d0ab93180c2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afb8305ada944293f978a20f3829d0ab93180c2d>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  adtrust: update Samba domain controller keytab with host keys
-   `commit <https://pagure.io/freeipa/c/d631e008ccec6827ca0c4b8d442469b0f0c994a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d631e008ccec6827ca0c4b8d442469b0f0c994a8>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  kdb: support SMB services on IPA domain members
-   `commit <https://pagure.io/freeipa/c/653f72079ee27cfdfb880afb20905b7099748c14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/653f72079ee27cfdfb880afb20905b7099748c14>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipasam: add handling of machine accounts
-   `commit <https://pagure.io/freeipa/c/91abd1f67ad86ecdaf3100e282b045a6be7de591>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91abd1f67ad86ecdaf3100e282b045a6be7de591>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipasam: add lookup of an account by SID
-   `commit <https://pagure.io/freeipa/c/a42352628df6ac4a9a174bee89032c356fac4801>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a42352628df6ac4a9a174bee89032c356fac4801>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipapython.ipautil.run: allow skipping stdout/stderr logging
-   `commit <https://pagure.io/freeipa/c/d85e0550cab58d64e65610314906d32bd21a9e39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d85e0550cab58d64e65610314906d32bd21a9e39>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipaserver.install.installutils: move commonly used utils to
    ipapython.ipautil
-   `commit <https://pagure.io/freeipa/c/cdb94e0ff2c7bc03b2f0064b77fedabfa0ae8121>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdb94e0ff2c7bc03b2f0064b77fedabfa0ae8121>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  adtrust: add design document for Samba domain member on IPA client
-   `commit <https://pagure.io/freeipa/c/84201e1daff7e2cd80352654dc7c81530b51dc74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84201e1daff7e2cd80352654dc7c81530b51dc74>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  trust-fetch-domains: make sure we use right KDC when --server is
    specified
-   `commit <https://pagure.io/freeipa/c/6c9fcccfbcbb78b49b65c12bf05b2647f1522609>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c9fcccfbcbb78b49b65c12bf05b2647f1522609>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  adtrust upgrade: fix wrong primary principal name, part 2
-   `commit <https://pagure.io/freeipa/c/7af4c7d4720227b5bff037a128061bf616e27096>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7af4c7d4720227b5bff037a128061bf616e27096>`__
    `#7992 <https://pagure.io/freeipa/issue/7992>`__
 -  adtrust upgrade: fix wrong primary principal name
-   `commit <https://pagure.io/freeipa/c/34bfffd1bed4ecd11fbcfe54904e0ac7e3f609e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34bfffd1bed4ecd11fbcfe54904e0ac7e3f609e7>`__
    `#7992 <https://pagure.io/freeipa/issue/7992>`__
 -  azure tests: make sure /etc/docker folder exists
-   `commit <https://pagure.io/freeipa/c/8f4ca3957c84e3f9339bcfb7c511f80553c58e00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f4ca3957c84e3f9339bcfb7c511f80553c58e00>`__
 -  ipa-pwd-extop: do not remove MagicRegen mod, replace it
-   `commit <https://pagure.io/freeipa/c/a9bcf531a69b8a39ee2df86b4eb783023b33928e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9bcf531a69b8a39ee2df86b4eb783023b33928e>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  test_ipagetkeytab: test retrieval of explicit encryption types
-   `commit <https://pagure.io/freeipa/c/46234f0cb91ad892b7420eb061e758e26c64e3c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46234f0cb91ad892b7420eb061e758e26c64e3c7>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  Keytab retrieval: allow requesting arcfour-hmac for SMB services
-   `commit <https://pagure.io/freeipa/c/b5fbbd1957873207afc2542a9d32246bccca0556>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5fbbd1957873207afc2542a9d32246bccca0556>`__
 -  test_ipagetkeytab: factor out DM password reader
-   `commit <https://pagure.io/freeipa/c/0f891c6a3fef7b75cb4b0a125e26e6e80b0bdcf3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f891c6a3fef7b75cb4b0a125e26e6e80b0bdcf3>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  test_ipagetkeytab: allow testing LDAP connection beyond bind
    operation
-   `commit <https://pagure.io/freeipa/c/6163cbc16658930f49794ebecd5a6ac14ba8cfd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6163cbc16658930f49794ebecd5a6ac14ba8cfd4>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  ldap2.can_read: fix py3 compatibility
-   `commit <https://pagure.io/freeipa/c/ef67dece522335fd26fcdddc822beb4bcc8e6b17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef67dece522335fd26fcdddc822beb4bcc8e6b17>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  LDAPCreate: allow callers to override objectclasses
-   `commit <https://pagure.io/freeipa/c/53a0fa9130493d383d2542622ccdbdd483650bad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53a0fa9130493d383d2542622ccdbdd483650bad>`__
    `#7953 <https://pagure.io/freeipa/issue/7953>`__
 -  Azure Pipelines: run fast linter in case of a pull request build
-   `commit <https://pagure.io/freeipa/c/5230e2a12ddbed0e27b107d7174d08e038f3bc1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5230e2a12ddbed0e27b107d7174d08e038f3bc1f>`__
 -  Azure Pipelines: simplify test job definitions
-   `commit <https://pagure.io/freeipa/c/c8ef093e56e8eaa9c53abb31bed51ff30c9c64ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8ef093e56e8eaa9c53abb31bed51ff30c9c64ef>`__
 -  ipa-run-tests: add support of globs for test targets and ignores
-   `commit <https://pagure.io/freeipa/c/6a2c356da0c603f209f2310c013ef085e0c11eda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a2c356da0c603f209f2310c013ef085e0c11eda>`__
 -  i18n_messages: get back a locale needed for testing
-   `commit <https://pagure.io/freeipa/c/74f3ca5db054d333a0a8d65abee90edba32a202a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74f3ca5db054d333a0a8d65abee90edba32a202a>`__
    `#7951 <https://pagure.io/freeipa/issue/7951>`__
 -  test_legacy_clients: fix class inheritance
-   `commit <https://pagure.io/freeipa/c/245a8bcdfe32f665a0a1902e54d49e4ba2cd4ce4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/245a8bcdfe32f665a0a1902e54d49e4ba2cd4ce4>`__
    `#7940 <https://pagure.io/freeipa/issue/7940>`__
 -  fix selenium imports in automount web UI test
-   `commit <https://pagure.io/freeipa/c/c41b3ae98f0782d05318dd2c36c88f66aa25909b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c41b3ae98f0782d05318dd2c36c88f66aa25909b>`__
    `#7942 <https://pagure.io/freeipa/issue/7942>`__
 -  azure-run-tests: handle single unexpanded parameter too
-   `commit <https://pagure.io/freeipa/c/9cb6817b3064da5a85d415b6b29dbfd9429d6d8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cb6817b3064da5a85d415b6b29dbfd9429d6d8d>`__
 -  Use nodejs 1.10 to avoid current issues with nodejs 1.11 in Fedora 30
-   `commit <https://pagure.io/freeipa/c/b7533d9c5fd66441699a764df3b225a3a62d6fab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7533d9c5fd66441699a764df3b225a3a62d6fab>`__
 -  upgrade: adtrust - catch empty result when retrieving list of trusts
-   `commit <https://pagure.io/freeipa/c/98b4c710d90f289322ebda457fdb84c2dd34aace>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98b4c710d90f289322ebda457fdb84c2dd34aace>`__
    `#7939 <https://pagure.io/freeipa/issue/7939>`__
 -  Revert "Require a minimum SASL security factor of 56"
-   `commit <https://pagure.io/freeipa/c/294aa3a33375dc246b2a733fce3cbd09a39071a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/294aa3a33375dc246b2a733fce3cbd09a39071a0>`__
 -  Turn master branch back after pre-release tagging
-   `commit <https://pagure.io/freeipa/c/dc113a0a31409a8383665c2fe013d17fd3d1b5da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc113a0a31409a8383665c2fe013d17fd3d1b5da>`__
 
 
 
@@ -531,13 +531,13 @@ Armando Neto (4)
 ----------------------------------------------------------------------------------------------
 
 -  prci: fix nightly_master test definitions
-   `commit <https://pagure.io/freeipa/c/f6b07c19389cdea33a9a7d503036d2a019cf0c6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6b07c19389cdea33a9a7d503036d2a019cf0c6e>`__
 -  prci: bump ci-master-f30 template
-   `commit <https://pagure.io/freeipa/c/672d808e0d1ba5a2bbfba1cfda1b2968f30c64aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/672d808e0d1ba5a2bbfba1cfda1b2968f30c64aa>`__
 -  Add Fedora 30 test definitions and bump template version
-   `commit <https://pagure.io/freeipa/c/e08a340aed94f3b728c5cf97761eedd84f1a37bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e08a340aed94f3b728c5cf97761eedd84f1a37bb>`__
 -  Bump PR-CI template version
-   `commit <https://pagure.io/freeipa/c/c0d408804972d5e207b4056220bdf725ffb7b6ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0d408804972d5e207b4056220bdf725ffb7b6ef>`__
 
 
 
@@ -545,7 +545,7 @@ Anuja More (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: POSIX attributes are no longer overwritten or missing
-   `commit <https://pagure.io/freeipa/c/986e16dafef9c5bf67e6c4bc047033800744764f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/986e16dafef9c5bf67e6c4bc047033800744764f>`__
 
 
 
@@ -553,7 +553,7 @@ Adam Williamson (1)
 ----------------------------------------------------------------------------------------------
 
 -  Correct default fontawesome path (broken by da2cf1c5)
-   `commit <https://pagure.io/freeipa/c/78652a52f083bac5238f9e0a6520e0e448dadabe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78652a52f083bac5238f9e0a6520e0e448dadabe>`__
 
 
 
@@ -561,40 +561,40 @@ Christian Heimes (14)
 ----------------------------------------------------------------------------------------------
 
 -  Use system-wide crypto policy for TLS ciphers
-   `commit <https://pagure.io/freeipa/c/b55344888478e2b05dc01200bed87e551aa7d00a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b55344888478e2b05dc01200bed87e551aa7d00a>`__
    `#7998 <https://pagure.io/freeipa/issue/7998>`__
 -  Use only TLS 1.2 by default
-   `commit <https://pagure.io/freeipa/c/b57c818fab3bb9627a8c287766cdb5bd8071c837>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b57c818fab3bb9627a8c287766cdb5bd8071c837>`__
    `#7667 <https://pagure.io/freeipa/issue/7667>`__
 -  Increase default debug level of certmonger
-   `commit <https://pagure.io/freeipa/c/ac86707de3b424aa76d72b55139e5aecdebc81b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac86707de3b424aa76d72b55139e5aecdebc81b8>`__
    `#7986 <https://pagure.io/freeipa/issue/7986>`__
 -  Replace PYTHONSHEBANG with valid shebang
-   `commit <https://pagure.io/freeipa/c/6d02eddd3ef7f65c1a922125371fcbb83e35d7f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d02eddd3ef7f65c1a922125371fcbb83e35d7f8>`__
    `#7984 <https://pagure.io/freeipa/issue/7984>`__
 -  Fix CustodiaClient ccache handling
-   `commit <https://pagure.io/freeipa/c/c027b9334b8c3fbb1f31674d7b46c9edb5445208>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c027b9334b8c3fbb1f31674d7b46c9edb5445208>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 -  Bump release number to 4.7.91
-   `commit <https://pagure.io/freeipa/c/02d6fc74749f4c8aacb6e5963c952fb65d0516f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02d6fc74749f4c8aacb6e5963c952fb65d0516f1>`__
 -  Forbid imports of ipaserver and install packages
-   `commit <https://pagure.io/freeipa/c/2d22fdafaa9c27327b55abec3ed9e96c5d51c1bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d22fdafaa9c27327b55abec3ed9e96c5d51c1bd>`__
 -  integration plugins import ldif
-   `commit <https://pagure.io/freeipa/c/984a44a46a7a1aecdd26ea9b2c5e9bf19a84fe02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/984a44a46a7a1aecdd26ea9b2c5e9bf19a84fe02>`__
 -  Don't import ipaserver in conf.py
-   `commit <https://pagure.io/freeipa/c/8bd469c54ea3d00652d252f3c97a771515a965a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8bd469c54ea3d00652d252f3c97a771515a965a8>`__
 -  Replace imports from ipaserver
-   `commit <https://pagure.io/freeipa/c/4b7e81fbbe5ae0b0b4178f1a8ff5544346339ce1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b7e81fbbe5ae0b0b4178f1a8ff5544346339ce1>`__
 -  Delay import of SSSDConfig
-   `commit <https://pagure.io/freeipa/c/289f9c7e254180b6c28a724f0e840f89756c11de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/289f9c7e254180b6c28a724f0e840f89756c11de>`__
 -  Use PKCS#8 instead of traditional privkey format
-   `commit <https://pagure.io/freeipa/c/2042b5a0d2236d27ce36a139b4e9e89a055f28b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2042b5a0d2236d27ce36a139b4e9e89a055f28b5>`__
    `#7943 <https://pagure.io/freeipa/issue/7943>`__
 -  Load libldap_r-\*.so.2
-   `commit <https://pagure.io/freeipa/c/64dc92ccb4f057ec49070b323f3b827d8642cece>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64dc92ccb4f057ec49070b323f3b827d8642cece>`__
    `#7941 <https://pagure.io/freeipa/issue/7941>`__
 -  Import urllib submodules
-   `commit <https://pagure.io/freeipa/c/e73fdcf8baf5c18ce2c3de011268aea9c81c1e1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e73fdcf8baf5c18ce2c3de011268aea9c81c1e1b>`__
 
 
 
@@ -602,44 +602,44 @@ François Cami (14)
 ----------------------------------------------------------------------------------------------
 
 -  Make dnf more robust and faster
-   `commit <https://pagure.io/freeipa/c/7027f7914e32bcf0942931f8915fe602e27dd7aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7027f7914e32bcf0942931f8915fe602e27dd7aa>`__
    `#7999 <https://pagure.io/freeipa/issue/7999>`__
 -  Makefile.am: add .in files to fastlint target
-   `commit <https://pagure.io/freeipa/c/6b2efdfae5302427543ef42686c35db737da6261>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b2efdfae5302427543ef42686c35db737da6261>`__
    `#7984 <https://pagure.io/freeipa/issue/7984>`__
 -  Introduce minimal ipa-client-automount.in and ipactl.in
-   `commit <https://pagure.io/freeipa/c/37ab150cc70be21ca57ca253d2a337533131457a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37ab150cc70be21ca57ca253d2a337533131457a>`__
    `#7984 <https://pagure.io/freeipa/issue/7984>`__
 -  ipa_client_automount.py and ipactl.py: fix codestyle
-   `commit <https://pagure.io/freeipa/c/b49c627aa688e0eb1e9b34ff626f2a19aa4f6c3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b49c627aa688e0eb1e9b34ff626f2a19aa4f6c3e>`__
    `#7984 <https://pagure.io/freeipa/issue/7984>`__
 -  Move ipa-client-automount.in and ipactl into modules
-   `commit <https://pagure.io/freeipa/c/c0cf65c4f78bdb410a472f63b98870321fd751e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0cf65c4f78bdb410a472f63b98870321fd751e1>`__
    `#7984 <https://pagure.io/freeipa/issue/7984>`__
 -  test_nfs.py: change pr-ci configuration to run on
    master_2repl_1client
-   `commit <https://pagure.io/freeipa/c/54836bce6e38221e6799f253d1c0b4920158e6da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54836bce6e38221e6799f253d1c0b4920158e6da>`__
 -  ipatests: add proper timeouts to nfs.py
-   `commit <https://pagure.io/freeipa/c/694c3667c7226d893617358a4161f6d754bb5db9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/694c3667c7226d893617358a4161f6d754bb5db9>`__
 -  ipa-client-automount: fix '--idmap-domain DNS' logic
-   `commit <https://pagure.io/freeipa/c/cc348b990e607cb574d6eb70b6a9e35f14e8700c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc348b990e607cb574d6eb70b6a9e35f14e8700c>`__
    `#7988 <https://pagure.io/freeipa/issue/7988>`__
 -  nfs.py: fix user creation
-   `commit <https://pagure.io/freeipa/c/3a233a907afbb134eb9310242f5a307ee5b6bd5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a233a907afbb134eb9310242f5a307ee5b6bd5c>`__
 -  Hidden replica documentation: fix typo
-   `commit <https://pagure.io/freeipa/c/c191c2573e90f48bd8d62f3b962d66fc0d2ef99b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c191c2573e90f48bd8d62f3b962d66fc0d2ef99b>`__
 -  ipa_backup.py: replace /var/lib/ipa/backup with paths.IPA_BACKUP_DIR
-   `commit <https://pagure.io/freeipa/c/5331510eabf81d0a93f0b1d547564e4d9379a108>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5331510eabf81d0a93f0b1d547564e4d9379a108>`__
 -  ipa-backup: better error message if ENOSPC
-   `commit <https://pagure.io/freeipa/c/e6415ec3210cda0808867642cb19f0df1ddd3c45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6415ec3210cda0808867642cb19f0df1ddd3c45>`__
    `#7647 <https://pagure.io/freeipa/issue/7647>`__
 -  ipatests: add tests for the new NFSv4 domain option of
    ipa-client-automount
-   `commit <https://pagure.io/freeipa/c/d76737e4c6131ae6b4f550b2b7c1a19304f1e3a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d76737e4c6131ae6b4f550b2b7c1a19304f1e3a8>`__
    `#7918 <https://pagure.io/freeipa/issue/7918>`__
 -  ipa-client-automount: add knob to configure NFSv4 Domain
    (idmapd.conf)
-   `commit <https://pagure.io/freeipa/c/660c4984c6281055752d74dc276fc39a07da324a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/660c4984c6281055752d74dc276fc39a07da324a>`__
    `#7918 <https://pagure.io/freeipa/issue/7918>`__
 
 
@@ -648,46 +648,46 @@ Florence Blanc-Renaud (14)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix ipatests/test_xmlrpc/test_dns_plugin.py
-   `commit <https://pagure.io/freeipa/c/71884176478917aa75a4277e580ed785f818b57d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71884176478917aa75a4277e580ed785f818b57d>`__
    `#7982 <https://pagure.io/freeipa/issue/7982>`__
 -  XMLRPC tests: add new test for ipa dsnrecord-mod $ZONE $RECORD --ttl
-   `commit <https://pagure.io/freeipa/c/f25a7c2e962e3165e54a01479067ca9a900db6a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f25a7c2e962e3165e54a01479067ca9a900db6a2>`__
    `#7982 <https://pagure.io/freeipa/issue/7982>`__
 -  dnsrecord-mod: allow to modify ttl without passing the record
-   `commit <https://pagure.io/freeipa/c/bb91fcabee352fcaa71c8e66998a25e01cfaf9f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb91fcabee352fcaa71c8e66998a25e01cfaf9f7>`__
    `#7982 <https://pagure.io/freeipa/issue/7982>`__
 -  ipatests: add a test for stageuser-find with non-posix account
-   `commit <https://pagure.io/freeipa/c/0294ad213388a208079ad29ef4f6ce1c47d8866d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0294ad213388a208079ad29ef4f6ce1c47d8866d>`__
    `#7983 <https://pagure.io/freeipa/issue/7983>`__
 -  stageuser-find: fix search with non-posix user
-   `commit <https://pagure.io/freeipa/c/e9c4dcdb8532297f4247b930f74a8d2e00db43d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9c4dcdb8532297f4247b930f74a8d2e00db43d9>`__
    `#7983 <https://pagure.io/freeipa/issue/7983>`__
 -  ipatests: fix TestUserPermissions::test_selinux_user_optimized
-   `commit <https://pagure.io/freeipa/c/910ff25badbea39c5b0381c7fa0d26131e77e1df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/910ff25badbea39c5b0381c7fa0d26131e77e1df>`__
    `#7974 <https://pagure.io/freeipa/issue/7974>`__
 -  ipatests: fix test_backup_and_restore.py::TestBackupAndRestore
-   `commit <https://pagure.io/freeipa/c/6ec3c84c0ca3f43d09272ffa6d656c1ed72067cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ec3c84c0ca3f43d09272ffa6d656c1ed72067cb>`__
    `#7970 <https://pagure.io/freeipa/issue/7970>`__
 -  ipatests: fix test_caless.py
-   `commit <https://pagure.io/freeipa/c/07f7e3eaecf781b45c972c4348a9db5794e3fcaf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07f7e3eaecf781b45c972c4348a9db5794e3fcaf>`__
    `#7969 <https://pagure.io/freeipa/issue/7969>`__
 -  ipatests: add integration test for ipa-replica-manage list
-   `commit <https://pagure.io/freeipa/c/0b21e2ab9f6f0cc08067d8b5a98efbe4de763904>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b21e2ab9f6f0cc08067d8b5a98efbe4de763904>`__
    `#7716 <https://pagure.io/freeipa/issue/7716>`__
 -  NSSDatabase: fix get_trust_chain
-   `commit <https://pagure.io/freeipa/c/64d187e56e02f3a400b2e6044e6ad670521160c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64d187e56e02f3a400b2e6044e6ad670521160c8>`__
    `#7926 <https://pagure.io/freeipa/issue/7926>`__
 -  ipatests: CA renewal must refresh cn=CAcert
-   `commit <https://pagure.io/freeipa/c/4804103315617bf1fab1db84a3ed4737418b4908>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4804103315617bf1fab1db84a3ed4737418b4908>`__
    `#7928 <https://pagure.io/freeipa/issue/7928>`__
 -  CA: set ipaconfigstring:compatCA in cn=DOMAIN IPA CA
-   `commit <https://pagure.io/freeipa/c/9cd88587e45c4a588b4cbd9ce1eb31d4a0c711b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cd88587e45c4a588b4cbd9ce1eb31d4a0c711b0>`__
    `#7928 <https://pagure.io/freeipa/issue/7928>`__
 -  ipatests: add integration test checking the files mode
-   `commit <https://pagure.io/freeipa/c/7fe10d9903878d25987c44a8def72b6f056f3dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fe10d9903878d25987c44a8def72b6f056f3dd1>`__
    `#7934 <https://pagure.io/freeipa/issue/7934>`__
 -  Fix expected file permissions for ghost files
-   `commit <https://pagure.io/freeipa/c/a4254489147eaa0d2e6b7810182f1f3ed35b6324>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4254489147eaa0d2e6b7810182f1f3ed35b6324>`__
    `#7934 <https://pagure.io/freeipa/issue/7934>`__
 
 
@@ -696,48 +696,48 @@ Fraser Tweedale (15)
 ----------------------------------------------------------------------------------------------
 
 -  Handle missing LWCA certificate or chain
-   `commit <https://pagure.io/freeipa/c/854d3053e294e775fac0e4e394ca3b7b71d04c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/854d3053e294e775fac0e4e394ca3b7b71d04c7d>`__
    `#7964 <https://pagure.io/freeipa/issue/7964>`__
 -  dn: sort AVAs when converting from x509.Name
-   `commit <https://pagure.io/freeipa/c/ad7472970305f7be2d3afc65fda1e86296d118dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad7472970305f7be2d3afc65fda1e86296d118dd>`__
    `#7963 <https://pagure.io/freeipa/issue/7963>`__
 -  .gitignore: add ipa-cert-fix program
-   `commit <https://pagure.io/freeipa/c/df99680eadcce43582d925711acab04f521e4aad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df99680eadcce43582d925711acab04f521e4aad>`__
 -  avoid realm_to_serverid deprecation warning
-   `commit <https://pagure.io/freeipa/c/f30f040dca1c262541933ebefbc08b6356e42530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f30f040dca1c262541933ebefbc08b6356e42530>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  ipa-cert-fix: fix spurious renewal master change
-   `commit <https://pagure.io/freeipa/c/162dce1c70f8585931e3b748790bc313d6fcd1fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/162dce1c70f8585931e3b748790bc313d6fcd1fe>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  ipa-cert-fix: handle 'pki-server cert-fix' failure
-   `commit <https://pagure.io/freeipa/c/582cc7da1dde44618b57d4073a8513e92ecd4783>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/582cc7da1dde44618b57d4073a8513e92ecd4783>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  require Dogtag 10.7.0-1
-   `commit <https://pagure.io/freeipa/c/72027226821f9dfc92b6ece0fefbccab1430c95c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72027226821f9dfc92b6ece0fefbccab1430c95c>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  ipa-cert-fix: use customary exit statuses
-   `commit <https://pagure.io/freeipa/c/e41b7457f3acd3bf6c1db17c5d14c23f81c0ad4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e41b7457f3acd3bf6c1db17c5d14c23f81c0ad4b>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  ipa-cert-fix: add man page
-   `commit <https://pagure.io/freeipa/c/a9f09fee56645120d2e202e5707dc017f8d3d3f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f09fee56645120d2e202e5707dc017f8d3d3f3>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  Add ipa-cert-fix tool
-   `commit <https://pagure.io/freeipa/c/09aa3d1f769ac532069e2c39c2ff1eaf8ba0331f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09aa3d1f769ac532069e2c39c2ff1eaf8ba0331f>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  constants: add ca_renewal container
-   `commit <https://pagure.io/freeipa/c/a3becc76dd22b3f26442261f163824264e7b8425>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3becc76dd22b3f26442261f163824264e7b8425>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  cainstance: add function to determine ca_renewal nickname
-   `commit <https://pagure.io/freeipa/c/c28a42e27e1cff115aca1066bf3c943ff46ccc48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c28a42e27e1cff115aca1066bf3c943ff46ccc48>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  Extract ca_renewal cert update subroutine
-   `commit <https://pagure.io/freeipa/c/a2a006c74667155e5e4c4a1bb0bd9c12da9b4aed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2a006c74667155e5e4c4a1bb0bd9c12da9b4aed>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  add test for external CA key size sanity check
-   `commit <https://pagure.io/freeipa/c/f9b22283dd2160ec073e93df9b52ef6b47d6c335>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9b22283dd2160ec073e93df9b52ef6b47d6c335>`__
    `#7761 <https://pagure.io/freeipa/issue/7761>`__
 -  dn: handle multi-valued RDNs in Name conversion
-   `commit <https://pagure.io/freeipa/c/891d54e46f9c237493f7985d4d8ea19d4d051d09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/891d54e46f9c237493f7985d4d8ea19d4d051d09>`__
    `#7963 <https://pagure.io/freeipa/issue/7963>`__
 
 
@@ -746,7 +746,7 @@ German Parente (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-replica-manage: remove "last init status" if it's None.
-   `commit <https://pagure.io/freeipa/c/ef324a7f13887c581d74d4c09c8436af8523c635>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef324a7f13887c581d74d4c09c8436af8523c635>`__
    `#7716 <https://pagure.io/freeipa/issue/7716>`__
 
 
@@ -755,9 +755,9 @@ Kaleemullah Siddiqui (2)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for autounmembership feature
-   `commit <https://pagure.io/freeipa/c/1d03afc908d7135609e2777de3fa6f9dcc9de9ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d03afc908d7135609e2777de3fa6f9dcc9de9ed>`__
 -  Order of master and replica corrected in logger.info
-   `commit <https://pagure.io/freeipa/c/c9c8b3e048b1c101d3cbf9abd14f0bd6214abde2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9c8b3e048b1c101d3cbf9abd14f0bd6214abde2>`__
 
 
 
@@ -765,7 +765,7 @@ Mohammad Rizwan Yusuf (1)
 ----------------------------------------------------------------------------------------------
 
 -  Test if ipactl restart restarts the pki-tomcatd
-   `commit <https://pagure.io/freeipa/c/581b7148f4560cd0595b2c771b6eef2fac5dc93b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/581b7148f4560cd0595b2c771b6eef2fac5dc93b>`__
    `#7927 <https://pagure.io/freeipa/issue/7927>`__
 
 
@@ -774,42 +774,42 @@ Rob Crittenden (14)
 ----------------------------------------------------------------------------------------------
 
 -  Add test_smb to night Fedora 30 test suite
-   `commit <https://pagure.io/freeipa/c/258cacb11607426364e92ae17726e7582af5c3d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/258cacb11607426364e92ae17726e7582af5c3d7>`__
 -  Remove DES3 and RC4 enctypes from Kerberos
-   `commit <https://pagure.io/freeipa/c/dd9fd0971f352e4bed50b79b8b3147d6a94956b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd9fd0971f352e4bed50b79b8b3147d6a94956b7>`__
 -  Don't configure disabled krb5 enctypes in FIPS mode
-   `commit <https://pagure.io/freeipa/c/a43100badc43a2b22efd472ff4108b9821631311>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a43100badc43a2b22efd472ff4108b9821631311>`__
 -  For Fedora and RHEL use system-wide crypto policy for mod_ssl
-   `commit <https://pagure.io/freeipa/c/c484d79ecfa1cc284b47b88377a4c2da23b9db2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c484d79ecfa1cc284b47b88377a4c2da23b9db2f>`__
    `#7667 <https://pagure.io/freeipa/issue/7667>`__
 -  Log the raised message when DNS check_zone_overlap fails
-   `commit <https://pagure.io/freeipa/c/0184e967e58fb7663219eacffeae894031794af0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0184e967e58fb7663219eacffeae894031794af0>`__
 -  admintool: don't display log file on errors unless logging is setup
-   `commit <https://pagure.io/freeipa/c/10b721d118a295b62a4c1df52ae47d8b106464a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10b721d118a295b62a4c1df52ae47d8b106464a2>`__
    `#7952 <https://pagure.io/freeipa/issue/7952>`__
 -  tests: Wait for automember rebuild --no-wait tasks to finish
-   `commit <https://pagure.io/freeipa/c/7ec0976cce61f829cb53dc96581dea2c569706d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ec0976cce61f829cb53dc96581dea2c569706d4>`__
    `#7972 <https://pagure.io/freeipa/issue/7972>`__
 -  Fix expected return code in tests when server is uninstalled
-   `commit <https://pagure.io/freeipa/c/cef4edd384baeda913e309ebcc9a9dd8753dc744>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cef4edd384baeda913e309ebcc9a9dd8753dc744>`__
    `#7836 <https://pagure.io/freeipa/issue/7836>`__
 -  Return 0 on uninstall when on_master for case of not installed
-   `commit <https://pagure.io/freeipa/c/c1c50650a7f359aa9fd77d4348c31169ca878003>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1c50650a7f359aa9fd77d4348c31169ca878003>`__
    `#7836 <https://pagure.io/freeipa/issue/7836>`__
 -  Drop list of return values to be ignored in AdminTool
-   `commit <https://pagure.io/freeipa/c/1284bf1588877d3549ddc98e4762038b8740c72e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1284bf1588877d3549ddc98e4762038b8740c72e>`__
    `#7836 <https://pagure.io/freeipa/issue/7836>`__
 -  When reading SSH pub key don't assume last character is newline
-   `commit <https://pagure.io/freeipa/c/21777e4ba04594c09a2a20ae92ab8fe2cd908fad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21777e4ba04594c09a2a20ae92ab8fe2cd908fad>`__
    `#7959 <https://pagure.io/freeipa/issue/7959>`__
 -  Stop using 389-ds legacy backup and restoration utilities
-   `commit <https://pagure.io/freeipa/c/f606d82024d3a74df2aeb5448944aa015e96cce2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f606d82024d3a74df2aeb5448944aa015e96cce2>`__
    `#7965 <https://pagure.io/freeipa/issue/7965>`__
 -  Add knob to limit hostname length
-   `commit <https://pagure.io/freeipa/c/6662e99e173a16059271528e1fa58e37a3028924>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6662e99e173a16059271528e1fa58e37a3028924>`__
    `#2018 <https://pagure.io/freeipa/issue/2018>`__
 -  Use AES-128-CBC for PKCS#12 encryption when creating files (FIPS)
-   `commit <https://pagure.io/freeipa/c/ecc08e3983c6579850a436f04f579f29a35620ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecc08e3983c6579850a436f04f579f29a35620ee>`__
    `#7948 <https://pagure.io/freeipa/issue/7948>`__
 
 
@@ -818,39 +818,39 @@ Stanislav Levin (12)
 ----------------------------------------------------------------------------------------------
 
 -  Make use of single configuration point for SELinux
-   `commit <https://pagure.io/freeipa/c/b2acd65013348c0f5d91582f240714b0f3357678>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2acd65013348c0f5d91582f240714b0f3357678>`__
    `#7996 <https://pagure.io/freeipa/issue/7996>`__
 -  Fix a typo in \`replace\` rule of 50-ipaconfig.update
-   `commit <https://pagure.io/freeipa/c/215e8f768c47261d78043dcea23add3da12f364e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/215e8f768c47261d78043dcea23add3da12f364e>`__
    `#7996 <https://pagure.io/freeipa/issue/7996>`__
 -  Exit on fail in azure multiline script
-   `commit <https://pagure.io/freeipa/c/b5bb436e9fece23f76b35055eddf638f7b8251fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5bb436e9fece23f76b35055eddf638f7b8251fe>`__
 -  Make use of \`named\` well-known service
-   `commit <https://pagure.io/freeipa/c/8f7d33356503794463611eb48317c9998187eddb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f7d33356503794463611eb48317c9998187eddb>`__
    `#7990 <https://pagure.io/freeipa/issue/7990>`__
 -  Make use of the single configuration point for the default shells
-   `commit <https://pagure.io/freeipa/c/d86b57c05764f771b1568409efd31c9e7b302919>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d86b57c05764f771b1568409efd31c9e7b302919>`__
    `#7978 <https://pagure.io/freeipa/issue/7978>`__
 -  Fix Pytest4.x warning about \`message\`
-   `commit <https://pagure.io/freeipa/c/9836511a2b6d7cf48b1a54cb3158e5eac674081a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9836511a2b6d7cf48b1a54cb3158e5eac674081a>`__
    `#7981 <https://pagure.io/freeipa/issue/7981>`__
 -  Fix Pytest4.1+ warnings about pytest.config
-   `commit <https://pagure.io/freeipa/c/d16dd2fd6258520d83eb6350b8aebc9bfdbb11f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d16dd2fd6258520d83eb6350b8aebc9bfdbb11f3>`__
    `#7981 <https://pagure.io/freeipa/issue/7981>`__
 -  Resolve tox substitutions to absolute paths
-   `commit <https://pagure.io/freeipa/c/77bfd5f9b695e022f84dedf57b58368716090594>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77bfd5f9b695e022f84dedf57b58368716090594>`__
    `#7977 <https://pagure.io/freeipa/issue/7977>`__
 -  Make \`pycodestyle\` results identical
-   `commit <https://pagure.io/freeipa/c/3f33ac88bd213f7626930b7769f5548ead77cecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f33ac88bd213f7626930b7769f5548ead77cecc>`__
    `#7962 <https://pagure.io/freeipa/issue/7962>`__
 -  Respect TMPDIR, TEMP or TMP environment variables during testing
-   `commit <https://pagure.io/freeipa/c/5263c36c1b3a0e1cbc8f3f368c81706a46a75687>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5263c36c1b3a0e1cbc8f3f368c81706a46a75687>`__
    `#7956 <https://pagure.io/freeipa/issue/7956>`__
 -  Fix \`build_requestinfo\` in LibreSSL environments
-   `commit <https://pagure.io/freeipa/c/7b8a2af2197381058ca532d1ae206defb16fac88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b8a2af2197381058ca532d1ae206defb16fac88>`__
    `#7937 <https://pagure.io/freeipa/issue/7937>`__
 -  Fix \`build_requestinfo\` in OpenSSL1.1.0+ environments
-   `commit <https://pagure.io/freeipa/c/ac6568dcf58ec8d06df5493d14a28aa41845d4ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac6568dcf58ec8d06df5493d14a28aa41845d4ef>`__
    `#7937 <https://pagure.io/freeipa/issue/7937>`__
 
 
@@ -860,11 +860,11 @@ Sergey Orlov (2)
 
 -  ipatests: allow to relax security of LDAP connection from controller
    to IPA host
-   `commit <https://pagure.io/freeipa/c/cd2b2443c5ba2f4885e3d85f98332b2fa8b30432>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd2b2443c5ba2f4885e3d85f98332b2fa8b30432>`__
    `#7960 <https://pagure.io/freeipa/issue/7960>`__
 -  ipatests: new tests for establishing one-way AD trust with shared
    secret
-   `commit <https://pagure.io/freeipa/c/3f02fc945e6306e8fb656db680d5a553683fabc4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f02fc945e6306e8fb656db680d5a553683fabc4>`__
    `#6077 <https://pagure.io/freeipa/issue/6077>`__
 
 
@@ -873,17 +873,17 @@ Serhii Tsymbaliuk (4)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix automount maps pagination
-   `commit <https://pagure.io/freeipa/c/dd7198acec797342a6ef0bed6573d8963164a77b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd7198acec797342a6ef0bed6573d8963164a77b>`__
    `#6627 <https://pagure.io/freeipa/issue/6627>`__
 -  WebUI: Disable 'Unlock' action for users with no password
-   `commit <https://pagure.io/freeipa/c/93dc2d569dad23a2d04523b2281af347ab93799c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93dc2d569dad23a2d04523b2281af347ab93799c>`__
    `#5062 <https://pagure.io/freeipa/issue/5062>`__
 -  WebUI: Fix 'user not found' traceback on user ID override details
    page
-   `commit <https://pagure.io/freeipa/c/881ec5a31775a5643ca3c6a37b651fd2104d25b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/881ec5a31775a5643ca3c6a37b651fd2104d25b9>`__
    `#7139 <https://pagure.io/freeipa/issue/7139>`__
 -  Fix occasional 'whoami.data is undefined' error in FreeIPA web UI
-   `commit <https://pagure.io/freeipa/c/6a9c20a87c2ae3eaa941120073cad34c328cb7df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a9c20a87c2ae3eaa941120073cad34c328cb7df>`__
    `#7917 <https://pagure.io/freeipa/issue/7917>`__
 
 
@@ -892,7 +892,7 @@ Thierry Bordaz (1)
 ----------------------------------------------------------------------------------------------
 
 -  Switch nsslapd-unhashed-pw-switch to nolog
-   `commit <https://pagure.io/freeipa/c/67490acb045697302cc16d34cac3a81bc1f909ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67490acb045697302cc16d34cac3a81bc1f909ba>`__
    `#4812 <https://pagure.io/freeipa/issue/4812>`__
 
 
@@ -901,13 +901,13 @@ Tibor Dudlák (4)
 ----------------------------------------------------------------------------------------------
 
 -  Add SMB attributes for users
-   `commit <https://pagure.io/freeipa/c/c18ee9b641ddc1e6b52d0413caa1fb98ac13785d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c18ee9b641ddc1e6b52d0413caa1fb98ac13785d>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  Remove unreachable code
-   `commit <https://pagure.io/freeipa/c/339771b0d87e787a496c7d193edf5c9c4a50195d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/339771b0d87e787a496c7d193edf5c9c4a50195d>`__
 -  ipatests: Add Unattended option to external ca task
-   `commit <https://pagure.io/freeipa/c/be39d3a99bfd676cd1661af7e8b2553337b4e1c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be39d3a99bfd676cd1661af7e8b2553337b4e1c8>`__
    `#7930 <https://pagure.io/freeipa/issue/7930>`__
 -  Moving prompt for NTP options to install_check
-   `commit <https://pagure.io/freeipa/c/e3f35843dc33fa6a3fb3071c5c89ecde9db1ce5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3f35843dc33fa6a3fb3071c5c89ecde9db1ce5e>`__
    `#7930 <https://pagure.io/freeipa/issue/7930>`__

--- a/src/page/Releases/4.8.10.rst
+++ b/src/page/Releases/4.8.10.rst
@@ -175,12 +175,12 @@ Armando Neto (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Add nightly definitions for enforcing mode
-   `commit <https://pagure.io/freeipa/c/02698275bc2b0a39058329f9cb7060a35d896eb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02698275bc2b0a39058329f9cb7060a35d896eb3>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/fe9f4a86ca27c56ec9f4db85f9aea0dae8880638>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe9f4a86ca27c56ec9f4db85f9aea0dae8880638>`__
    `#8473 <https://pagure.io/freeipa/issue/8473>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/57ea534c39232f65e8a4f0dc9917bd55331c8436>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57ea534c39232f65e8a4f0dc9917bd55331c8436>`__
 
 
 
@@ -188,22 +188,22 @@ Alexander Bokovoy (6)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA 4.8.10
-   `commit <https://pagure.io/freeipa/c/a44bb2e0682e0a1e061bdd6673d04f511807fb34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a44bb2e0682e0a1e061bdd6673d04f511807fb34>`__
 -  Specify memory limits as strings for docker compose
-   `commit <https://pagure.io/freeipa/c/93fff042f4bf78541e69371eeaef05c49e8f9463>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93fff042f4bf78541e69371eeaef05c49e8f9463>`__
    `#8494 <https://pagure.io/freeipa/issue/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
-   `commit <https://pagure.io/freeipa/c/f316d0118b8b00207e8d005f20d5de837c46a220>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f316d0118b8b00207e8d005f20d5de837c46a220>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
-   `commit <https://pagure.io/freeipa/c/ec8a560392c89da96a805e9779eaa2041dd992c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec8a560392c89da96a805e9779eaa2041dd992c1>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
-   `commit <https://pagure.io/freeipa/c/fc9840d83e2cd329281c1d42d75e4dbc4d4c0145>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc9840d83e2cd329281c1d42d75e4dbc4d4c0145>`__
    `#8344 <https://pagure.io/freeipa/issue/8344>`__
 -  Return to git snapshots
-   `commit <https://pagure.io/freeipa/c/e058c4d47ce9bb66ad93421b73f85fd5954e95d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e058c4d47ce9bb66ad93421b73f85fd5954e95d0>`__
 
 
 
@@ -211,36 +211,36 @@ Christian Heimes (11)
 ----------------------------------------------------------------------------------------------
 
 -  Fix nsslapd-db-lock tuning of BDB backend
-   `commit <https://pagure.io/freeipa/c/87e5c0500b76b7cbeecedc0c28d44095c7063186>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87e5c0500b76b7cbeecedc0c28d44095c7063186>`__
    `#5914 <https://pagure.io/freeipa/issue/5914>`__,
    `#8515 <https://pagure.io/freeipa/issue/8515>`__
 -  Create systemd-resolved configuration on update
-   `commit <https://pagure.io/freeipa/c/3b3cb99dc15d826b825701fd04b00d74617e526e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b3cb99dc15d826b825701fd04b00d74617e526e>`__
 -  Configure systemd-resolved to use IPA's BIND
-   `commit <https://pagure.io/freeipa/c/c67aba230fafd1ad9aded64fdac25081b4cd532d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c67aba230fafd1ad9aded64fdac25081b4cd532d>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Use new API for auto-forwarders
-   `commit <https://pagure.io/freeipa/c/6dc5566c7b1edfd40722a5740e9bf9f33d74a609>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6dc5566c7b1edfd40722a5740e9bf9f33d74a609>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Configure NetworkManager to use systemd-resolved
-   `commit <https://pagure.io/freeipa/c/d6827f52b629d2a6afdd1b60ad190efae0d55a3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6827f52b629d2a6afdd1b60ad190efae0d55a3e>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Add helpers for resolve1 and nameservers
-   `commit <https://pagure.io/freeipa/c/489ddc6d872b00fe5cddd1e9234fbb3e26f4aa0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/489ddc6d872b00fe5cddd1e9234fbb3e26f4aa0f>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Delay import of psutil to avoid AVC
-   `commit <https://pagure.io/freeipa/c/202d7da8df37b9e5fb58d4546ef996825021137a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/202d7da8df37b9e5fb58d4546ef996825021137a>`__
    `#8512 <https://pagure.io/freeipa/issue/8512>`__
 -  Make git a build requirement
-   `commit <https://pagure.io/freeipa/c/439170633f1e577561af289ec99d7426699adf95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/439170633f1e577561af289ec99d7426699adf95>`__
 -  Duplicate CA CRT: ignore expected cert
-   `commit <https://pagure.io/freeipa/c/d7f39287dac7ada64719330ac3da66c8cbbef757>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7f39287dac7ada64719330ac3da66c8cbbef757>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Add krbPrincipalName pres index correctly
-   `commit <https://pagure.io/freeipa/c/672fe14dfa49b8a15fb3c0353415425302924e07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/672fe14dfa49b8a15fb3c0353415425302924e07>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  Only restart DS when duplicate cacrt was found
-   `commit <https://pagure.io/freeipa/c/be7efc4dfbe16cb8d700ec16bbc1177b4fcbe3df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7efc4dfbe16cb8d700ec16bbc1177b4fcbe3df>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 
 
@@ -249,41 +249,41 @@ François Cami (12)
 ----------------------------------------------------------------------------------------------
 
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
-   `commit <https://pagure.io/freeipa/c/58c3343a67a3922dcc84d3d4b1deca515c48a6f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58c3343a67a3922dcc84d3d4b1deca515c48a6f8>`__
    `#8513 <https://pagure.io/freeipa/issue/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
-   `commit <https://pagure.io/freeipa/c/6a31605c1d249416ed7627755bca23a1cc45a581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a31605c1d249416ed7627755bca23a1cc45a581>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
-   `commit <https://pagure.io/freeipa/c/7ad04841245668e3126cb1718ef7ec1b744526e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ad04841245668e3126cb1718ef7ec1b744526e8>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
-   `commit <https://pagure.io/freeipa/c/25cf7af0d41bbd34621f37c95802675b42baeae9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25cf7af0d41bbd34621f37c95802675b42baeae9>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
-   `commit <https://pagure.io/freeipa/c/0518c63768b50973f3d3129547f5b4b95335f4a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0518c63768b50973f3d3129547f5b4b95335f4a8>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
-   `commit <https://pagure.io/freeipa/c/310dbd6eec337f0747d73fa87363083a742fc5dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/310dbd6eec337f0747d73fa87363083a742fc5dc>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
-   `commit <https://pagure.io/freeipa/c/c126610ea6605a1ff36cecf2e2f5b2cb97130831>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c126610ea6605a1ff36cecf2e2f5b2cb97130831>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
-   `commit <https://pagure.io/freeipa/c/5a5962426d8174212f0b7efef1a9e53aaecb5901>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a5962426d8174212f0b7efef1a9e53aaecb5901>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/52929cbadf0252fcac1019b74663a2808061ea1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52929cbadf0252fcac1019b74663a2808061ea1b>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
-   `commit <https://pagure.io/freeipa/c/97c6d2d2c2359b8ff5585afa0d2e5f5599cd5048>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97c6d2d2c2359b8ff5585afa0d2e5f5599cd5048>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  ipatests: check that pkispawn log is not empty
-   `commit <https://pagure.io/freeipa/c/d1c860e59b5237178066ed963cc2fa50d99cd690>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1c860e59b5237178066ed963cc2fa50d99cd690>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  SELinux Policy: let custodia replicate keys
-   `commit <https://pagure.io/freeipa/c/438285470610dee4aa6a56523df22307840ede87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/438285470610dee4aa6a56523df22307840ede87>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 
 
@@ -292,15 +292,15 @@ Florence Blanc-Renaud (4)
 ----------------------------------------------------------------------------------------------
 
 -  test_smb: skip test_smb_service_s4u2self for fed31
-   `commit <https://pagure.io/freeipa/c/707823a3703c4777dba5a260c391dc5887ae69d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/707823a3703c4777dba5a260c391dc5887ae69d3>`__
    `#8505 <https://pagure.io/freeipa/issue/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
-   `commit <https://pagure.io/freeipa/c/fefaeb4bf9f8ca0c64dd8ccb242ac7727ae4b70f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fefaeb4bf9f8ca0c64dd8ccb242ac7727ae4b70f>`__
    `#8481 <https://pagure.io/freeipa/issue/8481>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
-   `commit <https://pagure.io/freeipa/c/ab6811a131190d89c5ef8c55a2edb8b73499280a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab6811a131190d89c5ef8c55a2edb8b73499280a>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
-   `commit <https://pagure.io/freeipa/c/2ce880e900423cedbf7c7a9dd422585e8e1522b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ce880e900423cedbf7c7a9dd422585e8e1522b1>`__
    `#8472 <https://pagure.io/freeipa/issue/8472>`__
 
 
@@ -309,11 +309,11 @@ Mohammad Rizwan (3)
 ----------------------------------------------------------------------------------------------
 
 -  PEP8 fixes
-   `commit <https://pagure.io/freeipa/c/19ec19c037a679a8320112800565ae7758599f08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19ec19c037a679a8320112800565ae7758599f08>`__
 -  ipatests: add --skip-overlap-check option to prepare_reverse_zone()
-   `commit <https://pagure.io/freeipa/c/6b0f065729ecbb393ab79ce99d6e2cf83e62529c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b0f065729ecbb393ab79ce99d6e2cf83e62529c>`__
 -  ipatests: Add PTR record for IP SAN
-   `commit <https://pagure.io/freeipa/c/32b1242549f8f558edfebd22b5ffbc0d84a8aa6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32b1242549f8f558edfebd22b5ffbc0d84a8aa6a>`__
 
 
 
@@ -321,61 +321,61 @@ Rob Crittenden (19)
 ----------------------------------------------------------------------------------------------
 
 -  Test that ccaches are cleaned up during installation
-   `commit <https://pagure.io/freeipa/c/7cfd03db48060c61e6a7fecbb72d9995a7de2511>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cfd03db48060c61e6a7fecbb72d9995a7de2511>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
-   `commit <https://pagure.io/freeipa/c/ade428f51909b79a7ec0ced8f9810ce459aba1d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ade428f51909b79a7ec0ced8f9810ce459aba1d3>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
-   `commit <https://pagure.io/freeipa/c/8255bc7b92db44d375819857fed12faa85609c3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8255bc7b92db44d375819857fed12faa85609c3a>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Require a matching server package for the selinux subpackage
-   `commit <https://pagure.io/freeipa/c/80f66b751fda25cc48f3cf4727c2b55f6aa39a33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80f66b751fda25cc48f3cf4727c2b55f6aa39a33>`__
    `#8511 <https://pagure.io/freeipa/issue/8511>`__
 -  Add index for more trust-related attributes
-   `commit <https://pagure.io/freeipa/c/53a952f0cb55c8bd9cc0cd13adf24303d036bafd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53a952f0cb55c8bd9cc0cd13adf24303d036bafd>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
-   `commit <https://pagure.io/freeipa/c/a572df9616c1da69611ed5a172fd638011ba161f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a572df9616c1da69611ed5a172fd638011ba161f>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  Use ACI class set_permissions() method to set permissions
-   `commit <https://pagure.io/freeipa/c/939a72f47c4f9ddd55fd703fbe26dad847ab8d1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/939a72f47c4f9ddd55fd703fbe26dad847ab8d1e>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  De-duplicate ACI attributes and permissions
-   `commit <https://pagure.io/freeipa/c/4e5ba24bcf99daa4764b43093ff6a6dbcde52485>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e5ba24bcf99daa4764b43093ff6a6dbcde52485>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  ipatests: Add tests for checking available memory
-   `commit <https://pagure.io/freeipa/c/9fa534c92c31488d7dbf7fb84ec0ed934e0376a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fa534c92c31488d7dbf7fb84ec0ed934e0376a8>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
-   `commit <https://pagure.io/freeipa/c/1fd4440a2d49118c9be4f6a6bb9d90ca3abd7c53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fd4440a2d49118c9be4f6a6bb9d90ca3abd7c53>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
-   `commit <https://pagure.io/freeipa/c/8f19411a2e166120b53155e9ae85896990750d2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f19411a2e166120b53155e9ae85896990750d2e>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
-   `commit <https://pagure.io/freeipa/c/2a0c00c3c7bfa7b4270eb7a8b91fac2e8155140d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a0c00c3c7bfa7b4270eb7a8b91fac2e8155140d>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Set the certmonger subject with a string, not an object
-   `commit <https://pagure.io/freeipa/c/2a5a2a0bf3e99ab8aa11235c3d01fbac51e33176>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a5a2a0bf3e99ab8aa11235c3d01fbac51e33176>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
-   `commit <https://pagure.io/freeipa/c/099ab6c7156202cb1bd0fb6b27dc389dc56c82f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/099ab6c7156202cb1bd0fb6b27dc389dc56c82f7>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  ipatests: Add test for is_ipa_configured
-   `commit <https://pagure.io/freeipa/c/2057b330f8c3d89078ce2008660a799721ab3c57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2057b330f8c3d89078ce2008660a799721ab3c57>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Use is_ipa_configured from ipalib.facts
-   `commit <https://pagure.io/freeipa/c/774bbb1703cb37b5b0623a987738efd5207d65d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/774bbb1703cb37b5b0623a987738efd5207d65d6>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Fall back to old server installation detection when needed
-   `commit <https://pagure.io/freeipa/c/fe783b632a0649f1894416dbd74a2a074c64b5ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe783b632a0649f1894416dbd74a2a074c64b5ba>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  cli: When parsing options require name/value pairs
-   `commit <https://pagure.io/freeipa/c/dce5b1c854382058c62cb7c7155edf715088ca0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dce5b1c854382058c62cb7c7155edf715088ca0a>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
-   `commit <https://pagure.io/freeipa/c/6f4f7c616628a6200f7d3b56969d6e6204d3aea5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f4f7c616628a6200f7d3b56969d6e6204d3aea5>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 
 
@@ -385,37 +385,37 @@ Stanislav Levin (13)
 
 -  dns: Make use of \`resolve_address\` of a current resolver instead of
    the global one
-   `commit <https://pagure.io/freeipa/c/656aa91215d2c9142755fc0962dc13668e6f8f3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/656aa91215d2c9142755fc0962dc13668e6f8f3c>`__
 -  dnspython: Add compatibility shim
-   `commit <https://pagure.io/freeipa/c/ae8b723c1e0f5d66b0fa5e618b7274d872e918d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae8b723c1e0f5d66b0fa5e618b7274d872e918d3>`__
    `#8383 <https://pagure.io/freeipa/issue/8383>`__
 -  tox: Don't expand symlinks
-   `commit <https://pagure.io/freeipa/c/76502144dd71c957954ac44002d034e691713cb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76502144dd71c957954ac44002d034e691713cb3>`__
    `#8475 <https://pagure.io/freeipa/issue/8475>`__
 -  Azure: Increase verbosity for Tox task
-   `commit <https://pagure.io/freeipa/c/428373f127f69b4fee45b356c765e7a227c8788b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/428373f127f69b4fee45b356c765e7a227c8788b>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
-   `commit <https://pagure.io/freeipa/c/ee661dc7223bf107d30dda39184c402964f2982f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee661dc7223bf107d30dda39184c402964f2982f>`__
 -  nss: Raise exception earlier on unsupported DB type
-   `commit <https://pagure.io/freeipa/c/0a8997ff0be5b3ce67172da9b123a461be83f1e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a8997ff0be5b3ce67172da9b123a461be83f1e6>`__
    `#8474 <https://pagure.io/freeipa/issue/8474>`__
 -  Azure: base: Collect both install and uninstall logs
-   `commit <https://pagure.io/freeipa/c/0ff6b6ee55bfb633b1aee7948c885dfa3f711168>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ff6b6ee55bfb633b1aee7948c885dfa3f711168>`__
 -  Azure: Drop dependency on UsePythonVersion task
-   `commit <https://pagure.io/freeipa/c/ae219dffbcb71f6ab12b4e4831a1c02e4279f0b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae219dffbcb71f6ab12b4e4831a1c02e4279f0b8>`__
 -  Azure: Add Rawhide definitions
-   `commit <https://pagure.io/freeipa/c/5d13ef9bfe52442af7d8d39113a8b0a01f5f0bff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d13ef9bfe52442af7d8d39113a8b0a01f5f0bff>`__
 -  pylint: Ignore \`raise-missing-from\`
-   `commit <https://pagure.io/freeipa/c/ffbbc30146e3f0f9e995a99031860e6130847a4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffbbc30146e3f0f9e995a99031860e6130847a4c>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
-   `commit <https://pagure.io/freeipa/c/31e16f7216a5e66f372a1759c39a6a254a94a210>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31e16f7216a5e66f372a1759c39a6a254a94a210>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
-   `commit <https://pagure.io/freeipa/c/a283196b3da8aaa537fd506c50edbddb0ff2f045>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a283196b3da8aaa537fd506c50edbddb0ff2f045>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Teach pylint about more RRs types
-   `commit <https://pagure.io/freeipa/c/8c7414a51ea1895292dccf203f8c5e0aa1c00d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7414a51ea1895292dccf203f8c5e0aa1c00d2c>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 
 
@@ -424,9 +424,9 @@ Sergey Orlov (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: simplify fixture
-   `commit <https://pagure.io/freeipa/c/f3c6fb3a6c03e8ef6586fb61acc2d66d2416d0ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3c6fb3a6c03e8ef6586fb61acc2d66d2416d0ec>`__
 -  ipatests: refactor test for login using cifs alias principal
-   `commit <https://pagure.io/freeipa/c/d560505567da92e749b08b8a0a4295a5b2d5d8f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d560505567da92e749b08b8a0a4295a5b2d5d8f6>`__
 
 
 
@@ -435,7 +435,7 @@ Sumedh Sidhaye (1)
 
 -  This is a manual backport of
    https://github.com/freeipa/freeipa/pull/5053/
-   `commit <https://pagure.io/freeipa/c/6662f5fdf5b1e65e786fb26a1f037deba0fbe283>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6662f5fdf5b1e65e786fb26a1f037deba0fbe283>`__
 
 
 
@@ -443,7 +443,7 @@ Serhii Tsymbaliuk (1)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix jQuery DOM manipulation issues
-   `commit <https://pagure.io/freeipa/c/090a222879e5beb6a913821a903d49190401b847>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/090a222879e5beb6a913821a903d49190401b847>`__
    `#8507 <https://pagure.io/freeipa/issue/8507>`__
 
 
@@ -452,7 +452,7 @@ Sudhir Menon (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Install healthcheck pkg for TestIpaHealthCheckWithADtrust
-   `commit <https://pagure.io/freeipa/c/0a7fc535345892ee93aa736dcd94a4f23c544f61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a7fc535345892ee93aa736dcd94a4f23c544f61>`__
 
 
 
@@ -460,5 +460,5 @@ Zdenek Pytela (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add ipa_pki_retrieve_key_exec() interface
-   `commit <https://pagure.io/freeipa/c/c029eb7e732ee8b631c12ae17a154605ef2575e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c029eb7e732ee8b631c12ae17a154605ef2575e5>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__

--- a/src/page/Releases/4.8.4.rst
+++ b/src/page/Releases/4.8.4.rst
@@ -114,7 +114,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  travis: Remove CI integration
-   `commit <https://pagure.io/freeipa/c/6486b1aa4c52f765ed0f10a4d055be7eff479f1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6486b1aa4c52f765ed0f10a4d055be7eff479f1c>`__
    `#7323 <https://pagure.io/freeipa/issue/7323>`__
 
 
@@ -123,27 +123,27 @@ Alexander Bokovoy (8)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-client-samba: map domain sid of trust domain properly for display
-   `commit <https://pagure.io/freeipa/c/e1d11aa6b1b03b57adf8deba681aa0fa25861c5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1d11aa6b1b03b57adf8deba681aa0fa25861c5e>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
-   `commit <https://pagure.io/freeipa/c/4cf01e72ad2ab67229a7122aee24f6c4ebd40604>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cf01e72ad2ab67229a7122aee24f6c4ebd40604>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
-   `commit <https://pagure.io/freeipa/c/eebabb5c5fe7478b391770a857fb9be4f0d60a9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eebabb5c5fe7478b391770a857fb9be4f0d60a9c>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  covscan: free encryption types in case there is an error
-   `commit <https://pagure.io/freeipa/c/84592e32c5b59b7b654a0a74b5cc8c1350af6451>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84592e32c5b59b7b654a0a74b5cc8c1350af6451>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  Become FreeIPA 4.8.3
-   `commit <https://pagure.io/freeipa/c/11be139069d1c4312858cddccb6c3f578f256109>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11be139069d1c4312858cddccb6c3f578f256109>`__
 -  Add Authentication Indicator Kerberos ticket policy options
-   `commit <https://pagure.io/freeipa/c/14ff82f3b86ceeb0836b0354b7edb965db72b494>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14ff82f3b86ceeb0836b0354b7edb965db72b494>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Allow presence of LDAP attribute options
-   `commit <https://pagure.io/freeipa/c/4dbd689e301a20d38a40e827ba58bc5c667ff0d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4dbd689e301a20d38a40e827ba58bc5c667ff0d8>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
-   `commit <https://pagure.io/freeipa/c/18540386230e295087296e58761ced2b781ae4e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18540386230e295087296e58761ced2b781ae4e3>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -152,7 +152,7 @@ Anuja More (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests : Login via ssh using private-key for ipa-user should work.
-   `commit <https://pagure.io/freeipa/c/fa952666df448df89aa6f96758c4c1593a30e79f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa952666df448df89aa6f96758c4c1593a30e79f>`__
 
 
 
@@ -160,55 +160,55 @@ Christian Heimes (18)
 ----------------------------------------------------------------------------------------------
 
 -  Fix get_trusted_domain_object_from_sid()
-   `commit <https://pagure.io/freeipa/c/9462e4c4b6e37fd1178f96d6d901db8d115c4cfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9462e4c4b6e37fd1178f96d6d901db8d115c4cfb>`__
    `#7958 <https://pagure.io/freeipa/issue/7958>`__
 -  Fix service ldap_disable()
-   `commit <https://pagure.io/freeipa/c/b39ee3e1721b6d8234dd209343a8b01dbeaf3d3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b39ee3e1721b6d8234dd209343a8b01dbeaf3d3a>`__
    `#8143 <https://pagure.io/freeipa/issue/8143>`__
 -  Require idstart to be larger than UID_MAX
-   `commit <https://pagure.io/freeipa/c/6a953733f577f4e065a3bd2fa7c5597950d39f6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a953733f577f4e065a3bd2fa7c5597950d39f6f>`__
    `#8137 <https://pagure.io/freeipa/issue/8137>`__
 -  Check valid before/after of external certs
-   `commit <https://pagure.io/freeipa/c/2fc5990a73007bfc1273228efa09755b1db2983f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fc5990a73007bfc1273228efa09755b1db2983f>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix lite-server to work with GSS_NAME
-   `commit <https://pagure.io/freeipa/c/9f726a20d947b7d4a87a6f96a6967cfc85fbc2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f726a20d947b7d4a87a6f96a6967cfc85fbc2de>`__
 -  Fix logic of check_client_configuration
-   `commit <https://pagure.io/freeipa/c/5d847cfb1d3779524e28d186c260db438bdf1369>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d847cfb1d3779524e28d186c260db438bdf1369>`__
    `#8133 <https://pagure.io/freeipa/issue/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
-   `commit <https://pagure.io/freeipa/c/0785a032dfec0537aa90616fa0853abfe5ec058a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0785a032dfec0537aa90616fa0853abfe5ec058a>`__
    `#8134 <https://pagure.io/freeipa/issue/8134>`__
 -  Don't hard-code client's TLS versions and ciphers
-   `commit <https://pagure.io/freeipa/c/b655586225c8587fc9e4522d1e25458f10c63f86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b655586225c8587fc9e4522d1e25458f10c63f86>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
-   `commit <https://pagure.io/freeipa/c/ae9e41baddbf30ab2002455b06886be9e12ae453>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae9e41baddbf30ab2002455b06886be9e12ae453>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Enable TLS 1.3 support on the server
-   `commit <https://pagure.io/freeipa/c/f7de64c38b11d8fb22d313853b6113da1df449be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7de64c38b11d8fb22d313853b6113da1df449be>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Skip paramiko tests in FIPS mode
-   `commit <https://pagure.io/freeipa/c/82a4faefd2c719a1e269733280f4141241d89b68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82a4faefd2c719a1e269733280f4141241d89b68>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  FIPS: server key has different name in FIPS mode
-   `commit <https://pagure.io/freeipa/c/9091290a3e813f491f99626db3d07cbfe99a1d99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9091290a3e813f491f99626db3d07cbfe99a1d99>`__
 -  Remove FIPS noise from SSHd
-   `commit <https://pagure.io/freeipa/c/6ce6b53de376ff6338df318d37330d531725e1be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ce6b53de376ff6338df318d37330d531725e1be>`__
 -  Add test case for OTP login
-   `commit <https://pagure.io/freeipa/c/dfa356e3d60468fab9eb873adfa0b08a7f8fd842>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfa356e3d60468fab9eb873adfa0b08a7f8fd842>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Fix otptoken_sync plugin
-   `commit <https://pagure.io/freeipa/c/90f2866163b6fb4ec7f533e8d4820089b804d707>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90f2866163b6fb4ec7f533e8d4820089b804d707>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Show group-add/remove-member-manager failures
-   `commit <https://pagure.io/freeipa/c/2c98d76042ca37c499b4751e305d86b4a85d9286>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c98d76042ca37c499b4751e305d86b4a85d9286>`__
    `#8122 <https://pagure.io/freeipa/issue/8122>`__
 -  Test installation with (fake) userspace FIPS
-   `commit <https://pagure.io/freeipa/c/0cd2f4ee337595c7e39e00cfef5e99f5d87768c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cd2f4ee337595c7e39e00cfef5e99f5d87768c9>`__
    `#8118 <https://pagure.io/freeipa/issue/8118>`__
 -  Use default ssh host key algorithms
-   `commit <https://pagure.io/freeipa/c/2422970c34849192b15d1798eae9b11a400e7119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2422970c34849192b15d1798eae9b11a400e7119>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 
 
@@ -217,7 +217,7 @@ Cédric Jeanneret (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update selinux-policy minimal requirement
-   `commit <https://pagure.io/freeipa/c/e011906af7c5274ddcc551c68ba5438b6180b3cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e011906af7c5274ddcc551c68ba5438b6180b3cd>`__
 
 
 
@@ -225,15 +225,15 @@ François Cami (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix pr-ci templates' indentation
-   `commit <https://pagure.io/freeipa/c/d7a2c71742c62ce87d04b78542314b51247ba54c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7a2c71742c62ce87d04b78542314b51247ba54c>`__
 -  ipatests/test_nfs.py: wait before umount
-   `commit <https://pagure.io/freeipa/c/c00ec940db5ec759e152a646a7ee10f73f31bdfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c00ec940db5ec759e152a646a7ee10f73f31bdfb>`__
    `#8144 <https://pagure.io/freeipa/issue/8144>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
-   `commit <https://pagure.io/freeipa/c/62f0bd0bb8194b0998fca0e582725a6f63bc9154>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62f0bd0bb8194b0998fca0e582725a6f63bc9154>`__
    `#8148 <https://pagure.io/freeipa/issue/8148>`__
 -  DSU: add Design for Disable Stale Users
-   `commit <https://pagure.io/freeipa/c/d5be38a5bb4263a6e67552b5dd9b606aceec3d41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5be38a5bb4263a6e67552b5dd9b606aceec3d41>`__
    `#8104 <https://pagure.io/freeipa/issue/8104>`__
 
 
@@ -242,22 +242,22 @@ Florence Blanc-Renaud (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-cacert-manage man page: fix indentation
-   `commit <https://pagure.io/freeipa/c/668a6410373c39508e5e4c95f11c9e62efa0135c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/668a6410373c39508e5e4c95f11c9e62efa0135c>`__
    `#8138 <https://pagure.io/freeipa/issue/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
-   `commit <https://pagure.io/freeipa/c/bb8da7d388b1ff4077a443c04dbbf440d8f76b06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb8da7d388b1ff4077a443c04dbbf440d8f76b06>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
-   `commit <https://pagure.io/freeipa/c/b21128c2d7575c6eba6a52fa4448a9a2c7b56913>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b21128c2d7575c6eba6a52fa4448a9a2c7b56913>`__
 -  ipatests: fix test_crlgen_manage
-   `commit <https://pagure.io/freeipa/c/dd06dfc97c24ba31e102d675558561ddba5ca216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd06dfc97c24ba31e102d675558561ddba5ca216>`__
 -  ipatests: fix teardown
-   `commit <https://pagure.io/freeipa/c/ab67e0ed35a7a9f23e1b61f61ec6503a3a97231d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab67e0ed35a7a9f23e1b61f61ec6503a3a97231d>`__
 -  ipatests: generic uninstall should call ipa server-del
-   `commit <https://pagure.io/freeipa/c/c77b06265bfb08d85bb4bd875cdb104ce239356d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c77b06265bfb08d85bb4bd875cdb104ce239356d>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  Nightly definition: use right template for krbtpolicy
-   `commit <https://pagure.io/freeipa/c/04cfaa1861d4c88eab6b3d29fbb68e2ae2223214>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04cfaa1861d4c88eab6b3d29fbb68e2ae2223214>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -267,7 +267,7 @@ MIZUTA Takeshi (1)
 
 -  Add config that maintains existing content to ipa-client-install
    manpage
-   `commit <https://pagure.io/freeipa/c/999ebc176b50d5a097c72b0ef50d62acb8702f6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999ebc176b50d5a097c72b0ef50d62acb8702f6d>`__
 
 
 
@@ -276,9 +276,9 @@ Rob Crittenden (2)
 
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
-   `commit <https://pagure.io/freeipa/c/7db2000e12b217126febb6bcaf11acfe52388926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7db2000e12b217126febb6bcaf11acfe52388926>`__
 -  Add integration test for Kerberos ticket policy
-   `commit <https://pagure.io/freeipa/c/bc007eca9361709f65bb9da0a8cc101a0b978ef1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc007eca9361709f65bb9da0a8cc101a0b978ef1>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -287,7 +287,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: Remove keys if password auth is disabled
-   `commit <https://pagure.io/freeipa/c/aaf8fccbb65e82d33c6e3675f3195163feb8af34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aaf8fccbb65e82d33c6e3675f3195163feb8af34>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -296,7 +296,7 @@ Sergey Orlov (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
-   `commit <https://pagure.io/freeipa/c/8cbf47ae668c1cdff64b91bb0cda272b1c93b99e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cbf47ae668c1cdff64b91bb0cda272b1c93b99e>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 
 
@@ -305,7 +305,7 @@ Simo Sorce (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure to have storage space for tag
-   `commit <https://pagure.io/freeipa/c/d2e0d94521893bc5f002a335a8c0b99601e1afd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2e0d94521893bc5f002a335a8c0b99601e1afd6>`__
 
 
 
@@ -313,10 +313,10 @@ Serhii Tsymbaliuk (2)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix notification area layout
-   `commit <https://pagure.io/freeipa/c/d26429ea285857b55a4c78b63eea436618a861f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d26429ea285857b55a4c78b63eea436618a861f5>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
-   `commit <https://pagure.io/freeipa/c/444df81a3de320ebfabfa90c3e6c7a17d986f1b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/444df81a3de320ebfabfa90c3e6c7a17d986f1b1>`__
    `#8123 <https://pagure.io/freeipa/issue/8123>`__
 
 
@@ -325,7 +325,7 @@ Timo Aaltonen (1)
 ----------------------------------------------------------------------------------------------
 
 -  Debian: Fix font-awesome path.
-   `commit <https://pagure.io/freeipa/c/1ca93942b852285c81fb6b951051446841b4af8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ca93942b852285c81fb6b951051446841b4af8f>`__
 
 
 
@@ -333,7 +333,7 @@ Thomas Woerner (2)
 ----------------------------------------------------------------------------------------------
 
 -  Enable TestInstallMasterDNSRepeatedly in prci_definitions
-   `commit <https://pagure.io/freeipa/c/71ea25c60b2de3888a6b66dbfc8afc2c7882687a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71ea25c60b2de3888a6b66dbfc8afc2c7882687a>`__
 -  Test repeated installation of the primary with DNS enabled and domain
    set
-   `commit <https://pagure.io/freeipa/c/ba28073c19cf28d48911bf384da0257a27319a67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba28073c19cf28d48911bf384da0257a27319a67>`__

--- a/src/page/Releases/4.8.5.rst
+++ b/src/page/Releases/4.8.5.rst
@@ -222,14 +222,14 @@ Armando Neto (4)
 ----------------------------------------------------------------------------------------------
 
 -  prci: update fedora used for testing ipa-4-8
-   `commit <https://pagure.io/freeipa/c/c1660a4c023a28cdad40720fd91d7e57870b4808>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1660a4c023a28cdad40720fd91d7e57870b4808>`__
 -  prci: Bump template version
-   `commit <https://pagure.io/freeipa/c/59593194d3eaf646ae757b88dc8a9231c21301c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59593194d3eaf646ae757b88dc8a9231c21301c2>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
-   `commit <https://pagure.io/freeipa/c/011734279c37ca1e9a013694525563b4e77ace78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/011734279c37ca1e9a013694525563b4e77ace78>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: Improve test_commands reliability
-   `commit <https://pagure.io/freeipa/c/5431dd9706253ea7cd75f62f5cd387bbf25ac878>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5431dd9706253ea7cd75f62f5cd387bbf25ac878>`__
 
 
 
@@ -237,33 +237,33 @@ Alexander Bokovoy (11)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.8.5
-   `commit <https://pagure.io/freeipa/c/5f49e6d1aaab56f8dd72e991f16ff575b7f4c9ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f49e6d1aaab56f8dd72e991f16ff575b7f4c9ee>`__
 -  Add new contributors to the list
-   `commit <https://pagure.io/freeipa/c/1af953680ba95d7a9da382e05f373375d1e6a35d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1af953680ba95d7a9da382e05f373375d1e6a35d>`__
 -  Add more contributor emails to the mailmap
-   `commit <https://pagure.io/freeipa/c/b598982520891d2907070101c8953019613a4694>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b598982520891d2907070101c8953019613a4694>`__
 -  Secure AJP connector between Dogtag and Apache proxy
-   `commit <https://pagure.io/freeipa/c/d4d8b98c3588b212db6a26610e690cccb3af84ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4d8b98c3588b212db6a26610e690cccb3af84ca>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Tighten permissions on PKI proxy configuration
-   `commit <https://pagure.io/freeipa/c/1deb1010b245df6c363c5655f9a548bdf4dbc040>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1deb1010b245df6c363c5655f9a548bdf4dbc040>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
-   `commit <https://pagure.io/freeipa/c/4eb48492b354ecc30ffe1dd9654dcc0e0e833d64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4eb48492b354ecc30ffe1dd9654dcc0e0e833d64>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
-   `commit <https://pagure.io/freeipa/c/30b8c8b9985a5eb41e700b80fd03f95548e45fba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30b8c8b9985a5eb41e700b80fd03f95548e45fba>`__
    `#8200 <https://pagure.io/freeipa/issue/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
-   `commit <https://pagure.io/freeipa/c/936e27f75961c67e619ecfa641e256ce80662d68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/936e27f75961c67e619ecfa641e256ce80662d68>`__
    `#8192 <https://pagure.io/freeipa/issue/8192>`__
 -  Update Azure Pipelines to use Fedora 31
-   `commit <https://pagure.io/freeipa/c/f4e2acd1333f0f3d88da81d3fda80e85c9c418c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4e2acd1333f0f3d88da81d3fda80e85c9c418c2>`__
 -  install/updates: move external members past schema compat update
-   `commit <https://pagure.io/freeipa/c/14dbf04148c6284b176eca34aa70df4bef09b857>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14dbf04148c6284b176eca34aa70df4bef09b857>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Reset per-indicator Kerberos policy
-   `commit <https://pagure.io/freeipa/c/a8b52eaf3cf56c90e3d94fdef0b9e426052634ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8b52eaf3cf56c90e3d94fdef0b9e426052634ea>`__
    `#8153 <https://pagure.io/freeipa/issue/8153>`__
 
 
@@ -272,31 +272,31 @@ Anuja More (11)
 ----------------------------------------------------------------------------------------------
 
 -  Mark test to skip sssd-2.2.2
-   `commit <https://pagure.io/freeipa/c/a9922639f3541fe25cadbba79a94de7ada29c7f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9922639f3541fe25cadbba79a94de7ada29c7f3>`__
 -  ipatests: User and group with same name should not break reading AD
    user data.
-   `commit <https://pagure.io/freeipa/c/c3053e287b8d29da40ef9c36fbe8915f616f8501>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3053e287b8d29da40ef9c36fbe8915f616f8501>`__
 -  ipatests: Added test when 2FA prompting configurations is set.
-   `commit <https://pagure.io/freeipa/c/dcdcbe37f42a219541716938fd34ac1df7d8170c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcdcbe37f42a219541716938fd34ac1df7d8170c>`__
 -  ipatests: SSSD should fetch external groups without any limit.
-   `commit <https://pagure.io/freeipa/c/d4b8081e6c0a745451ff314f7a42d5ff344ac327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4b8081e6c0a745451ff314f7a42d5ff344ac327>`__
 -  ipatests: Add test for ipa-extdom-extop plugin should allow @ in
    group name
-   `commit <https://pagure.io/freeipa/c/985c99fc7ad6fdd30d428d099e006b1a0836a87d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/985c99fc7ad6fdd30d428d099e006b1a0836a87d>`__
 -  Update topology for test_integration/test_sssd.py
-   `commit <https://pagure.io/freeipa/c/2d0da2f9aff2e6256ae9f43838ca24335381e7e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d0da2f9aff2e6256ae9f43838ca24335381e7e8>`__
 -  After mounting "Unspecified GSS failure" should not be in logs.
-   `commit <https://pagure.io/freeipa/c/4d7eac93b0249d6f4081bb4857079875afa21423>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d7eac93b0249d6f4081bb4857079875afa21423>`__
 -  Add xmlrpc test with input validation check for kerberos ticket
    policy.
-   `commit <https://pagure.io/freeipa/c/acbbc52999f8c7694d549b709bc8caea801dc94c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acbbc52999f8c7694d549b709bc8caea801dc94c>`__
 -  Fix fedora version for xfail for sssd test
-   `commit <https://pagure.io/freeipa/c/2b19749a3769bbac5f11aa901bf6291b6240dddb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b19749a3769bbac5f11aa901bf6291b6240dddb>`__
 -  Add integration test for otp kerberos ticket policy.
-   `commit <https://pagure.io/freeipa/c/27a6920d50e5d63afbfc198e64885a2cd3fadc48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27a6920d50e5d63afbfc198e64885a2cd3fadc48>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  ipatests: filter_users should be applied correctly.
-   `commit <https://pagure.io/freeipa/c/71a4d574bd94eda3cb7490a2254ce764fe9bcdb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71a4d574bd94eda3cb7490a2254ce764fe9bcdb1>`__
 
 
 
@@ -304,23 +304,23 @@ Christian Heimes (7)
 ----------------------------------------------------------------------------------------------
 
 -  Allow hosts to read DNS records for IP SAN
-   `commit <https://pagure.io/freeipa/c/e4a611aee8ca839c59798210b56e65f21a24e965>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4a611aee8ca839c59798210b56e65f21a24e965>`__
    `#8098 <https://pagure.io/freeipa/issue/8098>`__
 -  Cleanup SELinux policy
-   `commit <https://pagure.io/freeipa/c/87e0d82dd4409cdecaacee1fa27d27033aa65f7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87e0d82dd4409cdecaacee1fa27d27033aa65f7a>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate SELinux policy into build system
-   `commit <https://pagure.io/freeipa/c/18ce2033c04aed2c4a34f61b9ee3642b01f53017>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18ce2033c04aed2c4a34f61b9ee3642b01f53017>`__
 -  dnsrecord: Treat empty list arguments correctly
-   `commit <https://pagure.io/freeipa/c/2ade60ac63ff9a626ae1ec17196121fe694ee212>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ade60ac63ff9a626ae1ec17196121fe694ee212>`__
    `#8196 <https://pagure.io/freeipa/issue/8196>`__
 -  Remove dependency on custodia package
-   `commit <https://pagure.io/freeipa/c/b240b54bb4ff160851c7681914eb210934ae2abc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b240b54bb4ff160851c7681914eb210934ae2abc>`__
 -  Make assert_error compatible with Python 3.6
-   `commit <https://pagure.io/freeipa/c/e9ed8e78454f12fcfc3d0484dd36995cbef65961>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9ed8e78454f12fcfc3d0484dd36995cbef65961>`__
    `#8179 <https://pagure.io/freeipa/issue/8179>`__
 -  Print LDAP diagnostic messages on error
-   `commit <https://pagure.io/freeipa/c/4fe1f7701a616c17167f75e1e81f3a479a2ee50f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fe1f7701a616c17167f75e1e81f3a479a2ee50f>`__
 
 
 
@@ -328,7 +328,7 @@ Dinesh Prasanth M K (1)
 ----------------------------------------------------------------------------------------------
 
 -  Adding auto COPR builds
-   `commit <https://pagure.io/freeipa/c/21fb038c9bdfa05fa96ac2a0fc6f4cc1e74ce916>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21fb038c9bdfa05fa96ac2a0fc6f4cc1e74ce916>`__
 
 
 
@@ -336,21 +336,21 @@ François Cami (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-restore: restart services at the end
-   `commit <https://pagure.io/freeipa/c/8d6a609d6e55dc11b4768ee54da46393228660f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d6a609d6e55dc11b4768ee54da46393228660f9>`__
    `#8226 <https://pagure.io/freeipa/issue/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
-   `commit <https://pagure.io/freeipa/c/7ae804c726970ae467a7f76efa21bae40405551d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ae804c726970ae467a7f76efa21bae40405551d>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipa-client-automount: call save_domain() for each change
-   `commit <https://pagure.io/freeipa/c/6332aed9ba67e2ee759a9d988ba92139486469d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6332aed9ba67e2ee759a9d988ba92139486469d4>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
-   `commit <https://pagure.io/freeipa/c/578bdce292c142b7fca6e237ccb3f5cec641e618>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/578bdce292c142b7fca6e237ccb3f5cec641e618>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
-   `commit <https://pagure.io/freeipa/c/e3cff5d152fc36802f7ddfcd0730696e154d1b4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3cff5d152fc36802f7ddfcd0730696e154d1b4c>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 
 
@@ -359,52 +359,52 @@ Florence Blanc-Renaud (16)
 ----------------------------------------------------------------------------------------------
 
 -  opendnssec2.1 support: move all ods tasks to specific file
-   `commit <https://pagure.io/freeipa/c/799ebc8be681165e622778848a9b2989434a29dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/799ebc8be681165e622778848a9b2989434a29dd>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
-   `commit <https://pagure.io/freeipa/c/598c55cc0dc884aa780ac2dc2f3adfd8299e6ea0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/598c55cc0dc884aa780ac2dc2f3adfd8299e6ea0>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
-   `commit <https://pagure.io/freeipa/c/fc4ccfa5c3a7ecd7c9e5539595e0440965d62336>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc4ccfa5c3a7ecd7c9e5539595e0440965d62336>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  With opendnssec 2, read the zone list from file
-   `commit <https://pagure.io/freeipa/c/6cb3b11a61d5b9b7df93130188c7feef83398090>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cb3b11a61d5b9b7df93130188c7feef83398090>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Remove the from opendnssec conf
-   `commit <https://pagure.io/freeipa/c/5716c3b78f43391d2ab7b4b1fd672135f3b55bdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5716c3b78f43391d2ab7b4b1fd672135f3b55bdb>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support opendnssec 2.1.6
-   `commit <https://pagure.io/freeipa/c/23993f58e1da98e537b03b9274d91308cbc63a6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23993f58e1da98e537b03b9274d91308cbc63a6c>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
-   `commit <https://pagure.io/freeipa/c/df0df14bf31dba5800747aa08824b24b8be41eab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df0df14bf31dba5800747aa08824b24b8be41eab>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
-   `commit <https://pagure.io/freeipa/c/21c923c4cf21f30f20ec4b21c488db6f6fa92b67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21c923c4cf21f30f20ec4b21c488db6f6fa92b67>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/c444f7a35ada0dcb4f565557b7c71f3644fdd446>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c444f7a35ada0dcb4f565557b7c71f3644fdd446>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
-   `commit <https://pagure.io/freeipa/c/4afd6e5e07061dde6e30b5352668bdf23cd6dedd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4afd6e5e07061dde6e30b5352668bdf23cd6dedd>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
-   `commit <https://pagure.io/freeipa/c/5edc674e7262ce4506c40b8c066207f9e5f55c33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5edc674e7262ce4506c40b8c066207f9e5f55c33>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
-   `commit <https://pagure.io/freeipa/c/66154f8bf79584b8fa6792e3d2ca534900dfa481>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66154f8bf79584b8fa6792e3d2ca534900dfa481>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/8a5bfaba83da700bed29fc82ef1d280bfabb8379>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a5bfaba83da700bed29fc82ef1d280bfabb8379>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  ipatests: fix modify_sssd_conf()
-   `commit <https://pagure.io/freeipa/c/8e527507c0971ed1a8468e10246232491b1ef36c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e527507c0971ed1a8468e10246232491b1ef36c>`__
 -  ipatests: fix backup and restore
-   `commit <https://pagure.io/freeipa/c/1b7cf51e292b917a18ec7959708cb62ceddd44b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b7cf51e292b917a18ec7959708cb62ceddd44b7>`__
    `#8170 <https://pagure.io/freeipa/issue/8170>`__
 -  AD user without override receive InternalServerError with API
-   `commit <https://pagure.io/freeipa/c/4db18be5467c0b8f7633b281c724f469f907e573>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4db18be5467c0b8f7633b281c724f469f907e573>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 
 
@@ -413,16 +413,16 @@ Fraser Tweedale (4)
 ----------------------------------------------------------------------------------------------
 
 -  Do not renew externally-signed CA as self-signed
-   `commit <https://pagure.io/freeipa/c/4b5513660cb73ee685e09c4f84634ac9d1fa792d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b5513660cb73ee685e09c4f84634ac9d1fa792d>`__
    `#8176 <https://pagure.io/freeipa/issue/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
-   `commit <https://pagure.io/freeipa/c/25310105da0540eb84b6d0ee4c30649750583703>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25310105da0540eb84b6d0ee4c30649750583703>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix test regressions caused by certificate validation changes
-   `commit <https://pagure.io/freeipa/c/d833b5ba607f79a495e0245722e8ccef7cefbd7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d833b5ba607f79a495e0245722e8ccef7cefbd7a>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  ipatests: assert_error: allow regexp match
-   `commit <https://pagure.io/freeipa/c/44fca092ead0316084d68917032e28e5cbb20ad4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44fca092ead0316084d68917032e28e5cbb20ad4>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 
 
@@ -431,7 +431,7 @@ Gaurav Talreja (1)
 ----------------------------------------------------------------------------------------------
 
 -  Normalize test definations titles
-   `commit <https://pagure.io/freeipa/c/875769c7c0a66a217a152b7c8cb064c3ceabf541>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/875769c7c0a66a217a152b7c8cb064c3ceabf541>`__
 
 
 
@@ -439,9 +439,9 @@ Isaac Boukris (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix legacy S4U2Proxy in DAL v8 support
-   `commit <https://pagure.io/freeipa/c/0806c1582b2f1dfaf04eb2e8fa222c190e24d818>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0806c1582b2f1dfaf04eb2e8fa222c190e24d818>`__
 -  Fix DAL v8 support
-   `commit <https://pagure.io/freeipa/c/99a920cb69e213d211a6ff9622950e81c3e71c8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a920cb69e213d211a6ff9622950e81c3e71c8d>`__
 
 
 
@@ -449,11 +449,11 @@ Jayesh (3)
 ----------------------------------------------------------------------------------------------
 
 -  Test for ipa-ca-install on replica
-   `commit <https://pagure.io/freeipa/c/e1ff95fc618f22886b505a8dbfdfa7651e1a3b9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1ff95fc618f22886b505a8dbfdfa7651e1a3b9b>`__
 -  Test ipa-getkeytab quiet mode, encryptons
-   `commit <https://pagure.io/freeipa/c/631054a1c9aff849378278f99722a8711d6bacf3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/631054a1c9aff849378278f99722a8711d6bacf3>`__
 -  Test if ipactl starts services stopped by systemctl
-   `commit <https://pagure.io/freeipa/c/acbd90d9fb16e76964d36b3d6e8e542a30631172>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acbd90d9fb16e76964d36b3d6e8e542a30631172>`__
 
 
 
@@ -461,7 +461,7 @@ Kaleemullah Siddiqui (1)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for backup-restore when pkg required is missing
-   `commit <https://pagure.io/freeipa/c/3ced5532576779ee7bb2e7f15ff4b5039ba4daba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ced5532576779ee7bb2e7f15ff4b5039ba4daba>`__
    `#7630 <https://pagure.io/freeipa/issue/7630>`__
 
 
@@ -470,19 +470,19 @@ Mohammad Rizwan Yusuf (6)
 ----------------------------------------------------------------------------------------------
 
 -  Test if getcert creates cacert file with -F option
-   `commit <https://pagure.io/freeipa/c/937fb1d9518c54bf9c05bc0b7d6f43b29971eb3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/937fb1d9518c54bf9c05bc0b7d6f43b29971eb3c>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Move wait_for_request() method to tasks.py
-   `commit <https://pagure.io/freeipa/c/5d8d9198ce1ddfd44eb7c0268c397359e6239fca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d8d9198ce1ddfd44eb7c0268c397359e6239fca>`__
 -  Test if server installer lock Bind9 recursion
-   `commit <https://pagure.io/freeipa/c/3fbbd02b0e8bc5e4f196e8d26ecfa8c989dadabb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fbbd02b0e8bc5e4f196e8d26ecfa8c989dadabb>`__
    `#8079 <https://pagure.io/freeipa/issue/8079>`__
 -  Add certmonger wait_for_request that uses run_command
-   `commit <https://pagure.io/freeipa/c/84ae778c8731b0934e011155b668acbb97d775c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84ae778c8731b0934e011155b668acbb97d775c2>`__
 -  Test if certmonger reads the token in HSM
-   `commit <https://pagure.io/freeipa/c/eaf9e79c8000118317527caad4cf6aa521fd0028>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eaf9e79c8000118317527caad4cf6aa521fd0028>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
-   `commit <https://pagure.io/freeipa/c/61577c851e81beabc65e5b96603b88e9f7ec973b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61577c851e81beabc65e5b96603b88e9f7ec973b>`__
    `#8110 <https://pagure.io/freeipa/issue/8110>`__
 
 
@@ -491,24 +491,24 @@ Rob Crittenden (7)
 ----------------------------------------------------------------------------------------------
 
 -  Move execution of ipa-healthcheck to a separate function
-   `commit <https://pagure.io/freeipa/c/f36b8697a1d7dcf0f698147b3791c8ed338863d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f36b8697a1d7dcf0f698147b3791c8ed338863d7>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
-   `commit <https://pagure.io/freeipa/c/12d6864b6dc30155414e2483f7634684ccc9ee3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12d6864b6dc30155414e2483f7634684ccc9ee3e>`__
    `#8135 <https://pagure.io/freeipa/issue/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/f356d5734662d0a20f06702353b2f10f29b9f55d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f356d5734662d0a20f06702353b2f10f29b9f55d>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  Add tests for ipa-cacert-manage delete command
-   `commit <https://pagure.io/freeipa/c/78827db1aa561613d3fb40f39525f7e8fcae2b98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78827db1aa561613d3fb40f39525f7e8fcae2b98>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
-   `commit <https://pagure.io/freeipa/c/7d81a3458c266a1e0c4baa07717aac110c435e59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d81a3458c266a1e0c4baa07717aac110c435e59>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
-   `commit <https://pagure.io/freeipa/c/37f81cc566cc37a47b7d1b0d900a53273eae01ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37f81cc566cc37a47b7d1b0d900a53273eae01ac>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/3d7d58d8214f3c899c0afd1a3a6a6678f38b7b39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d7d58d8214f3c899c0afd1a3a6a6678f38b7b39>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 
 
@@ -517,17 +517,17 @@ Robbie Harwood (6)
 ----------------------------------------------------------------------------------------------
 
 -  Drop support for DAL version 5.0
-   `commit <https://pagure.io/freeipa/c/196350444ccab2b99e86accf7eb19ff8327a1e95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/196350444ccab2b99e86accf7eb19ff8327a1e95>`__
 -  Support DAL version 8.0
-   `commit <https://pagure.io/freeipa/c/089c47e212ac077dcd27bc60013d7ac7bf2270ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/089c47e212ac077dcd27bc60013d7ac7bf2270ee>`__
 -  Handle the removal of KRB5_KDB_FLAG_ALIAS_OK
-   `commit <https://pagure.io/freeipa/c/d97cfd72721ed2f7e77f5c397a0ca7b389ea6d72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d97cfd72721ed2f7e77f5c397a0ca7b389ea6d72>`__
 -  Fix several leaks in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/6bdd6b3d265ffc2f437e2a69707978758c2efdd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bdd6b3d265ffc2f437e2a69707978758c2efdd8>`__
 -  Use separate variable for client fetch in kdcpolicy
-   `commit <https://pagure.io/freeipa/c/01c1b270cd83ab6573dc0a502ac37d0182503c3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01c1b270cd83ab6573dc0a502ac37d0182503c3d>`__
 -  Make the coding style explicit
-   `commit <https://pagure.io/freeipa/c/86a8d9480aa402f885c72ccbcfeeb2bac488f268>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86a8d9480aa402f885c72ccbcfeeb2bac488f268>`__
 
 
 
@@ -535,69 +535,69 @@ Stanislav Levin (24)
 ----------------------------------------------------------------------------------------------
 
 -  spec: Take the ownership over '/usr/libexec/ipa/custodia'
-   `commit <https://pagure.io/freeipa/c/5df2f5d856f15c6283644a00004fad5873eb1671>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5df2f5d856f15c6283644a00004fad5873eb1671>`__
 -  Azure: Report elapsed time
-   `commit <https://pagure.io/freeipa/c/8fd1eacfb5c49738f9a26124cfa7a2423244637b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fd1eacfb5c49738f9a26124cfa7a2423244637b>`__
 -  Azure: Rebalance tests
-   `commit <https://pagure.io/freeipa/c/1fe5c04cdd2f5f998f92debc7f3f46f2807ddc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fe5c04cdd2f5f998f92debc7f3f46f2807ddc88>`__
 -  Azure: Skip tests requiring external DNS
-   `commit <https://pagure.io/freeipa/c/ec21ecc5c6677f9e87fc8ffa5652645469865230>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec21ecc5c6677f9e87fc8ffa5652645469865230>`__
 -  Azure: Free Docker resources after usage
-   `commit <https://pagure.io/freeipa/c/4b2cdeef29094dd6b3e4f485993ad5f69c8d84b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b2cdeef29094dd6b3e4f485993ad5f69c8d84b5>`__
 -  Azure: Preliminary check for provided limits
-   `commit <https://pagure.io/freeipa/c/4e6e0c88bb2831b65c1a5a6f1f4a7f09c0b112cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e6e0c88bb2831b65c1a5a6f1f4a7f09c0b112cf>`__
 -  Azure: Sync Gating definitions to current PR-CI
-   `commit <https://pagure.io/freeipa/c/0fbdb1357ca3e861bba14d21ceb6e2a6e753a14c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fbdb1357ca3e861bba14d21ceb6e2a6e753a14c>`__
 -  pylint: Run Pylint over Azure Python scripts
-   `commit <https://pagure.io/freeipa/c/3fff86757cfc7a78db33801e3c75e208b01660f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fff86757cfc7a78db33801e3c75e208b01660f7>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Add support for testing multi IPA environments
-   `commit <https://pagure.io/freeipa/c/245a9dc93f086b685b09984ea4a3395b93fd5789>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/245a9dc93f086b685b09984ea4a3395b93fd5789>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
-   `commit <https://pagure.io/freeipa/c/685d902ca4cf10c8c440036016c2dd3e05d76222>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/685d902ca4cf10c8c440036016c2dd3e05d76222>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  yamllint: Lint all the YAML files
-   `commit <https://pagure.io/freeipa/c/2988f5f30c9379f8ac7cbfc56af382f2779479cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2988f5f30c9379f8ac7cbfc56af382f2779479cf>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
-   `commit <https://pagure.io/freeipa/c/198cd506592c8dc078e7956a42d0d4e0342cf86d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/198cd506592c8dc078e7956a42d0d4e0342cf86d>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to run integration tests
-   `commit <https://pagure.io/freeipa/c/d33b7d61fc8e012ecfd0354a6d3431301a66d768>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d33b7d61fc8e012ecfd0354a6d3431301a66d768>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow SSH for Docker environments
-   `commit <https://pagure.io/freeipa/c/6a6e3f2339c5773f051aaea08922f6853ef5942d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a6e3f2339c5773f051aaea08922f6853ef5942d>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to not provide tests to be ignored
-   `commit <https://pagure.io/freeipa/c/11d145300dcd1b9b986f259efa57eddcca9b2e32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11d145300dcd1b9b986f259efa57eddcca9b2e32>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  ipatests: Allow zero-length arguments
-   `commit <https://pagure.io/freeipa/c/c35c066a6d7b7a493e22a4af3043d5d2a72133d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c35c066a6d7b7a493e22a4af3043d5d2a72133d4>`__
    `#8173 <https://pagure.io/freeipa/issue/8173>`__
 -  lint: Make Pylint-2.4 happy again
-   `commit <https://pagure.io/freeipa/c/44a59ff39a3f481e90043e546c892c9108231d67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44a59ff39a3f481e90043e546c892c9108231d67>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Clean up comment
-   `commit <https://pagure.io/freeipa/c/6f48848562f4e9ab9584154fd85e6ad1ac331ecd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f48848562f4e9ab9584154fd85e6ad1ac331ecd>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
-   `commit <https://pagure.io/freeipa/c/3460db4ee7c7ce6c9a639a644a39c4df09ce31ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3460db4ee7c7ce6c9a639a644a39c4df09ce31ac>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Teach Pylint how to handle request.context
-   `commit <https://pagure.io/freeipa/c/5939c90752db9da1adaf8c0bfe6bec3d6c1e2ad6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5939c90752db9da1adaf8c0bfe6bec3d6c1e2ad6>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  ipatests: Properly kill gpg-agent
-   `commit <https://pagure.io/freeipa/c/294694ad69fa909e2f699cb2dad0f36b966a246f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/294694ad69fa909e2f699cb2dad0f36b966a246f>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
-   `commit <https://pagure.io/freeipa/c/3659b46d6aeea06b4875860ec69a9215afcbdd91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3659b46d6aeea06b4875860ec69a9215afcbdd91>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/356f907fc255ab3a9f93ff2808646b92a6652aec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/356f907fc255ab3a9f93ff2808646b92a6652aec>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/87bc31464b6133af9befd412af54403665c22628>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87bc31464b6133af9befd412af54403665c22628>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 
 
@@ -606,27 +606,27 @@ Sergey Orlov (9)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add test for SSSD updating expired cache items
-   `commit <https://pagure.io/freeipa/c/40fd96f27d2512212ac99fff9ace0fef1f5a57d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40fd96f27d2512212ac99fff9ace0fef1f5a57d4>`__
 -  ipatests: provide docstrings instead of imporperly placed comments
-   `commit <https://pagure.io/freeipa/c/1d416a5a5ceaaf3fff9df423cea9114f1918aad2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d416a5a5ceaaf3fff9df423cea9114f1918aad2>`__
 -  ipatests: remove invalid parameter from sssd.conf
-   `commit <https://pagure.io/freeipa/c/a1695722125674204b6e880b6ac652d78b783c88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1695722125674204b6e880b6ac652d78b783c88>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
-   `commit <https://pagure.io/freeipa/c/32584ed34f466e8f474e22d778e3e964d0fcd2c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32584ed34f466e8f474e22d778e3e964d0fcd2c4>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: replace utility for editing sssd.conf
-   `commit <https://pagure.io/freeipa/c/5ff9b6e2a506c3ef1179655ae2d2e479005ec99e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ff9b6e2a506c3ef1179655ae2d2e479005ec99e>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
-   `commit <https://pagure.io/freeipa/c/9cb8984112ff31721b71dcdd4febcc23c2641691>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cb8984112ff31721b71dcdd4febcc23c2641691>`__
 -  ipatests: add test_trust suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/0ff0ab85a8b1d90fb94e09bdbb3e9eeeb11d191a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ff0ab85a8b1d90fb94e09bdbb3e9eeeb11d191a>`__
 -  ipatests: add check for output contents of ipa-client-samba
-   `commit <https://pagure.io/freeipa/c/577dd1e47a092cf7e4527707111d28297bb58f53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/577dd1e47a092cf7e4527707111d28297bb58f53>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/72e1b135b3862a16df4e8b5a1a7c2bbfcd5b08c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72e1b135b3862a16df4e8b5a1a7c2bbfcd5b08c9>`__
 
 
 
@@ -635,7 +635,7 @@ Sumedh Sidhaye (1)
 
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
-   `commit <https://pagure.io/freeipa/c/2cd67d5a9a22c009f050e493d4b3e2882dbfd81f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2cd67d5a9a22c009f050e493d4b3e2882dbfd81f>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 
 
@@ -645,10 +645,10 @@ Serhii Tsymbaliuk (2)
 
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
-   `commit <https://pagure.io/freeipa/c/4e1d27c22a90d579a9019829f8ffd0bed51c2e5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e1d27c22a90d579a9019829f8ffd0bed51c2e5f>`__
    `#8157 <https://pagure.io/freeipa/issue/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
-   `commit <https://pagure.io/freeipa/c/664eed7d0885791a3b16ad082d56f9a14682673e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/664eed7d0885791a3b16ad082d56f9a14682673e>`__
    `#8169 <https://pagure.io/freeipa/issue/8169>`__
 
 
@@ -657,11 +657,11 @@ sumenon (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: check that ipa-healthcheck warns if no dna range is set
-   `commit <https://pagure.io/freeipa/c/59bd2fec85a49ff75fbcad05cfd5a641a67c5d56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59bd2fec85a49ff75fbcad05cfd5a641a67c5d56>`__
 -  Nightly definition for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/7a45cd179f846920ffa91df7f28f21e7de09f328>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a45cd179f846920ffa91df7f28f21e7de09f328>`__
 -  Tier-1 test for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/a6dae4843c2fbaba984bf6bd3add6e2b62b1f59f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6dae4843c2fbaba984bf6bd3add6e2b62b1f59f>`__
 
 
 
@@ -670,9 +670,9 @@ Thomas Woerner (2)
 
 -  ipaserver/plugins/hbacrule: Add HBAC to memberservice_hbacsvc\*
    labels
-   `commit <https://pagure.io/freeipa/c/8b5dc6a29e5e1893f9ec864bdde1f769ad6efc39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b5dc6a29e5e1893f9ec864bdde1f769ad6efc39>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
-   `commit <https://pagure.io/freeipa/c/2c2cef7063315766d893b275185b422be3f3c019>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c2cef7063315766d893b275185b422be3f3c019>`__
    `#8150 <https://pagure.io/freeipa/issue/8150>`__
 
 
@@ -681,8 +681,8 @@ Vit Mojzis (3)
 ----------------------------------------------------------------------------------------------
 
 -  selinux: Remove obsolete memcached access
-   `commit <https://pagure.io/freeipa/c/96565414b3fd1e2c946b21f205a3ac3c4b5bad0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96565414b3fd1e2c946b21f205a3ac3c4b5bad0c>`__
 -  selinux: move BUILD_SELINUX_POLICY definition
-   `commit <https://pagure.io/freeipa/c/bb6a5a5d9f850bde9b8d81c2dd51d41263c22cd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb6a5a5d9f850bde9b8d81c2dd51d41263c22cd4>`__
 -  Add freeipa-selinux subpackage
-   `commit <https://pagure.io/freeipa/c/4ca100999b691c22ff63154edd32af0e8040ef1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ca100999b691c22ff63154edd32af0e8040ef1f>`__

--- a/src/page/Releases/4.8.6.rst
+++ b/src/page/Releases/4.8.6.rst
@@ -147,85 +147,85 @@ Alexander Bokovoy (35)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.8.6
-   `commit <https://pagure.io/freeipa/c/75d04b5e0e5709d98440209f803175242a52d119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75d04b5e0e5709d98440209f803175242a52d119>`__
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
-   `commit <https://pagure.io/freeipa/c/bcbf64b1bf287d2b0b23bc7ac0cca9e8b789ba4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcbf64b1bf287d2b0b23bc7ac0cca9e8b789ba4a>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
-   `commit <https://pagure.io/freeipa/c/5bae736bc81eaa1167ec64a69a32506dad2ca286>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bae736bc81eaa1167ec64a69a32506dad2ca286>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
-   `commit <https://pagure.io/freeipa/c/313542e8a125c4904750826ef9eabdead7d874bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/313542e8a125c4904750826ef9eabdead7d874bd>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
-   `commit <https://pagure.io/freeipa/c/f4dc10b8caac44f5c2a8edbb4c647e6dcf71c3bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4dc10b8caac44f5c2a8edbb4c647e6dcf71c3bd>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  Fix indentation levels
-   `commit <https://pagure.io/freeipa/c/c62b9e7f6ab0dec54540dc6cd389fe58f8858275>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c62b9e7f6ab0dec54540dc6cd389fe58f8858275>`__
 -  ipatests: always skip additional input for group-add-member
    --external
-   `commit <https://pagure.io/freeipa/c/74f36e7c2f7f6d17b56e06b5f05205edb8a286d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74f36e7c2f7f6d17b56e06b5f05205edb8a286d7>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  po: update Chinese (China) translation
-   `commit <https://pagure.io/freeipa/c/c6adee04068ce946f8c9b8ad5db19721db13c602>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6adee04068ce946f8c9b8ad5db19721db13c602>`__
 -  po: update Ukrainian translation
-   `commit <https://pagure.io/freeipa/c/855a36b6c093fd21af7cf87524acc5d297692de3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/855a36b6c093fd21af7cf87524acc5d297692de3>`__
 -  po: update Tajik translation timestamp
-   `commit <https://pagure.io/freeipa/c/3d411cf29f29e1d391ed8f6eb159b88d450a332b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d411cf29f29e1d391ed8f6eb159b88d450a332b>`__
 -  po: update Slovak translation timestamp
-   `commit <https://pagure.io/freeipa/c/3c15e47a7c2212aab0ecdc320093bee2afa0bfdc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c15e47a7c2212aab0ecdc320093bee2afa0bfdc>`__
 -  po: update Russian translation
-   `commit <https://pagure.io/freeipa/c/db433fbe4e521d08dee2cdc2e65344d8203e03a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db433fbe4e521d08dee2cdc2e65344d8203e03a4>`__
 -  po: update Portuguese (Brazil) translation timestamp
-   `commit <https://pagure.io/freeipa/c/eab195ff3884b482279279326b3a84ced4723b7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eab195ff3884b482279279326b3a84ced4723b7e>`__
 -  po: update Portuguese translation timestamp
-   `commit <https://pagure.io/freeipa/c/31a9da8efa793d492352f646fc804b902beec088>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31a9da8efa793d492352f646fc804b902beec088>`__
 -  po: update Polish translation
-   `commit <https://pagure.io/freeipa/c/4e3867fcc49a8d2ff1085e630abd77666a06d838>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e3867fcc49a8d2ff1085e630abd77666a06d838>`__
 -  po: update Punjabi translation timestamp
-   `commit <https://pagure.io/freeipa/c/e4dfb7409bd25dc5bc2cc1e99562f912a98509f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4dfb7409bd25dc5bc2cc1e99562f912a98509f8>`__
 -  po: update Dutch translation timestamp
-   `commit <https://pagure.io/freeipa/c/e7945284906998da0a798a1ff15a42dd3fdb96d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7945284906998da0a798a1ff15a42dd3fdb96d9>`__
 -  po: update Marathi translation timestamp
-   `commit <https://pagure.io/freeipa/c/28a963eed0f27c214543b02fc34e15182e6fcc04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28a963eed0f27c214543b02fc34e15182e6fcc04>`__
 -  po: update Kannada translation timestamp
-   `commit <https://pagure.io/freeipa/c/89b048d1408834dde38321ac4f402083ebd30247>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89b048d1408834dde38321ac4f402083ebd30247>`__
 -  po: update Japanese translation timestamp
-   `commit <https://pagure.io/freeipa/c/89dbf88abb108cad7f44f92b4e94e66f21746cd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89dbf88abb108cad7f44f92b4e94e66f21746cd3>`__
 -  po: update Indonesian translation timestamp
-   `commit <https://pagure.io/freeipa/c/124a563eb64d7f9a2190a13e9d68a7b608be2d22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/124a563eb64d7f9a2190a13e9d68a7b608be2d22>`__
 -  po: update Hungarian translation timestamp
-   `commit <https://pagure.io/freeipa/c/595d5062b9e770a946156f69df2fe522d4745d9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/595d5062b9e770a946156f69df2fe522d4745d9e>`__
 -  po: update Hindi translation timestamp
-   `commit <https://pagure.io/freeipa/c/c4dd8b226ae97011bcc0546209f8473fbcd75ab8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4dd8b226ae97011bcc0546209f8473fbcd75ab8>`__
 -  po: update French translation
-   `commit <https://pagure.io/freeipa/c/a2ca393d35a1f34b2dbbd54c9c1d24b9f20960f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2ca393d35a1f34b2dbbd54c9c1d24b9f20960f0>`__
 -  po: update Basque translation timestamp
-   `commit <https://pagure.io/freeipa/c/92fb5c5268b8b1b02b7a1d12b9a6417c893a18f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92fb5c5268b8b1b02b7a1d12b9a6417c893a18f1>`__
 -  po: update Spanish translation
-   `commit <https://pagure.io/freeipa/c/7af52df7a8e54afe36649c5436fcfce759111751>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7af52df7a8e54afe36649c5436fcfce759111751>`__
 -  po: update English (United Kingdom) translation timestamp
-   `commit <https://pagure.io/freeipa/c/37a1e927a1f123b8b9fdbaf815003cb04726f72c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37a1e927a1f123b8b9fdbaf815003cb04726f72c>`__
 -  po: update German translation
-   `commit <https://pagure.io/freeipa/c/0d053d8b1df33f5602ae0e154743f1d1dce2c72d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d053d8b1df33f5602ae0e154743f1d1dce2c72d>`__
 -  po: update Czech translation timestamp
-   `commit <https://pagure.io/freeipa/c/c8ba436c0dad467bf12dec4d4f141916d0b3fbbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8ba436c0dad467bf12dec4d4f141916d0b3fbbd>`__
 -  po: update Catalan translation timestamp
-   `commit <https://pagure.io/freeipa/c/29e3ade05c8bea23c07ed1a1b5612af01f924d2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29e3ade05c8bea23c07ed1a1b5612af01f924d2d>`__
 -  po: update Bengali translation timestamp
-   `commit <https://pagure.io/freeipa/c/16d9556c6f3d19f73256d6698a7659f78961a378>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16d9556c6f3d19f73256d6698a7659f78961a378>`__
 -  po: update ipa.pot template
-   `commit <https://pagure.io/freeipa/c/e23ba779d3aefd871e348b91e7b0fa003d97c96e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e23ba779d3aefd871e348b91e7b0fa003d97c96e>`__
 -  Update translation infrastructure
-   `commit <https://pagure.io/freeipa/c/831f4dd320a93d01df6b06058c3ab618a98c9fd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/831f4dd320a93d01df6b06058c3ab618a98c9fd8>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Keep ipa.pot translation file in git for weblate
-   `commit <https://pagure.io/freeipa/c/9ff7b4a411d13ca148d2f53603dbcc812d92380a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ff7b4a411d13ca148d2f53603dbcc812d92380a>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Prevent adding IPA objects as external members of external groups
-   `commit <https://pagure.io/freeipa/c/127b8d9cf23bf65aa42e6ee9ed8d7f8628bbac19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/127b8d9cf23bf65aa42e6ee9ed8d7f8628bbac19>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 
 
@@ -234,18 +234,18 @@ Christian Heimes (5)
 ----------------------------------------------------------------------------------------------
 
 -  po: fix LINGUAS to use whitespace separation
-   `commit <https://pagure.io/freeipa/c/616ad399c99292542638e9e8f0995873e5c4f311>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/616ad399c99292542638e9e8f0995873e5c4f311>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  SELinux: apache_manage_pid_files for F30
-   `commit <https://pagure.io/freeipa/c/f08ced1b25e14f91526c82610a8219ae8ed898a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f08ced1b25e14f91526c82610a8219ae8ed898a3>`__
    `#8241 <https://pagure.io/freeipa/issue/8241>`__
 -  Add pytest OpenSSH transport with password
-   `commit <https://pagure.io/freeipa/c/42aa86fadd7a7f2209e05291be9c76a8497998dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42aa86fadd7a7f2209e05291be9c76a8497998dd>`__
 -  Move freeipa-selinux dependency to freeipa-common
-   `commit <https://pagure.io/freeipa/c/7d525ab4308060435808a311de55a76fb26a28c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d525ab4308060435808a311de55a76fb26a28c6>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate ipa_custodia policy
-   `commit <https://pagure.io/freeipa/c/04cc0450125e3c9e989c3e769a25ba2f1f336060>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04cc0450125e3c9e989c3e769a25ba2f1f336060>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 
 
@@ -254,7 +254,7 @@ François Cami (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
-   `commit <https://pagure.io/freeipa/c/a692212e3bee36fbccba73ed21f7825381eeade4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a692212e3bee36fbccba73ed21f7825381eeade4>`__
    `#8240 <https://pagure.io/freeipa/issue/8240>`__
 
 
@@ -263,13 +263,13 @@ Florence Blanc-Renaud (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: wait for SSSD to become online in backup/restore tests
-   `commit <https://pagure.io/freeipa/c/ebb3c22ddb998997eb05e7bd4da2157e88b6c8f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebb3c22ddb998997eb05e7bd4da2157e88b6c8f3>`__
    `#8228 <https://pagure.io/freeipa/issue/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
-   `commit <https://pagure.io/freeipa/c/c37a84628601d369f83546085b7e29be8fe11a59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c37a84628601d369f83546085b7e29be8fe11a59>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  idviews: prevent applying to a master
-   `commit <https://pagure.io/freeipa/c/7905891341197cb90faf635cf93ce63ae7a7a38b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7905891341197cb90faf635cf93ce63ae7a7a38b>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 
 
@@ -278,12 +278,12 @@ Mohammad Rizwan Yusuf (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Skip test using paramiko when FIPS is enabled
-   `commit <https://pagure.io/freeipa/c/45507c1e86b634507fdc21dbb88ea9edd43e4166>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45507c1e86b634507fdc21dbb88ea9edd43e4166>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/3f3fa403a944035cf5531939fe3a2e338da99612>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f3fa403a944035cf5531939fe3a2e338da99612>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/210619a98f0d8a042a181bab5891bdd595aa5351>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/210619a98f0d8a042a181bab5891bdd595aa5351>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 
 
@@ -292,13 +292,13 @@ Rob Crittenden (4)
 ----------------------------------------------------------------------------------------------
 
 -  Test that pwpolicy only applied on Kerberos entries
-   `commit <https://pagure.io/freeipa/c/b34063e700ac4c65b117705bafb0255c26bca060>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b34063e700ac4c65b117705bafb0255c26bca060>`__
 -  Add ability to change a user password as the Directory Manager
-   `commit <https://pagure.io/freeipa/c/840671b1cdc508ea86f8412e6423f00b8c3bf809>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/840671b1cdc508ea86f8412e6423f00b8c3bf809>`__
 -  Don't save password history on non-Kerberos accounts
-   `commit <https://pagure.io/freeipa/c/8b7bb96b327207284c8c0a45cf2979843482cf48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b7bb96b327207284c8c0a45cf2979843482cf48>`__
 -  Test that ipa-healthcheck human output translates error strings
-   `commit <https://pagure.io/freeipa/c/7974ac9f8c7969df85f689d94f5b30c18e661daa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7974ac9f8c7969df85f689d94f5b30c18e661daa>`__
 
 
 
@@ -306,7 +306,7 @@ Stanislav Levin (1)
 ----------------------------------------------------------------------------------------------
 
 -  pki-proxy: Don't rely on running apache until it's configured
-   `commit <https://pagure.io/freeipa/c/24c6ea3c9f2df757b3d714044c16083716e377ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ea3c9f2df757b3d714044c16083716e377ca>`__
    `#8233 <https://pagure.io/freeipa/issue/8233>`__
 
 
@@ -315,10 +315,10 @@ Sergey Orlov (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: provide AD admin password when trying to establish trust
-   `commit <https://pagure.io/freeipa/c/814b47e85c87bc3c80c91ebd0aa9085ac06b521e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/814b47e85c87bc3c80c91ebd0aa9085ac06b521e>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  ipatests: remove test_ordering
-   `commit <https://pagure.io/freeipa/c/0e9b020db201ff5797f0dabff05c3fc16a9bf79a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e9b020db201ff5797f0dabff05c3fc16a9bf79a>`__
 
 
 
@@ -326,7 +326,7 @@ Serhii Tsymbaliuk (1)
 ----------------------------------------------------------------------------------------------
 
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/f1855dd51e1544a77f1b4a3d4c90f173c29fbed4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1855dd51e1544a77f1b4a3d4c90f173c29fbed4>`__
    `#8239 <https://pagure.io/freeipa/issue/8239>`__
 
 
@@ -336,7 +336,7 @@ sumenon (1)
 
 -  ipatests: Added testcase to check logrotate is added for healthcheck
    tool
-   `commit <https://pagure.io/freeipa/c/7d4687926e9866c378db8075dd7b55b3c40e71a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d4687926e9866c378db8075dd7b55b3c40e71a9>`__
 
 
 
@@ -344,5 +344,5 @@ Vit Mojzis (1)
 ----------------------------------------------------------------------------------------------
 
 -  selinux: disable ipa_custodia when installing custom policy
-   `commit <https://pagure.io/freeipa/c/f99cfa1443dfa33422eb4a7613d3dd9e921ccacd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f99cfa1443dfa33422eb4a7613d3dd9e921ccacd>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__

--- a/src/page/Releases/4.8.7.rst
+++ b/src/page/Releases/4.8.7.rst
@@ -428,7 +428,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  prci: update templates for new Fedora release
-   `commit <https://pagure.io/freeipa/c/d758b6a4b9503da7c880dfa486fd68c4ee9f0c91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d758b6a4b9503da7c880dfa486fd68c4ee9f0c91>`__
 
 
 
@@ -436,102 +436,102 @@ Alexander Bokovoy (35)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.8.7
-   `commit <https://pagure.io/freeipa/c/9d1d3547299a3b4dc6887636adf5a383459c0c70>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d1d3547299a3b4dc6887636adf5a383459c0c70>`__
 -  ipa-4-8: update list of contributors
-   `commit <https://pagure.io/freeipa/c/89d5907e6871ee7c37fbd664adcdb7821aa5ebcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d5907e6871ee7c37fbd664adcdb7821aa5ebcc>`__
 -  ipa-4-8: Update translation files before 4.8.7 release
-   `commit <https://pagure.io/freeipa/c/071393626e0b2e34bcd96cbf15af92caf554a729>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/071393626e0b2e34bcd96cbf15af92caf554a729>`__
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
-   `commit <https://pagure.io/freeipa/c/ca0a62eac36ecf6b55b0983eaa139a25ed2a1ca2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca0a62eac36ecf6b55b0983eaa139a25ed2a1ca2>`__
    `#8362 <https://pagure.io/freeipa/issue/8362>`__
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
-   `commit <https://pagure.io/freeipa/c/6b0f8f3617378da41ead8640e194e5b9415a38b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b0f8f3617378da41ead8640e194e5b9415a38b1>`__
    `#8357 <https://pagure.io/freeipa/issue/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
-   `commit <https://pagure.io/freeipa/c/99e613e478f7925d0f470a04d4de5a2f93385b7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99e613e478f7925d0f470a04d4de5a2f93385b7a>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 -  tests: account for ID overrides as members of groups and roles
-   `commit <https://pagure.io/freeipa/c/5e8df37e4cca155bf58aa4e61b9fa3f28eddd526>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e8df37e4cca155bf58aa4e61b9fa3f28eddd526>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  Support adding user ID overrides as group and role members
-   `commit <https://pagure.io/freeipa/c/8cce2bb31ab96f6ce6edba95f54575576f2b1a40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cce2bb31ab96f6ce6edba95f54575576f2b1a40>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
-   `commit <https://pagure.io/freeipa/c/2ffb4fd18fceb509773951ce4f02aa0c5e2f851a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ffb4fd18fceb509773951ce4f02aa0c5e2f851a>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  support using trust-related operations in the server console
-   `commit <https://pagure.io/freeipa/c/afe9191f99e034bcf52475b57996d81609de6837>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afe9191f99e034bcf52475b57996d81609de6837>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
-   `commit <https://pagure.io/freeipa/c/6abade3f8daed8dfa024936114209d19319c4f12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6abade3f8daed8dfa024936114209d19319c4f12>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  azure: do not run test_commands due to failures in low memory cases
-   `commit <https://pagure.io/freeipa/c/5f292b2953460a7ae6b7784fd7dfb63d2994a28c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f292b2953460a7ae6b7784fd7dfb63d2994a28c>`__
 -  test_smb: test S4U2Self operation by IPA service
-   `commit <https://pagure.io/freeipa/c/eeb70047c9849fcc59686bdd3edd2923ee1be134>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eeb70047c9849fcc59686bdd3edd2923ee1be134>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
-   `commit <https://pagure.io/freeipa/c/601151e7c6e99d67723af9e20e80252e71e9c49e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/601151e7c6e99d67723af9e20e80252e71e9c49e>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
-   `commit <https://pagure.io/freeipa/c/68a0790b9da12ccb9f3a9f211f6d806ca604a861>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68a0790b9da12ccb9f3a9f211f6d806ca604a861>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
-   `commit <https://pagure.io/freeipa/c/6c844c704d4f7ca8837f0d034325a379ec9294af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c844c704d4f7ca8837f0d034325a379ec9294af>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
-   `commit <https://pagure.io/freeipa/c/741f64f4b5428ccfa8105c61a91de8e0fab37bc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/741f64f4b5428ccfa8105c61a91de8e0fab37bc3>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add asserted identity SIDs
-   `commit <https://pagure.io/freeipa/c/110812b43b202c83d4a90d01aab1cf7610b2de41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/110812b43b202c83d4a90d01aab1cf7610b2de41>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
-   `commit <https://pagure.io/freeipa/c/1990e3954b3c566a52697e38569ad472a62a7895>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1990e3954b3c566a52697e38569ad472a62a7895>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
-   `commit <https://pagure.io/freeipa/c/ca99bf2abc793d77e889c91d2a436c3de96eb36e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca99bf2abc793d77e889c91d2a436c3de96eb36e>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
-   `commit <https://pagure.io/freeipa/c/1a01e46aa0cd7e3cfd53b380b0ab3975ae1dc524>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a01e46aa0cd7e3cfd53b380b0ab3975ae1dc524>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
-   `commit <https://pagure.io/freeipa/c/4723100791663b8eb6053c6b9f17b8c34e362891>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4723100791663b8eb6053c6b9f17b8c34e362891>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
-   `commit <https://pagure.io/freeipa/c/363cb9fd7f3d8d57dcad91d92918bfb513164706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/363cb9fd7f3d8d57dcad91d92918bfb513164706>`__
    `#8328 <https://pagure.io/freeipa/issue/8328>`__
 -  service delegation: allow to add and remove host principals
-   `commit <https://pagure.io/freeipa/c/c8009e1caf141d57f68590bd60e1966d46090481>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8009e1caf141d57f68590bd60e1966d46090481>`__
    `#8289 <https://pagure.io/freeipa/issue/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
-   `commit <https://pagure.io/freeipa/c/831de842a7eca0df44367d8cb182cedc53680d77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/831de842a7eca0df44367d8cb182cedc53680d77>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
-   `commit <https://pagure.io/freeipa/c/77c2e425cc82bb34847ea8f1456e69f098a071c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77c2e425cc82bb34847ea8f1456e69f098a071c5>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/5c62fbd256798d6c9a0ec56bd12991e1c134ef3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c62fbd256798d6c9a0ec56bd12991e1c134ef3e>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
-   `commit <https://pagure.io/freeipa/c/4de1586ec3bb220f63a0889fbf8c09667ba87788>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4de1586ec3bb220f63a0889fbf8c09667ba87788>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  Azure Pipelines: switch to Fedora 32
-   `commit <https://pagure.io/freeipa/c/60ed4b09e1af597927ce471fc0d65b7809414292>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60ed4b09e1af597927ce471fc0d65b7809414292>`__
 -  Azure Pipelines: Override services known to not work in containers
-   `commit <https://pagure.io/freeipa/c/e37b3d8cf1d1a87dea32914067f4aac3e74b6a91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e37b3d8cf1d1a87dea32914067f4aac3e74b6a91>`__
 -  Add pytest.skip_if_container()
-   `commit <https://pagure.io/freeipa/c/898891677f6eac36d0d566c5bc8f9d3ca1e27ec6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/898891677f6eac36d0d566c5bc8f9d3ca1e27ec6>`__
 -  CVE-2020-1722: prevent use of too long passwords
-   `commit <https://pagure.io/freeipa/c/089a393581aa249ddec66ce1455fff4951cdb827>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/089a393581aa249ddec66ce1455fff4951cdb827>`__
    `#8268 <https://pagure.io/freeipa/issue/8268>`__
 -  Allow rename of a host group
-   `commit <https://pagure.io/freeipa/c/b4fdb83355e27c2e6f3d216cdc892f301391af6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4fdb83355e27c2e6f3d216cdc892f301391af6d>`__
    `#6783 <https://pagure.io/freeipa/issue/6783>`__
 -  Add 'api' and 'aci' targets to make
-   `commit <https://pagure.io/freeipa/c/38e026821cce2c6763a53ae6c675bbbaf68c8ff7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38e026821cce2c6763a53ae6c675bbbaf68c8ff7>`__
 -  Remove Fedora repository fastmirror selection
-   `commit <https://pagure.io/freeipa/c/a4ae4562f594f93df1b2647ba67f18b11fd24526>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4ae4562f594f93df1b2647ba67f18b11fd24526>`__
 
 
 
@@ -539,33 +539,33 @@ Peter Keresztes Schmidt (10)
 ----------------------------------------------------------------------------------------------
 
 -  Split named custom config to allow changes in options stanza
-   `commit <https://pagure.io/freeipa/c/539d46918f5c0e0c912965addd286ee31bcb93e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/539d46918f5c0e0c912965addd286ee31bcb93e1>`__
    `#8287 <https://pagure.io/freeipa/issue/8287>`__
 -  util: replace NSS usage with OpenSSL
-   `commit <https://pagure.io/freeipa/c/41a20fef10382a3d2c7f3260a8e0fba8a29d809a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41a20fef10382a3d2c7f3260a8e0fba8a29d809a>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  util: add unit test for pw hashing
-   `commit <https://pagure.io/freeipa/c/0fe645efc16995f159db31dc514c8a8e0e13c706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fe645efc16995f159db31dc514c8a8e0e13c706>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  po: remove zanata config since translation was moved to weblate
-   `commit <https://pagure.io/freeipa/c/a29eec33fa2bc4b5e57f3f63c67d212aeb5c5ff4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a29eec33fa2bc4b5e57f3f63c67d212aeb5c5ff4>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Specify min and max values for TTL of a DNS record
-   `commit <https://pagure.io/freeipa/c/ac47599ebf006d34d06d23654cb93f707cbd7d1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac47599ebf006d34d06d23654cb93f707cbd7d1f>`__
    `#8358 <https://pagure.io/freeipa/issue/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
-   `commit <https://pagure.io/freeipa/c/ca4cc7abe1cad87cd1e80702aedaca43cb6660d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca4cc7abe1cad87cd1e80702aedaca43cb6660d1>`__
 -  WebUI: Expose TTL of DNS records
-   `commit <https://pagure.io/freeipa/c/df8bcc9637844c5058145eff5ed99097b6e9ca73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df8bcc9637844c5058145eff5ed99097b6e9ca73>`__
    `#3827 <https://pagure.io/freeipa/issue/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
-   `commit <https://pagure.io/freeipa/c/7dad4a5987fa001b1bc8f7740503e359ca0449e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7dad4a5987fa001b1bc8f7740503e359ca0449e3>`__
    `#8359 <https://pagure.io/freeipa/issue/8359>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
-   `commit <https://pagure.io/freeipa/c/2af2373c57c6828db922008ce1e3b7fd9b3e0da8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2af2373c57c6828db922008ce1e3b7fd9b3e0da8>`__
    `#8338 <https://pagure.io/freeipa/issue/8338>`__
 -  WebUI: Use data adapter to load facet header data
-   `commit <https://pagure.io/freeipa/c/7e7d0d8397d466553268a52e3c4cf327f01a6957>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e7d0d8397d466553268a52e3c4cf327f01a6957>`__
    `#8339 <https://pagure.io/freeipa/issue/8339>`__
 
 
@@ -574,123 +574,123 @@ Christian Heimes (43)
 ----------------------------------------------------------------------------------------------
 
 -  Overhaul bind upgrade process
-   `commit <https://pagure.io/freeipa/c/b2c3c040ddb7cf3c509b8221ce25574b8d6774d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2c3c040ddb7cf3c509b8221ce25574b8d6774d0>`__
 -  Fix named.conf named_conf_include_re
-   `commit <https://pagure.io/freeipa/c/1d3649ebb720d21ac06b23c947107abe20de2d1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d3649ebb720d21ac06b23c947107abe20de2d1e>`__
 -  Remove named_validate_dnssec update step
-   `commit <https://pagure.io/freeipa/c/03abb28afeb3983799a112ba96c2674e24cce81d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03abb28afeb3983799a112ba96c2674e24cce81d>`__
 -  More upgrade tests
-   `commit <https://pagure.io/freeipa/c/6ddaead3d70f0de8aa40a3eef313fa1ff24eb25c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ddaead3d70f0de8aa40a3eef313fa1ff24eb25c>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
-   `commit <https://pagure.io/freeipa/c/aa2f93262f187b122cb3e3e0c755e21d98bb95d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa2f93262f187b122cb3e3e0c755e21d98bb95d3>`__
    `#8363 <https://pagure.io/freeipa/issue/8363>`__
 -  Auto-generated ipa-epn files to gitignore
-   `commit <https://pagure.io/freeipa/c/0fbd29d5d956646f2babf5166a8df43b3c8c44c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fbd29d5d956646f2babf5166a8df43b3c8c44c2>`__
 -  libotp: Replace NSS with OpenSSL HMAC
-   `commit <https://pagure.io/freeipa/c/47adde99c28d1f7da5180a29ebcd2d70158217b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47adde99c28d1f7da5180a29ebcd2d70158217b5>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  Include named config files in backup
-   `commit <https://pagure.io/freeipa/c/782ee1162fbf82c6ab54cb7918d26aba8acbc665>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/782ee1162fbf82c6ab54cb7918d26aba8acbc665>`__
 -  Handle DatabaseError in RPC-Server connect()
-   `commit <https://pagure.io/freeipa/c/1062caaae6380fcf79ed11eb3ec5b015c0102e6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1062caaae6380fcf79ed11eb3ec5b015c0102e6a>`__
    `#8352 <https://pagure.io/freeipa/issue/8352>`__
 -  Allow permissions with 'self' bindruletype
-   `commit <https://pagure.io/freeipa/c/f2caafb58ec578002fdf88de9cca5a3f5eaa1b2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2caafb58ec578002fdf88de9cca5a3f5eaa1b2e>`__
    `#8348 <https://pagure.io/freeipa/issue/8348>`__
 -  make: serialize strip-po / strip-pot
-   `commit <https://pagure.io/freeipa/c/8d759d3836aa36799978cd0333e1836ea2480f4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d759d3836aa36799978cd0333e1836ea2480f4b>`__
    `#8323 <https://pagure.io/freeipa/issue/8323>`__
 -  Remove obsolete BIND named.conf options
-   `commit <https://pagure.io/freeipa/c/91f94612f3021a631dd8a97d08a6327c98f6e689>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91f94612f3021a631dd8a97d08a6327c98f6e689>`__
    `#8349 <https://pagure.io/freeipa/issue/8349>`__,
    `#8350 <https://pagure.io/freeipa/issue/8350>`__
 -  Add ipa-print-pac to gitignore
-   `commit <https://pagure.io/freeipa/c/5aa5f678828033e109112c45547b55553a377895>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5aa5f678828033e109112c45547b55553a377895>`__
 -  Allow dnsrecord-add --force on clients
-   `commit <https://pagure.io/freeipa/c/c261a6eb768483f7ac45aab34994dcec01e819bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c261a6eb768483f7ac45aab34994dcec01e819bd>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Check for freeipa-server-dns package early
-   `commit <https://pagure.io/freeipa/c/f16a4b06b76412ac22763ca9e0a53d3560bfe4c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16a4b06b76412ac22763ca9e0a53d3560bfe4c1>`__
    `#7577 <https://pagure.io/freeipa/issue/7577>`__
 -  Hard-code in_tree=True for tests
-   `commit <https://pagure.io/freeipa/c/834b04b91dff670d3f0feb1b403705074a8f3d5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/834b04b91dff670d3f0feb1b403705074a8f3d5b>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Fix detection logic for api.env.in_tree
-   `commit <https://pagure.io/freeipa/c/6cd2d44707c69b6c83c0eaae3a94d6f64c6c1622>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cd2d44707c69b6c83c0eaae3a94d6f64c6c1622>`__
    `#8312 <https://pagure.io/freeipa/issue/8312>`__
 -  Make api.env.mode consistent
-   `commit <https://pagure.io/freeipa/c/3234892336f9bf1775127fb19504110c8dec70b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3234892336f9bf1775127fb19504110c8dec70b1>`__
    `#8313 <https://pagure.io/freeipa/issue/8313>`__
 -  Disable password schema update on LDAP bind
-   `commit <https://pagure.io/freeipa/c/27656669f7126ef92272530118d2d52122bb3008>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27656669f7126ef92272530118d2d52122bb3008>`__
    `#8315 <https://pagure.io/freeipa/issue/8315>`__
 -  Use httpd 2.4 syntax for access control
-   `commit <https://pagure.io/freeipa/c/84d15da5b11e44db71bff5b487c57e1e32b97c7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84d15da5b11e44db71bff5b487c57e1e32b97c7f>`__
 -  Fix make devcheck
-   `commit <https://pagure.io/freeipa/c/c2893b84967630be483e4321a22a5d7157470788>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2893b84967630be483e4321a22a5d7157470788>`__
    `#8307 <https://pagure.io/freeipa/issue/8307>`__
 -  Make ipaplatform a regular top-level package
-   `commit <https://pagure.io/freeipa/c/07da5abd13a0691d5c9fc0c37609ebcb543c691e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07da5abd13a0691d5c9fc0c37609ebcb543c691e>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__,
    `#8309 <https://pagure.io/freeipa/issue/8309>`__
 -  Reconfigure pycodestyle
-   `commit <https://pagure.io/freeipa/c/d80b98b9daff3da019542117bd52d349a101eab8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d80b98b9daff3da019542117bd52d349a101eab8>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Manually reformat ipapython/version.py.in
-   `commit <https://pagure.io/freeipa/c/9c3d00b17570104f4a1bc7a802496f515e810ae6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c3d00b17570104f4a1bc7a802496f515e810ae6>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Silence W601 .has_key() is deprecated
-   `commit <https://pagure.io/freeipa/c/d44a392568bfbe058407f7ab3169a5778ec528b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d44a392568bfbe058407f7ab3169a5778ec528b6>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E722 do not use bare 'except'
-   `commit <https://pagure.io/freeipa/c/45ddb4f17492bedfcf4e144c14ee0a5f03c1231c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45ddb4f17492bedfcf4e144c14ee0a5f03c1231c>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
-   `commit <https://pagure.io/freeipa/c/7be2ffea6a93e1d16e548bcb1d4870dccbe38c8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7be2ffea6a93e1d16e548bcb1d4870dccbe38c8c>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E714 test for object identity should be 'is not'
-   `commit <https://pagure.io/freeipa/c/70dc448280496edcc4971b60ece044cbbec10840>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70dc448280496edcc4971b60ece044cbbec10840>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E713 test for membership should be 'not in'
-   `commit <https://pagure.io/freeipa/c/ef068bd30dddcc653726bd2602be288bef351385>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef068bd30dddcc653726bd2602be288bef351385>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E712 comparison to True / False
-   `commit <https://pagure.io/freeipa/c/01c1cf67e5e88a4af7f149652af378d36f64a471>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01c1cf67e5e88a4af7f149652af378d36f64a471>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E711 comparison to None
-   `commit <https://pagure.io/freeipa/c/c136aab0f87ac5b53db3193e0f1a4cd0cc5c832f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c136aab0f87ac5b53db3193e0f1a4cd0cc5c832f>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E266 too many leading '#' for block comment
-   `commit <https://pagure.io/freeipa/c/033f8dc626c0ad2e13594d964869b72cad228142>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/033f8dc626c0ad2e13594d964869b72cad228142>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Simplify pki proxy conf
-   `commit <https://pagure.io/freeipa/c/e3f7d9befc0abdb4d5fb518a498b359675238828>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3f7d9befc0abdb4d5fb518a498b359675238828>`__
 -  Make check_required_principal() case-insensitive
-   `commit <https://pagure.io/freeipa/c/b590a674e7134333b14eeeef5bda077e7e831a62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b590a674e7134333b14eeeef5bda077e7e831a62>`__
    `#8308 <https://pagure.io/freeipa/issue/8308>`__
 -  Address issues found by new pylint 2.5.0
-   `commit <https://pagure.io/freeipa/c/ef2a74565d829ac47a1b2961b2966fcfa9e43aab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef2a74565d829ac47a1b2961b2966fcfa9e43aab>`__
    `#8297 <https://pagure.io/freeipa/issue/8297>`__
 -  Add skip_if_platform marker
-   `commit <https://pagure.io/freeipa/c/c43f3a7139efda747744f2b58500bcae203125f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c43f3a7139efda747744f2b58500bcae203125f9>`__
 -  Define default password policy for sysaccounts
-   `commit <https://pagure.io/freeipa/c/e74cfcc96e0f7c43303b4121683c3d1b3594ce3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e74cfcc96e0f7c43303b4121683c3d1b3594ce3a>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Use api.env.container_sysaccounts
-   `commit <https://pagure.io/freeipa/c/7509f42516246a012a51a798859dbecbc708642d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7509f42516246a012a51a798859dbecbc708642d>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Fix exception escape warning
-   `commit <https://pagure.io/freeipa/c/26a9241c37b349090f5adcf1567c845c70e1c33d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26a9241c37b349090f5adcf1567c845c70e1c33d>`__
 -  Fix APIVersion.__getnewargs_\_
-   `commit <https://pagure.io/freeipa/c/f812e2cdbcc514cee0fe70e21f57d57b50059504>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f812e2cdbcc514cee0fe70e21f57d57b50059504>`__
 -  servrole: takes_params must be a tuple
-   `commit <https://pagure.io/freeipa/c/1d2ec1824845dda1af96d2f12cdfe976499572c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d2ec1824845dda1af96d2f12cdfe976499572c4>`__
    `#8290 <https://pagure.io/freeipa/issue/8290>`__
 -  Fix various OpenDNSSEC 2.1 issues
-   `commit <https://pagure.io/freeipa/c/c3f97a9a080f1ca30d863640801eed920063b35c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3f97a9a080f1ca30d863640801eed920063b35c>`__
    `#8283 <https://pagure.io/freeipa/issue/8283>`__
 -  Use /run and /run/lock instead of /var
-   `commit <https://pagure.io/freeipa/c/d22ce3d0ad09835d1a5ef94177752ff380cc6223>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d22ce3d0ad09835d1a5ef94177752ff380cc6223>`__
    `#8272 <https://pagure.io/freeipa/issue/8272>`__
 
 
@@ -699,39 +699,39 @@ François Cami (13)
 ----------------------------------------------------------------------------------------------
 
 -  IPA-EPN: Test suite.
-   `commit <https://pagure.io/freeipa/c/3552185c3ca740b538d1516955cae094dc29bebd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3552185c3ca740b538d1516955cae094dc29bebd>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: First version.
-   `commit <https://pagure.io/freeipa/c/98bb4e94fdc6e683bcc59bb58377c504d172800f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98bb4e94fdc6e683bcc59bb58377c504d172800f>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/2032a619bb0a618b0d39fee0f61fbbc0a71ad77c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2032a619bb0a618b0d39fee0f61fbbc0a71ad77c>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
-   `commit <https://pagure.io/freeipa/c/01f27e292211e949c1ee2de727a203503ddfffa8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01f27e292211e949c1ee2de727a203503ddfffa8>`__
 -  tox.ini: switch from W503 to W504
-   `commit <https://pagure.io/freeipa/c/6681871084cb69477a48c93772f18d3103324593>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6681871084cb69477a48c93772f18d3103324593>`__
 -  ipatests: increase test_webui_server timeout
-   `commit <https://pagure.io/freeipa/c/589c7fd0f75fe1d83817df7e3b14bf0ecd63d643>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/589c7fd0f75fe1d83817df7e3b14bf0ecd63d643>`__
    `#8266 <https://pagure.io/freeipa/issue/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
-   `commit <https://pagure.io/freeipa/c/fa395cec8910cb07b23367e24eed6db1c64f06c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa395cec8910cb07b23367e24eed6db1c64f06c9>`__
    `#8262 <https://pagure.io/freeipa/issue/8262>`__
 -  ipatests: move ipa_backup to tasks
-   `commit <https://pagure.io/freeipa/c/8691e5f8d33e7f023b1535d15637dedaee5bddec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8691e5f8d33e7f023b1535d15637dedaee5bddec>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
-   `commit <https://pagure.io/freeipa/c/37a60b25a342d723bfe4b4b91373ad5003bd4d29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37a60b25a342d723bfe4b4b91373ad5003bd4d29>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  test_backup_and_restore: add server role verification steps
-   `commit <https://pagure.io/freeipa/c/69a2b6d71478094356ed78295b4c7177e200825c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69a2b6d71478094356ed78295b4c7177e200825c>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
-   `commit <https://pagure.io/freeipa/c/00e2a488726a353b7183d5d3b4c2084b9bf5dbc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00e2a488726a353b7183d5d3b4c2084b9bf5dbc2>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  nightly_ipa-4-8_previous.yaml: fix typo
-   `commit <https://pagure.io/freeipa/c/48be293e470b6d9061c8e3e5836ed17e0eaf52d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48be293e470b6d9061c8e3e5836ed17e0eaf52d9>`__
 -  pr-ci templates: update test_fips timeouts
-   `commit <https://pagure.io/freeipa/c/d847f123244bb2aed23f901b9df17711219ad8b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d847f123244bb2aed23f901b9df17711219ad8b0>`__
    `#8247 <https://pagure.io/freeipa/issue/8247>`__
 
 
@@ -741,17 +741,17 @@ Florence Blanc-Renaud (4)
 
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
-   `commit <https://pagure.io/freeipa/c/a457b79d1e5af3c1bd1d9517db07c5a85154c932>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a457b79d1e5af3c1bd1d9517db07c5a85154c932>`__
    `#6884 <https://pagure.io/freeipa/issue/6884>`__
 -  ipatests: enable 389-ds audit log and collect audit file
-   `commit <https://pagure.io/freeipa/c/7b39e5fbd8db10b5af3402e2c88194e351486614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b39e5fbd8db10b5af3402e2c88194e351486614>`__
    `#8064 <https://pagure.io/freeipa/issue/8064>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
-   `commit <https://pagure.io/freeipa/c/787ce4555a203bd3f31c1f6cc577855f779fe6cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/787ce4555a203bd3f31c1f6cc577855f779fe6cf>`__
    `#8311 <https://pagure.io/freeipa/issue/8311>`__
 -  Man pages: fix syntax issues
-   `commit <https://pagure.io/freeipa/c/98045dc4a3b3be21c9badf75ce1b62df27fa5be0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98045dc4a3b3be21c9badf75ce1b62df27fa5be0>`__
    `#8273 <https://pagure.io/freeipa/issue/8273>`__
 
 
@@ -760,7 +760,7 @@ Francisco Trivino (1)
 ----------------------------------------------------------------------------------------------
 
 -  prci_definitions: remove test_smb from ipa-4-8 gating workflow
-   `commit <https://pagure.io/freeipa/c/f289771bd29371d4e38119ba09db8e59a0e9f71a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f289771bd29371d4e38119ba09db8e59a0e9f71a>`__
 
 
 
@@ -768,34 +768,34 @@ Fraser Tweedale (10)
 ----------------------------------------------------------------------------------------------
 
 -  upgrade: avoid stopping certmonger when fixing requests
-   `commit <https://pagure.io/freeipa/c/f1564cd228068d54b949277f7bdc00203b5da81a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1564cd228068d54b949277f7bdc00203b5da81a>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
-   `commit <https://pagure.io/freeipa/c/00dd80b77e115734e6f8942339cd2e0d3cc7fbdc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00dd80b77e115734e6f8942339cd2e0d3cc7fbdc>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
-   `commit <https://pagure.io/freeipa/c/8e92190db866e7eb05aaaf41609b442f201d5c08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e92190db866e7eb05aaaf41609b442f201d5c08>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
-   `commit <https://pagure.io/freeipa/c/c445cefacf7713746f0bb0399d33b3f4008b71b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c445cefacf7713746f0bb0399d33b3f4008b71b4>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
-   `commit <https://pagure.io/freeipa/c/5275342b691b2f74b365cb3422459779544be16a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5275342b691b2f74b365cb3422459779544be16a>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
-   `commit <https://pagure.io/freeipa/c/4b24129f9e1ceb322c5477f9a0869f7a6b521f09>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b24129f9e1ceb322c5477f9a0869f7a6b521f09>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
-   `commit <https://pagure.io/freeipa/c/52873581e7ab1de8c02a4d80cdeeb9bf27b2f168>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52873581e7ab1de8c02a4d80cdeeb9bf27b2f168>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: support dnsname as request search criterion
-   `commit <https://pagure.io/freeipa/c/b127bad8a93967c09c24edadd31d7d6e5b812186>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b127bad8a93967c09c24edadd31d7d6e5b812186>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: move 'criteria' description to module docstring
-   `commit <https://pagure.io/freeipa/c/ff7d0661a71ff2c9a66c8c9a1a48837d041f9099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff7d0661a71ff2c9a66c8c9a1a48837d041f9099>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: avoid mutable default argument
-   `commit <https://pagure.io/freeipa/c/0e9b7773fb613889eacaa95504f1c40f21628c0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e9b7773fb613889eacaa95504f1c40f21628c0f>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 
 
@@ -804,7 +804,7 @@ Kaleemullah Siddiqui (1)
 ----------------------------------------------------------------------------------------------
 
 -  Test for check of HostKeyAlgorithms option in ssh_config
-   `commit <https://pagure.io/freeipa/c/ac67dc9d385e622750c0e205e7848cf2fde88387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac67dc9d385e622750c0e205e7848cf2fde88387>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 
 
@@ -813,7 +813,7 @@ Miro Hrončok (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix a syntax typo
-   `commit <https://pagure.io/freeipa/c/0392dca510fe2105edd69c2a1f39098086174337>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0392dca510fe2105edd69c2a1f39098086174337>`__
 
 
 
@@ -821,10 +821,10 @@ Michal Polovka (2)
 ----------------------------------------------------------------------------------------------
 
 -  Test for healthcheck being run on replica with stopped master
-   `commit <https://pagure.io/freeipa/c/b6b41b347924d1ab2754ffe8445dfdf98555ae92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6b41b347924d1ab2754ffe8445dfdf98555ae92>`__
 -  Test for output being indented by default value if not stated
    implicitly.
-   `commit <https://pagure.io/freeipa/c/80fe55d78c8cb409290bb8dd9619cc1089080bb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80fe55d78c8cb409290bb8dd9619cc1089080bb2>`__
 
 
 
@@ -832,22 +832,22 @@ Mohammad Rizwan Yusuf (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test deletion of required principal throws proper error
-   `commit <https://pagure.io/freeipa/c/f0ef4180cfb7616482f8ded16ad5c46fcf9f5286>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0ef4180cfb7616482f8ded16ad5c46fcf9f5286>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  Display principal name while del required principal
-   `commit <https://pagure.io/freeipa/c/87377493bd67939d6e90f08d1e26d1fc3bcfd708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87377493bd67939d6e90f08d1e26d1fc3bcfd708>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  WebUI tests: fix PEP8 issues in test_webui/test_user.py
-   `commit <https://pagure.io/freeipa/c/b626a79e831f644a8d6f21576f05a460787f8e2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b626a79e831f644a8d6f21576f05a460787f8e2b>`__
 -  webui: check if notification area doesn't intercept menu button
-   `commit <https://pagure.io/freeipa/c/b68f98aa67e9b2d43efe6c6d101cb37d5cef5891>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b68f98aa67e9b2d43efe6c6d101cb37d5cef5891>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  ipatests: Test to check password leak in apache error log
-   `commit <https://pagure.io/freeipa/c/cd7dcb19f71b11c9eccb056bfd54f6101c1040c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd7dcb19f71b11c9eccb056bfd54f6101c1040c5>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
-   `commit <https://pagure.io/freeipa/c/90eef2f84d3ad61894a1656c529000072e6cb036>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90eef2f84d3ad61894a1656c529000072e6cb036>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 
 
@@ -856,41 +856,41 @@ Rob Crittenden (12)
 ----------------------------------------------------------------------------------------------
 
 -  IPA-EPN: Don't treat givenname differently
-   `commit <https://pagure.io/freeipa/c/bf28d4c8d0f085329105a4232c1a2ff3d61f067f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf28d4c8d0f085329105a4232c1a2ff3d61f067f>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
-   `commit <https://pagure.io/freeipa/c/4124bb6d6a665dc2fce665af577daa278e6b9f23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4124bb6d6a665dc2fce665af577daa278e6b9f23>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
-   `commit <https://pagure.io/freeipa/c/37a4a79cc00a036ae11640462d880b7ea1ba7524>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37a4a79cc00a036ae11640462d880b7ea1ba7524>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
-   `commit <https://pagure.io/freeipa/c/672c9f55b70a05aaa8f0baec6381a8b4ee935216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/672c9f55b70a05aaa8f0baec6381a8b4ee935216>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
-   `commit <https://pagure.io/freeipa/c/dca3f116a41af5476a8abf860d0dda3b4c80f8b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dca3f116a41af5476a8abf860d0dda3b4c80f8b5>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: test using SSL against port 465
-   `commit <https://pagure.io/freeipa/c/6587edd4b283e37da7b214fce4c3c9d013fe1118>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6587edd4b283e37da7b214fce4c3c9d013fe1118>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add test for starttls mode
-   `commit <https://pagure.io/freeipa/c/fc2b3aab5042a9125e74647493c0f4faecd87d20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc2b3aab5042a9125e74647493c0f4faecd87d20>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
-   `commit <https://pagure.io/freeipa/c/bbe3397393c2fa7121fa05a656d682036bffbe9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe3397393c2fa7121fa05a656d682036bffbe9c>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
-   `commit <https://pagure.io/freeipa/c/ca1c374ebf58ccc5ed00346876835026958fe7bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca1c374ebf58ccc5ed00346876835026958fe7bd>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add index for krbPasswordExpiration for EPN
-   `commit <https://pagure.io/freeipa/c/ab444db0accedeefc42264cd03c2abe4ed90ea19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab444db0accedeefc42264cd03c2abe4ed90ea19>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add a jinja2 e-mail template for EPN
-   `commit <https://pagure.io/freeipa/c/0869765536cd036221f6cd12921bac18e3e3df46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0869765536cd036221f6cd12921bac18e3e3df46>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Perform baseline healthcheck
-   `commit <https://pagure.io/freeipa/c/435e2bee19030756c8cdc3c809426bd2172c7ce5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/435e2bee19030756c8cdc3c809426bd2172c7ce5>`__
 
 
 
@@ -898,7 +898,7 @@ Sam Morris (1)
 ----------------------------------------------------------------------------------------------
 
 -  Debian: write out only one CA certificate per file
-   `commit <https://pagure.io/freeipa/c/6fcc78b8317f2c2412916016ac66a5a380a41173>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fcc78b8317f2c2412916016ac66a5a380a41173>`__
    `#8106 <https://pagure.io/freeipa/issue/8106>`__
 
 
@@ -907,7 +907,7 @@ Sergio Oliveira Campos (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add test for sssd ad trust lookup with dn in certmaprule
-   `commit <https://pagure.io/freeipa/c/1f22ae50be0268b7bb19ccb3f2f9cc832cd9f7c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f22ae50be0268b7bb19ccb3f2f9cc832cd9f7c5>`__
 
 
 
@@ -915,57 +915,57 @@ Stanislav Levin (18)
 ----------------------------------------------------------------------------------------------
 
 -  Azure: Make dnf repos consistent
-   `commit <https://pagure.io/freeipa/c/7f2bfd9f7bfdc9b9e260e45b725b92521565570b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f2bfd9f7bfdc9b9e260e45b725b92521565570b>`__
    `#8330 <https://pagure.io/freeipa/issue/8330>`__
 -  Azure: Always update apt cache
-   `commit <https://pagure.io/freeipa/c/273f580b95ac5a2cb91ce336cf82b085eb7929e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273f580b95ac5a2cb91ce336cf82b085eb7929e0>`__
 -  Azure: Allow chronyd to sync time
-   `commit <https://pagure.io/freeipa/c/9d01875d12c20855d4be1351717ee4105e34e5ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d01875d12c20855d4be1351717ee4105e34e5ac>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Add custom seccomp profile
-   `commit <https://pagure.io/freeipa/c/fd58bac1c3feeb7f64c97278e841c553f026e917>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd58bac1c3feeb7f64c97278e841c553f026e917>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Increase memory limit
-   `commit <https://pagure.io/freeipa/c/97581ec6b3ccb2043f1ad0f26589467badae3819>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97581ec6b3ccb2043f1ad0f26589467badae3819>`__
    `#8264 <https://pagure.io/freeipa/issue/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
-   `commit <https://pagure.io/freeipa/c/736b8ba5a0c4cfbb0a158d9eae800ae843281b9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/736b8ba5a0c4cfbb0a158d9eae800ae843281b9c>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Pretty print multihost config
-   `commit <https://pagure.io/freeipa/c/5da643f1b270ccad3a261ff700ddc163ea60bc93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5da643f1b270ccad3a261ff700ddc163ea60bc93>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
-   `commit <https://pagure.io/freeipa/c/295d207245a626e57e1024504ba9e0098081adbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/295d207245a626e57e1024504ba9e0098081adbc>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Specify shell implementation
-   `commit <https://pagure.io/freeipa/c/9d06a4a29fb304856e48f5b91556e735a0a447d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d06a4a29fb304856e48f5b91556e735a0a447d8>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Specify Pytest XML report schema
-   `commit <https://pagure.io/freeipa/c/b62f59fdd0b6a0f917ac41da38366b2178a74b17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b62f59fdd0b6a0f917ac41da38366b2178a74b17>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
-   `commit <https://pagure.io/freeipa/c/46518b494f215a49c1906508a1bb9661e30dcd98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46518b494f215a49c1906508a1bb9661e30dcd98>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
-   `commit <https://pagure.io/freeipa/c/f97341c66a81ee395e4c18129b056d890b941315>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f97341c66a81ee395e4c18129b056d890b941315>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
-   `commit <https://pagure.io/freeipa/c/6e14cfc4d0fb6f334d4daebe746c38e8356fb349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e14cfc4d0fb6f334d4daebe746c38e8356fb349>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove deprecated yield_fixture
-   `commit <https://pagure.io/freeipa/c/8c0192ac3de157ec4ef17c5492bfcb2fe370ac46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c0192ac3de157ec4ef17c5492bfcb2fe370ac46>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Bump required Pytest
-   `commit <https://pagure.io/freeipa/c/9d10bc8db9f78d2a541bad5b4ce70ec2e6a58c2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d10bc8db9f78d2a541bad5b4ce70ec2e6a58c2d>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
-   `commit <https://pagure.io/freeipa/c/d320997807b8fb25a4bbfbf507ecff172c06f284>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d320997807b8fb25a4bbfbf507ecff172c06f284>`__
    `#8261 <https://pagure.io/freeipa/issue/8261>`__
 -  Azure: Gather coredumps
-   `commit <https://pagure.io/freeipa/c/5325c723dad7d1f47311e0d73bc7b7b58577b870>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5325c723dad7d1f47311e0d73bc7b7b58577b870>`__
    `#8251 <https://pagure.io/freeipa/issue/8251>`__
 -  Azure: Allow distros to install Python they want
-   `commit <https://pagure.io/freeipa/c/60d6defe0e5d82270601bb96bb2d74495db632fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60d6defe0e5d82270601bb96bb2d74495db632fc>`__
    `#8254 <https://pagure.io/freeipa/issue/8254>`__
 
 
@@ -974,26 +974,26 @@ Sergey Orlov (10)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: mark test_trustdomain_disable test as expectedly failing
-   `commit <https://pagure.io/freeipa/c/8c68b920627ebf10deb0f071b0d6111a3bc45524>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c68b920627ebf10deb0f071b0d6111a3bc45524>`__
 -  ipatests: add context manager for declaring part of test as xfail
-   `commit <https://pagure.io/freeipa/c/fc253fe4cad1f0f6b6cec4d07ca791a758ac3071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc253fe4cad1f0f6b6cec4d07ca791a758ac3071>`__
 -  ipatests: add utility for getting sssd version on remote host
-   `commit <https://pagure.io/freeipa/c/3e81b0f3b13db296937b51f971d0db756b6963d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e81b0f3b13db296937b51f971d0db756b6963d1>`__
 -  update prci definitions for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/edbb913f56b2ef937055e89a9e75758361596166>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edbb913f56b2ef937055e89a9e75758361596166>`__
 -  ipatests: add test for sssd behavior with disabled trustdomains
-   `commit <https://pagure.io/freeipa/c/fed6ad2048e9e71ad0c483ccd58d9a489927ff1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fed6ad2048e9e71ad0c483ccd58d9a489927ff1e>`__
 -  ipatests: run all cases from test_integration/test_idviews.py in
    nightlies
-   `commit <https://pagure.io/freeipa/c/e86558d1c7db43cb5d4def2bd77c0b24dee4c179>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e86558d1c7db43cb5d4def2bd77c0b24dee4c179>`__
 -  ipatests: explicitly save output of certutil
-   `commit <https://pagure.io/freeipa/c/8e1d5244568bb409a2898b4c310392256380553d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e1d5244568bb409a2898b4c310392256380553d>`__
 -  ipatests: add AD DC as a DNS forwarder before establishing trust
-   `commit <https://pagure.io/freeipa/c/cc16712cc5e5d086f0d62304277911be9b276ee0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc16712cc5e5d086f0d62304277911be9b276ee0>`__
 -  ipatests: add missing classes from test_installation in nightly runs
-   `commit <https://pagure.io/freeipa/c/d22d55dfb1eecc6060b4ce32c7eab5fa7c1713de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d22d55dfb1eecc6060b4ce32c7eab5fa7c1713de>`__
 -  ipatests: run test_integration/test_cert.py in PR-CI
-   `commit <https://pagure.io/freeipa/c/b55bdd21392895512de2a135aaa7f339236c5cd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b55bdd21392895512de2a135aaa7f339236c5cd3>`__
 
 
 
@@ -1001,10 +1001,10 @@ Sumedh Sidhaye (2)
 ----------------------------------------------------------------------------------------------
 
 -  Test for removing a subgroup
-   `commit <https://pagure.io/freeipa/c/c39a2e2bb90c0ccde9084edcfc17b0f29250a35b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c39a2e2bb90c0ccde9084edcfc17b0f29250a35b>`__
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
-   `commit <https://pagure.io/freeipa/c/77409e2be01984ff9bdd61989a94845cf9206116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77409e2be01984ff9bdd61989a94845cf9206116>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 
 
@@ -1013,7 +1013,7 @@ Stasiek Michalski (1)
 ----------------------------------------------------------------------------------------------
 
 -  Support for SUSE/openSUSE ipaplatform
-   `commit <https://pagure.io/freeipa/c/f0c6d1e16bed99af5a00f5407c316a51a210242f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0c6d1e16bed99af5a00f5407c316a51a210242f>`__
 
 
 
@@ -1021,23 +1021,23 @@ Serhii Tsymbaliuk (6)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
-   `commit <https://pagure.io/freeipa/c/062022996d6efeef3c0a9d5d0611890bdf416e28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/062022996d6efeef3c0a9d5d0611890bdf416e28>`__
    `#8325 <https://pagure.io/freeipa/issue/8325>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
-   `commit <https://pagure.io/freeipa/c/d8c8ba7d476b4f2a9a03be5bebe8a75a8a5028a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8c8ba7d476b4f2a9a03be5bebe8a75a8a5028a1>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
-   `commit <https://pagure.io/freeipa/c/5d3364a543a65eaa6ed94005cdab6dd1d3745c49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d3364a543a65eaa6ed94005cdab6dd1d3745c49>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI tests: cover membership management with UI tests
-   `commit <https://pagure.io/freeipa/c/e58ca6a4ab40d876efd1c4bcec888e58c5fc738a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e58ca6a4ab40d876efd1c4bcec888e58c5fc738a>`__
    `#8298 <https://pagure.io/freeipa/issue/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/46008f5e76af87efe75c7f8700262d026005bd9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46008f5e76af87efe75c7f8700262d026005bd9c>`__
    `#8284 <https://pagure.io/freeipa/issue/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
-   `commit <https://pagure.io/freeipa/c/fa09cc29323c2d14985e19f1b2473b62f9df249a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa09cc29323c2d14985e19f1b2473b62f9df249a>`__
    `#8222 <https://pagure.io/freeipa/issue/8222>`__
 
 
@@ -1047,21 +1047,21 @@ sumenon (7)
 
 -  ipatests: Test to check warning state for TomcatFileCheck in
    ipahealthcheck.ipa.files
-   `commit <https://pagure.io/freeipa/c/a571043380f0b08c6b3768a1fe176fee5073e2c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a571043380f0b08c6b3768a1fe176fee5073e2c5>`__
 -  ipatests: Test for ipahealthcheck.ipa.files for TomcatFilecheck
-   `commit <https://pagure.io/freeipa/c/c64075b127ce4a79889bf65f925dd07ae0d53f01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c64075b127ce4a79889bf65f925dd07ae0d53f01>`__
 -  ipatests: Test for ipahealthcheck DogtagCertsConnectivityCheck
-   `commit <https://pagure.io/freeipa/c/81f924f49a7736b808545db0e84b3796e35c6657>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81f924f49a7736b808545db0e84b3796e35c6657>`__
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
-   `commit <https://pagure.io/freeipa/c/c59106f005d520f1c84f12a15902cf005162d15c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c59106f005d520f1c84f12a15902cf005162d15c>`__
    `#8066 <https://pagure.io/freeipa/issue/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
-   `commit <https://pagure.io/freeipa/c/1bec170288df5052851626304edf2aeabd606c1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bec170288df5052851626304edf2aeabd606c1b>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
-   `commit <https://pagure.io/freeipa/c/3244e27962659c79e40ab7e82b985dd3ef61c96b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3244e27962659c79e40ab7e82b985dd3ef61c96b>`__
 -  Test for ipahealthcheck.ipa.idns check when integrated DNS is setup
-   `commit <https://pagure.io/freeipa/c/f6171fd6271d8a9de47337ea1852c08980a83302>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6171fd6271d8a9de47337ea1852c08980a83302>`__
 
 
 
@@ -1070,13 +1070,13 @@ Timo Aaltonen (4)
 
 -  ipatests/test_installation: Use knownservices to map the service
    name.
-   `commit <https://pagure.io/freeipa/c/99f4cb01a662c679ba680f335d0ae60b2eea9a95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99f4cb01a662c679ba680f335d0ae60b2eea9a95>`__
 -  ipatests/test_commands: Check sssd version like on test_sssd
-   `commit <https://pagure.io/freeipa/c/af94aad859b04bae5befe0a649c285a601e06fd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af94aad859b04bae5befe0a649c285a601e06fd7>`__
 -  Debian: Use parse_ipa_version from redhat.
-   `commit <https://pagure.io/freeipa/c/fc2e8549b5764a8a110234a306793fc0a483dc3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc2e8549b5764a8a110234a306793fc0a483dc3b>`__
 -  Debian: Use enable/disable_ldap_automount() from base
-   `commit <https://pagure.io/freeipa/c/c45d4c8b2fa46e3577fbf19a4cc6103d371a038e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c45d4c8b2fa46e3577fbf19a4cc6103d371a038e>`__
 
 
 
@@ -1084,5 +1084,5 @@ Viktor Ashirov (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update ACIs with the correct syntax
-   `commit <https://pagure.io/freeipa/c/218e655617400097e5dcd2fa0aae82b21e8c2366>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/218e655617400097e5dcd2fa0aae82b21e8c2366>`__
    `#8301 <https://pagure.io/freeipa/issue/8301>`__

--- a/src/page/Releases/4.8.8.rst
+++ b/src/page/Releases/4.8.8.rst
@@ -108,7 +108,7 @@ Alexander Bokovoy (1)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.8.8
-   `commit <https://pagure.io/freeipa/c/86ab7590779b9e25c6a52cf5a785925103d9ee8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86ab7590779b9e25c6a52cf5a785925103d9ee8a>`__
 
 
 
@@ -116,5 +116,5 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Prevent local account takeover
-   `commit <https://pagure.io/freeipa/c/65c2736bd20ffb9d98769e71d905f71d1a4d857e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65c2736bd20ffb9d98769e71d905f71d1a4d857e>`__
    `#8326 <https://pagure.io/freeipa/issue/8326>`__

--- a/src/page/Releases/4.8.9.rst
+++ b/src/page/Releases/4.8.9.rst
@@ -307,13 +307,13 @@ Armando Neto (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/aa54002ce4fa4fb8d133e0367022b2bc7576b8a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa54002ce4fa4fb8d133e0367022b2bc7576b8a7>`__
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/5c44e2338ce8c49d5192d7dbd60c3833cfdc9836>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c44e2338ce8c49d5192d7dbd60c3833cfdc9836>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/5820573dc7932213ee74dc883239e2cecc8fb2eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5820573dc7932213ee74dc883239e2cecc8fb2eb>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/3f89bd2ca704dfe4ec80dc8bbc340bdf8153bf18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f89bd2ca704dfe4ec80dc8bbc340bdf8153bf18>`__
 
 
 
@@ -321,29 +321,29 @@ Alexander Bokovoy (10)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.8.9
-   `commit <https://pagure.io/freeipa/c/c409fc65df4108c7f8ba06bdcf5f61275a16c8d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c409fc65df4108c7f8ba06bdcf5f61275a16c8d7>`__
 -  ipa-4-8: Add new contributors
-   `commit <https://pagure.io/freeipa/c/26d8267244fd232b3c075677a10d41fada3484aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26d8267244fd232b3c075677a10d41fada3484aa>`__
 -  ipa-4-8: update po/ipa.pot
-   `commit <https://pagure.io/freeipa/c/2c1fb997e99a90e42118b9022eea95d07138a7fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c1fb997e99a90e42118b9022eea95d07138a7fc>`__
 -  Add alternative email to the mailmap for myself
-   `commit <https://pagure.io/freeipa/c/8492ba16e31523db024b154eb30d81dcfecdadb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8492ba16e31523db024b154eb30d81dcfecdadb7>`__
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
-   `commit <https://pagure.io/freeipa/c/96aa09b947d2b1e50c694853debf2f349197d8a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96aa09b947d2b1e50c694853debf2f349197d8a0>`__
    `#8437 <https://pagure.io/freeipa/issue/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
-   `commit <https://pagure.io/freeipa/c/0d70addbbf2a99e7398a518bc98d5fe109469bb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d70addbbf2a99e7398a518bc98d5fe109469bb5>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
-   `commit <https://pagure.io/freeipa/c/42dd1628a1211363c860917e474ecc5b9c1fdb84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42dd1628a1211363c860917e474ecc5b9c1fdb84>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  Get back to git snapshots
-   `commit <https://pagure.io/freeipa/c/7ca6129ffdcbe4c794aee669c96a96d2e59134d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ca6129ffdcbe4c794aee669c96a96d2e59134d4>`__
 -  Become FreeIPA 4.8.8
-   `commit <https://pagure.io/freeipa/c/71b8ecde882cba4882e41a529b50736f69500395>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71b8ecde882cba4882e41a529b50736f69500395>`__
 -  VERSION: back to git snapshots
-   `commit <https://pagure.io/freeipa/c/57034ce28bb4e1287f9db467347815ab5f6ef938>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57034ce28bb4e1287f9db467347815ab5f6ef938>`__
 
 
 
@@ -352,16 +352,16 @@ Anuja More (5)
 
 -  ipatests: cleanup in
    test_subdomain_lookup_with_certmaprule_containing_dn
-   `commit <https://pagure.io/freeipa/c/068646f0b5379527d0f91efeecdf6d9f0a35811d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/068646f0b5379527d0f91efeecdf6d9f0a35811d>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/460fea3cc1ca9524acd22616b55a939564e0a973>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/460fea3cc1ca9524acd22616b55a939564e0a973>`__
 -  ipatests : Test to verify override_gid works with subdomain.
-   `commit <https://pagure.io/freeipa/c/cb5c094ba260d903fc02cfbe156cc9ef3c16c765>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb5c094ba260d903fc02cfbe156cc9ef3c16c765>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/022cd49ef5f9043df805e19ed094dc4eebd615a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/022cd49ef5f9043df805e19ed094dc4eebd615a5>`__
 -  ipatests: Test that trusted AD users should not lose their AD
    domains.
-   `commit <https://pagure.io/freeipa/c/494838e822dfd681e640cee0e140a224b8e67104>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/494838e822dfd681e640cee0e140a224b8e67104>`__
 
 
 
@@ -369,13 +369,13 @@ Alexander Scheel (3)
 ----------------------------------------------------------------------------------------------
 
 -  Specify cert_paths when calling PKIConnection
-   `commit <https://pagure.io/freeipa/c/9ded9e2573a00c388533f2a09365c499a4e2961e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ded9e2573a00c388533f2a09365c499a4e2961e>`__
    `#8379 <https://pagure.io/freeipa/issue/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
-   `commit <https://pagure.io/freeipa/c/1e804bf19da4ee274e735fd49452d4df5d73a002>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e804bf19da4ee274e735fd49452d4df5d73a002>`__
    `#8372 <https://pagure.io/freeipa/issue/8372>`__
 -  Clarify AJP connector creation process
-   `commit <https://pagure.io/freeipa/c/be48983558a560dadad410a70a4a1684565ed481>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be48983558a560dadad410a70a4a1684565ed481>`__
 
 
 
@@ -383,25 +383,25 @@ Peter Keresztes Schmidt (7)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Unify adapter property definition for state evaluators
-   `commit <https://pagure.io/freeipa/c/6f9c20ba7585e8f110806596806d292891682932>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f9c20ba7585e8f110806596806d292891682932>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
-   `commit <https://pagure.io/freeipa/c/a0518f7ff6ddc37887970af91c2575c15812fca8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0518f7ff6ddc37887970af91c2575c15812fca8>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  Populate nshardwareplatform and nsosversion during join operation
-   `commit <https://pagure.io/freeipa/c/92ef9d1706c331b674eced04a3485de24c200998>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92ef9d1706c331b674eced04a3485de24c200998>`__
    `#8370 <https://pagure.io/freeipa/issue/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
-   `commit <https://pagure.io/freeipa/c/42ad338c070096dbcab7facb70e57ba6ea63535e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42ad338c070096dbcab7facb70e57ba6ea63535e>`__
    `#8396 <https://pagure.io/freeipa/issue/8396>`__
 -  Unify spelling of "One-Time Password"
-   `commit <https://pagure.io/freeipa/c/0320de78571bb75ed17cd31727f7b25360941f67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0320de78571bb75ed17cd31727f7b25360941f67>`__
 -  WebUI: reword OTP info message displayed during PW reset
-   `commit <https://pagure.io/freeipa/c/82475aab31a5f8e06360d43b4e3d5e1aa2daf0fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82475aab31a5f8e06360d43b4e3d5e1aa2daf0fb>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
-   `commit <https://pagure.io/freeipa/c/2c3bf183634cb5615528daa88339e834e5400530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c3bf183634cb5615528daa88339e834e5400530>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 
 
@@ -410,50 +410,50 @@ Christian Heimes (17)
 ----------------------------------------------------------------------------------------------
 
 -  Treat container subplatforms like main platform
-   `commit <https://pagure.io/freeipa/c/508c5e5d3bd003a854090bae7ebd3dccf74cd6a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/508c5e5d3bd003a854090bae7ebd3dccf74cd6a9>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Don't configure authselect in containers
-   `commit <https://pagure.io/freeipa/c/6926131f258d82b9a8634e3b292c6ecf83f2a5be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6926131f258d82b9a8634e3b292c6ecf83f2a5be>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
-   `commit <https://pagure.io/freeipa/c/c68d14b6be858523c06939c2e7f4f4e3de3221de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c68d14b6be858523c06939c2e7f4f4e3de3221de>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Explicitly pass keytab to ipa-join
-   `commit <https://pagure.io/freeipa/c/305deb450c564e561b5facafee8ed6966de7bc83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/305deb450c564e561b5facafee8ed6966de7bc83>`__
 -  Write state dir to smb.conf
-   `commit <https://pagure.io/freeipa/c/c3bf50b1b2611f0dfea699ae7ba134c2857187d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3bf50b1b2611f0dfea699ae7ba134c2857187d9>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
-   `commit <https://pagure.io/freeipa/c/61807788f40c2596686b79f4bbd4e0e766e995dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61807788f40c2596686b79f4bbd4e0e766e995dd>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Allow to override ipaplatform with env var
-   `commit <https://pagure.io/freeipa/c/90ae22b8e54fc6108e39ad93f26035446ab728f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90ae22b8e54fc6108e39ad93f26035446ab728f1>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Teach pylint how dnspython 2.x works
-   `commit <https://pagure.io/freeipa/c/abfe4bfe459ff4f7329d0b0ec674a8cb9c7d99cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abfe4bfe459ff4f7329d0b0ec674a8cb9c7d99cc>`__
    `#8419 <https://pagure.io/freeipa/issue/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
-   `commit <https://pagure.io/freeipa/c/d83b760d1f76a3ba8e527dd27551e51a600b22c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d83b760d1f76a3ba8e527dd27551e51a600b22c0>`__
    `#8412 <https://pagure.io/freeipa/issue/8412>`__
 -  Make tab completion in console more useful
-   `commit <https://pagure.io/freeipa/c/c21d3cf001c886889c06facafc44f1f9230203c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c21d3cf001c886889c06facafc44f1f9230203c7>`__
 -  Add \__signature_\_ to plugins
-   `commit <https://pagure.io/freeipa/c/e334415fc5c579f9faa1649b4f8e5ba0db0c7429>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e334415fc5c579f9faa1649b4f8e5ba0db0c7429>`__
    `#8388 <https://pagure.io/freeipa/issue/8388>`__
 -  SELinux: Backport dirsrv_systemctl interface
-   `commit <https://pagure.io/freeipa/c/c72ef1ed965aca79da4576d9579dec5459e14b99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c72ef1ed965aca79da4576d9579dec5459e14b99>`__
 -  RHEL 8.3 has KRB5 1.18 with KDB 8.0
-   `commit <https://pagure.io/freeipa/c/7473bd11f04f46f2d91068ec3ba4130386d6fc0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7473bd11f04f46f2d91068ec3ba4130386d6fc0a>`__
 -  Use old uglifyjs on RHEL 8
-   `commit <https://pagure.io/freeipa/c/5cefc6df114b162f3cd33622e87ba5a88dc03f0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cefc6df114b162f3cd33622e87ba5a88dc03f0e>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  Build ipa-selinux package on RHEL 8
-   `commit <https://pagure.io/freeipa/c/351f3061514cb80faf644f4a067e5a596b087d7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/351f3061514cb80faf644f4a067e5a596b087d7e>`__
 -  Prevent local account takeover
-   `commit <https://pagure.io/freeipa/c/930f4b3d1dc03f9e365b007b027d65e146a08f05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/930f4b3d1dc03f9e365b007b027d65e146a08f05>`__
    `#8326 <https://pagure.io/freeipa/issue/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
-   `commit <https://pagure.io/freeipa/c/77fae8c48bbe0f4499f4d8ed91b268568c64cd7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77fae8c48bbe0f4499f4d8ed91b268568c64cd7c>`__
    `#8367 <https://pagure.io/freeipa/issue/8367>`__
 
 
@@ -462,88 +462,88 @@ François Cami (28)
 ----------------------------------------------------------------------------------------------
 
 -  IPA-EPN: enhance input validation
-   `commit <https://pagure.io/freeipa/c/2809084a44e3b174fa48a611e79f04358e1d6dca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2809084a44e3b174fa48a611e79f04358e1d6dca>`__
    `#8444 <https://pagure.io/freeipa/issue/8444>`__
 -  ipatests: test_epn: update error messages
-   `commit <https://pagure.io/freeipa/c/b4266023e04729db12de2f7e0de4da9e1d00db38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4266023e04729db12de2f7e0de4da9e1d00db38>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  IPA-EPN: Fix SMTP connection error handling
-   `commit <https://pagure.io/freeipa/c/53f330b053740b169d211aa16b3b36fb61157bbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53f330b053740b169d211aa16b3b36fb61157bbd>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
-   `commit <https://pagure.io/freeipa/c/3cf7fb1014ae40fd5a5278f27577a8196a4af051>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cf7fb1014ae40fd5a5278f27577a8196a4af051>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  IPA-EPN: fix configuration file typo
-   `commit <https://pagure.io/freeipa/c/8e810d8cf38ec60d76178bd673e218fb05d56c8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e810d8cf38ec60d76178bd673e218fb05d56c8e>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
-   `commit <https://pagure.io/freeipa/c/b95817e35716bbab000633043817202e17d7c53e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b95817e35716bbab000633043817202e17d7c53e>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
-   `commit <https://pagure.io/freeipa/c/3b8fdd87760cfb8ec739c67298f012cf0bd3ac39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b8fdd87760cfb8ec739c67298f012cf0bd3ac39>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
-   `commit <https://pagure.io/freeipa/c/9479a393a71fe1de7d62ca2b50a7d3d8698d4ba1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9479a393a71fe1de7d62ca2b50a7d3d8698d4ba1>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/b0d4db548cfa14fbc596a40e742db96cd9ec00bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0d4db548cfa14fbc596a40e742db96cd9ec00bb>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/027d0bbe1c0bafc326815b6ecc224a8f8fc5bd55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/027d0bbe1c0bafc326815b6ecc224a8f8fc5bd55>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/17759ec76aeac450ce9c85704b68100df75c8af5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17759ec76aeac450ce9c85704b68100df75c8af5>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/ee57dd230191be40a39ef9677b308dee35fa183e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee57dd230191be40a39ef9677b308dee35fa183e>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
-   `commit <https://pagure.io/freeipa/c/262a7121046132fbb7bb101ecf7d595814757819>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/262a7121046132fbb7bb101ecf7d595814757819>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/26e58031d1f0c63f6e62a59c52d1da80a85ce9bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26e58031d1f0c63f6e62a59c52d1da80a85ce9bd>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/326ddff25e8c45da5ae708e036bfa6315d449672>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326ddff25e8c45da5ae708e036bfa6315d449672>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  tasks: add run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/034526a4bd6a9547cd394d19e5275d24f7f00362>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/034526a4bd6a9547cd394d19e5275d24f7f00362>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
-   `commit <https://pagure.io/freeipa/c/64ef1a8e727689cd434888ba555a003934986d13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64ef1a8e727689cd434888ba555a003934986d13>`__
    `#8432 <https://pagure.io/freeipa/issue/8432>`__
 -  ipatests: test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/cf6877a4864cebc15833b1b6638dcd53cc643712>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf6877a4864cebc15833b1b6638dcd53cc643712>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/59ad3ae4227fa20f0cd0e76b446bb4cfdc08debf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59ad3ae4227fa20f0cd0e76b446bb4cfdc08debf>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
-   `commit <https://pagure.io/freeipa/c/020905338423f0539f79f61772f117764ef88717>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/020905338423f0539f79f61772f117764ef88717>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
-   `commit <https://pagure.io/freeipa/c/2afe21b884e330018281980004e8175c2f9a3624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2afe21b884e330018281980004e8175c2f9a3624>`__
    `#8391 <https://pagure.io/freeipa/issue/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/c5abea2341b9e478625ea5a46c346550bc648a01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5abea2341b9e478625ea5a46c346550bc648a01>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
-   `commit <https://pagure.io/freeipa/c/766a80c14165e7eca99a44785f00f4b296e4cf62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/766a80c14165e7eca99a44785f00f4b296e4cf62>`__
    `#8377 <https://pagure.io/freeipa/issue/8377>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
-   `commit <https://pagure.io/freeipa/c/06accac8906f66ebbb31849d6528b39ae006b124>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06accac8906f66ebbb31849d6528b39ae006b124>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
-   `commit <https://pagure.io/freeipa/c/2648c218467792e907435eaa5267a0f3457f634f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2648c218467792e907435eaa5267a0f3457f634f>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
-   `commit <https://pagure.io/freeipa/c/3b43950d35f78b28d4edde4fda475b5aa84f4587>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b43950d35f78b28d4edde4fda475b5aa84f4587>`__
 -  EPN: ship the configuration file.
-   `commit <https://pagure.io/freeipa/c/23e2935e5c5cb402dd4f6f44eaa4b013e6a8188a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23e2935e5c5cb402dd4f6f44eaa4b013e6a8188a>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  .mailmap: add fcami
-   `commit <https://pagure.io/freeipa/c/6de941ce2c04c9ed6c8c33ed01c93fd6baa2fc5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6de941ce2c04c9ed6c8c33ed01c93fd6baa2fc5f>`__
 
 
 
@@ -551,64 +551,64 @@ Florence Blanc-Renaud (20)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: remove xfail from test_dnssec
-   `commit <https://pagure.io/freeipa/c/3919c9c8d7c2187e4d2a00b8276b241bf23f52b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3919c9c8d7c2187e4d2a00b8276b241bf23f52b0>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
-   `commit <https://pagure.io/freeipa/c/c4bd1f17a8aaa65482a6b28c1d6ed0f8ee94f667>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4bd1f17a8aaa65482a6b28c1d6ed0f8ee94f667>`__
    `#8447 <https://pagure.io/freeipa/issue/8447>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
-   `commit <https://pagure.io/freeipa/c/2fa03c5f583dad5f654669eb59255b0fc2991837>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fa03c5f583dad5f654669eb59255b0fc2991837>`__
    `#8439 <https://pagure.io/freeipa/issue/8439>`__
 -  ipatests: increase test_trust timeout
-   `commit <https://pagure.io/freeipa/c/55144ab6a18f275ec1472313755e2d07b71bee03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55144ab6a18f275ec1472313755e2d07b71bee03>`__
 -  ipatests: check KDC cert permissions in CA less install
-   `commit <https://pagure.io/freeipa/c/295dd4235f693b7b4b4270b46a28cb6e7b3d00b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/295dd4235f693b7b4b4270b46a28cb6e7b3d00b4>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  CAless installation: set the perms on KDC cert file
-   `commit <https://pagure.io/freeipa/c/81c955e561dd42ab70a39bf636c90e82a9d7d899>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81c955e561dd42ab70a39bf636c90e82a9d7d899>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  ipatests: fix test_authselect
-   `commit <https://pagure.io/freeipa/c/4baf6b292f28481ece483bb8ecbd6a0807d9d45a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4baf6b292f28481ece483bb8ecbd6a0807d9d45a>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
-   `commit <https://pagure.io/freeipa/c/3eaab97e317584bc47d4a27a607267ed90df7ff7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3eaab97e317584bc47d4a27a607267ed90df7ff7>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
-   `commit <https://pagure.io/freeipa/c/ca880cfb117fc870a6e2710b9e31b2f67d5651e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca880cfb117fc870a6e2710b9e31b2f67d5651e1>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
-   `commit <https://pagure.io/freeipa/c/3c53c7036a8a214eeb93c241d730d5c737950cd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c53c7036a8a214eeb93c241d730d5c737950cd1>`__
    `#8414 <https://pagure.io/freeipa/issue/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
-   `commit <https://pagure.io/freeipa/c/819bcacb81f942ac31691638beb64f77c0e74a40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/819bcacb81f942ac31691638beb64f77c0e74a40>`__
    `#8413 <https://pagure.io/freeipa/issue/8413>`__
 -  sshd template must be part of client package
-   `commit <https://pagure.io/freeipa/c/668fdc63e3e886208dca8bdc5a68a20972150985>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/668fdc63e3e886208dca8bdc5a68a20972150985>`__
    `#8400 <https://pagure.io/freeipa/issue/8400>`__
 -  Bump requires for selinux-policy
-   `commit <https://pagure.io/freeipa/c/388e793d5c47befbea01c48cdd679c99348ccc85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/388e793d5c47befbea01c48cdd679c99348ccc85>`__
 -  ipatests: fix the method adding ifp to sssd.conf
-   `commit <https://pagure.io/freeipa/c/437fc60639bedbac2e5af85244962f60f374961a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/437fc60639bedbac2e5af85244962f60f374961a>`__
    `#8371 <https://pagure.io/freeipa/issue/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
-   `commit <https://pagure.io/freeipa/c/8c7f54d1ffbddbfabd4f4547edeeb38a24152518>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7f54d1ffbddbfabd4f4547edeeb38a24152518>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__,
    `#8381 <https://pagure.io/freeipa/issue/8381>`__
 -  client install: fix broken sshd config
-   `commit <https://pagure.io/freeipa/c/3ea611c98b1e01c54e5ce6c64fe108b140631722>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ea611c98b1e01c54e5ce6c64fe108b140631722>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
-   `commit <https://pagure.io/freeipa/c/b317222d515e51504b4c8342008f2981b508c82a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b317222d515e51504b4c8342008f2981b508c82a>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
-   `commit <https://pagure.io/freeipa/c/0e325bd0c01eecc6d48b10f9b7f654b16068a522>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e325bd0c01eecc6d48b10f9b7f654b16068a522>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
-   `commit <https://pagure.io/freeipa/c/32c4df70e36a0aeafc12e2ade85ee9c915774c44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32c4df70e36a0aeafc12e2ade85ee9c915774c44>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
-   `commit <https://pagure.io/freeipa/c/7f19fda0d1fbd4431b0bd704f5c242e499e66e98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f19fda0d1fbd4431b0bd704f5c242e499e66e98>`__
    `#8364 <https://pagure.io/freeipa/issue/8364>`__
 
 
@@ -617,18 +617,18 @@ Fraser Tweedale (5)
 ----------------------------------------------------------------------------------------------
 
 -  certupdate: only add LWCA tracking requests on CA servers
-   `commit <https://pagure.io/freeipa/c/72d70fa27f61367a5fbc81b171b125ecf85d8fd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72d70fa27f61367a5fbc81b171b125ecf85d8fd8>`__
    `#8399 <https://pagure.io/freeipa/issue/8399>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
-   `commit <https://pagure.io/freeipa/c/d13a33da6d472ed61ea0aaa9d050a8d5638beae5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d13a33da6d472ed61ea0aaa9d050a8d5638beae5>`__
 -  Define errors_by_code in ipalib.errors
-   `commit <https://pagure.io/freeipa/c/7bfe6b261fa03ecc05d9f75ef24175f588d45e16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bfe6b261fa03ecc05d9f75ef24175f588d45e16>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
-   `commit <https://pagure.io/freeipa/c/128500198d3782a76616cf1d971d5aeb17e8c1da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/128500198d3782a76616cf1d971d5aeb17e8c1da>`__
    `#8368 <https://pagure.io/freeipa/issue/8368>`__
 -  fix cert-find errors in CA-less deployment
-   `commit <https://pagure.io/freeipa/c/60a58eac02ed2c0741fbce3c1fb3acceef61fdbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60a58eac02ed2c0741fbce3c1fb3acceef61fdbc>`__
    `#8369 <https://pagure.io/freeipa/issue/8369>`__
 
 
@@ -638,10 +638,10 @@ Jeremy Frasier (2)
 
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
-   `commit <https://pagure.io/freeipa/c/6de4b0fb85d9e2c51c60bc921cf6ee078ca1c219>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6de4b0fb85d9e2c51c60bc921cf6ee078ca1c219>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
-   `commit <https://pagure.io/freeipa/c/4b8da1b7c7cd5686240b9c8e8c7e41fe9c604c57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b8da1b7c7cd5686240b9c8e8c7e41fe9c604c57>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 
 
@@ -650,7 +650,7 @@ Kaleemullah Siddiqui (1)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for fake_mname parameter setup
-   `commit <https://pagure.io/freeipa/c/b93f2a70d09f44a64a320ad558c76536e9b625ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b93f2a70d09f44a64a320ad558c76536e9b625ad>`__
 
 
 
@@ -658,9 +658,9 @@ Michal Polovka (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_epn: test_EPN_config_file: Package name fix
-   `commit <https://pagure.io/freeipa/c/8318b2b37c821f90637e8b08fbaf6320f6f1f477>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8318b2b37c821f90637e8b08fbaf6320f6f1f477>`__
 -  ipatests: test_epn: Fix package installation
-   `commit <https://pagure.io/freeipa/c/9281133c7c0d1bb3696fba036b5f79fb8e75828f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9281133c7c0d1bb3696fba036b5f79fb8e75828f>`__
 
 
 
@@ -668,13 +668,13 @@ Mark Reynolds (3)
 ----------------------------------------------------------------------------------------------
 
 -  Increase replication changelog trimming to 30 days
-   `commit <https://pagure.io/freeipa/c/14f27d284f4d9a37f2bd599f98602fb2eb84edd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14f27d284f4d9a37f2bd599f98602fb2eb84edd1>`__
    `#8464 <https://pagure.io/freeipa/issue/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
-   `commit <https://pagure.io/freeipa/c/c2f8c84a74c2aa007027261f052131fcc7041cb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2f8c84a74c2aa007027261f052131fcc7041cb4>`__
    `#8456 <https://pagure.io/freeipa/issue/8456>`__
 -  Issue 8407 - Support changelog integration into main database
-   `commit <https://pagure.io/freeipa/c/0a83d8201a8a7ca56c6173fb643733b350ef5b9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a83d8201a8a7ca56c6173fb643733b350ef5b9b>`__
    `#8407 <https://pagure.io/freeipa/issue/8407>`__
 
 
@@ -683,11 +683,11 @@ Mohammad Rizwan (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test certmonger rekey command works fine
-   `commit <https://pagure.io/freeipa/c/9b52ba606d2f0e3ff8f8f5dd7bbe87e6b9d2cfbe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b52ba606d2f0e3ff8f8f5dd7bbe87e6b9d2cfbe>`__
 -  Xfail test for sssd < 2.3.0
-   `commit <https://pagure.io/freeipa/c/40804b5e06151fb0e73def2b9a6b706063205723>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40804b5e06151fb0e73def2b9a6b706063205723>`__
 -  ipatests: Test ipa user login with wrong password
-   `commit <https://pagure.io/freeipa/c/34b4d9bce56f62121e1e0ef0bf57cd1724aefe82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34b4d9bce56f62121e1e0ef0bf57cd1724aefe82>`__
 
 
 
@@ -695,9 +695,9 @@ Petr Voborník (2)
 ----------------------------------------------------------------------------------------------
 
 -  baseuser: fix ipanthomedirectorydrive option name
-   `commit <https://pagure.io/freeipa/c/a090b429fda35c5a9c3cfb672ab42a5985d00ff9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a090b429fda35c5a9c3cfb672ab42a5985d00ff9>`__
 -  webui: hide user attributes for SMB services section if empty
-   `commit <https://pagure.io/freeipa/c/691b3cddb275821630f443f22706fa75e7c7a5c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/691b3cddb275821630f443f22706fa75e7c7a5c8>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 
 
@@ -706,61 +706,61 @@ Rob Crittenden (23)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: stop the CA during healthcheck expiration test
-   `commit <https://pagure.io/freeipa/c/715ec234373fc8b4aa0d00a4e9e0126522f38de1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/715ec234373fc8b4aa0d00a4e9e0126522f38de1>`__
    `#8463 <https://pagure.io/freeipa/issue/8463>`__
 -  Improve performance of ipa-server-guard
-   `commit <https://pagure.io/freeipa/c/aac717988f63ab4b8b808a6d48ee01e8fcb0c9e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aac717988f63ab4b8b808a6d48ee01e8fcb0c9e7>`__
    `#8425 <https://pagure.io/freeipa/issue/8425>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
-   `commit <https://pagure.io/freeipa/c/6f09f97791035cad01e237ed084ffc44f1ff7e85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f09f97791035cad01e237ed084ffc44f1ff7e85>`__
 -  Added negative test case for --list-sources option
-   `commit <https://pagure.io/freeipa/c/d6c425613f4a978bd77f6f6a6b94a910f9fa3fe0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6c425613f4a978bd77f6f6a6b94a910f9fa3fe0>`__
 -  ipatests: CLI validation of ipa-healthcheck command
-   `commit <https://pagure.io/freeipa/c/8e460c68569074a59463771291dcff6a13fa9796>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e460c68569074a59463771291dcff6a13fa9796>`__
 -  IPA-EPN: Test that users without givenname and/or mail are handled
-   `commit <https://pagure.io/freeipa/c/1b1dbcbe9d83ba35f3cfdd01399f123816ec6e5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b1dbcbe9d83ba35f3cfdd01399f123816ec6e5b>`__
 -  Address legacy pylint issues in sysrestore.py
-   `commit <https://pagure.io/freeipa/c/4454af4bf31b73550eb5be2ed14be3e15c585ca3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4454af4bf31b73550eb5be2ed14be3e15c585ca3>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Update check_client_configuration to use new client fact
-   `commit <https://pagure.io/freeipa/c/b9e4c686634f5ba41f50f0aa0f75b5e214e25a4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9e4c686634f5ba41f50f0aa0f75b5e214e25a4d>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Don't use the has_files() to know if client/server is configured
-   `commit <https://pagure.io/freeipa/c/cb6c48b21118abb198066126647709b7c9e26e10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb6c48b21118abb198066126647709b7c9e26e10>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
-   `commit <https://pagure.io/freeipa/c/ee755a580c1f136b2501a395116ddf7e43c913b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee755a580c1f136b2501a395116ddf7e43c913b6>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if IPA client configuration is complete
-   `commit <https://pagure.io/freeipa/c/80a7e346a514530ea3af75d2cc338c18ec211537>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80a7e346a514530ea3af75d2cc338c18ec211537>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if an IPA server installation is complete
-   `commit <https://pagure.io/freeipa/c/1a47748499256544e6692ef0578073938015f7ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a47748499256544e6692ef0578073938015f7ea>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
-   `commit <https://pagure.io/freeipa/c/da2079ce2cc841aec56da872131112eb24326f81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da2079ce2cc841aec56da872131112eb24326f81>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
-   `commit <https://pagure.io/freeipa/c/4a97145c3a76a4d9ebf52b3905410a0bd7bec856>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a97145c3a76a4d9ebf52b3905410a0bd7bec856>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  ipatests: Test healthcheck revocation checker
-   `commit <https://pagure.io/freeipa/c/ea288b014414c62389d7b3a7572a665fefc11b0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea288b014414c62389d7b3a7572a665fefc11b0f>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
-   `commit <https://pagure.io/freeipa/c/e91c7bcd76cd41e6dd82bb5571a8299d4ccf67ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e91c7bcd76cd41e6dd82bb5571a8299d4ccf67ee>`__
 -  ipatests: lib389 is now providing healthchecks, update naming
-   `commit <https://pagure.io/freeipa/c/d0cdae4836418272d69e572f0327a66a6fd81b35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0cdae4836418272d69e572f0327a66a6fd81b35>`__
 -  ipatests: Add healthcheck test for FileSystemSpaceCheck
-   `commit <https://pagure.io/freeipa/c/81949c2dda7abb768c0dc23c885f45591d6b787f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81949c2dda7abb768c0dc23c885f45591d6b787f>`__
 -  ipatests: verify that all services can be detected by healthcheck
-   `commit <https://pagure.io/freeipa/c/bdd0c4a7fc589124fa588288bed2c6982e6479e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdd0c4a7fc589124fa588288bed2c6982e6479e8>`__
 -  ipatests: Test that healthcheck detects and reports expiration
-   `commit <https://pagure.io/freeipa/c/40fe3542054a8543f8ba1f2ec469ef2e44fcd576>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40fe3542054a8543f8ba1f2ec469ef2e44fcd576>`__
 -  ipatests: Test cases for healthcheck File checker(s)
-   `commit <https://pagure.io/freeipa/c/3d3e8a4eabd8112954e7c6bfe9024595b02aee6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d3e8a4eabd8112954e7c6bfe9024595b02aee6a>`__
 -  Replace SSLCertVerificationError with CertificateError for py36
-   `commit <https://pagure.io/freeipa/c/66a5a0efd538e31a190ca6ecb775bc1dfc4ee232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66a5a0efd538e31a190ca6ecb775bc1dfc4ee232>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
-   `commit <https://pagure.io/freeipa/c/cc06361907c8fdb986a581eb3e20abf8a7c1c476>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc06361907c8fdb986a581eb3e20abf8a7c1c476>`__
    `#8429 <https://pagure.io/freeipa/issue/8429>`__
 
 
@@ -769,28 +769,28 @@ Stanislav Levin (9)
 ----------------------------------------------------------------------------------------------
 
 -  spec: Move ipa-cldap plugin out to freeipa-server-trust-ad package
-   `commit <https://pagure.io/freeipa/c/3084930e596b5d6e9b2b81cf9ce6532feb620b02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3084930e596b5d6e9b2b81cf9ce6532feb620b02>`__
 -  uninstall: Clean up no longer used flag
-   `commit <https://pagure.io/freeipa/c/bba69960f6c26b5b97e72359bc382e25a8ca8ec9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bba69960f6c26b5b97e72359bc382e25a8ca8ec9>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
-   `commit <https://pagure.io/freeipa/c/602f3f3151e58084ebd9b10d3997efeae5417d12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/602f3f3151e58084ebd9b10d3997efeae5417d12>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
-   `commit <https://pagure.io/freeipa/c/dbf1d858449ff37dbbe73f3853f98578b236615a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbf1d858449ff37dbbe73f3853f98578b236615a>`__
    `#8459 <https://pagure.io/freeipa/issue/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
-   `commit <https://pagure.io/freeipa/c/50cf90f09398c949797f7fe71ae2075799e14a7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50cf90f09398c949797f7fe71ae2075799e14a7f>`__
 -  Azure: Switch to dockerhub provider
-   `commit <https://pagure.io/freeipa/c/c89718a60113d1c72fecc3b1549341f2050d6922>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c89718a60113d1c72fecc3b1549341f2050d6922>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
-   `commit <https://pagure.io/freeipa/c/a55ccdb12de3f39c49513fea3ed695e4900916f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a55ccdb12de3f39c49513fea3ed695e4900916f5>`__
    `#8428 <https://pagure.io/freeipa/issue/8428>`__
 -  pylint: Fix warning and error
-   `commit <https://pagure.io/freeipa/c/e4c753dc03c48b8c3509e6077dd7fa5074f73670>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4c753dc03c48b8c3509e6077dd7fa5074f73670>`__
    `#8442 <https://pagure.io/freeipa/issue/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
-   `commit <https://pagure.io/freeipa/c/66216e908546b45974a4fbf81804b8184d603b78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66216e908546b45974a4fbf81804b8184d603b78>`__
    `#8435 <https://pagure.io/freeipa/issue/8435>`__
 
 
@@ -799,7 +799,7 @@ Sergey Orlov (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix password file permission
-   `commit <https://pagure.io/freeipa/c/ec2b1462899a6b0226dbb68fc7c5ee47db3e33f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec2b1462899a6b0226dbb68fc7c5ee47db3e33f5>`__
 
 
 
@@ -807,21 +807,21 @@ Serhii Tsymbaliuk (5)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI tests: Add test case to cover user ID override feature
-   `commit <https://pagure.io/freeipa/c/e35739b7e9f6bb016b37abbd92bdaee71a59a288>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e35739b7e9f6bb016b37abbd92bdaee71a59a288>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
-   `commit <https://pagure.io/freeipa/c/f6c460aee8542d4d81cd9970d71051c240156973>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6c460aee8542d4d81cd9970d71051c240156973>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
-   `commit <https://pagure.io/freeipa/c/a9e3e40f6910d34aaabadeb4a4e1f30d83a29a5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9e3e40f6910d34aaabadeb4a4e1f30d83a29a5d>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
-   `commit <https://pagure.io/freeipa/c/1502cb47df39f58082967012d4f9e227d6971652>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1502cb47df39f58082967012d4f9e227d6971652>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
-   `commit <https://pagure.io/freeipa/c/ffe7f7b35907f9adab004ce63ce78f67fbd7aed8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffe7f7b35907f9adab004ce63ce78f67fbd7aed8>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 
 
@@ -830,27 +830,27 @@ sumenon (9)
 ----------------------------------------------------------------------------------------------
 
 -  Modified YAML files to include healthcheck externalCA tests
-   `commit <https://pagure.io/freeipa/c/4da4dd8d7b03164c29e25e6a2b58c9e8fda39062>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4da4dd8d7b03164c29e25e6a2b58c9e8fda39062>`__
 -  ipatests: Tests for ipahealthcheck tool with IPA external
-   `commit <https://pagure.io/freeipa/c/8f19233d910237fbfd68c2c50bd31e13a49f8ff3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f19233d910237fbfd68c2c50bd31e13a49f8ff3>`__
 -  ipatests: Test IPACertNSSTrust check when trust attributes is
    modified for specific cert
-   `commit <https://pagure.io/freeipa/c/06b33007a733861a4e262e001af0a3f10b7061b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06b33007a733861a4e262e001af0a3f10b7061b8>`__
 -  ipatests: Test to check IPACAChainExpirationCheck when IPA cacrt is
    renamed
-   `commit <https://pagure.io/freeipa/c/a52aa06e1a6220c18a3b4c8f51f1b2efb3596bfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a52aa06e1a6220c18a3b4c8f51f1b2efb3596bfa>`__
 -  ipatests: Increase timeout value in
    test_getcert_list_profile_using_subca
-   `commit <https://pagure.io/freeipa/c/7f205b8946d071cb2d0e11977dfc1b5dc6d5e312>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f205b8946d071cb2d0e11977dfc1b5dc6d5e312>`__
 -  ipatests: Test for ipa-nis-manage CLI tool.
-   `commit <https://pagure.io/freeipa/c/ab36d79adc3a061e34eeb528ac0ad2d35b417731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab36d79adc3a061e34eeb528ac0ad2d35b417731>`__
 -  ipatests: Tests to check profile is displayed for getcert request.
-   `commit <https://pagure.io/freeipa/c/07d1b9d33b9515047dcd41f569a3dcf0b183260e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07d1b9d33b9515047dcd41f569a3dcf0b183260e>`__
 -  Modified YAML to include healthcheck IPA-AD trust scenario
-   `commit <https://pagure.io/freeipa/c/2e8cd60bc1918508e79dbec84f5854aea749db11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e8cd60bc1918508e79dbec84f5854aea749db11>`__
 -  ipatests: Tests to check ipahealthcheck tool with IPA-AD trust
    scenario
-   `commit <https://pagure.io/freeipa/c/73df4e1bf83ecb209a580c79e73170ccd7cc1106>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73df4e1bf83ecb209a580c79e73170ccd7cc1106>`__
 
 
 
@@ -858,4 +858,4 @@ Zdenek Pytela (1)
 ----------------------------------------------------------------------------------------------
 
 -  Allow ipa-adtrust-install restart sssd and dirsrv services
-   `commit <https://pagure.io/freeipa/c/f76c56c6072418c78f138678b1c4dd917fea6ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f76c56c6072418c78f138678b1c4dd917fea6ee1>`__

--- a/src/page/Releases/4.9.0.rst
+++ b/src/page/Releases/4.9.0.rst
@@ -1547,61 +1547,61 @@ Armando Neto (26)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/a3c5c71925b5fd8faa56379d92fa19631d230108>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c5c71925b5fd8faa56379d92fa19631d230108>`__
 -  ipatests: Update PRCI Fedora 32 templates
-   `commit <https://pagure.io/freeipa/c/3722013dcd6d03d3adbdfb518c733b1a90e5af39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3722013dcd6d03d3adbdfb518c733b1a90e5af39>`__
 -  ipatests: Add nightly definitions for enforcing mode
-   `commit <https://pagure.io/freeipa/c/26ae95f4b492b98078b5deb16825df3fd525f305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26ae95f4b492b98078b5deb16825df3fd525f305>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/21186540f0425840e544a3cead8da909744aeac0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21186540f0425840e544a3cead8da909744aeac0>`__
    `#8473 <https://pagure.io/freeipa/issue/8473>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/7de20e8e07306d7a7f751283f257f544b24a0eef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de20e8e07306d7a7f751283f257f544b24a0eef>`__
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/67d4517f7321f363e785937a23fe521ccee76d52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67d4517f7321f363e785937a23fe521ccee76d52>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/cc624fb178291062e30a11b8dc6a6b67cbe5dea8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc624fb178291062e30a11b8dc6a6b67cbe5dea8>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/04ce1a415b33a95ad5bd65cb93e511a16940b123>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04ce1a415b33a95ad5bd65cb93e511a16940b123>`__
 -  prci: update templates for new Fedora release
-   `commit <https://pagure.io/freeipa/c/40b8174c347ff49df0d83d3aaf9b6f19c5f3461c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b8174c347ff49df0d83d3aaf9b6f19c5f3461c>`__
 -  Update instructions for Fedora 28 / FreeIPA 4.6.90
-   `commit <https://pagure.io/freeipa/c/33cd0bb625d3aa2cede2b7bbe6cd49d4a0db5f29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33cd0bb625d3aa2cede2b7bbe6cd49d4a0db5f29>`__
 -  prci: bump version for latest and previous templates
-   `commit <https://pagure.io/freeipa/c/132ef03acbe15f02fd2a2212741bdc1fa030fc84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132ef03acbe15f02fd2a2212741bdc1fa030fc84>`__
 -  prci: Bump version of all templates
-   `commit <https://pagure.io/freeipa/c/19f0142e792c5da783312eb7c67fd3999883b38d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19f0142e792c5da783312eb7c67fd3999883b38d>`__
 -  prci: update packages for rawhide nightly runs
-   `commit <https://pagure.io/freeipa/c/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
-   `commit <https://pagure.io/freeipa/c/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: Improve test_commands reliability
-   `commit <https://pagure.io/freeipa/c/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
 -  travis: Remove CI integration
-   `commit <https://pagure.io/freeipa/c/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
    `#7323 <https://pagure.io/freeipa/issue/7323>`__
 -  prci: bump template version for temp_commit and nightly_latest
-   `commit <https://pagure.io/freeipa/c/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
 -  prci: bump fedora release
-   `commit <https://pagure.io/freeipa/c/99d6845dbe803bd81badc0e064fe3578886377cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99d6845dbe803bd81badc0e064fe3578886377cd>`__
 -  prci: rename definitions files and jobs to change how fedora releases
    are referenced
-   `commit <https://pagure.io/freeipa/c/c62bd1608e3a4aea27751826d7b8790367b1b5e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c62bd1608e3a4aea27751826d7b8790367b1b5e3>`__
 -  prci: increase timeout argument for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/3d8a444f624b431706838f243fc19f92e8fbc63e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d8a444f624b431706838f243fc19f92e8fbc63e>`__
 -  prci: increase timeout for jobs that required AD
-   `commit <https://pagure.io/freeipa/c/a4ca34261a55af96e3428822f08f8b2292e6234a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4ca34261a55af96e3428822f08f8b2292e6234a>`__
 -  prci: update packages for pki and testing nightly runs
-   `commit <https://pagure.io/freeipa/c/98ee5f247252041c5135b00a55daa765072fb6d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98ee5f247252041c5135b00a55daa765072fb6d5>`__
 -  Update definitions for nightly tests
-   `commit <https://pagure.io/freeipa/c/78d27f8252c9bd7a3f1ac9a4fbe4d10c8c5d02ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78d27f8252c9bd7a3f1ac9a4fbe4d10c8c5d02ad>`__
 -  prci: fix typo on nightly test definitions
-   `commit <https://pagure.io/freeipa/c/2e0850e70e87a1affd78ae9544f5767cb5e13c5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e0850e70e87a1affd78ae9544f5767cb5e13c5a>`__
 -  prci: update test definitions
-   `commit <https://pagure.io/freeipa/c/481c540000f3c6546e00a8117919e8bbe72db2f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/481c540000f3c6546e00a8117919e8bbe72db2f1>`__
 
 
 
@@ -1609,486 +1609,486 @@ Alexander Bokovoy (189)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.0
-   `commit <https://pagure.io/freeipa/c/44914cf1faaf3704c55c0ef39fe680e63710d3f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44914cf1faaf3704c55c0ef39fe680e63710d3f0>`__
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/a3058d528a0f7a647f5090b4bcd3b2a19e7b54fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3058d528a0f7a647f5090b4bcd3b2a19e7b54fd>`__
 -  odsexporterinstance: use late binding for UID/GID resolution
-   `commit <https://pagure.io/freeipa/c/eca22818c911646a111d2257213ee22737e2555f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eca22818c911646a111d2257213ee22737e2555f>`__
    `#8630 <https://pagure.io/freeipa/issue/8630>`__
 -  dnskeysyncinstance: use late binding for UID/GID resolution
-   `commit <https://pagure.io/freeipa/c/eae9f0d80c8fe67fdd44a9c772ce2c4234b35ba0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eae9f0d80c8fe67fdd44a9c772ce2c4234b35ba0>`__
    `#8630 <https://pagure.io/freeipa/issue/8630>`__
 -  opendnssecinstance: use late binding for UID/GID resolution
-   `commit <https://pagure.io/freeipa/c/eb42b1097a89c5e863bd4fd1714d5ce84a47b718>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb42b1097a89c5e863bd4fd1714d5ce84a47b718>`__
    `#8630 <https://pagure.io/freeipa/issue/8630>`__
 -  tests_webui: fix wrong user name key for trail space case
-   `commit <https://pagure.io/freeipa/c/7d13d704b9552ab8ec1c7c5428655297fbdbf09c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d13d704b9552ab8ec1c7c5428655297fbdbf09c>`__
    `#8629 <https://pagure.io/freeipa/issue/8629>`__
 -  tests_webui: flip leading and trailing space password test
-   `commit <https://pagure.io/freeipa/c/d9bdd3e93048ff4f08c2d53f1fd89b05dcd7861c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9bdd3e93048ff4f08c2d53f1fd89b05dcd7861c>`__
    `#8629 <https://pagure.io/freeipa/issue/8629>`__
 -  Update IPA translation template before release
-   `commit <https://pagure.io/freeipa/c/4db85bed81ba9a8cca0f34ca067312d15c9f2868>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4db85bed81ba9a8cca0f34ca067312d15c9f2868>`__
 -  Update po/zh_CN translation before release
-   `commit <https://pagure.io/freeipa/c/6c58f825ec84016753c89e8c573d7731181776d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c58f825ec84016753c89e8c573d7731181776d4>`__
 -  Update po/uk translation before release
-   `commit <https://pagure.io/freeipa/c/bdb759ac7e23cedc19b91ddd2712ddf4f8bd2648>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdb759ac7e23cedc19b91ddd2712ddf4f8bd2648>`__
 -  Update po/tr translation before release
-   `commit <https://pagure.io/freeipa/c/29f797d442b4c9753ed6b789b9bb297df2019d51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29f797d442b4c9753ed6b789b9bb297df2019d51>`__
 -  Update po/tg translation before release
-   `commit <https://pagure.io/freeipa/c/1bf4b41f1198388c039292d71c41e131fae3fa88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bf4b41f1198388c039292d71c41e131fae3fa88>`__
 -  Update po/sk translation before release
-   `commit <https://pagure.io/freeipa/c/badd9551f3406109efa24a927ee73ca4861b9413>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/badd9551f3406109efa24a927ee73ca4861b9413>`__
 -  Update po/ru translation before release
-   `commit <https://pagure.io/freeipa/c/ad37d39ea4ccd7860adc98de11db33e45c92bede>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad37d39ea4ccd7860adc98de11db33e45c92bede>`__
 -  Update po/pt translation before release
-   `commit <https://pagure.io/freeipa/c/acd2f3054af5ada3b3efb0f0a035775ffa8452a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acd2f3054af5ada3b3efb0f0a035775ffa8452a7>`__
 -  Update po/pt_BR translation before release
-   `commit <https://pagure.io/freeipa/c/970c4050abd6813d0a1817f57be06135b4e7cfab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/970c4050abd6813d0a1817f57be06135b4e7cfab>`__
 -  Update po/pl translation before release
-   `commit <https://pagure.io/freeipa/c/9ed9eb7c85209717c574fb815629bfcdac7fc6e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ed9eb7c85209717c574fb815629bfcdac7fc6e6>`__
 -  Update po/pa translation before release
-   `commit <https://pagure.io/freeipa/c/4bf0a13a85411307d5430a1b5483770f90884c6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4bf0a13a85411307d5430a1b5483770f90884c6c>`__
 -  Update po/nl translation before release
-   `commit <https://pagure.io/freeipa/c/5ea6048240cd4dc5add0bb9b09a0c3276d3e0459>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ea6048240cd4dc5add0bb9b09a0c3276d3e0459>`__
 -  Update po/mr translation before release
-   `commit <https://pagure.io/freeipa/c/58d201715287ee2784da85d760c88609f0ca9f3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58d201715287ee2784da85d760c88609f0ca9f3c>`__
 -  Update po/kn translation before release
-   `commit <https://pagure.io/freeipa/c/162aa652295a46e1dafbe8102a9d8f3b0b36018c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/162aa652295a46e1dafbe8102a9d8f3b0b36018c>`__
 -  Update po/ja translation before release
-   `commit <https://pagure.io/freeipa/c/12de97fca7600e1d01dc5289387064845043a7b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12de97fca7600e1d01dc5289387064845043a7b7>`__
 -  Update po/id translation before release
-   `commit <https://pagure.io/freeipa/c/036c96754dd0dca5cda2ecb07b1514c65c4a73fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/036c96754dd0dca5cda2ecb07b1514c65c4a73fe>`__
 -  Update po/hu translation before release
-   `commit <https://pagure.io/freeipa/c/9d4d4d278887ad89657c1832eb2486da85968964>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d4d4d278887ad89657c1832eb2486da85968964>`__
 -  Update po/hi translation before release
-   `commit <https://pagure.io/freeipa/c/fa4ac630669200e84da69f150a6e3304fcc5751f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa4ac630669200e84da69f150a6e3304fcc5751f>`__
 -  Update po/fr translation before release
-   `commit <https://pagure.io/freeipa/c/33f4e6588f70aeef415260dd176b77e2c9ea285c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33f4e6588f70aeef415260dd176b77e2c9ea285c>`__
 -  Update po/eu translation before release
-   `commit <https://pagure.io/freeipa/c/0b02b0514abe5393f64590436598f8b7a2cc09c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b02b0514abe5393f64590436598f8b7a2cc09c4>`__
 -  Update po/es translation before release
-   `commit <https://pagure.io/freeipa/c/03cf8ffe144e373c70145c01869b0f7e0c4977b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03cf8ffe144e373c70145c01869b0f7e0c4977b9>`__
 -  Update po/en_GB translation before release
-   `commit <https://pagure.io/freeipa/c/09f97d2e1e5e6105a44be4e76b1e6570d7093de1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09f97d2e1e5e6105a44be4e76b1e6570d7093de1>`__
 -  Update po/de translation before release
-   `commit <https://pagure.io/freeipa/c/9c166cfca6bc3bbe92bf0a9384b67e95ff70b266>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c166cfca6bc3bbe92bf0a9384b67e95ff70b266>`__
 -  Update po/cs translation before release
-   `commit <https://pagure.io/freeipa/c/7b63b5b84213731a3d324aac2988398bcde2111d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b63b5b84213731a3d324aac2988398bcde2111d>`__
 -  Update po/ca translation before release
-   `commit <https://pagure.io/freeipa/c/57b41e0dd587e605dce34241d8e6053ccf43e7a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57b41e0dd587e605dce34241d8e6053ccf43e7a8>`__
 -  Update po/bn_IN translation before release
-   `commit <https://pagure.io/freeipa/c/8f6b4a0780c704dfb58675f367ff8bb50e5e1788>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f6b4a0780c704dfb58675f367ff8bb50e5e1788>`__
 -  upgrade: ensure service state is synchronized with the server state
-   `commit <https://pagure.io/freeipa/c/56c8b174d183fe7c4001ec3eb3fab650a0695994>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56c8b174d183fe7c4001ec3eb3fab650a0695994>`__
    `#8623 <https://pagure.io/freeipa/issue/8623>`__
 -  upgrade: do not overshadow service module in upgrade_configuration
-   `commit <https://pagure.io/freeipa/c/59432e92a54b2d4881af882b559aa33793c4558e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59432e92a54b2d4881af882b559aa33793c4558e>`__
 -  service: handle empty list of services to update their state
-   `commit <https://pagure.io/freeipa/c/06fbb8b42e29de23b9e9ae9e212a9ce39f09e407>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06fbb8b42e29de23b9e9ae9e212a9ce39f09e407>`__
    `#8623 <https://pagure.io/freeipa/issue/8623>`__
 -  ipa-kdb: use predefined filters for a wild-card searches
-   `commit <https://pagure.io/freeipa/c/2d1594c3c6136559de7df88fb2a9895a3c47463a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d1594c3c6136559de7df88fb2a9895a3c47463a>`__
    `#8624 <https://pagure.io/freeipa/issue/8624>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/f5cd9d0792328e0070457a96b8bd32aa365a7892>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5cd9d0792328e0070457a96b8bd32aa365a7892>`__
 -  Become FreeIPA 4.9.0rc3
-   `commit <https://pagure.io/freeipa/c/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
 -  systemd: enforce en_US.UTF-8 locale in systemd units
-   `commit <https://pagure.io/freeipa/c/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
    `#8617 <https://pagure.io/freeipa/issue/8617>`__
 -  upgrade: provide DOMAIN to the server upgrade dictionary
-   `commit <https://pagure.io/freeipa/c/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__,
    `#8615 <https://pagure.io/freeipa/issue/8615>`__
 -  Allow mod_auth_gssapi to create and access ccaches in
    /run/ipa/ccaches
-   `commit <https://pagure.io/freeipa/c/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
    `#8613 <https://pagure.io/freeipa/issue/8613>`__
 -  Correct SELinux policy requirements
-   `commit <https://pagure.io/freeipa/c/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/77674077b4e1e6ff2d2608ad0661704d4a47ac41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77674077b4e1e6ff2d2608ad0661704d4a47ac41>`__
 -  Become FreeIPA 4.9.0rc2
-   `commit <https://pagure.io/freeipa/c/e74d6409902b83fb81a0aec251280375a90d6f07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e74d6409902b83fb81a0aec251280375a90d6f07>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/5f36ee51e4f9d270cc65668d9ab4666e0ac8c07f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f36ee51e4f9d270cc65668d9ab4666e0ac8c07f>`__
 -  freeipa.spec.in: unify spec files across upstream RHEL, and Fedora
-   `commit <https://pagure.io/freeipa/c/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
 -  ad trust: accept subordinate domains of the forest trust root
-   `commit <https://pagure.io/freeipa/c/381cc5e8eae1b7437fc15cb699983887d398f498>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/381cc5e8eae1b7437fc15cb699983887d398f498>`__
    `#8554 <https://pagure.io/freeipa/issue/8554>`__
 -  util: Fix client-only build
-   `commit <https://pagure.io/freeipa/c/244704cc156dba0731671c55661d82073f970c9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/244704cc156dba0731671c55661d82073f970c9b>`__
    `#8587 <https://pagure.io/freeipa/issue/8587>`__
 -  Become FreeIPA 4.9.0 release candidate 1
-   `commit <https://pagure.io/freeipa/c/a1f3e3b836f357cd3fe8698a4ecdc92c919a6306>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1f3e3b836f357cd3fe8698a4ecdc92c919a6306>`__
 -  Translations: update translations template
-   `commit <https://pagure.io/freeipa/c/038645d8c24c67b9136859b6b9d7c159c33148f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/038645d8c24c67b9136859b6b9d7c159c33148f5>`__
 -  Add contributors from translations project at Weblate
-   `commit <https://pagure.io/freeipa/c/ff79c0cea54c0bd3ce3883927da156360f516e5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff79c0cea54c0bd3ce3883927da156360f516e5d>`__
 -  Azure CI: mask chronyd in the container
-   `commit <https://pagure.io/freeipa/c/f977629182324d0511dfab89cebfa5decd97353e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f977629182324d0511dfab89cebfa5decd97353e>`__
 -  spec: use pkgconf to find out krb5 version
-   `commit <https://pagure.io/freeipa/c/39d0dd332c798044f95b5cc2c24b5eece57f5555>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39d0dd332c798044f95b5cc2c24b5eece57f5555>`__
 -  Azure CI: use PPA to provide newer libseccomp version
-   `commit <https://pagure.io/freeipa/c/1bf0d628281f33693a1f6c6e156b0c258eee929e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bf0d628281f33693a1f6c6e156b0c258eee929e>`__
 -  Azure CI: use Ubuntu-20.04 image by default
-   `commit <https://pagure.io/freeipa/c/6e1eaad873d69baa9b2d0250d91aaadc7c69c6a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e1eaad873d69baa9b2d0250d91aaadc7c69c6a5>`__
 -  ipa-acme-manage: user a cookie created for the communication with
    dogtag REST endpoints
-   `commit <https://pagure.io/freeipa/c/935a46158251d52b16f6e0f531a8851778795c67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/935a46158251d52b16f6e0f531a8851778795c67>`__
    `#8584 <https://pagure.io/freeipa/issue/8584>`__
 -  ipa-otpd: fix gcc complaints in Rawhide
-   `commit <https://pagure.io/freeipa/c/b36f224892152af786e69bb166497e6fd9c44cd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36f224892152af786e69bb166497e6fd9c44cd6>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-sam: fix gcc complaints on Rawhide
-   `commit <https://pagure.io/freeipa/c/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-kdb: fix gcc complaints in kdb tests
-   `commit <https://pagure.io/freeipa/c/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-kdb: fix gcc complaints
-   `commit <https://pagure.io/freeipa/c/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  wgi/plugins.py: ignore empty plugin directories
-   `commit <https://pagure.io/freeipa/c/91706690e0c894864c93716c4fbecb285722e77d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91706690e0c894864c93716c4fbecb285722e77d>`__
    `#8567 <https://pagure.io/freeipa/issue/8567>`__
 -  ipa-kdb: fix crash in MS-PAC cache init code
-   `commit <https://pagure.io/freeipa/c/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
    `#8566 <https://pagure.io/freeipa/issue/8566>`__
 -  rpcserver: fix exception handling for FAST armor failure
-   `commit <https://pagure.io/freeipa/c/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
 -  rpcserver: fallback to non-armored kinit in case of trusted domains
-   `commit <https://pagure.io/freeipa/c/b8b46779dc239cf5b007ad11b5b8c9cf51e34ed0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8b46779dc239cf5b007ad11b5b8c9cf51e34ed0>`__
 -  pylint: remove unused variable
-   `commit <https://pagure.io/freeipa/c/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
 -  ipa-kdb: support subordinate/superior UPN suffixes
-   `commit <https://pagure.io/freeipa/c/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
    `#8554 <https://pagure.io/freeipa/issue/8554>`__
 -  Pre-populate IP addresses for the name server upgrades
-   `commit <https://pagure.io/freeipa/c/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
    `#8518 <https://pagure.io/freeipa/issue/8518>`__
 -  Specify memory limits as strings for docker compose
-   `commit <https://pagure.io/freeipa/c/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
    `#8494 <https://pagure.io/freeipa/issue/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
-   `commit <https://pagure.io/freeipa/c/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
-   `commit <https://pagure.io/freeipa/c/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
-   `commit <https://pagure.io/freeipa/c/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
    `#8344 <https://pagure.io/freeipa/issue/8344>`__
 -  Add new contributors
-   `commit <https://pagure.io/freeipa/c/11a64478b32985e3c92258aecdd97a28b2351176>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11a64478b32985e3c92258aecdd97a28b2351176>`__
 -  Add alternative email to the mailmap for myself
-   `commit <https://pagure.io/freeipa/c/4fdf69adf288102633bb733620e5009684d134ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fdf69adf288102633bb733620e5009684d134ce>`__
 -  master: update po/ipa.pot
-   `commit <https://pagure.io/freeipa/c/20ece52b9a1cad43c4fa99e37b1748608c9ce926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ece52b9a1cad43c4fa99e37b1748608c9ce926>`__
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
-   `commit <https://pagure.io/freeipa/c/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
    `#8437 <https://pagure.io/freeipa/issue/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
-   `commit <https://pagure.io/freeipa/c/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
-   `commit <https://pagure.io/freeipa/c/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  handle Y2038 in timestamp to datetime conversions
-   `commit <https://pagure.io/freeipa/c/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
    `#8378 <https://pagure.io/freeipa/issue/8378>`__
 -  update list of contributors
-   `commit <https://pagure.io/freeipa/c/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/81f7863b3f294748f6500ecbcf354ab20ef907a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81f7863b3f294748f6500ecbcf354ab20ef907a3>`__
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
-   `commit <https://pagure.io/freeipa/c/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
    `#8357 <https://pagure.io/freeipa/issue/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
-   `commit <https://pagure.io/freeipa/c/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 -  tests: account for ID overrides as members of groups and roles
-   `commit <https://pagure.io/freeipa/c/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  Support adding user ID overrides as group and role members
-   `commit <https://pagure.io/freeipa/c/bee4204039dac9cd858e823b839183ba2cdbd216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bee4204039dac9cd858e823b839183ba2cdbd216>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
-   `commit <https://pagure.io/freeipa/c/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  support using trust-related operations in the server console
-   `commit <https://pagure.io/freeipa/c/ecc0a96d161717960058e22eecad43754de06f11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecc0a96d161717960058e22eecad43754de06f11>`__
 -  Add design page for managing IPA resources as a user from a trusted
    Active Directory forest
-   `commit <https://pagure.io/freeipa/c/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
    `#7816 <https://pagure.io/freeipa/issue/7816>`__,
    `#8357 <https://pagure.io/freeipa/issue/8357>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
-   `commit <https://pagure.io/freeipa/c/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
-   `commit <https://pagure.io/freeipa/c/b9a6027410814832f9228621abd2bbd2acebb944>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9a6027410814832f9228621abd2bbd2acebb944>`__
    `#8362 <https://pagure.io/freeipa/issue/8362>`__
 -  azure: do not run test_commands due to failures in low memory cases
-   `commit <https://pagure.io/freeipa/c/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
 -  test_smb: test S4U2Self operation by IPA service
-   `commit <https://pagure.io/freeipa/c/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
-   `commit <https://pagure.io/freeipa/c/b5876f30d4000424cc8122498c411f812b3a0959>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5876f30d4000424cc8122498c411f812b3a0959>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
-   `commit <https://pagure.io/freeipa/c/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
-   `commit <https://pagure.io/freeipa/c/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
-   `commit <https://pagure.io/freeipa/c/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add asserted identity SIDs
-   `commit <https://pagure.io/freeipa/c/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
-   `commit <https://pagure.io/freeipa/c/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
-   `commit <https://pagure.io/freeipa/c/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
-   `commit <https://pagure.io/freeipa/c/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
-   `commit <https://pagure.io/freeipa/c/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
-   `commit <https://pagure.io/freeipa/c/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
    `#8328 <https://pagure.io/freeipa/issue/8328>`__
 -  service delegation: allow to add and remove host principals
-   `commit <https://pagure.io/freeipa/c/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
    `#8289 <https://pagure.io/freeipa/issue/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
-   `commit <https://pagure.io/freeipa/c/d986e844bbd37ccc7a532175631a55acd315cda3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d986e844bbd37ccc7a532175631a55acd315cda3>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
-   `commit <https://pagure.io/freeipa/c/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
-   `commit <https://pagure.io/freeipa/c/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  Azure Pipelines: switch to Fedora 32
-   `commit <https://pagure.io/freeipa/c/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
 -  Azure Pipelines: Override services known to not work in containers
-   `commit <https://pagure.io/freeipa/c/b8a1d130ad561acd3594c269dffa126f8242bd7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8a1d130ad561acd3594c269dffa126f8242bd7a>`__
 -  Add pytest.skip_if_container()
-   `commit <https://pagure.io/freeipa/c/a009b9e0342ca2633355fb9347855676110d678c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a009b9e0342ca2633355fb9347855676110d678c>`__
 -  CVE-2020-1722: prevent use of too long passwords
-   `commit <https://pagure.io/freeipa/c/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
    `#8268 <https://pagure.io/freeipa/issue/8268>`__
 -  Allow rename of a host group
-   `commit <https://pagure.io/freeipa/c/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
    `#6783 <https://pagure.io/freeipa/issue/6783>`__
 -  Add 'api' and 'aci' targets to make
-   `commit <https://pagure.io/freeipa/c/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
 -  Remove Fedora repository fastmirror selection
-   `commit <https://pagure.io/freeipa/c/77ed0918a7e419baf99527b5b73c9ee0a56c8767>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77ed0918a7e419baf99527b5b73c9ee0a56c8767>`__
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
-   `commit <https://pagure.io/freeipa/c/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
-   `commit <https://pagure.io/freeipa/c/527f30be76f0da6d4453745ace25f64948c0504f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/527f30be76f0da6d4453745ace25f64948c0504f>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
-   `commit <https://pagure.io/freeipa/c/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
-   `commit <https://pagure.io/freeipa/c/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  Fix indentation levels
-   `commit <https://pagure.io/freeipa/c/38204856fd72e5191bae07a47907314aacf43d1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38204856fd72e5191bae07a47907314aacf43d1a>`__
 -  ipatests: always skip additional input for group-add-member
    --external
-   `commit <https://pagure.io/freeipa/c/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  po: update Chinese (China) translation
-   `commit <https://pagure.io/freeipa/c/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
 -  po: update Ukrainian translation
-   `commit <https://pagure.io/freeipa/c/9fcae1590ddb2fd240b200d0960e33323d594acb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fcae1590ddb2fd240b200d0960e33323d594acb>`__
 -  po: update Tajik translation timestamp
-   `commit <https://pagure.io/freeipa/c/e50c2500f440caa59fa78320ed669db9f0a25d10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e50c2500f440caa59fa78320ed669db9f0a25d10>`__
 -  po: update Slovak translation timestamp
-   `commit <https://pagure.io/freeipa/c/ed55c408f8599dd4c0be8261c34930b9c7416171>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed55c408f8599dd4c0be8261c34930b9c7416171>`__
 -  po: update Russian translation
-   `commit <https://pagure.io/freeipa/c/ad3ef9de44f41051fed8f743fb4bc7cf2e896ea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3ef9de44f41051fed8f743fb4bc7cf2e896ea7>`__
 -  po: update Portuguese (Brazil) translation timestamp
-   `commit <https://pagure.io/freeipa/c/45dede73c7106b234f0c1d022bd20260d9c7c7fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45dede73c7106b234f0c1d022bd20260d9c7c7fa>`__
 -  po: update Portuguese translation timestamp
-   `commit <https://pagure.io/freeipa/c/baf1a7217d35c2142953a098f4caf88f181e42b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/baf1a7217d35c2142953a098f4caf88f181e42b0>`__
 -  po: update Polish translation
-   `commit <https://pagure.io/freeipa/c/047c8cc55d0845123160e94c69bf0f4efe47059e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/047c8cc55d0845123160e94c69bf0f4efe47059e>`__
 -  po: update Punjabi translation timestamp
-   `commit <https://pagure.io/freeipa/c/3e636959ff14e454329a6806bf4fe4f560ccf398>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e636959ff14e454329a6806bf4fe4f560ccf398>`__
 -  po: update Dutch translation timestamp
-   `commit <https://pagure.io/freeipa/c/7f3cc11a20ad1705cb62ec0075d1e7ec863fced7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f3cc11a20ad1705cb62ec0075d1e7ec863fced7>`__
 -  po: update Marathi translation timestamp
-   `commit <https://pagure.io/freeipa/c/0c9066e8f3b7b78fb7cf4763fa51919aa6c4965c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c9066e8f3b7b78fb7cf4763fa51919aa6c4965c>`__
 -  po: update Kannada translation timestamp
-   `commit <https://pagure.io/freeipa/c/1c30d18611519aca5244b2315a5d8a3e198eea38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c30d18611519aca5244b2315a5d8a3e198eea38>`__
 -  po: update Japanese translation timestamp
-   `commit <https://pagure.io/freeipa/c/60d69a8755d3f32d6fed70ba541f70e4069e0647>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60d69a8755d3f32d6fed70ba541f70e4069e0647>`__
 -  po: update Indonesian translation timestamp
-   `commit <https://pagure.io/freeipa/c/347d9c78b17176e7677995c2ecbbfc7b13d50dcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/347d9c78b17176e7677995c2ecbbfc7b13d50dcc>`__
 -  po: update Hungarian translation timestamp
-   `commit <https://pagure.io/freeipa/c/f18a4f8dd34134b3c08b1169ba42ebcffa49ac72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f18a4f8dd34134b3c08b1169ba42ebcffa49ac72>`__
 -  po: update Hindi translation timestamp
-   `commit <https://pagure.io/freeipa/c/35c1da8346c1b671b1a1bffa51199324c3947d9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35c1da8346c1b671b1a1bffa51199324c3947d9f>`__
 -  po: update French translation
-   `commit <https://pagure.io/freeipa/c/1a0232a6938c64277c4b8f2cdc35be650da644cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a0232a6938c64277c4b8f2cdc35be650da644cc>`__
 -  po: update Basque translation timestamp
-   `commit <https://pagure.io/freeipa/c/e6574914ade837f1d49579394437dfe720b55b22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6574914ade837f1d49579394437dfe720b55b22>`__
 -  po: update Spanish translation
-   `commit <https://pagure.io/freeipa/c/2859216b4cbb763a25792cffe6204da8edb4a232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2859216b4cbb763a25792cffe6204da8edb4a232>`__
 -  po: update English (United Kingdom) translation timestamp
-   `commit <https://pagure.io/freeipa/c/439c488f04b857cfb83f779e450c34b93f7c38bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/439c488f04b857cfb83f779e450c34b93f7c38bb>`__
 -  po: update German translation
-   `commit <https://pagure.io/freeipa/c/117893f03e4f26044e7b15053e336b8d42b4f180>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/117893f03e4f26044e7b15053e336b8d42b4f180>`__
 -  po: update Czech translation timestamp
-   `commit <https://pagure.io/freeipa/c/68cc049124f2acf66b4fdd4588e1fb25d50a9364>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68cc049124f2acf66b4fdd4588e1fb25d50a9364>`__
 -  po: update Catalan translation timestamp
-   `commit <https://pagure.io/freeipa/c/6cd244da6be890e577bf381c6303363e2a6f237f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cd244da6be890e577bf381c6303363e2a6f237f>`__
 -  po: update Bengali translation timestamp
-   `commit <https://pagure.io/freeipa/c/0be22a6ae71a3261c9e9333a01dc028f55554924>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be22a6ae71a3261c9e9333a01dc028f55554924>`__
 -  po: update ipa.pot template
-   `commit <https://pagure.io/freeipa/c/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
 -  Update translation infrastructure
-   `commit <https://pagure.io/freeipa/c/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Keep ipa.pot translation file in git for weblate
-   `commit <https://pagure.io/freeipa/c/92e36258cee838a378729d06fc4134b5c4428f87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92e36258cee838a378729d06fc4134b5c4428f87>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Do not force any particular sphinx theme
-   `commit <https://pagure.io/freeipa/c/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
 -  Override master document for ReadTheDocs
-   `commit <https://pagure.io/freeipa/c/34b961dc2032f56ccf1f8d905de42649d7ff7d3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34b961dc2032f56ccf1f8d905de42649d7ff7d3e>`__
 -  Move workshop documents to doc/workshop
-   `commit <https://pagure.io/freeipa/c/c6a379c432c7bc1a1a009fdc081db1470562ed8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6a379c432c7bc1a1a009fdc081db1470562ed8d>`__
 -  Add unit 11: Kerberos ticket policy
-   `commit <https://pagure.io/freeipa/c/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
 -  Prevent adding IPA objects as external members of external groups
-   `commit <https://pagure.io/freeipa/c/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
-   `commit <https://pagure.io/freeipa/c/ec73de969f55b7a005b6401029f87fe6a225a417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec73de969f55b7a005b6401029f87fe6a225a417>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Tighten permissions on PKI proxy configuration
-   `commit <https://pagure.io/freeipa/c/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
-   `commit <https://pagure.io/freeipa/c/ba904672a21add3b0ab1808c5640ac786f194aad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba904672a21add3b0ab1808c5640ac786f194aad>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
-   `commit <https://pagure.io/freeipa/c/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
    `#8200 <https://pagure.io/freeipa/issue/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
-   `commit <https://pagure.io/freeipa/c/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
    `#8192 <https://pagure.io/freeipa/issue/8192>`__
 -  Update Azure Pipelines to use Fedora 31
-   `commit <https://pagure.io/freeipa/c/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
 -  install/updates: move external members past schema compat update
-   `commit <https://pagure.io/freeipa/c/ff547a2777d63609faba42101e9802f5e988fa00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff547a2777d63609faba42101e9802f5e988fa00>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Reset per-indicator Kerberos policy
-   `commit <https://pagure.io/freeipa/c/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
    `#8153 <https://pagure.io/freeipa/issue/8153>`__
 -  ipa-client-samba: map domain sid of trust domain properly for display
-   `commit <https://pagure.io/freeipa/c/3d402b69eb484a14944ccc23fcf945963977e348>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d402b69eb484a14944ccc23fcf945963977e348>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
-   `commit <https://pagure.io/freeipa/c/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
-   `commit <https://pagure.io/freeipa/c/e9dd757763c76402e07f533f19e269eeebc554fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9dd757763c76402e07f533f19e269eeebc554fa>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  covscan: free encryption types in case there is an error
-   `commit <https://pagure.io/freeipa/c/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  Add Authentication Indicator Kerberos ticket policy options
-   `commit <https://pagure.io/freeipa/c/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Allow presence of LDAP attribute options
-   `commit <https://pagure.io/freeipa/c/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
-   `commit <https://pagure.io/freeipa/c/ba466a802129cbe61964653fdfddacd5d43f6771>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba466a802129cbe61964653fdfddacd5d43f6771>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/d243c188f26c50a056be5e88554daec6116f5f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d243c188f26c50a056be5e88554daec6116f5f8f>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/d317fd4de7b16dd2f50a360d7f8d2954b975fe1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d317fd4de7b16dd2f50a360d7f8d2954b975fe1e>`__
 -  Add local helpers to handle unixid structure
-   `commit <https://pagure.io/freeipa/c/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
 -  adtrust: add default read_keys permission for TDO objects
-   `commit <https://pagure.io/freeipa/c/0be98884991ff14720dfce428e4f23ebc4a42311>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be98884991ff14720dfce428e4f23ebc4a42311>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  add default access control when migrating trust objects
-   `commit <https://pagure.io/freeipa/c/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  adtrust: avoid using timestamp in klist output
-   `commit <https://pagure.io/freeipa/c/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
    `#8066 <https://pagure.io/freeipa/issue/8066>`__
 -  Mark failing test as xfail for use of python-dns make_ds method
-   `commit <https://pagure.io/freeipa/c/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
-   `commit <https://pagure.io/freeipa/c/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/661804b748bc09b0a619416af896ee83007f9229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/661804b748bc09b0a619416af896ee83007f9229>`__
 -  Add Theodor van Nahl to the Contributors.txt
-   `commit <https://pagure.io/freeipa/c/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
 -  Restore SELinux context for p11-kit config overrides
-   `commit <https://pagure.io/freeipa/c/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
    `#7810 <https://pagure.io/freeipa/issue/7810>`__
 -  Change RA agent certificate profile to caSubsystemCert
-   `commit <https://pagure.io/freeipa/c/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
 -  certmaprule: add negative test for altSecurityIdentities
-   `commit <https://pagure.io/freeipa/c/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__
 -  certmap rules: altSecurityIdentities should only be used for trusted
    domains
-   `commit <https://pagure.io/freeipa/c/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__
 -  Create indexes for altSecurityIdentities and ipaCertmapData
    attributes
-   `commit <https://pagure.io/freeipa/c/725899595f42b607989db96d849e1b4f01de7faa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/725899595f42b607989db96d849e1b4f01de7faa>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__,
    `#7933 <https://pagure.io/freeipa/issue/7933>`__
 -  Add altSecurityIdentities attribute from MS-WSPP schema definition
-   `commit <https://pagure.io/freeipa/c/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__,
    `#7933 <https://pagure.io/freeipa/issue/7933>`__
 -  Use stage and phase attempt counters when saving test artifacts
-   `commit <https://pagure.io/freeipa/c/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
 -  Use any nodejs version instead of forcing a version before nodejs 11
-   `commit <https://pagure.io/freeipa/c/d55c9b6d7f0eefa5648fec5c0fb05ca475acd4fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d55c9b6d7f0eefa5648fec5c0fb05ca475acd4fd>`__
 -  Fix rpmlint errors for Rawhide
-   `commit <https://pagure.io/freeipa/c/5530911f20a7a6d2831c9ce35948d63b226f212f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5530911f20a7a6d2831c9ce35948d63b226f212f>`__
 -  Set git master to 4.9.0
-   `commit <https://pagure.io/freeipa/c/56b1b5ac5b3a2aad9cf005ac9d5c720c2a9fca0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56b1b5ac5b3a2aad9cf005ac9d5c720c2a9fca0e>`__
 -  Changing IPA master back to git snapshots
-   `commit <https://pagure.io/freeipa/c/21a5938a3e6a02b140dd0df64abde63f4df1d777>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21a5938a3e6a02b140dd0df64abde63f4df1d777>`__
 
 
 
@@ -2096,7 +2096,7 @@ Abhijeet (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update workshop.rst
-   `commit <https://pagure.io/freeipa/c/4a48fe3102040d164e9a4247f1b8539ccd8ef295>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a48fe3102040d164e9a4247f1b8539ccd8ef295>`__
 
 
 
@@ -2104,10 +2104,10 @@ Alexandre Mulatinho (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-join: allowing call with jsonrpc into freeipa API
-   `commit <https://pagure.io/freeipa/c/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-scripts: fix all ipa command line scripts to operate with -I
-   `commit <https://pagure.io/freeipa/c/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
    `#7987 <https://pagure.io/freeipa/issue/7987>`__
 
 
@@ -2117,46 +2117,46 @@ Anuja More (18)
 
 -  ipatests: cleanup in
    test_subdomain_lookup_with_certmaprule_containing_dn
-   `commit <https://pagure.io/freeipa/c/ea7b8d66536e388152619c99f8cc83e3fd7e92b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea7b8d66536e388152619c99f8cc83e3fd7e92b8>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/4247fb9c73e940f459ab62dcd32157e6148c319e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4247fb9c73e940f459ab62dcd32157e6148c319e>`__
 -  ipatests : Test to verify override_gid works with subdomain.
-   `commit <https://pagure.io/freeipa/c/0dfb44c3c793623686258794c3c8fc8ec6216e29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dfb44c3c793623686258794c3c8fc8ec6216e29>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/d39786c0514b124f0e11a3fbcfef104d1eccea3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d39786c0514b124f0e11a3fbcfef104d1eccea3b>`__
 -  ipatests: Test that trusted AD users should not lose their AD
    domains.
-   `commit <https://pagure.io/freeipa/c/0cb0056fd6fc3f8665b11a196d8c613926d40a95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cb0056fd6fc3f8665b11a196d8c613926d40a95>`__
 -  Mark test to skip sssd-2.2.2
-   `commit <https://pagure.io/freeipa/c/6018ccaa8dfeccf27494369a8ba9a6c670779e2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6018ccaa8dfeccf27494369a8ba9a6c670779e2e>`__
 -  ipatests: User and group with same name should not break reading AD
    user data.
-   `commit <https://pagure.io/freeipa/c/b2ab2863ca121d94e7519cd53a9fdbb43b6c5d27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2ab2863ca121d94e7519cd53a9fdbb43b6c5d27>`__
 -  ipatests: Added test when 2FA prompting configurations is set.
-   `commit <https://pagure.io/freeipa/c/8007cec855fedc89593b0af92be282aa0e65e5c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8007cec855fedc89593b0af92be282aa0e65e5c6>`__
 -  ipatests: SSSD should fetch external groups without any limit.
-   `commit <https://pagure.io/freeipa/c/87a1d34c3bf1e86ff6ac0fe0a3c26f0709893476>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87a1d34c3bf1e86ff6ac0fe0a3c26f0709893476>`__
 -  Update topology for test_integration/test_sssd.py
-   `commit <https://pagure.io/freeipa/c/0a4bec2a1f2a1fbf6b6b05a5cdbdf5bf08d66344>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a4bec2a1f2a1fbf6b6b05a5cdbdf5bf08d66344>`__
 -  ipatests: Add test for ipa-extdom-extop plugin should allow @ in
    group name
-   `commit <https://pagure.io/freeipa/c/4f09416f2f01cee03213f7d5186fe1a7104e6d66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f09416f2f01cee03213f7d5186fe1a7104e6d66>`__
 -  After mounting "Unspecified GSS failure" should not be in logs.
-   `commit <https://pagure.io/freeipa/c/ab1999deb687f77fcad6c466ab3d472c8417d6ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab1999deb687f77fcad6c466ab3d472c8417d6ee>`__
 -  Add xmlrpc test with input validation check for kerberos ticket
    policy.
-   `commit <https://pagure.io/freeipa/c/f35738ef22aac54c09d64e3a7985298faf9ac1eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f35738ef22aac54c09d64e3a7985298faf9ac1eb>`__
 -  Fix fedora version for xfail for sssd test
-   `commit <https://pagure.io/freeipa/c/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
 -  Add integration test for otp kerberos ticket policy.
-   `commit <https://pagure.io/freeipa/c/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  ipatests: filter_users should be applied correctly.
-   `commit <https://pagure.io/freeipa/c/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
 -  ipatests : Login via ssh using private-key for ipa-user should work.
-   `commit <https://pagure.io/freeipa/c/836b90f65244a0407e74627b550297d0962d882e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/836b90f65244a0407e74627b550297d0962d882e>`__
 -  Extdom plugin should not return error (32)/'No such object'
-   `commit <https://pagure.io/freeipa/c/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -2165,7 +2165,7 @@ Andika Triwidada (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/5915031830125246b51346dddcadc8fc892e1793>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5915031830125246b51346dddcadc8fc892e1793>`__
 
 
 
@@ -2173,7 +2173,7 @@ Ariel O. Barria (1)
 ----------------------------------------------------------------------------------------------
 
 -  vagrant user does not have permission to write to /etc/resolv.conf
-   `commit <https://pagure.io/freeipa/c/2f9c9c8757d3d31860adbee0a68a6466e33643dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f9c9c8757d3d31860adbee0a68a6466e33643dc>`__
 
 
 
@@ -2181,15 +2181,15 @@ Alexander Scheel (4)
 ----------------------------------------------------------------------------------------------
 
 -  Fix spelling mistake: filen ame -> filename
-   `commit <https://pagure.io/freeipa/c/2efc44d00266d844cbac26381eea2340a2c8dfe4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2efc44d00266d844cbac26381eea2340a2c8dfe4>`__
 -  Specify cert_paths when calling PKIConnection
-   `commit <https://pagure.io/freeipa/c/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
    `#8379 <https://pagure.io/freeipa/issue/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
-   `commit <https://pagure.io/freeipa/c/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
    `#8372 <https://pagure.io/freeipa/issue/8372>`__
 -  Clarify AJP connector creation process
-   `commit <https://pagure.io/freeipa/c/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
 
 
 
@@ -2197,7 +2197,7 @@ Antonio Torres Moríñigo (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-client-install manpage: add ipa.p11-kit to list of files created
-   `commit <https://pagure.io/freeipa/c/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
    `#8424 <https://pagure.io/freeipa/issue/8424>`__
 
 
@@ -2206,103 +2206,103 @@ Peter Keresztes Schmidt (33)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Unify adapter property definition for state evaluators
-   `commit <https://pagure.io/freeipa/c/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
-   `commit <https://pagure.io/freeipa/c/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  ipa-backup/restore: remove remaining chdir calls
-   `commit <https://pagure.io/freeipa/c/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
    `#7416 <https://pagure.io/freeipa/issue/7416>`__
 -  ipa-join: handle JSON-RPC error codes
-   `commit <https://pagure.io/freeipa/c/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
    `#8408 <https://pagure.io/freeipa/issue/8408>`__
 -  ipa-join: extract common JSON-RPC response parsing to common function
-   `commit <https://pagure.io/freeipa/c/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
    `#8408 <https://pagure.io/freeipa/issue/8408>`__
 -  ipa-join: Generalize XML-RPC references in man page
-   `commit <https://pagure.io/freeipa/c/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: Use bool type where appropriate
-   `commit <https://pagure.io/freeipa/c/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: select {JSON,XML}-RPC at build time
-   `commit <https://pagure.io/freeipa/c/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: implement JSON-RPC based unenrollment
-   `commit <https://pagure.io/freeipa/c/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: extract unenrollment code common to JSON and XML-RPC to
    separate function
-   `commit <https://pagure.io/freeipa/c/677659c8da27de7b256b7067e513f089892d05b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/677659c8da27de7b256b7067e513f089892d05b8>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: switch to jansson for json handling
-   `commit <https://pagure.io/freeipa/c/25205f44a10b9e4846121d1a9b05aafa74485292>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25205f44a10b9e4846121d1a9b05aafa74485292>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: buffer curl response before parsing json
-   `commit <https://pagure.io/freeipa/c/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: improve curl error handling in JSON-RPC code
-   `commit <https://pagure.io/freeipa/c/c197918e8d220f10676f42b3589e47599b7a11e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c197918e8d220f10676f42b3589e47599b7a11e5>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: don't set TLS related curl options for JSON-RPC
-   `commit <https://pagure.io/freeipa/c/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  Populate nshardwareplatform and nsosversion during join operation
-   `commit <https://pagure.io/freeipa/c/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
    `#8370 <https://pagure.io/freeipa/issue/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
-   `commit <https://pagure.io/freeipa/c/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
    `#8396 <https://pagure.io/freeipa/issue/8396>`__
 -  Unify spelling of "One-Time Password"
-   `commit <https://pagure.io/freeipa/c/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
 -  WebUI: reword OTP info message displayed during PW reset
-   `commit <https://pagure.io/freeipa/c/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
-   `commit <https://pagure.io/freeipa/c/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 -  Split named custom config to allow changes in options stanza
-   `commit <https://pagure.io/freeipa/c/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
    `#8287 <https://pagure.io/freeipa/issue/8287>`__
 -  lite-server: Fix werkzeug deprecation warnings
-   `commit <https://pagure.io/freeipa/c/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
    `#8360 <https://pagure.io/freeipa/issue/8360>`__
 -  util: replace NSS usage with OpenSSL
-   `commit <https://pagure.io/freeipa/c/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  util: add unit test for pw hashing
-   `commit <https://pagure.io/freeipa/c/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  po: remove zanata config since translation was moved to weblate
-   `commit <https://pagure.io/freeipa/c/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Remove unused support for dm_password arg from ldapupdate.connect
-   `commit <https://pagure.io/freeipa/c/0f232a30116751f38722c65ae607c6e6958c8061>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f232a30116751f38722c65ae607c6e6958c8061>`__
    `#7610 <https://pagure.io/freeipa/issue/7610>`__
 -  Use ipaldap exceptions rather than ldap error codes in LDAP updater
-   `commit <https://pagure.io/freeipa/c/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
    `#7610 <https://pagure.io/freeipa/issue/7610>`__
 -  Specify min and max values for TTL of a DNS record
-   `commit <https://pagure.io/freeipa/c/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
    `#8358 <https://pagure.io/freeipa/issue/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
-   `commit <https://pagure.io/freeipa/c/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
 -  WebUI: Expose TTL of DNS records
-   `commit <https://pagure.io/freeipa/c/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
    `#3827 <https://pagure.io/freeipa/issue/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
-   `commit <https://pagure.io/freeipa/c/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
    `#8359 <https://pagure.io/freeipa/issue/8359>`__
 -  WebUI: Use data adapter to load facet header data
-   `commit <https://pagure.io/freeipa/c/517c7ab2153e701355732bc8d49076653e090a01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/517c7ab2153e701355732bc8d49076653e090a01>`__
    `#8339 <https://pagure.io/freeipa/issue/8339>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
-   `commit <https://pagure.io/freeipa/c/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
    `#8338 <https://pagure.io/freeipa/issue/8338>`__
 -  Remove remains of unused config options
-   `commit <https://pagure.io/freeipa/c/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
    `#6708 <https://pagure.io/freeipa/issue/6708>`__
 
 
@@ -2311,7 +2311,7 @@ Carl George (1)
 ----------------------------------------------------------------------------------------------
 
 -  Use uglifyjs on CentOS too
-   `commit <https://pagure.io/freeipa/c/2244a7a2922176c6930a23261883d53c5e0b9c49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2244a7a2922176c6930a23261883d53c5e0b9c49>`__
 
 
 
@@ -2319,490 +2319,490 @@ Christian Heimes (182)
 ----------------------------------------------------------------------------------------------
 
 -  Change mkdir logic in DNSSEC
-   `commit <https://pagure.io/freeipa/c/f3a1b4af001bf843fbb07bad0b2b8cc37c49fa66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3a1b4af001bf843fbb07bad0b2b8cc37c49fa66>`__
 -  Easier to use ipa_gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/727a2ffb9336a050c26c790989edaf41864c6911>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/727a2ffb9336a050c26c790989edaf41864c6911>`__
 -  Update debug strings to reflect new calls
-   `commit <https://pagure.io/freeipa/c/3d796a7e5102eded524e4847f8f9dd26f508ae94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d796a7e5102eded524e4847f8f9dd26f508ae94>`__
 -  Remove problematic optimization from gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
 -  Replace nodename with ipa_gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  Unify access to FQDN
-   `commit <https://pagure.io/freeipa/c/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  Reuse main LDAP connection
-   `commit <https://pagure.io/freeipa/c/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Speed up cainstance.migrate_profiles_to_ldap
-   `commit <https://pagure.io/freeipa/c/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__,
    `#8522 <https://pagure.io/freeipa/issue/8522>`__
 -  Lookup ipa-ca record with NSS
-   `commit <https://pagure.io/freeipa/c/731c5b211041ee18940082b29e6a21b3f084fc57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/731c5b211041ee18940082b29e6a21b3f084fc57>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__,
    `#8521 <https://pagure.io/freeipa/issue/8521>`__,
    `#8529 <https://pagure.io/freeipa/issue/8529>`__
 -  Simplify update code
-   `commit <https://pagure.io/freeipa/c/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Don't add 127.0.0.1 to resolv.conf twice
-   `commit <https://pagure.io/freeipa/c/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Require(post) systemd with resolved enabled on F33
-   `commit <https://pagure.io/freeipa/c/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Replace sudo with runuser
-   `commit <https://pagure.io/freeipa/c/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  Use separate install logs for AD and DNS instance
-   `commit <https://pagure.io/freeipa/c/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
    `#8528 <https://pagure.io/freeipa/issue/8528>`__
 -  Spawn PKI: Execute more steps early
-   `commit <https://pagure.io/freeipa/c/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Dogtag: Remove set_audit_renewal step
-   `commit <https://pagure.io/freeipa/c/8882680ee167c535e7539fe0452892aae617aac3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8882680ee167c535e7539fe0452892aae617aac3>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Skip offline dse.ldif patching by default
-   `commit <https://pagure.io/freeipa/c/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Remove magic sleep from create_index_task
-   `commit <https://pagure.io/freeipa/c/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Remove root-autobind configuration
-   `commit <https://pagure.io/freeipa/c/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Verify freeipa-selinux's ipa module is loaded
-   `commit <https://pagure.io/freeipa/c/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
 -  Check ca_wrapped in ipa-custodia-check
-   `commit <https://pagure.io/freeipa/c/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  Retry chronyc waitsync only once
-   `commit <https://pagure.io/freeipa/c/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  configure_dns_resolver: call self.restore_context
-   `commit <https://pagure.io/freeipa/c/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
    `#8518 <https://pagure.io/freeipa/issue/8518>`__
 -  Drop unused extended sleep feature from Sleeper
-   `commit <https://pagure.io/freeipa/c/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Faster certmonger wait_for_request()
-   `commit <https://pagure.io/freeipa/c/b79191f7107fbc1890631f4c65be48b646798131>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b79191f7107fbc1890631f4c65be48b646798131>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Add helper for poll/sleep loops with timeout
-   `commit <https://pagure.io/freeipa/c/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Add missing fedora_container platform members
-   `commit <https://pagure.io/freeipa/c/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
    `#8519 <https://pagure.io/freeipa/issue/8519>`__
 -  Add more indices
-   `commit <https://pagure.io/freeipa/c/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
 -  Use single update LDIF for indices
-   `commit <https://pagure.io/freeipa/c/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
    `#8493 <https://pagure.io/freeipa/issue/8493>`__
 -  Also backup DNS config drop-ins
-   `commit <https://pagure.io/freeipa/c/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Ensure that resolved.conf.d is accessible
-   `commit <https://pagure.io/freeipa/c/34e47778b47748e94792455699b35e8c126c5db7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34e47778b47748e94792455699b35e8c126c5db7>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Fix compiler warning in ipa-kdb
-   `commit <https://pagure.io/freeipa/c/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
 -  Fix compiler warnings in libotp
-   `commit <https://pagure.io/freeipa/c/7de2c9bc82c5ffb5ab68adbf13a130aac009ff11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de2c9bc82c5ffb5ab68adbf13a130aac009ff11>`__
 -  Fix compiler warning in ipa-pwd-extop
-   `commit <https://pagure.io/freeipa/c/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
 -  trust-add: Catch correct exception when chown SSSD
-   `commit <https://pagure.io/freeipa/c/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
    `#8516 <https://pagure.io/freeipa/issue/8516>`__
 -  Fix nsslapd-db-lock tuning of BDB backend
-   `commit <https://pagure.io/freeipa/c/69ebe41525116639ec512205319197dd278e15e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ebe41525116639ec512205319197dd278e15e6>`__
    `#5914 <https://pagure.io/freeipa/issue/5914>`__,
    `#8515 <https://pagure.io/freeipa/issue/8515>`__
 -  Create systemd-resolved configuration on update
-   `commit <https://pagure.io/freeipa/c/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
 -  Configure systemd-resolved to use IPA's BIND
-   `commit <https://pagure.io/freeipa/c/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Use new API for auto-forwarders
-   `commit <https://pagure.io/freeipa/c/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Configure NetworkManager to use systemd-resolved
-   `commit <https://pagure.io/freeipa/c/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Add helpers for resolve1 and nameservers
-   `commit <https://pagure.io/freeipa/c/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Make git a build requirement
-   `commit <https://pagure.io/freeipa/c/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
 -  Delay import of psutil to avoid AVC
-   `commit <https://pagure.io/freeipa/c/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
    `#8512 <https://pagure.io/freeipa/issue/8512>`__
 -  Add User and Group to all ipaplatform.constants
-   `commit <https://pagure.io/freeipa/c/bc128cae471dae6e070953333d5d76f211aa7688>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc128cae471dae6e070953333d5d76f211aa7688>`__
 -  Use new classes for run_command and Service
-   `commit <https://pagure.io/freeipa/c/b19d20e2db9441334ef412dcdefa06bd5c790216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b19d20e2db9441334ef412dcdefa06bd5c790216>`__
 -  Add user and group wrappers
-   `commit <https://pagure.io/freeipa/c/72fb4e60c8d8eec854b4986e00037ff3a85e4389>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72fb4e60c8d8eec854b4986e00037ff3a85e4389>`__
 -  Simplify LDAPUpdater
-   `commit <https://pagure.io/freeipa/c/99a40cbbe95b629ccfd49cb3c809889731148779>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a40cbbe95b629ccfd49cb3c809889731148779>`__
 -  Add ldap_update() helper to service class
-   `commit <https://pagure.io/freeipa/c/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
 -  Don't create DS SSCA and self-signed cert
-   `commit <https://pagure.io/freeipa/c/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
    `#8502 <https://pagure.io/freeipa/issue/8502>`__
 -  Duplicate CA CRT: ignore expected cert
-   `commit <https://pagure.io/freeipa/c/b606fa6cca87706730fa20bfa437956194398c82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b606fa6cca87706730fa20bfa437956194398c82>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Add krbPrincipalName pres index correctly
-   `commit <https://pagure.io/freeipa/c/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  Only restart DS when duplicate cacrt was found
-   `commit <https://pagure.io/freeipa/c/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Treat container subplatforms like main platform
-   `commit <https://pagure.io/freeipa/c/e89b40071356b1c3050accee54f8332531d9bac2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e89b40071356b1c3050accee54f8332531d9bac2>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Don't configure authselect in containers
-   `commit <https://pagure.io/freeipa/c/999485909a0bc654570f05cd2127d86d14d6f25a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999485909a0bc654570f05cd2127d86d14d6f25a>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
-   `commit <https://pagure.io/freeipa/c/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Explicitly pass keytab to ipa-join
-   `commit <https://pagure.io/freeipa/c/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
 -  Write state dir to smb.conf
-   `commit <https://pagure.io/freeipa/c/64b20aad283c6a0a9557e77993b09679a72efa88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64b20aad283c6a0a9557e77993b09679a72efa88>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
-   `commit <https://pagure.io/freeipa/c/02986ff42b97dceb689abb32cf937da993880ddd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02986ff42b97dceb689abb32cf937da993880ddd>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Allow to override ipaplatform with env var
-   `commit <https://pagure.io/freeipa/c/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Teach pylint how dnspython 2.x works
-   `commit <https://pagure.io/freeipa/c/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
    `#8419 <https://pagure.io/freeipa/issue/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
-   `commit <https://pagure.io/freeipa/c/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
    `#8412 <https://pagure.io/freeipa/issue/8412>`__
 -  Make tab completion in console more useful
-   `commit <https://pagure.io/freeipa/c/80794f6b5e263566a1da9685aba82762208a6219>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80794f6b5e263566a1da9685aba82762208a6219>`__
 -  Add \__signature_\_ to plugins
-   `commit <https://pagure.io/freeipa/c/069f41a01e65f07367000c6d9605167242a88736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/069f41a01e65f07367000c6d9605167242a88736>`__
    `#8388 <https://pagure.io/freeipa/issue/8388>`__
 -  Run test_fips in DS and PKI nightly
-   `commit <https://pagure.io/freeipa/c/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
 -  SELinux: Backport dirsrv_systemctl interface
-   `commit <https://pagure.io/freeipa/c/b56fa015280f98d20f883b4799a91ada49413fbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b56fa015280f98d20f883b4799a91ada49413fbc>`__
 -  RHEL 8.3 has KRB5 1.18 with KDB 8.0
-   `commit <https://pagure.io/freeipa/c/1144da5d94aa75e882929e136d7d322dc4a93732>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1144da5d94aa75e882929e136d7d322dc4a93732>`__
 -  Terminology improvements: use block list
-   `commit <https://pagure.io/freeipa/c/3ec1b77f6a03886936299a9d34ed8fd640c3984d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ec1b77f6a03886936299a9d34ed8fd640c3984d>`__
 -  Terminology improvements: use allow list
-   `commit <https://pagure.io/freeipa/c/3ce816ba772ffae6b0bd05e4589727513fa76e3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ce816ba772ffae6b0bd05e4589727513fa76e3c>`__
 -  Grammar: whitespace is a word
-   `commit <https://pagure.io/freeipa/c/5c09dcdb981df7837ac1bb75547d23fc7d8946d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c09dcdb981df7837ac1bb75547d23fc7d8946d0>`__
 -  Terminology improvements: CA renewal
-   `commit <https://pagure.io/freeipa/c/523f70ae46127161556a0881fc9a01e138a90666>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/523f70ae46127161556a0881fc9a01e138a90666>`__
 -  Use old uglifyjs on RHEL 8
-   `commit <https://pagure.io/freeipa/c/6e3346f0a7d820cb3643044884657fa60a80f918>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e3346f0a7d820cb3643044884657fa60a80f918>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  Build ipa-selinux package on RHEL 8
-   `commit <https://pagure.io/freeipa/c/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
 -  Prevent local account takeover
-   `commit <https://pagure.io/freeipa/c/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
    `#8326 <https://pagure.io/freeipa/issue/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
-   `commit <https://pagure.io/freeipa/c/a18d406b5631f80134e202ae3310580683937f92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a18d406b5631f80134e202ae3310580683937f92>`__
    `#8367 <https://pagure.io/freeipa/issue/8367>`__
 -  Auto-generated ipa-epn files to gitignore
-   `commit <https://pagure.io/freeipa/c/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
 -  Overhaul bind upgrade process
-   `commit <https://pagure.io/freeipa/c/f52a15b808aa4d827c1f77f807611d49c9563d03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f52a15b808aa4d827c1f77f807611d49c9563d03>`__
 -  More upgrade tests
-   `commit <https://pagure.io/freeipa/c/43dd1e8a65826898ebcf2351cd248b876c625ed1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43dd1e8a65826898ebcf2351cd248b876c625ed1>`__
 -  Fix named.conf named_conf_include_re
-   `commit <https://pagure.io/freeipa/c/996a220900502ed5b6450af14c271e4f344f8cf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/996a220900502ed5b6450af14c271e4f344f8cf6>`__
 -  Remove named_validate_dnssec update step
-   `commit <https://pagure.io/freeipa/c/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
-   `commit <https://pagure.io/freeipa/c/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
    `#8363 <https://pagure.io/freeipa/issue/8363>`__
 -  libotp: Replace NSS with OpenSSL HMAC
-   `commit <https://pagure.io/freeipa/c/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  Include named config files in backup
-   `commit <https://pagure.io/freeipa/c/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
 -  Handle DatabaseError in RPC-Server connect()
-   `commit <https://pagure.io/freeipa/c/d79a7a9696ff634141bdff3423157d08513da310>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d79a7a9696ff634141bdff3423157d08513da310>`__
    `#8352 <https://pagure.io/freeipa/issue/8352>`__
 -  Allow permissions with 'self' bindruletype
-   `commit <https://pagure.io/freeipa/c/9dda004f270f321685597be276ca51e6b32fcd59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dda004f270f321685597be276ca51e6b32fcd59>`__
    `#8348 <https://pagure.io/freeipa/issue/8348>`__
 -  make: serialize strip-po / strip-pot
-   `commit <https://pagure.io/freeipa/c/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
    `#8323 <https://pagure.io/freeipa/issue/8323>`__
 -  Remove obsolete BIND named.conf options
-   `commit <https://pagure.io/freeipa/c/f5964b71572579acad9d1731b62eb3c088358c6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5964b71572579acad9d1731b62eb3c088358c6f>`__
    `#8349 <https://pagure.io/freeipa/issue/8349>`__,
    `#8350 <https://pagure.io/freeipa/issue/8350>`__
 -  Add ipa-print-pac to gitignore
-   `commit <https://pagure.io/freeipa/c/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
 -  Allow dnsrecord-add --force on clients
-   `commit <https://pagure.io/freeipa/c/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Explain the effect of OPT_X_TLS_PROTOCOL_MIN
-   `commit <https://pagure.io/freeipa/c/f3e117156436bbf715232bea730a9172c14a8c1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3e117156436bbf715232bea730a9172c14a8c1f>`__
 -  Check for freeipa-server-dns package early
-   `commit <https://pagure.io/freeipa/c/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
    `#7577 <https://pagure.io/freeipa/issue/7577>`__
 -  Hard-code in_tree=True for tests
-   `commit <https://pagure.io/freeipa/c/0fa31ef123a544378f04a2177524c9f72181a812>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa31ef123a544378f04a2177524c9f72181a812>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Fix detection logic for api.env.in_tree
-   `commit <https://pagure.io/freeipa/c/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
    `#8312 <https://pagure.io/freeipa/issue/8312>`__
 -  Make api.env.mode consistent
-   `commit <https://pagure.io/freeipa/c/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
    `#8313 <https://pagure.io/freeipa/issue/8313>`__
 -  Disable password schema update on LDAP bind
-   `commit <https://pagure.io/freeipa/c/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
    `#8315 <https://pagure.io/freeipa/issue/8315>`__
 -  Use httpd 2.4 syntax for access control
-   `commit <https://pagure.io/freeipa/c/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
 -  Let GH auto-notify and auto-close stale PRs
-   `commit <https://pagure.io/freeipa/c/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
 -  Fix make devcheck
-   `commit <https://pagure.io/freeipa/c/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
    `#8307 <https://pagure.io/freeipa/issue/8307>`__
 -  Simplify pki proxy conf
-   `commit <https://pagure.io/freeipa/c/19ea1b97a1559609014e0784c6f973c0e073878a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19ea1b97a1559609014e0784c6f973c0e073878a>`__
 -  Make check_required_principal() case-insensitive
-   `commit <https://pagure.io/freeipa/c/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
    `#8308 <https://pagure.io/freeipa/issue/8308>`__
 -  Make ipaplatform a regular top-level package
-   `commit <https://pagure.io/freeipa/c/490682ac3cab8978635655bdcc880f28227e900b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/490682ac3cab8978635655bdcc880f28227e900b>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__,
    `#8309 <https://pagure.io/freeipa/issue/8309>`__
 -  Reconfigure pycodestyle
-   `commit <https://pagure.io/freeipa/c/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Manually reformat ipapython/version.py.in
-   `commit <https://pagure.io/freeipa/c/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Silence W601 .has_key() is deprecated
-   `commit <https://pagure.io/freeipa/c/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E722 do not use bare 'except'
-   `commit <https://pagure.io/freeipa/c/186d739d7f54989e9ed6ea08371825b29f21b811>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/186d739d7f54989e9ed6ea08371825b29f21b811>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
-   `commit <https://pagure.io/freeipa/c/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E714 test for object identity should be 'is not'
-   `commit <https://pagure.io/freeipa/c/8c9bba8e1ad1def3745497de24b14786148a64af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c9bba8e1ad1def3745497de24b14786148a64af>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E713 test for membership should be 'not in'
-   `commit <https://pagure.io/freeipa/c/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E712 comparison to True / False
-   `commit <https://pagure.io/freeipa/c/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E711 comparison to None
-   `commit <https://pagure.io/freeipa/c/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E266 too many leading '#' for block comment
-   `commit <https://pagure.io/freeipa/c/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Address issues found by new pylint 2.5.0
-   `commit <https://pagure.io/freeipa/c/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
    `#8297 <https://pagure.io/freeipa/issue/8297>`__
 -  Require Sphinx >2.1
-   `commit <https://pagure.io/freeipa/c/b7415c3ddcdbd826bc25761d78840c4417381571>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7415c3ddcdbd826bc25761d78840c4417381571>`__
 -  Fix /doc/workshop subtree merge
-   `commit <https://pagure.io/freeipa/c/d34db063774952814e0cae7e4499c7462ef04687>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d34db063774952814e0cae7e4499c7462ef04687>`__
 -  Create ipasphinx package for Sphinx plugins
-   `commit <https://pagure.io/freeipa/c/e00dc40feadf7be9d5b1aec995d59cadb83b5b92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e00dc40feadf7be9d5b1aec995d59cadb83b5b92>`__
 -  Add skip_if_platform marker
-   `commit <https://pagure.io/freeipa/c/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
 -  Define default password policy for sysaccounts
-   `commit <https://pagure.io/freeipa/c/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Use api.env.container_sysaccounts
-   `commit <https://pagure.io/freeipa/c/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Fix exception escape warning
-   `commit <https://pagure.io/freeipa/c/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
 -  Fix APIVersion.__getnewargs_\_
-   `commit <https://pagure.io/freeipa/c/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
 -  servrole: takes_params must be a tuple
-   `commit <https://pagure.io/freeipa/c/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
    `#8290 <https://pagure.io/freeipa/issue/8290>`__
 -  Improve Sphinx building and linting
-   `commit <https://pagure.io/freeipa/c/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
 -  Fix various OpenDNSSEC 2.1 issues
-   `commit <https://pagure.io/freeipa/c/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
    `#8283 <https://pagure.io/freeipa/issue/8283>`__
 -  Use /run and /run/lock instead of /var
-   `commit <https://pagure.io/freeipa/c/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
    `#8272 <https://pagure.io/freeipa/issue/8272>`__
 -  po: fix LINGUAS to use whitespace separation
-   `commit <https://pagure.io/freeipa/c/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  SELinux: apache_manage_pid_files for F30
-   `commit <https://pagure.io/freeipa/c/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
    `#8241 <https://pagure.io/freeipa/issue/8241>`__
 -  Add pytest OpenSSH transport with password
-   `commit <https://pagure.io/freeipa/c/e8602b158680a92903b930a9d9a25e9c2c458685>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8602b158680a92903b930a9d9a25e9c2c458685>`__
 -  Add explicit syntax language to code blocks
-   `commit <https://pagure.io/freeipa/c/9f2553c64f06ac496b0063239942443b8f6c435d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f2553c64f06ac496b0063239942443b8f6c435d>`__
 -  Use m2r instead of recommonmark
-   `commit <https://pagure.io/freeipa/c/a9a225d7153474331933213db0ee8cf8470e5020>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9a225d7153474331933213db0ee8cf8470e5020>`__
 -  Include workshop in sphinx build
-   `commit <https://pagure.io/freeipa/c/145afd68e504a817a87448395c206be89cac6d22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/145afd68e504a817a87448395c206be89cac6d22>`__
 -  Fix codestyle
-   `commit <https://pagure.io/freeipa/c/c4a55522eed2165d550f6f1c93bb20e902348149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4a55522eed2165d550f6f1c93bb20e902348149>`__
 -  Test documentation builds in Azure
-   `commit <https://pagure.io/freeipa/c/a4efb3028b933e0dce1da907c6a6f1a30ce41269>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4efb3028b933e0dce1da907c6a6f1a30ce41269>`__
 -  Include design documentation
-   `commit <https://pagure.io/freeipa/c/a4456b010a4eeaa3225426a0ade67e1461613d18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4456b010a4eeaa3225426a0ade67e1461613d18>`__
 -  Introduce FreeIPA
-   `commit <https://pagure.io/freeipa/c/d267d43447a00aa96c14c4f8853e0c0793757c2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d267d43447a00aa96c14c4f8853e0c0793757c2c>`__
 -  Bootstrap Sphinx documentation
-   `commit <https://pagure.io/freeipa/c/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
 -  Move freeipa-selinux dependency to freeipa-common
-   `commit <https://pagure.io/freeipa/c/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate ipa_custodia policy
-   `commit <https://pagure.io/freeipa/c/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Allow hosts to read DNS records for IP SAN
-   `commit <https://pagure.io/freeipa/c/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
    `#8098 <https://pagure.io/freeipa/issue/8098>`__
 -  Cleanup SELinux policy
-   `commit <https://pagure.io/freeipa/c/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate SELinux policy into build system
-   `commit <https://pagure.io/freeipa/c/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
 -  dnsrecord: Treat empty list arguments correctly
-   `commit <https://pagure.io/freeipa/c/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
    `#8196 <https://pagure.io/freeipa/issue/8196>`__
 -  Remove dependency on custodia package
-   `commit <https://pagure.io/freeipa/c/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
 -  lite-setup: configure lite-server test env
-   `commit <https://pagure.io/freeipa/c/e9ae7c4b898e570440245714cf20f03d8ee35159>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9ae7c4b898e570440245714cf20f03d8ee35159>`__
 -  Add tracemalloc support to profile memory usage
-   `commit <https://pagure.io/freeipa/c/0a55e82d916b38472bd38032946ea9b249a765f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a55e82d916b38472bd38032946ea9b249a765f2>`__
 -  Make assert_error compatible with Python 3.6
-   `commit <https://pagure.io/freeipa/c/10b62ad6bc967e022202d657b7493440fb5cf736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10b62ad6bc967e022202d657b7493440fb5cf736>`__
    `#8179 <https://pagure.io/freeipa/issue/8179>`__
 -  Print LDAP diagnostic messages on error
-   `commit <https://pagure.io/freeipa/c/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
 -  Fix get_trusted_domain_object_from_sid()
-   `commit <https://pagure.io/freeipa/c/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
    `#7958 <https://pagure.io/freeipa/issue/7958>`__
 -  Check valid before/after of external certs
-   `commit <https://pagure.io/freeipa/c/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix service ldap_disable()
-   `commit <https://pagure.io/freeipa/c/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
    `#8143 <https://pagure.io/freeipa/issue/8143>`__
 -  Require idstart to be larger than UID_MAX
-   `commit <https://pagure.io/freeipa/c/44b3791bc3a14ede0708538347954871df6496fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44b3791bc3a14ede0708538347954871df6496fa>`__
    `#8137 <https://pagure.io/freeipa/issue/8137>`__
 -  Fix lite-server to work with GSS_NAME
-   `commit <https://pagure.io/freeipa/c/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
 -  Fix logic of check_client_configuration
-   `commit <https://pagure.io/freeipa/c/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
    `#8133 <https://pagure.io/freeipa/issue/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
-   `commit <https://pagure.io/freeipa/c/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
    `#8134 <https://pagure.io/freeipa/issue/8134>`__
 -  Don't run test_smb in gating tests
-   `commit <https://pagure.io/freeipa/c/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
 -  Don't hard-code client's TLS versions and ciphers
-   `commit <https://pagure.io/freeipa/c/639bb71940daddd15efb3b4fa922d185235c0b33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/639bb71940daddd15efb3b4fa922d185235c0b33>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
-   `commit <https://pagure.io/freeipa/c/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Enable TLS 1.3 support on the server
-   `commit <https://pagure.io/freeipa/c/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Skip paramiko tests in FIPS mode
-   `commit <https://pagure.io/freeipa/c/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  FIPS: server key has different name in FIPS mode
-   `commit <https://pagure.io/freeipa/c/d153957990b7456d53af5903a0e62b2716f61183>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d153957990b7456d53af5903a0e62b2716f61183>`__
 -  Remove FIPS noise from SSHd
-   `commit <https://pagure.io/freeipa/c/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
 -  Fix otptoken_sync plugin
-   `commit <https://pagure.io/freeipa/c/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Add test case for OTP login
-   `commit <https://pagure.io/freeipa/c/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Show group-add/remove-member-manager failures
-   `commit <https://pagure.io/freeipa/c/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
    `#8122 <https://pagure.io/freeipa/issue/8122>`__
 -  Test installation with (fake) userspace FIPS
-   `commit <https://pagure.io/freeipa/c/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
    `#8118 <https://pagure.io/freeipa/issue/8118>`__
 -  Use default ssh host key algorithms
-   `commit <https://pagure.io/freeipa/c/97a31e69e8399933d45006c744ddafcf036eca5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97a31e69e8399933d45006c744ddafcf036eca5f>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 -  Add tests for member management
-   `commit <https://pagure.io/freeipa/c/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
 -  Add group membership management
-   `commit <https://pagure.io/freeipa/c/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
    `#8114 <https://pagure.io/freeipa/issue/8114>`__
 -  Skip commented lines after substitution
-   `commit <https://pagure.io/freeipa/c/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
    `#8111 <https://pagure.io/freeipa/issue/8111>`__
 -  Block camellia in krbenctypes update in FIPS
-   `commit <https://pagure.io/freeipa/c/bc56642bf9e59821322903e7470be6ec1d857034>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc56642bf9e59821322903e7470be6ec1d857034>`__
    `#8111 <https://pagure.io/freeipa/issue/8111>`__
 -  Don't install a preexec_fn by default
-   `commit <https://pagure.io/freeipa/c/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
 -  Don't create log files from help scripts
-   `commit <https://pagure.io/freeipa/c/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
    `#8075 <https://pagure.io/freeipa/issue/8075>`__
 -  Add new env vars to pylint plugin
-   `commit <https://pagure.io/freeipa/c/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  Fix wrong use of identity operation
-   `commit <https://pagure.io/freeipa/c/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  Enable literal-comparison linter again
-   `commit <https://pagure.io/freeipa/c/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  Replace %{_libdir} macro in BuildRequires
-   `commit <https://pagure.io/freeipa/c/51836c0594d9f97ace8392c03d47aae883b87724>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51836c0594d9f97ace8392c03d47aae883b87724>`__
    `#8056 <https://pagure.io/freeipa/issue/8056>`__
 -  Fix ca_initialize_hsm_state
-   `commit <https://pagure.io/freeipa/c/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__
 -  Store HSM token and state
-   `commit <https://pagure.io/freeipa/c/076d955b9373ad8603f3885ea6841d367f866327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/076d955b9373ad8603f3885ea6841d367f866327>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__
 -  Allow insecure binds for migration
-   `commit <https://pagure.io/freeipa/c/a36556e1064900af7a75ca6f07aba66212cf321a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a36556e1064900af7a75ca6f07aba66212cf321a>`__
    `#8040 <https://pagure.io/freeipa/issue/8040>`__
 -  Don't move keys when key backup is disabled
-   `commit <https://pagure.io/freeipa/c/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
    `#7677 <https://pagure.io/freeipa/issue/7677>`__
 -  Update comments to explain caSubsystemCert switch
-   `commit <https://pagure.io/freeipa/c/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
 -  Test external CA with DNS name constraints
-   `commit <https://pagure.io/freeipa/c/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
 -  Add PKCS#11 module name to p11helper errors
-   `commit <https://pagure.io/freeipa/c/94b4af55b0b4f376e687fae777c51678b99816f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94b4af55b0b4f376e687fae777c51678b99816f3>`__
    `#8015 <https://pagure.io/freeipa/issue/8015>`__
 -  Use nis-domainname.service on all RH platforms
-   `commit <https://pagure.io/freeipa/c/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
    `#8004 <https://pagure.io/freeipa/issue/8004>`__
 
 
@@ -2811,12 +2811,12 @@ Cédric Jeanneret (3)
 ----------------------------------------------------------------------------------------------
 
 -  Update selinux-policy minimal requirement
-   `commit <https://pagure.io/freeipa/c/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
 -  Prevents DNS Amplification Attack and allow to customize named
-   `commit <https://pagure.io/freeipa/c/6c2710446718828e6840ac34ea6fc704ae6790db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c2710446718828e6840ac34ea6fc704ae6790db>`__
    `#8079 <https://pagure.io/freeipa/issue/8079>`__
 -  Add new tip for dependencies
-   `commit <https://pagure.io/freeipa/c/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
 
 
 
@@ -2824,19 +2824,19 @@ Changmin Teng (5)
 ----------------------------------------------------------------------------------------------
 
 -  Add design document
-   `commit <https://pagure.io/freeipa/c/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Modify webUI to adhere to new IPA server API
-   `commit <https://pagure.io/freeipa/c/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Implement user pre-authentication control with kdcpolicy plugin
-   `commit <https://pagure.io/freeipa/c/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Extend the list of supported pre-auth mechanisms in IPA server API
-   `commit <https://pagure.io/freeipa/c/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Add new authentication indicators in kdc.conf.template
-   `commit <https://pagure.io/freeipa/c/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -2845,7 +2845,7 @@ Daniel Lara Souza (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/11828cf87ca3def972839cdec290d0ea91df4733>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11828cf87ca3def972839cdec290d0ea91df4733>`__
 
 
 
@@ -2853,7 +2853,7 @@ Dinesh Prasanth M K (1)
 ----------------------------------------------------------------------------------------------
 
 -  Adding auto COPR builds
-   `commit <https://pagure.io/freeipa/c/df59f09eed698b76a9089614a170c771c9dfb7b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df59f09eed698b76a9089614a170c771c9dfb7b6>`__
 
 
 
@@ -2861,7 +2861,7 @@ Endi Sukma Dewata (1)
 ----------------------------------------------------------------------------------------------
 
 -  Removed hard-coded default profile subsystem class name
-   `commit <https://pagure.io/freeipa/c/edfe95b120edd4794c7d1e1290c99116fac3b194>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edfe95b120edd4794c7d1e1290c99116fac3b194>`__
 
 
 
@@ -2869,7 +2869,7 @@ Emilio Herrera (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/4cc9c942d121e06edfca734b5e69c035dff7c9c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cc9c942d121e06edfca734b5e69c035dff7c9c5>`__
 
 
 
@@ -2877,282 +2877,282 @@ François Cami (97)
 ----------------------------------------------------------------------------------------------
 
 -  set SELinux back to Permissive in gating.xml
-   `commit <https://pagure.io/freeipa/c/6f8e48863549f387658ed82d00a1a1cffc015084>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f8e48863549f387658ed82d00a1a1cffc015084>`__
 -  set SELinux to Enforcing in gating.xml
-   `commit <https://pagure.io/freeipa/c/0b3f87196dedbfb207dccb70893f5c1d466e96f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b3f87196dedbfb207dccb70893f5c1d466e96f7>`__
 -  ipa-client-install: unilaterally set dns_lookup_kdc to True
-   `commit <https://pagure.io/freeipa/c/352f2beeb77b3a08fabc94ccb08d0b561b457408>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/352f2beeb77b3a08fabc94ccb08d0b561b457408>`__
    `#6523 <https://pagure.io/freeipa/issue/6523>`__
 -  ipatests: make sure dns_lookup_kdc is always true
-   `commit <https://pagure.io/freeipa/c/3c965a07f6cca68a039bbaae5d6a54067f5f38c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c965a07f6cca68a039bbaae5d6a54067f5f38c5>`__
    `#6523 <https://pagure.io/freeipa/issue/6523>`__
 -  ipatests: run freeipa-healthcheck on hidden replica
-   `commit <https://pagure.io/freeipa/c/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
    `#8536 <https://pagure.io/freeipa/issue/8536>`__
 -  ipatests: tasks: add user_del
-   `commit <https://pagure.io/freeipa/c/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
    `#8536 <https://pagure.io/freeipa/issue/8536>`__
 -  ipatests: kinit_as_user improvements
-   `commit <https://pagure.io/freeipa/c/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: create_active_user improvements
-   `commit <https://pagure.io/freeipa/c/e0586f33a60a44e340889ec5adea0800bde21592>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0586f33a60a44e340889ec5adea0800bde21592>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: add get_kdcinfo
-   `commit <https://pagure.io/freeipa/c/884e0d36e9f655d0456229d0e259592e65714660>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/884e0d36e9f655d0456229d0e259592e65714660>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: add check_if_sssd_is_online
-   `commit <https://pagure.io/freeipa/c/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
-   `commit <https://pagure.io/freeipa/c/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
    `#8513 <https://pagure.io/freeipa/issue/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
-   `commit <https://pagure.io/freeipa/c/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
-   `commit <https://pagure.io/freeipa/c/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
-   `commit <https://pagure.io/freeipa/c/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
-   `commit <https://pagure.io/freeipa/c/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
-   `commit <https://pagure.io/freeipa/c/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
-   `commit <https://pagure.io/freeipa/c/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
-   `commit <https://pagure.io/freeipa/c/7823da0630379d642f4a19b3ae0c063963041a82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7823da0630379d642f4a19b3ae0c063963041a82>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
-   `commit <https://pagure.io/freeipa/c/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  ipatests: check that pkispawn log is not empty
-   `commit <https://pagure.io/freeipa/c/c31bf3d430763ef5b0ef28510995af48dccde287>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c31bf3d430763ef5b0ef28510995af48dccde287>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  SELinux Policy: let custodia replicate keys
-   `commit <https://pagure.io/freeipa/c/68328299c881df497dab32b145157d6e0e42d6c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68328299c881df497dab32b145157d6e0e42d6c6>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  ipatests: test_epn: update error messages
-   `commit <https://pagure.io/freeipa/c/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  IPA-EPN: enhance input validation
-   `commit <https://pagure.io/freeipa/c/97006786dfed7947aaa96737201ef7e0e53dd952>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97006786dfed7947aaa96737201ef7e0e53dd952>`__
    `#8444 <https://pagure.io/freeipa/issue/8444>`__
 -  IPA-EPN: Fix SMTP connection error handling
-   `commit <https://pagure.io/freeipa/c/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
-   `commit <https://pagure.io/freeipa/c/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  IPA-EPN: fix configuration file typo
-   `commit <https://pagure.io/freeipa/c/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
-   `commit <https://pagure.io/freeipa/c/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
-   `commit <https://pagure.io/freeipa/c/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
-   `commit <https://pagure.io/freeipa/c/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/763d3b059bccc37744764985b57d97554a2a6947>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/763d3b059bccc37744764985b57d97554a2a6947>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
-   `commit <https://pagure.io/freeipa/c/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  tasks: add run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
-   `commit <https://pagure.io/freeipa/c/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
    `#8432 <https://pagure.io/freeipa/issue/8432>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
-   `commit <https://pagure.io/freeipa/c/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
-   `commit <https://pagure.io/freeipa/c/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
    `#8391 <https://pagure.io/freeipa/issue/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
-   `commit <https://pagure.io/freeipa/c/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
-   `commit <https://pagure.io/freeipa/c/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
-   `commit <https://pagure.io/freeipa/c/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
 -  EPN: ship the configuration file.
-   `commit <https://pagure.io/freeipa/c/6efe9917970f81a400793d4339d6826d8350ec55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6efe9917970f81a400793d4339d6826d8350ec55>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
-   `commit <https://pagure.io/freeipa/c/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
    `#8377 <https://pagure.io/freeipa/issue/8377>`__
 -  .mailmap: add fcami
-   `commit <https://pagure.io/freeipa/c/533ec75494127694692a46503e031df51a83f0c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/533ec75494127694692a46503e031df51a83f0c2>`__
 -  IPA-EPN: Test suite.
-   `commit <https://pagure.io/freeipa/c/3805eff4178285f0189c355d17594b5e09dce9b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3805eff4178285f0189c355d17594b5e09dce9b0>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: First version.
-   `commit <https://pagure.io/freeipa/c/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
-   `commit <https://pagure.io/freeipa/c/e7319f628fd70bb7abc77aff1a819326bf52cb5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7319f628fd70bb7abc77aff1a819326bf52cb5c>`__
 -  tox.ini: switch from W503 to W504
-   `commit <https://pagure.io/freeipa/c/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
 -  IPA-EPN: Add design draft
-   `commit <https://pagure.io/freeipa/c/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  doc/Makefile: use sphinx-build -W by default
-   `commit <https://pagure.io/freeipa/c/7558e1413dca240a77893352b5bb62bd21103b46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7558e1413dca240a77893352b5bb62bd21103b46>`__
 -  Makefile.am: add doclint to fastcheck
-   `commit <https://pagure.io/freeipa/c/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
 -  ipatests: increase test_webui_server timeout
-   `commit <https://pagure.io/freeipa/c/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
    `#8266 <https://pagure.io/freeipa/issue/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
-   `commit <https://pagure.io/freeipa/c/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
    `#8262 <https://pagure.io/freeipa/issue/8262>`__
 -  ipatests: move ipa_backup to tasks
-   `commit <https://pagure.io/freeipa/c/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  pr-ci templates: update test_fips timeouts
-   `commit <https://pagure.io/freeipa/c/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
    `#8247 <https://pagure.io/freeipa/issue/8247>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
-   `commit <https://pagure.io/freeipa/c/3665ba928b25c017465588bd505e93d15d72290f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3665ba928b25c017465588bd505e93d15d72290f>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  test_backup_and_restore: add server role verification steps
-   `commit <https://pagure.io/freeipa/c/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
-   `commit <https://pagure.io/freeipa/c/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  pr-ci templates: update test_fips timeouts
-   `commit <https://pagure.io/freeipa/c/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
    `#8247 <https://pagure.io/freeipa/issue/8247>`__
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
-   `commit <https://pagure.io/freeipa/c/f9804558bbe745df1141c84f00be83edcbe06c91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9804558bbe745df1141c84f00be83edcbe06c91>`__
    `#8240 <https://pagure.io/freeipa/issue/8240>`__
 -  8-sudorule.rst: add sudo and su-l as services for bob's HBAC rule.
-   `commit <https://pagure.io/freeipa/c/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
 -  ipa-restore: restart services at the end
-   `commit <https://pagure.io/freeipa/c/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
    `#8226 <https://pagure.io/freeipa/issue/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
-   `commit <https://pagure.io/freeipa/c/5f9d5281848a4de3acd669caa277d1b830722b71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f9d5281848a4de3acd669caa277d1b830722b71>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipa-client-automount: call save_domain() for each change
-   `commit <https://pagure.io/freeipa/c/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
-   `commit <https://pagure.io/freeipa/c/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
-   `commit <https://pagure.io/freeipa/c/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 -  ipatests/test_nfs.py: wait before umount
-   `commit <https://pagure.io/freeipa/c/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
    `#8144 <https://pagure.io/freeipa/issue/8144>`__
 -  ipatests: fix pr-ci templates' indentation
-   `commit <https://pagure.io/freeipa/c/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
-   `commit <https://pagure.io/freeipa/c/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
    `#8148 <https://pagure.io/freeipa/issue/8148>`__
 -  DSU: add Design for Disable Stale Users
-   `commit <https://pagure.io/freeipa/c/438094f868e1a96444e148d9a2481b559cab9a11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/438094f868e1a96444e148d9a2481b559cab9a11>`__
    `#8104 <https://pagure.io/freeipa/issue/8104>`__
 -  ipatests: nightly_f29: disable TestIpaClientAutomountFileRestore
-   `commit <https://pagure.io/freeipa/c/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
    `#8063 <https://pagure.io/freeipa/issue/8063>`__
 -  ipatests: temporarily remove test_smb from gating
-   `commit <https://pagure.io/freeipa/c/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
 -  ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)
-   `commit <https://pagure.io/freeipa/c/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
 -  ipapython/ipachangeconf.py: change "is not 0" for "!= 0"
-   `commit <https://pagure.io/freeipa/c/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  authconfig.py: restore user-nsswitch.conf at uninstall time
-   `commit <https://pagure.io/freeipa/c/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
    `#8054 <https://pagure.io/freeipa/issue/8054>`__
 -  ipatests: remove xfail in TestIpaClientAutomountFileRestore
-   `commit <https://pagure.io/freeipa/c/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
 -  ipa-client-automount: always restore nsswitch.conf at uninstall time
-   `commit <https://pagure.io/freeipa/c/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
    `#8038 <https://pagure.io/freeipa/issue/8038>`__
 -  ipatests: check that ipa-client-automount restores nsswitch.conf at
    uninstall time
-   `commit <https://pagure.io/freeipa/c/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
 -  travis-ci: make dnf invocations more resilient
-   `commit <https://pagure.io/freeipa/c/c709f131712370d567064bb286d32d36f2307e0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c709f131712370d567064bb286d32d36f2307e0f>`__
    `#8048 <https://pagure.io/freeipa/issue/8048>`__
 -  azure-pipelines.yml: switch to Python 3.7
-   `commit <https://pagure.io/freeipa/c/70b96d76cb97b386da27e05d81240f946b206378>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70b96d76cb97b386da27e05d81240f946b206378>`__
    `#8030 <https://pagure.io/freeipa/issue/8030>`__
 -  test_nfs.py: switch to master_3repl
-   `commit <https://pagure.io/freeipa/c/80561224abcdc738a127e1ad70f3966cbb955c66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80561224abcdc738a127e1ad70f3966cbb955c66>`__
    `#8027 <https://pagure.io/freeipa/issue/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
    `#7949 <https://pagure.io/freeipa/issue/7949>`__
 -  prci_definitions: add master_3client topology
-   `commit <https://pagure.io/freeipa/c/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
    `#8026 <https://pagure.io/freeipa/issue/8026>`__
 -  ipapython/admintool.py: use SERVER_NOT_CONFIGURED
-   `commit <https://pagure.io/freeipa/c/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
 -  ipa-client-samba: remove state on uninstall
-   `commit <https://pagure.io/freeipa/c/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
    `#8021 <https://pagure.io/freeipa/issue/8021>`__
 -  ipatests: test ipa-client-samba after --uninstall
-   `commit <https://pagure.io/freeipa/c/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
 -  ipa-client-samba: remove and restore smb.conf only on first uninstall
-   `commit <https://pagure.io/freeipa/c/5b65551b3107e46853afcc4901a60ea6e661a511>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b65551b3107e46853afcc4901a60ea6e661a511>`__
    `#8019 <https://pagure.io/freeipa/issue/8019>`__
 -  ipatests: test multiple invocations of ipa-client-samba --uninstall
-   `commit <https://pagure.io/freeipa/c/68b85703d8ab2ede823d96e317dd106de27b108b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68b85703d8ab2ede823d96e317dd106de27b108b>`__
 -  ipatests/azure: display actual dnf repo URLs
-   `commit <https://pagure.io/freeipa/c/be7f54d40c33d147fdaf0d3cd65b56452a4f001a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7f54d40c33d147fdaf0d3cd65b56452a4f001a>`__
 
 
 
@@ -3160,282 +3160,282 @@ Florence Blanc-Renaud (94)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add test for PKI subsystem detection
-   `commit <https://pagure.io/freeipa/c/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
    `#8596 <https://pagure.io/freeipa/issue/8596>`__
 -  Improve PKI subsystem detection
-   `commit <https://pagure.io/freeipa/c/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
    `#8596 <https://pagure.io/freeipa/issue/8596>`__
 -  xmlrpctests: remove harcoded expiration date from test_user_plugin
-   `commit <https://pagure.io/freeipa/c/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
    `#8616 <https://pagure.io/freeipa/issue/8616>`__
 -  ipatests: fix TestTrust::test_subordinate_suffix
-   `commit <https://pagure.io/freeipa/c/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
    `#8601 <https://pagure.io/freeipa/issue/8601>`__
 -  Always define the path DNSSEC_OPENSSL_CONF
-   `commit <https://pagure.io/freeipa/c/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
    `#8597 <https://pagure.io/freeipa/issue/8597>`__
 -  ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst
    from gating
-   `commit <https://pagure.io/freeipa/c/a33530f2f6cc7933edc537eb5055d4f147741654>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a33530f2f6cc7933edc537eb5055d4f147741654>`__
    `#8496 <https://pagure.io/freeipa/issue/8496>`__
 -  ipatests: ipa-acme-manage status returns 3 on a CA-less server
-   `commit <https://pagure.io/freeipa/c/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
    `#8572 <https://pagure.io/freeipa/issue/8572>`__
 -  ipatests: IPADNSSystemRecordsCheck also checks for AAAA records
-   `commit <https://pagure.io/freeipa/c/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
    `#8573 <https://pagure.io/freeipa/issue/8573>`__
 -  ipatests: curl outputs the cookie in stderr and not in sdtout
-   `commit <https://pagure.io/freeipa/c/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
    `#8559 <https://pagure.io/freeipa/issue/8559>`__
 -  ipatests: properly handle journalctl return code
-   `commit <https://pagure.io/freeipa/c/cb7d09642205cba07ef614065d106f7f84d8921b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb7d09642205cba07ef614065d106f7f84d8921b>`__
    `#8541 <https://pagure.io/freeipa/issue/8541>`__
 -  rpmspec: ensure ipa snippet for sshd is always included
-   `commit <https://pagure.io/freeipa/c/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
    `#8535 <https://pagure.io/freeipa/issue/8535>`__
 -  ipatests: add tests to 389ds regression
-   `commit <https://pagure.io/freeipa/c/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
 -  test_smb: skip test_smb_service_s4u2self for fed31
-   `commit <https://pagure.io/freeipa/c/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
    `#8505 <https://pagure.io/freeipa/issue/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
-   `commit <https://pagure.io/freeipa/c/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
    `#8481 <https://pagure.io/freeipa/issue/8481>`__
 -  ipatests: fix bind service name
-   `commit <https://pagure.io/freeipa/c/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
    `#8482 <https://pagure.io/freeipa/issue/8482>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
-   `commit <https://pagure.io/freeipa/c/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
-   `commit <https://pagure.io/freeipa/c/ec67022af204f1d34bb2da302aa0e3b874812399>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec67022af204f1d34bb2da302aa0e3b874812399>`__
    `#8472 <https://pagure.io/freeipa/issue/8472>`__
 -  ipatests: remove xfail from test_dnssec
-   `commit <https://pagure.io/freeipa/c/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
-   `commit <https://pagure.io/freeipa/c/f2711321679f99be9a8521f07c81e715bad74b06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2711321679f99be9a8521f07c81e715bad74b06>`__
    `#8447 <https://pagure.io/freeipa/issue/8447>`__
 -  ipatests: collect IPA_RENEWAL_LOCK file
-   `commit <https://pagure.io/freeipa/c/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
-   `commit <https://pagure.io/freeipa/c/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
    `#8439 <https://pagure.io/freeipa/issue/8439>`__
 -  ipatests: check KDC cert permissions in CA less install
-   `commit <https://pagure.io/freeipa/c/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  CAless installation: set the perms on KDC cert file
-   `commit <https://pagure.io/freeipa/c/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  ipatests: increase test_trust timeout
-   `commit <https://pagure.io/freeipa/c/0a3c98d236758274a719c2beeca2080df1390594>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a3c98d236758274a719c2beeca2080df1390594>`__
 -  ipatests: fix test_authselect
-   `commit <https://pagure.io/freeipa/c/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
-   `commit <https://pagure.io/freeipa/c/aac570bb4558798ef0b868a88a3b796361c400ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aac570bb4558798ef0b868a88a3b796361c400ba>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
-   `commit <https://pagure.io/freeipa/c/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
-   `commit <https://pagure.io/freeipa/c/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
    `#8414 <https://pagure.io/freeipa/issue/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
-   `commit <https://pagure.io/freeipa/c/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
    `#8413 <https://pagure.io/freeipa/issue/8413>`__
 -  sshd template must be part of client package
-   `commit <https://pagure.io/freeipa/c/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
    `#8400 <https://pagure.io/freeipa/issue/8400>`__
 -  Add test_dnssec to 389ds nightly tests
-   `commit <https://pagure.io/freeipa/c/17cf8edb4073fb1db67e5541409dd28943909750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17cf8edb4073fb1db67e5541409dd28943909750>`__
 -  ipa cert-show: fix the code setting revocation reason
-   `commit <https://pagure.io/freeipa/c/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
    `#8394 <https://pagure.io/freeipa/issue/8394>`__
 -  Bump requires for selinux-policy
-   `commit <https://pagure.io/freeipa/c/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
 -  ipatests: fix the method adding ifp to sssd.conf
-   `commit <https://pagure.io/freeipa/c/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
    `#8371 <https://pagure.io/freeipa/issue/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
-   `commit <https://pagure.io/freeipa/c/dc11b98e4a6650040731405a0e954e20be12afa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc11b98e4a6650040731405a0e954e20be12afa6>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__,
    `#8381 <https://pagure.io/freeipa/issue/8381>`__
 -  client install: fix broken sshd config
-   `commit <https://pagure.io/freeipa/c/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
-   `commit <https://pagure.io/freeipa/c/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipatests: Update the pki-master-f32 image version
-   `commit <https://pagure.io/freeipa/c/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
-   `commit <https://pagure.io/freeipa/c/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
-   `commit <https://pagure.io/freeipa/c/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
-   `commit <https://pagure.io/freeipa/c/14876657794949e8acfeb63e7ccaa512becde7e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14876657794949e8acfeb63e7ccaa512becde7e1>`__
    `#8364 <https://pagure.io/freeipa/issue/8364>`__
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
-   `commit <https://pagure.io/freeipa/c/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
    `#6884 <https://pagure.io/freeipa/issue/6884>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
-   `commit <https://pagure.io/freeipa/c/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
    `#8311 <https://pagure.io/freeipa/issue/8311>`__
 -  Man pages: fix syntax issues
-   `commit <https://pagure.io/freeipa/c/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
    `#8273 <https://pagure.io/freeipa/issue/8273>`__
 -  ipatests: wait for SSSD to become online in backup/restore tests
-   `commit <https://pagure.io/freeipa/c/3753862401b8500b7498d2723ccb727b5dd6263e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3753862401b8500b7498d2723ccb727b5dd6263e>`__
    `#8228 <https://pagure.io/freeipa/issue/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
-   `commit <https://pagure.io/freeipa/c/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  idviews: prevent applying to a master
-   `commit <https://pagure.io/freeipa/c/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  opendnssec2.1 support: move all ods tasks to specific file
-   `commit <https://pagure.io/freeipa/c/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
-   `commit <https://pagure.io/freeipa/c/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
-   `commit <https://pagure.io/freeipa/c/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  With opendnssec 2, read the zone list from file
-   `commit <https://pagure.io/freeipa/c/b857828180c650d7b2db17663a9413323eaef73d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b857828180c650d7b2db17663a9413323eaef73d>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Remove the from opendnssec conf
-   `commit <https://pagure.io/freeipa/c/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support opendnssec 2.1.6
-   `commit <https://pagure.io/freeipa/c/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
-   `commit <https://pagure.io/freeipa/c/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
-   `commit <https://pagure.io/freeipa/c/233a18b2a24d814518a119bd3f1688a0eb361917>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/233a18b2a24d814518a119bd3f1688a0eb361917>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
-   `commit <https://pagure.io/freeipa/c/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
-   `commit <https://pagure.io/freeipa/c/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
-   `commit <https://pagure.io/freeipa/c/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/9eb1be875276c61127663c3860228f03a66ebfbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9eb1be875276c61127663c3860228f03a66ebfbd>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  ipatests: fix modify_sssd_conf()
-   `commit <https://pagure.io/freeipa/c/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
 -  ipatests: update packages for rawhide and updates-testing nightlies
-   `commit <https://pagure.io/freeipa/c/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
 -  ipatests: fix backup and restore
-   `commit <https://pagure.io/freeipa/c/ae140ae40692154ce692c03901f6e17c0e227498>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae140ae40692154ce692c03901f6e17c0e227498>`__
    `#8170 <https://pagure.io/freeipa/issue/8170>`__
 -  AD user without override receive InternalServerError with API
-   `commit <https://pagure.io/freeipa/c/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 -  ipa-cacert-manage man page: fix indentation
-   `commit <https://pagure.io/freeipa/c/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
    `#8138 <https://pagure.io/freeipa/issue/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
-   `commit <https://pagure.io/freeipa/c/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
-   `commit <https://pagure.io/freeipa/c/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
 -  ipatests: fix test_crlgen_manage
-   `commit <https://pagure.io/freeipa/c/b3d650370cfa181a68c7ce332a0013ef2e23ad21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3d650370cfa181a68c7ce332a0013ef2e23ad21>`__
 -  ipatests: fix teardown
-   `commit <https://pagure.io/freeipa/c/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
 -  ipatests: generic uninstall should call ipa server-del
-   `commit <https://pagure.io/freeipa/c/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  Nightly definition: use right template for krbtpolicy
-   `commit <https://pagure.io/freeipa/c/094cf629b338b78d13b15b87b4844c487c150e39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/094cf629b338b78d13b15b87b4844c487c150e39>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  test_ipalib: add test for DNParam class
-   `commit <https://pagure.io/freeipa/c/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  XMLRPCtest: add a test for add-certmapdata with multiple
    subject/issuer
-   `commit <https://pagure.io/freeipa/c/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  DNParam: raise Exception when multiple values provided to a 1-val
    param
-   `commit <https://pagure.io/freeipa/c/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
-   `commit <https://pagure.io/freeipa/c/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
    `#8113 <https://pagure.io/freeipa/issue/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
-   `commit <https://pagure.io/freeipa/c/921f500240fc0861e099a97a2b412e8610eaf198>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/921f500240fc0861e099a97a2b412e8610eaf198>`__
    `#8099 <https://pagure.io/freeipa/issue/8099>`__
 -  ipa-server-certinstall manpage: add missing options
-   `commit <https://pagure.io/freeipa/c/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
    `#8086 <https://pagure.io/freeipa/issue/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
-   `commit <https://pagure.io/freeipa/c/121971a51e6a652f3bc0c8c481a361954bab886e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/121971a51e6a652f3bc0c8c481a361954bab886e>`__
    `#8070 <https://pagure.io/freeipa/issue/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
-   `commit <https://pagure.io/freeipa/c/387ee6e60f398efcdaf91c8097794ed24179150d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/387ee6e60f398efcdaf91c8097794ed24179150d>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
-   `commit <https://pagure.io/freeipa/c/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipatests: fix fedora29 nightly definition
-   `commit <https://pagure.io/freeipa/c/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
 -  replica install: enforce --server arg
-   `commit <https://pagure.io/freeipa/c/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
-   `commit <https://pagure.io/freeipa/c/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
-   `commit <https://pagure.io/freeipa/c/055ea253dfe0182671cba16916840a013daa8b74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/055ea253dfe0182671cba16916840a013daa8b74>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 -  ipatests: enable 389-ds audit log and collect audit file
-   `commit <https://pagure.io/freeipa/c/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
    `#8064 <https://pagure.io/freeipa/issue/8064>`__
 -  ipatests: add nightly definition for DS integration tests
-   `commit <https://pagure.io/freeipa/c/c1af6aa27c6a3c69185507fb99da172526875db3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1af6aa27c6a3c69185507fb99da172526875db3>`__
 -  config plugin: replace 'is 0' with '== 0'
-   `commit <https://pagure.io/freeipa/c/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  ipatests: fix wrong xfail in test_domain_resolution_order
-   `commit <https://pagure.io/freeipa/c/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
    `#8052 <https://pagure.io/freeipa/issue/8052>`__
 -  Nightly test definition: add missing tests
-   `commit <https://pagure.io/freeipa/c/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
 -  xmlrpc test: add test for preserved > stage user
-   `commit <https://pagure.io/freeipa/c/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
-   `commit <https://pagure.io/freeipa/c/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 -  test_xmlrpc: fix
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
-   `commit <https://pagure.io/freeipa/c/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
    `#7902 <https://pagure.io/freeipa/issue/7902>`__
 -  Azure pipeline: report failure in prepare-build step
-   `commit <https://pagure.io/freeipa/c/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
    `#8022 <https://pagure.io/freeipa/issue/8022>`__
 -  upgrade: remove ipaCert and key from /etc/httpd/alias
-   `commit <https://pagure.io/freeipa/c/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
    `#7329 <https://pagure.io/freeipa/issue/7329>`__
 
 
@@ -3444,9 +3444,9 @@ Francisco Trivino (2)
 ----------------------------------------------------------------------------------------------
 
 -  prci: bump template version and fix test_smb gating definition
-   `commit <https://pagure.io/freeipa/c/cd887a48b510fe17ed181d61d4fc69eb978c771d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd887a48b510fe17ed181d61d4fc69eb978c771d>`__
 -  prci: increase gating tasks priority
-   `commit <https://pagure.io/freeipa/c/991d508a5c9ec6b19e9a937864fd24b765dff7f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/991d508a5c9ec6b19e9a937864fd24b765dff7f2>`__
 
 
 
@@ -3454,368 +3454,368 @@ Fraser Tweedale (141)
 ----------------------------------------------------------------------------------------------
 
 -  mailmap: add ftweedal
-   `commit <https://pagure.io/freeipa/c/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
 -  dns: allow PTR records in arbitrary zones
-   `commit <https://pagure.io/freeipa/c/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
    `#5566 <https://pagure.io/freeipa/issue/5566>`__
 -  ipa_sam: do not modify static buffer holding fqdn
-   `commit <https://pagure.io/freeipa/c/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  spec: require pki-acme if pki-ca >= 10.10
-   `commit <https://pagure.io/freeipa/c/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
 -  install: simplify host name verification
-   `commit <https://pagure.io/freeipa/c/9094dfc294ff0fc85e153bd7ae2cdbcbac423c3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9094dfc294ff0fc85e153bd7ae2cdbcbac423c3b>`__
 -  delete unused subroutine get_host_name()
-   `commit <https://pagure.io/freeipa/c/b54d936487202a16031e5fdc23f5dfabde28af58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b54d936487202a16031e5fdc23f5dfabde28af58>`__
 -  certupdate: update config after deployment becomes CA-ful
-   `commit <https://pagure.io/freeipa/c/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  cainstance: extract function import_ra_key
-   `commit <https://pagure.io/freeipa/c/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  cainstance.update_ipa_conf: allow specifying ca_host
-   `commit <https://pagure.io/freeipa/c/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  acme: delete ACME RA account on server uninstall
-   `commit <https://pagure.io/freeipa/c/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: enable mod_md tests on Fedora
-   `commit <https://pagure.io/freeipa/c/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certbot dns-01 test
-   `commit <https://pagure.io/freeipa/c/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certbot dns script
-   `commit <https://pagure.io/freeipa/c/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add revocation test
-   `commit <https://pagure.io/freeipa/c/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: handle alternative schema ldif location
-   `commit <https://pagure.io/freeipa/c/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add mod_md integration test
-   `commit <https://pagure.io/freeipa/c/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration tests to gating
-   `commit <https://pagure.io/freeipa/c/bb6d84903967bc6176d8a0817b602ba314129417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb6d84903967bc6176d8a0817b602ba314129417>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration test to nightly CI
-   `commit <https://pagure.io/freeipa/c/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration test
-   `commit <https://pagure.io/freeipa/c/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add ipa-acme-manage command
-   `commit <https://pagure.io/freeipa/c/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: configure engine.conf and disable by default
-   `commit <https://pagure.io/freeipa/c/00a84464eae31150714f667df67774ebe34b8514>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00a84464eae31150714f667df67774ebe34b8514>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: configure ACME service on upgrade
-   `commit <https://pagure.io/freeipa/c/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certificate profile
-   `commit <https://pagure.io/freeipa/c/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add Dogtag ACL to allow ACME agents to revoke certs
-   `commit <https://pagure.io/freeipa/c/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: create ACME RA account
-   `commit <https://pagure.io/freeipa/c/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  dogtaginstance: add ensure_group method
-   `commit <https://pagure.io/freeipa/c/a21823da7fcce521838764df5280295ccbdb8157>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a21823da7fcce521838764df5280295ccbdb8157>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  dogtaginstance: extract user creation to subroutine.
-   `commit <https://pagure.io/freeipa/c/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: set up ACME service when configuring CA
-   `commit <https://pagure.io/freeipa/c/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: ipa-pki-proxy: proxy /acme to Dogtag
-   `commit <https://pagure.io/freeipa/c/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  certupdate: only add LWCA tracking requests on CA servers
-   `commit <https://pagure.io/freeipa/c/e4462a94433e75da622118873d300d61a8e5f53f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4462a94433e75da622118873d300d61a8e5f53f>`__
    `#8399 <https://pagure.io/freeipa/issue/8399>`__
 -  tests: fix cleanup for CATracker
-   `commit <https://pagure.io/freeipa/c/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  ca plugin: improve doc
-   `commit <https://pagure.io/freeipa/c/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  ca-del: require CA to already be disabled
-   `commit <https://pagure.io/freeipa/c/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
-   `commit <https://pagure.io/freeipa/c/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
 -  ra.get_certificate: use REST API
-   `commit <https://pagure.io/freeipa/c/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  extract virtual operation access check subroutine
-   `commit <https://pagure.io/freeipa/c/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__,
    `#6423 <https://pagure.io/freeipa/issue/6423>`__
 -  Define errors_by_code in ipalib.errors
-   `commit <https://pagure.io/freeipa/c/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
-   `commit <https://pagure.io/freeipa/c/68ada5f2040bb207a5402220fb93e360bae215fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68ada5f2040bb207a5402220fb93e360bae215fe>`__
    `#8368 <https://pagure.io/freeipa/issue/8368>`__
 -  fix cert-find errors in CA-less deployment
-   `commit <https://pagure.io/freeipa/c/19544d53aeada733eb63d596be0a8576b17b9d04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19544d53aeada733eb63d596be0a8576b17b9d04>`__
    `#8369 <https://pagure.io/freeipa/issue/8369>`__
 -  upgrade: avoid stopping certmonger when fixing requests
-   `commit <https://pagure.io/freeipa/c/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
-   `commit <https://pagure.io/freeipa/c/9d9012f682a2dcff7676580fbc622771b427fcef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d9012f682a2dcff7676580fbc622771b427fcef>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
-   `commit <https://pagure.io/freeipa/c/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
-   `commit <https://pagure.io/freeipa/c/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
-   `commit <https://pagure.io/freeipa/c/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
-   `commit <https://pagure.io/freeipa/c/f7c45641fe356364175899399b51b07987b44a1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7c45641fe356364175899399b51b07987b44a1b>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
-   `commit <https://pagure.io/freeipa/c/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: support dnsname as request search criterion
-   `commit <https://pagure.io/freeipa/c/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: move 'criteria' description to module docstring
-   `commit <https://pagure.io/freeipa/c/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: avoid mutable default argument
-   `commit <https://pagure.io/freeipa/c/0711c4a0d45f9e28459596552ca751890b13c265>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0711c4a0d45f9e28459596552ca751890b13c265>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  add resources section
-   `commit <https://pagure.io/freeipa/c/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/a2f3088a21b9db2e79a717c9b4afae04fafc658e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2f3088a21b9db2e79a717c9b4afae04fafc658e>`__
 -  suggest \`ipa help topics\`
-   `commit <https://pagure.io/freeipa/c/8e0d4bcccecc7dd405c8d71895c95d4a1a2eddd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e0d4bcccecc7dd405c8d71895c95d4a1a2eddd2>`__
 -  lots of minor tweaks and updates
-   `commit <https://pagure.io/freeipa/c/3a0f8a114b72936e74cac7ad5ce8def1ca0299f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a0f8a114b72936e74cac7ad5ce8def1ca0299f6>`__
 -  rename certificates module
-   `commit <https://pagure.io/freeipa/c/0678ed564992879e1f70429e51554fec2380dc8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0678ed564992879e1f70429e51554fec2380dc8b>`__
 -  Vagrantfile: set DNS configuration in network-scripts
-   `commit <https://pagure.io/freeipa/c/345850eb6cdcf5ca608ed0b3508a78da6bd908ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/345850eb6cdcf5ca608ed0b3508a78da6bd908ef>`__
 -  add more prerequisites and fix some links
-   `commit <https://pagure.io/freeipa/c/bc1c5a84bda16e6ed19a4226519c994a483568ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc1c5a84bda16e6ed19a4226519c994a483568ea>`__
 -  add inter-module links
-   `commit <https://pagure.io/freeipa/c/66ff3675c898daeffac6b675cceef0c0edc91b1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66ff3675c898daeffac6b675cceef0c0edc91b1a>`__
 -  split workshop into separate files
-   `commit <https://pagure.io/freeipa/c/b6c50da05942ba8703aa296c3e0de8369ecf9581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6c50da05942ba8703aa296c3e0de8369ecf9581>`__
 -  add sudorule and selinux units to TOC
-   `commit <https://pagure.io/freeipa/c/a097485eb155b199159196fb30d57e0101af4599>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a097485eb155b199159196fb30d57e0101af4599>`__
 -  add selinuxusermap unit
-   `commit <https://pagure.io/freeipa/c/7a6b914747440e7c266d0eb54f90c22cf3ffcae8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a6b914747440e7c266d0eb54f90c22cf3ffcae8>`__
 -  add sudorule unit
-   `commit <https://pagure.io/freeipa/c/d14dc294005596b86cdfab69df94c238dcce47d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d14dc294005596b86cdfab69df94c238dcce47d0>`__
 -  minor editoral improvements
-   `commit <https://pagure.io/freeipa/c/0f7a460fea88ae83f4b657ac52f2f3d64a38984f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f7a460fea88ae83f4b657ac52f2f3d64a38984f>`__
 -  Change workshop "Modules" to "Units"
-   `commit <https://pagure.io/freeipa/c/77eea677053f8865ce6d5e082f513c44d6e738ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77eea677053f8865ce6d5e082f513c44d6e738ad>`__
 -  prep: updates for f24, box version 0.0.7
-   `commit <https://pagure.io/freeipa/c/44b6c2bedcec01d34adad08f20fa77a08d15274a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44b6c2bedcec01d34adad08f20fa77a08d15274a>`__
 -  certs: request SAN DNS name
-   `commit <https://pagure.io/freeipa/c/3be3ca97f6099d30dd9299ff825f065452203146>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3be3ca97f6099d30dd9299ff825f065452203146>`__
 -  updates for FreeIPA 4.3
-   `commit <https://pagure.io/freeipa/c/65489291894a45d1af4bb1cdd5bdeae2d13a7501>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65489291894a45d1af4bb1cdd5bdeae2d13a7501>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/18c0ef421bfac1a20e127696c46988f4c4d10131>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18c0ef421bfac1a20e127696c46988f4c4d10131>`__
 -  add facilitator notes; remove feedback link
-   `commit <https://pagure.io/freeipa/c/9cf596564aa27d482b866475a5c40d4d4def1953>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cf596564aa27d482b866475a5c40d4d4def1953>`__
 -  building: note disk and memory requirements
-   `commit <https://pagure.io/freeipa/c/ae56b9a276bb729fdbe9b987bfcc288628ef0330>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae56b9a276bb729fdbe9b987bfcc288628ef0330>`__
 -  bump libvirt vm mem to 1G; other fixes
-   `commit <https://pagure.io/freeipa/c/f8d94388d4b43843fcc5de7bcb514dda29820299>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8d94388d4b43843fcc5de7bcb514dda29820299>`__
 -  update feedback url
-   `commit <https://pagure.io/freeipa/c/73d8f7bb450e55bb2d443a1eb3182d65fbd3ae0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73d8f7bb450e55bb2d443a1eb3182d65fbd3ae0a>`__
 -  update clone url
-   `commit <https://pagure.io/freeipa/c/1e1de65e03947971b1ded64cef917dac900f8530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e1de65e03947971b1ded64cef917dac900f8530>`__
 -  add internal links to modules
-   `commit <https://pagure.io/freeipa/c/88b7708069e8c84cbae043ef9acc866c8b223e12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88b7708069e8c84cbae043ef9acc866c8b223e12>`__
 -  symlink README to workshop.rst
-   `commit <https://pagure.io/freeipa/c/73b1b05a3a3b0a3d118db621d45967932636f0f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73b1b05a3a3b0a3d118db621d45967932636f0f7>`__
 -  add replica installation module
-   `commit <https://pagure.io/freeipa/c/40f6a1b7beee2c87d9cbc13b1211f5f1de43f328>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40f6a1b7beee2c87d9cbc13b1211f5f1de43f328>`__
 -  update to f23
-   `commit <https://pagure.io/freeipa/c/25e55198b4c14704afa917d436ceca3334cdd7c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25e55198b4c14704afa917d436ceca3334cdd7c0>`__
 -  add vagrant box building instructions
-   `commit <https://pagure.io/freeipa/c/05ab50a127b001ed2e59328445829d8270323d0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05ab50a127b001ed2e59328445829d8270323d0c>`__
 -  workshop: remove references to freeipa-workshop-vagrantfile repo
-   `commit <https://pagure.io/freeipa/c/17b87fbc3b948c534e83a0b95498d783139bd948>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17b87fbc3b948c534e83a0b95498d783139bd948>`__
 -  enable and start httpd on client
-   `commit <https://pagure.io/freeipa/c/08a96bdf81a323aa79431a8900be7f07708d9317>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08a96bdf81a323aa79431a8900be7f07708d9317>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/3ed5610f6418f20b0bae32bfca8f2a07b8be1d49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ed5610f6418f20b0bae32bfca8f2a07b8be1d49>`__
 -  initial commit
-   `commit <https://pagure.io/freeipa/c/638d98625c26293a404903730cbd2326123790a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/638d98625c26293a404903730cbd2326123790a6>`__
 -  remove proposal
-   `commit <https://pagure.io/freeipa/c/73da58024d8aa11dcdf2beb0b90039540eaf58f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73da58024d8aa11dcdf2beb0b90039540eaf58f6>`__
 -  add copyright notice
-   `commit <https://pagure.io/freeipa/c/fb5ab1d4af8c3c716fa80ee3f5a9ea5dc1dd0fc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb5ab1d4af8c3c716fa80ee3f5a9ea5dc1dd0fc0>`__
 -  freeipa-workshop: fix mod_authnz_pam link
-   `commit <https://pagure.io/freeipa/c/1723910accba6f2e39327ccc2eab59ed143798ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1723910accba6f2e39327ccc2eab59ed143798ab>`__
 -  merge (most of) zdover's edits
-   `commit <https://pagure.io/freeipa/c/df3115680e143dac9d9f94bf7ea44909dc03eb25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df3115680e143dac9d9f94bf7ea44909dc03eb25>`__
 -  20151029-osdc-freeipa-workshop: add app.py
-   `commit <https://pagure.io/freeipa/c/a209cb9d373997586610e93cd05370f53e031b84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a209cb9d373997586610e93cd05370f53e031b84>`__
 -  osdc-freeipa-workshop: add certificate management module
-   `commit <https://pagure.io/freeipa/c/32b37185ba5acda95fc983e54e94f4368f0d37ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32b37185ba5acda95fc983e54e94f4368f0d37ed>`__
 -  osdc-freeipa-workshop: add OS X and update Debian/Ubuntu details
-   `commit <https://pagure.io/freeipa/c/855556e06411fbee67a5c9673991c0468b3f8893>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/855556e06411fbee67a5c9673991c0468b3f8893>`__
 -  osdc-freeipa-workshop: add debian/ubuntu prep instructions
-   `commit <https://pagure.io/freeipa/c/326011dad850af390631e60b21ab98ffe8a6c73f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326011dad850af390631e60b21ab98ffe8a6c73f>`__
 -  osdc-freeipa-workshop: support vagrant-libvirt on Fedora
-   `commit <https://pagure.io/freeipa/c/9c2072c6432c04f7c3ba8846845eb743d0655b60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c2072c6432c04f7c3ba8846845eb743d0655b60>`__
 -  osdc-freeipa-workshop: presentation, minor curriculum edits
-   `commit <https://pagure.io/freeipa/c/69b2fd6f1cffe27aa75af4751b67e953e3395ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69b2fd6f1cffe27aa75af4751b67e953e3395ba5>`__
 -  osdc-freeipa-workshop: typospotting
-   `commit <https://pagure.io/freeipa/c/31676d7c9bbeb33b29a412df3a466a65866e9605>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31676d7c9bbeb33b29a412df3a466a65866e9605>`__
 -  osdc-freeipa-workshop: remove definition list of VMs
-   `commit <https://pagure.io/freeipa/c/7a865b7fbab5e014f9dd7bbd2e5cc7ea2061f099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a865b7fbab5e014f9dd7bbd2e5cc7ea2061f099>`__
 -  osdc-freeipa-workshop: add missing dnf install vagrant
-   `commit <https://pagure.io/freeipa/c/fe03beb0e7a81d83f7bcf04ad8fb8d4ae0aca9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe03beb0e7a81d83f7bcf04ad8fb8d4ae0aca9d1>`__
 -  osdc-freeipa-workshop: clarify prep goals and VirtualBox version
-   `commit <https://pagure.io/freeipa/c/514f4c298c7a3ffc8af6431866b86ed2f653e36a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/514f4c298c7a3ffc8af6431866b86ed2f653e36a>`__
 -  osdc-freeipa-workshop: update troubleshooting doc
-   `commit <https://pagure.io/freeipa/c/e76d1726824410ef0b544b96bfe9654ac2fab349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e76d1726824410ef0b544b96bfe9654ac2fab349>`__
 -  osdc-freeipa-workshop: incorporate wibrown\'s feedback
-   `commit <https://pagure.io/freeipa/c/77cb86bcf3b7dbf522029715f724f1bdaa5160ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77cb86bcf3b7dbf522029715f724f1bdaa5160ce>`__
 -  osdc-freeipa-workshop: update f22 installation steps
-   `commit <https://pagure.io/freeipa/c/1445311e743609eab89668f6a5250e20605a3098>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1445311e743609eab89668f6a5250e20605a3098>`__
 -  osdc-freeipa-workshop: add Windows prep details
-   `commit <https://pagure.io/freeipa/c/4c5db754459a62671b8fac8cda64410d7dc5677a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c5db754459a62671b8fac8cda64410d7dc5677a>`__
 -  osdc-freeipa-workshop: add Vagrantfile clone instructions and
    curriculum overview
-   `commit <https://pagure.io/freeipa/c/c90fabd6b10cfb3a84c6cc35131a4e8a85383309>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c90fabd6b10cfb3a84c6cc35131a4e8a85383309>`__
 -  osdc-freeipa-workshop: remove vagrant-hostmanager steps, add editing
    notes
-   `commit <https://pagure.io/freeipa/c/0417063d49c83ce60026bd10b09566266ea7435e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0417063d49c83ce60026bd10b09566266ea7435e>`__
 -  osdc-freeipa-workshop: selinux and other minor fixes
-   `commit <https://pagure.io/freeipa/c/aafbbd9bcee862aa3dbed2937452a61453ffebe9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aafbbd9bcee862aa3dbed2937452a61453ffebe9>`__
 -  osdc-freeipa-workshop: add mod_lookup_identity and mod_authnz_pam
    sections
-   `commit <https://pagure.io/freeipa/c/ea16b85390b1ff81c6cdfc6adecc66d3d12db5f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea16b85390b1ff81c6cdfc6adecc66d3d12db5f3>`__
 -  osdc-freeipa-workshop: add mod_auth_gssapi section
-   `commit <https://pagure.io/freeipa/c/70ec83dd398dd5b59f9ea497fcc111a18771d38c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70ec83dd398dd5b59f9ea497fcc111a18771d38c>`__
 -  sudo make me a sandwich
-   `commit <https://pagure.io/freeipa/c/26f4be5839444bf7b04d8e743d5541281bf44bf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26f4be5839444bf7b04d8e743d5541281bf44bf2>`__
 -  osdc-freeipa-workshop: add rpmfusion instructions
-   `commit <https://pagure.io/freeipa/c/96f93687d9e193520636bc928ca99c51a67beb88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96f93687d9e193520636bc928ca99c51a67beb88>`__
 -  osdc-freeipa-workshop: external authnz module (WIP); minor fixes
-   `commit <https://pagure.io/freeipa/c/64109d5ac4255bebf5ad29dbe87e8203c22436d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64109d5ac4255bebf5ad29dbe87e8203c22436d6>`__
 -  osdc-freeipa-workshop: add initial workshop modules
-   `commit <https://pagure.io/freeipa/c/71ec597caa783296398008fc824af0e9ed809071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71ec597caa783296398008fc824af0e9ed809071>`__
 -  fix osdc2015 and lca2016 dates
-   `commit <https://pagure.io/freeipa/c/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
 -  Do not renew externally-signed CA as self-signed
-   `commit <https://pagure.io/freeipa/c/769180c2c60205a453f87d7d1b88c27d238728db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/769180c2c60205a453f87d7d1b88c27d238728db>`__
    `#8176 <https://pagure.io/freeipa/issue/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
-   `commit <https://pagure.io/freeipa/c/2a2cc961666af1e41e127f043d571a93da800ef5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a2cc961666af1e41e127f043d571a93da800ef5>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix test regressions caused by certificate validation changes
-   `commit <https://pagure.io/freeipa/c/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  ipatests: assert_error: allow regexp match
-   `commit <https://pagure.io/freeipa/c/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  removed unused function export_pem_p12
-   `commit <https://pagure.io/freeipa/c/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
 -  test_integration: add tests for custom CA subject DN
-   `commit <https://pagure.io/freeipa/c/e767386e7120be3515d6a34529b51ae658248038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e767386e7120be3515d6a34529b51ae658248038>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
-   `commit <https://pagure.io/freeipa/c/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
-   `commit <https://pagure.io/freeipa/c/326d417d98b092e175623cd28e46586df00e60a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326d417d98b092e175623cd28e46586df00e60a2>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  Bump Dogtag min version to 10.7.3
-   `commit <https://pagure.io/freeipa/c/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  ipa-pki-retrieve-key: request AES encryption (with fallback)
-   `commit <https://pagure.io/freeipa/c/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  NSSWrappedCertDB: accept optional symmetric algorithm
-   `commit <https://pagure.io/freeipa/c/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  IPASecStore: support extra key arguments
-   `commit <https://pagure.io/freeipa/c/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  dsinstance: add proflie when tracking certificate
-   `commit <https://pagure.io/freeipa/c/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  ipatests: test ipa-server-upgrade in CA-less deployment
-   `commit <https://pagure.io/freeipa/c/65d9a9be520ea9402143d9f06878eff53647925a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65d9a9be520ea9402143d9f06878eff53647925a>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  Use RENEWAL_CA_NAME and RA_AGENT_PROFILE constants
-   `commit <https://pagure.io/freeipa/c/bb779baadf0df3333bd853599a21e81907c8c116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb779baadf0df3333bd853599a21e81907c8c116>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  cainstance: add profile to IPA RA tracking request
-   `commit <https://pagure.io/freeipa/c/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: fix spurious certmonger re-tracking
-   `commit <https://pagure.io/freeipa/c/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: log missing/misconfigured tracking requests
-   `commit <https://pagure.io/freeipa/c/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: update KRA tracking requests
-   `commit <https://pagure.io/freeipa/c/482866e47e20520fbe39ef05439badbb3069bef6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/482866e47e20520fbe39ef05439badbb3069bef6>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: always add profile to tracking requests
-   `commit <https://pagure.io/freeipa/c/4f4e2f96b022a056777fed59583f204edb797a2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f4e2f96b022a056777fed59583f204edb797a2e>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtaginstance: avoid special cases for Server-Cert
-   `commit <https://pagure.io/freeipa/c/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtag-ipa-ca-renew-agent: always use profile-based renewal
-   `commit <https://pagure.io/freeipa/c/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  certmonger: use long options when invoking dogtag-ipa-renew-agent
-   `commit <https://pagure.io/freeipa/c/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: add profile to Dogtag tracking requests
-   `commit <https://pagure.io/freeipa/c/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtaginstance: add profile to tracking requests
-   `commit <https://pagure.io/freeipa/c/3c388f5a228b767dfd92bd824dfced166acda143>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c388f5a228b767dfd92bd824dfced166acda143>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  ci: add --external-ca-profile tests to gating
-   `commit <https://pagure.io/freeipa/c/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  ci: add --external-ca-profile tests to nightly
-   `commit <https://pagure.io/freeipa/c/2c8352fe8536be0e630fdb910dc90831847ad119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c8352fe8536be0e630fdb910dc90831847ad119>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Collapse --external-ca-profile tests into single class
-   `commit <https://pagure.io/freeipa/c/80e76f094c234710ff58917e7ce4661d823c4de7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80e76f094c234710ff58917e7ce4661d823c4de7>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Add more tests for --external-ca-profile handling
-   `commit <https://pagure.io/freeipa/c/b15bd50e6db919279e25a8bed796df4836b845a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b15bd50e6db919279e25a8bed796df4836b845a8>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Fix use of incorrect variable
-   `commit <https://pagure.io/freeipa/c/7171142aaf91d6079798d015af9862d6e5474c8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7171142aaf91d6079798d015af9862d6e5474c8c>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__,
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  install: fix --external-ca-profile option
-   `commit <https://pagure.io/freeipa/c/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__,
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  move MSCSTemplate classes to ipalib
-   `commit <https://pagure.io/freeipa/c/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 
 
@@ -3824,11 +3824,11 @@ Gaurav Talreja (3)
 ----------------------------------------------------------------------------------------------
 
 -  Normalize title of test external_ca in prci-definition
-   `commit <https://pagure.io/freeipa/c/7862e9bec5133b7416b649a84e2ef5b3d906f2ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7862e9bec5133b7416b649a84e2ef5b3d906f2ea>`__
 -  Normalize test definations titles
-   `commit <https://pagure.io/freeipa/c/4a1f56ecdc3398faf67b7a6e162cfd6b41befa5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a1f56ecdc3398faf67b7a6e162cfd6b41befa5a>`__
 -  prci: bump template version for nightly_rawhide
-   `commit <https://pagure.io/freeipa/c/775bbb919ac9967fe65ba2982e79078810849527>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/775bbb919ac9967fe65ba2982e79078810849527>`__
 
 
 
@@ -3836,9 +3836,9 @@ Isaac Boukris (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix legacy S4U2Proxy in DAL v8 support
-   `commit <https://pagure.io/freeipa/c/c940f96b700d845afda014d41a0004068d379a9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c940f96b700d845afda014d41a0004068d379a9a>`__
 -  Fix DAL v8 support
-   `commit <https://pagure.io/freeipa/c/d92f21ae1b3051f96043c64320a768551de39d5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d92f21ae1b3051f96043c64320a768551de39d5a>`__
 
 
 
@@ -3847,10 +3847,10 @@ Jeremy Frasier (2)
 
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
-   `commit <https://pagure.io/freeipa/c/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
-   `commit <https://pagure.io/freeipa/c/12529d7ef184846ca3852821b813c725b22e11c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12529d7ef184846ca3852821b813c725b22e11c6>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 
 
@@ -3859,13 +3859,13 @@ Jayesh Garg (4)
 ----------------------------------------------------------------------------------------------
 
 -  Nightly definations commit
-   `commit <https://pagure.io/freeipa/c/fb3c2c140220b7d6d88558f9bb0a485f47079a5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb3c2c140220b7d6d88558f9bb0a485f47079a5e>`__
 -  Test for ipa-ca-install on replica
-   `commit <https://pagure.io/freeipa/c/ad3bf5042d35b2d16646170b09489fb964fbdb93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3bf5042d35b2d16646170b09489fb964fbdb93>`__
 -  Test ipa-getkeytab quiet mode, encryptons
-   `commit <https://pagure.io/freeipa/c/09a5192f252635d58b205946384cb29c033441f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09a5192f252635d58b205946384cb29c033441f6>`__
 -  Test if ipactl starts services stopped by systemctl
-   `commit <https://pagure.io/freeipa/c/d7b3aafc638353880045faf41b0fb647d174f3e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7b3aafc638353880045faf41b0fb647d174f3e6>`__
 
 
 
@@ -3873,7 +3873,7 @@ Julian Gethmann (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix typo in idrange.py docstring
-   `commit <https://pagure.io/freeipa/c/273ff2708cb99dded5e7ef51504cc8de9a4496db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273ff2708cb99dded5e7ef51504cc8de9a4496db>`__
 
 
 
@@ -3881,14 +3881,14 @@ Kaleemullah Siddiqui (4)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for fake_mname parameter setup
-   `commit <https://pagure.io/freeipa/c/592f3fe65986077ec0a19158d061a371c86307c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/592f3fe65986077ec0a19158d061a371c86307c7>`__
 -  Test for check of HostKeyAlgorithms option in ssh_config
-   `commit <https://pagure.io/freeipa/c/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 -  Fix for regression from PR#3962
-   `commit <https://pagure.io/freeipa/c/939ee59c2716aa2abf93ac78d44df937105b430d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/939ee59c2716aa2abf93ac78d44df937105b430d>`__
 -  Tests for backup-restore when pkg required is missing
-   `commit <https://pagure.io/freeipa/c/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
    `#7630 <https://pagure.io/freeipa/issue/7630>`__
 
 
@@ -3897,7 +3897,7 @@ Christian Hermann (1)
 ----------------------------------------------------------------------------------------------
 
 -  configure.ac: don't rely on bashisms
-   `commit <https://pagure.io/freeipa/c/9a440ae8855a5bc7b49ffe43c4a6654b17eed0a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a440ae8855a5bc7b49ffe43c4a6654b17eed0a9>`__
 
 
 
@@ -3905,7 +3905,7 @@ Miro Hrončok (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix a syntax typo
-   `commit <https://pagure.io/freeipa/c/35e1ebb2f3eb2d46f4080860ebe4e71421f80b54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35e1ebb2f3eb2d46f4080860ebe4e71421f80b54>`__
 
 
 
@@ -3914,7 +3914,7 @@ MIZUTA Takeshi (1)
 
 -  Add config that maintains existing content to ipa-client-install
    manpage
-   `commit <https://pagure.io/freeipa/c/650db3b80d5f1ec68131d0e17993fb31f9488d7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/650db3b80d5f1ec68131d0e17993fb31f9488d7c>`__
 
 
 
@@ -3922,25 +3922,25 @@ Michal Polovka (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_epn: test_EPN_config_file: Package name fix
-   `commit <https://pagure.io/freeipa/c/147b808ffb58217443562ade56da212829539817>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/147b808ffb58217443562ade56da212829539817>`__
 -  ipatests: test_epn: Fix package installation
-   `commit <https://pagure.io/freeipa/c/3c18f94b29b15cf652c14e3dd828a27827dad239>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c18f94b29b15cf652c14e3dd828a27827dad239>`__
 -  Test for healthcheck being run on replica with stopped master
-   `commit <https://pagure.io/freeipa/c/3a64ac08e1b3202bb469fcf0f2a17bd5114bab8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a64ac08e1b3202bb469fcf0f2a17bd5114bab8f>`__
 -  Test for output being indented by default value if not stated
    implicitly.
-   `commit <https://pagure.io/freeipa/c/f5f960ed2ab08208b52260ab2dbe99da500ee04e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5f960ed2ab08208b52260ab2dbe99da500ee04e>`__
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
-   `commit <https://pagure.io/freeipa/c/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
    `#2018 <https://pagure.io/freeipa/issue/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
-   `commit <https://pagure.io/freeipa/c/253779afc4432d02aa37b44dda789c4b152568fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/253779afc4432d02aa37b44dda789c4b152568fb>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__,
    `#8055 <https://pagure.io/freeipa/issue/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
-   `commit <https://pagure.io/freeipa/c/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__
 
 
@@ -3949,19 +3949,19 @@ Mark Reynolds (5)
 ----------------------------------------------------------------------------------------------
 
 -  Accept 389-ds JSON replication status messages
-   `commit <https://pagure.io/freeipa/c/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
    `#7975 <https://pagure.io/freeipa/issue/7975>`__
 -  Reorder creation of the CA mapping tree and database backend
-   `commit <https://pagure.io/freeipa/c/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
    `#8558 <https://pagure.io/freeipa/issue/8558>`__
 -  Increase replication changelog trimming to 30 days
-   `commit <https://pagure.io/freeipa/c/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
    `#8464 <https://pagure.io/freeipa/issue/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
-   `commit <https://pagure.io/freeipa/c/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
    `#8456 <https://pagure.io/freeipa/issue/8456>`__
 -  Issue 8407 - Support changelog integration into main database
-   `commit <https://pagure.io/freeipa/c/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
    `#8407 <https://pagure.io/freeipa/issue/8407>`__
 
 
@@ -3970,78 +3970,78 @@ Mohammad Rizwan (29)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test certmonger IPA responder switched to JSONRPC
-   `commit <https://pagure.io/freeipa/c/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
    `#3299 <https://pagure.io/freeipa/issue/3299>`__
 -  Move acme client installation part to classmethod
-   `commit <https://pagure.io/freeipa/c/c4a6b0e5662f539b8438cdbc593eb713ea8c6da2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4a6b0e5662f539b8438cdbc593eb713ea8c6da2>`__
 -  PEP8 fixes for test_acme.py
-   `commit <https://pagure.io/freeipa/c/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
 -  External-CA scenarios for ACME service
-   `commit <https://pagure.io/freeipa/c/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  ipatests: Check if ACME is enabled on all CA servers
-   `commit <https://pagure.io/freeipa/c/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  PEP8 fixes
-   `commit <https://pagure.io/freeipa/c/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
 -  ipatests: add --skip-overlap-check option to prepare_reverse_zone()
-   `commit <https://pagure.io/freeipa/c/bddbfb79e4749713dd2b22445fb95e3e53d080e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddbfb79e4749713dd2b22445fb95e3e53d080e8>`__
 -  ipatests: Add PTR record for IP SAN
-   `commit <https://pagure.io/freeipa/c/b3d7a70ee00bb5e8a0f1781a378dc169ee455624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3d7a70ee00bb5e8a0f1781a378dc169ee455624>`__
 -  ipatests: Test certmonger rekey command works fine
-   `commit <https://pagure.io/freeipa/c/abd0cbfcfdb913e4576721bc9c5acd43bdd2bae2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abd0cbfcfdb913e4576721bc9c5acd43bdd2bae2>`__
 -  Xfail test for sssd < 2.3.0
-   `commit <https://pagure.io/freeipa/c/32a5359ece5b449b1cedb700d79cfa2744a288cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32a5359ece5b449b1cedb700d79cfa2744a288cb>`__
 -  ipatests: Test ipa user login with wrong password
-   `commit <https://pagure.io/freeipa/c/e33ffab534c9ecce26fbd069956d15da182ce6ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e33ffab534c9ecce26fbd069956d15da182ce6ed>`__
 -  WebUI tests: fix PEP8 issues in test_webui/test_user.py
-   `commit <https://pagure.io/freeipa/c/0c02920529306aaa1a8be1fae185390e2e115859>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c02920529306aaa1a8be1fae185390e2e115859>`__
 -  webui: check if notification area doesn't intercept menu button
-   `commit <https://pagure.io/freeipa/c/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  ipatests: Test deletion of required principal throws proper error
-   `commit <https://pagure.io/freeipa/c/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  Display principal name while del required principal
-   `commit <https://pagure.io/freeipa/c/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  ipatests: Test to check password leak in apache error log
-   `commit <https://pagure.io/freeipa/c/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
-   `commit <https://pagure.io/freeipa/c/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 -  ipatests: Skip test using paramiko when FIPS is enabled
-   `commit <https://pagure.io/freeipa/c/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if getcert creates cacert file with -F option
-   `commit <https://pagure.io/freeipa/c/9bcc57d9e01625a122811a50f78acde247b5791d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bcc57d9e01625a122811a50f78acde247b5791d>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Move wait_for_request() method to tasks.py
-   `commit <https://pagure.io/freeipa/c/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
 -  Test if server installer lock Bind9 recursion
-   `commit <https://pagure.io/freeipa/c/1556f3f767c3fab7634b46a9193e363887558db0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1556f3f767c3fab7634b46a9193e363887558db0>`__
    `#8079 <https://pagure.io/freeipa/issue/8079>`__
 -  Add certmonger wait_for_request that uses run_command
-   `commit <https://pagure.io/freeipa/c/806795422934c3220856bcaaf8810cdebd782fd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/806795422934c3220856bcaaf8810cdebd782fd4>`__
 -  Test if certmonger reads the token in HSM
-   `commit <https://pagure.io/freeipa/c/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
-   `commit <https://pagure.io/freeipa/c/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
    `#8110 <https://pagure.io/freeipa/issue/8110>`__
 -  Add test to nightly yamls
-   `commit <https://pagure.io/freeipa/c/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
 -  Installation of replica against a specific server
-   `commit <https://pagure.io/freeipa/c/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  Check file ownership and permission for dirsrv log instance
-   `commit <https://pagure.io/freeipa/c/7aec6f10374129d75cd99a4012980516ca535551>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7aec6f10374129d75cd99a4012980516ca535551>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 
 
@@ -4050,7 +4050,7 @@ ndehadra (1)
 ----------------------------------------------------------------------------------------------
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
-   `commit <https://pagure.io/freeipa/c/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
    `#7307 <https://pagure.io/freeipa/issue/7307>`__
 
 
@@ -4059,15 +4059,15 @@ Weblate (5)
 ----------------------------------------------------------------------------------------------
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/1354031def399ea79d6cbb7ed7e35f707a38f3ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1354031def399ea79d6cbb7ed7e35f707a38f3ec>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/afa0f5d1877d297a455d1dfec7e0304031ad5078>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afa0f5d1877d297a455d1dfec7e0304031ad5078>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/90c1a00f046b7cd2e54c27039db98ac795595304>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90c1a00f046b7cd2e54c27039db98ac795595304>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/89d85182667d137c2ee8d68b2f1b8d6f7d1da38e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d85182667d137c2ee8d68b2f1b8d6f7d1da38e>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/a2f7e917a13a99bcdc7daa5171fe234a971e913c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2f7e917a13a99bcdc7daa5171fe234a971e913c>`__
 
 
 
@@ -4075,9 +4075,9 @@ Oğuz Ersen (2)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Turkish)
-   `commit <https://pagure.io/freeipa/c/0464a5ffff35fbb37e7d0561c39d9d8e8c65b496>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0464a5ffff35fbb37e7d0561c39d9d8e8c65b496>`__
 -  Translated using Weblate (Turkish)
-   `commit <https://pagure.io/freeipa/c/54dff05cd29dc8ef473a7c6a3056d30d5cb1982d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54dff05cd29dc8ef473a7c6a3056d30d5cb1982d>`__
 
 
 
@@ -4085,7 +4085,7 @@ Spencer E. Olson (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes debian path for IPA_CUSTODIA_HANDLER
-   `commit <https://pagure.io/freeipa/c/73796c779758fdd8f3c2d8ede3ef24d5b7d025e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73796c779758fdd8f3c2d8ede3ef24d5b7d025e7>`__
 
 
 
@@ -4093,7 +4093,7 @@ Piotr Drąg (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/a96b89388d222db607edd57486b5dde16568fdda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a96b89388d222db607edd57486b5dde16568fdda>`__
 
 
 
@@ -4101,7 +4101,7 @@ Slava Aseev (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: handle dates up to 2106-02-07 06:28:16
-   `commit <https://pagure.io/freeipa/c/18721cc83035359a2f7d49cfe09e7f4b1376b090>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18721cc83035359a2f7d49cfe09e7f4b1376b090>`__
    `#8028 <https://pagure.io/freeipa/issue/8028>`__
 
 
@@ -4110,9 +4110,9 @@ Petr Voborník (2)
 ----------------------------------------------------------------------------------------------
 
 -  baseuser: fix ipanthomedirectorydrive option name
-   `commit <https://pagure.io/freeipa/c/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
 -  webui: hide user attributes for SMB services section if empty
-   `commit <https://pagure.io/freeipa/c/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 
 
@@ -4121,7 +4121,7 @@ Rafael Fontenelle (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/1eaa5974e4cd03724f8a43a59a5de4ab1568f769>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1eaa5974e4cd03724f8a43a59a5de4ab1568f769>`__
 
 
 
@@ -4129,443 +4129,443 @@ Rob Crittenden (141)
 ----------------------------------------------------------------------------------------------
 
 -  Skip the ACME mod_md test when the client is in enforcing mode
-   `commit <https://pagure.io/freeipa/c/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
    `#8514 <https://pagure.io/freeipa/issue/8514>`__
 -  Increase timeout for krbtpolicy to 4800
-   `commit <https://pagure.io/freeipa/c/28ed75ca0251724e34a447174ae775edca9763e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28ed75ca0251724e34a447174ae775edca9763e2>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Enable the ccache sweep systemd timer
-   `commit <https://pagure.io/freeipa/c/068d08577d97258267917f81363a1a033a681803>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/068d08577d97258267917f81363a1a033a681803>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  ipatests: test that stale caches are removed using the sweeper
-   `commit <https://pagure.io/freeipa/c/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Generate a unique cache for each connection
-   `commit <https://pagure.io/freeipa/c/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Convert reset_to_default_policy into a pytest fixture
-   `commit <https://pagure.io/freeipa/c/848dffb59273493ef3abde2a86864e85c8d19eff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/848dffb59273493ef3abde2a86864e85c8d19eff>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  VERSION: back to git snapshots
-   `commit <https://pagure.io/freeipa/c/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
 -  ipatests: Test that ipa-ca.$domain can retrieve CRLs without redirect
-   `commit <https://pagure.io/freeipa/c/b478bf99d9f158dabae145169f242b2b5d26404c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b478bf99d9f158dabae145169f242b2b5d26404c>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__
 -  Allow Apache to answer to ipa-ca requests without a redirect
-   `commit <https://pagure.io/freeipa/c/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__
 -  Move where the restore state is marked during IPA server upgrade
-   `commit <https://pagure.io/freeipa/c/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
    `#7534 <https://pagure.io/freeipa/issue/7534>`__
 -  Reorder when ACME is enabled to fix failure on upgrade
-   `commit <https://pagure.io/freeipa/c/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
    `#8603 <https://pagure.io/freeipa/issue/8603>`__
 -  Remove test for minimum ACME support and rely on package deps
-   `commit <https://pagure.io/freeipa/c/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
 -  Require PKI 10.10+ for KRA profile and ACME support
-   `commit <https://pagure.io/freeipa/c/3e530e93c37ee71a560714e26285cd85e71557c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e530e93c37ee71a560714e26285cd85e71557c9>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__,
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  Test that the KRA profiles can renewal its three certificates
-   `commit <https://pagure.io/freeipa/c/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  Change KRA profiles in certmonger tracking so they can renew
-   `commit <https://pagure.io/freeipa/c/a9e1c014f601a567f4aa5135d02883c498835268>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9e1c014f601a567f4aa5135d02883c498835268>`__
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  ipatests: Increase timeout for ACME in gating.yaml
-   `commit <https://pagure.io/freeipa/c/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: honor class inheritance in TestACMEwithExternalCA
-   `commit <https://pagure.io/freeipa/c/75ad5757528491616f7f4e596bb9f6b152944d99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75ad5757528491616f7f4e596bb9f6b152944d99>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: configure MDStoreDir for mod_md ACME test
-   `commit <https://pagure.io/freeipa/c/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Clean up existing ACME registration and certs
-   `commit <https://pagure.io/freeipa/c/5d286e79515c8a6c856a5acde6300271422acfac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d286e79515c8a6c856a5acde6300271422acfac>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Configure a replica in TestACMEwithExternalCA
-   `commit <https://pagure.io/freeipa/c/de5baf8516cde060f1606070b2a8824f71178f16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de5baf8516cde060f1606070b2a8824f71178f16>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: call the CALess install method to generate the CA
-   `commit <https://pagure.io/freeipa/c/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Test that Match ProxyCommand masks on no shell exec
-   `commit <https://pagure.io/freeipa/c/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
    `#7676 <https://pagure.io/freeipa/issue/7676>`__
 -  Create IPA ssh client configuration and move ProxyCommand
-   `commit <https://pagure.io/freeipa/c/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
    `#7676 <https://pagure.io/freeipa/issue/7676>`__
 -  ipatests: Test that ipa-certupdate can run without credentials
-   `commit <https://pagure.io/freeipa/c/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
    `#8531 <https://pagure.io/freeipa/issue/8531>`__
 -  Use host keytab to obtain credentials needed for ipa-certupdate
-   `commit <https://pagure.io/freeipa/c/1a09ce9f3fa503eeefe394856be538892652accf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a09ce9f3fa503eeefe394856be538892652accf>`__
    `#8531 <https://pagure.io/freeipa/issue/8531>`__
 -  ipatests: Test that password reset unlocks users too
-   `commit <https://pagure.io/freeipa/c/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
    `#8551 <https://pagure.io/freeipa/issue/8551>`__
 -  On password reset also set krbLastAdminUnlock to unlock account
-   `commit <https://pagure.io/freeipa/c/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
    `#8551 <https://pagure.io/freeipa/issue/8551>`__
 -  Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test
-   `commit <https://pagure.io/freeipa/c/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Catch EmptyResult exception in update_idranges
-   `commit <https://pagure.io/freeipa/c/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  Test that ipapwpolicy objectclass is added on upgrade
-   `commit <https://pagure.io/freeipa/c/f86250a9a592f2549bc1446c8e3493b256618107>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f86250a9a592f2549bc1446c8e3493b256618107>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  Add ipwpwdpolicy objectclass to all policies on upgrade
-   `commit <https://pagure.io/freeipa/c/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  ipatests: Add tests for requiring ipa-ca SAN when ACME is enabled
-   `commit <https://pagure.io/freeipa/c/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  Change the return codes of ipa-acme-manage
-   `commit <https://pagure.io/freeipa/c/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  Require an ipa-ca SAN on 3rd party certs if ACME is enabled
-   `commit <https://pagure.io/freeipa/c/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  ipatests: Collect the let's encrypt log
-   `commit <https://pagure.io/freeipa/c/d4ef64b229541200564131e927cd0b4b32662fe2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ef64b229541200564131e927cd0b4b32662fe2>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Add a status option to ipa-acme-manage
-   `commit <https://pagure.io/freeipa/c/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Don't install ACME if full support is not available
-   `commit <https://pagure.io/freeipa/c/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Centralize enable/disable of the ACME service
-   `commit <https://pagure.io/freeipa/c/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Let dogtag.py be imported if the api is not initialized
-   `commit <https://pagure.io/freeipa/c/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Enable importing LDIF files not shipped by IPA
-   `commit <https://pagure.io/freeipa/c/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Use a state to determine if a 389-ds upgrade is in progress
-   `commit <https://pagure.io/freeipa/c/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
    `#7534 <https://pagure.io/freeipa/issue/7534>`__
 -  ipatests: Add test_pwpolicy to nightly runs
-   `commit <https://pagure.io/freeipa/c/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Requirements and design for libpwquality integration
-   `commit <https://pagure.io/freeipa/c/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add SELinux policy so kadmind can read the crackdb dictionary
-   `commit <https://pagure.io/freeipa/c/68aa7c05542422aca05bec4967133be09a32496e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68aa7c05542422aca05bec4967133be09a32496e>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  ipatests: add test for password policies
-   `commit <https://pagure.io/freeipa/c/fe44835970eca197543eb3c908c51a240204d846>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe44835970eca197543eb3c908c51a240204d846>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add a raiseonerr option to ldappasswd_user_change
-   `commit <https://pagure.io/freeipa/c/be2efc12d37018794200fee874f27d83e0442ea4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be2efc12d37018794200fee874f27d83e0442ea4>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Pass the user to the password policy check in the kdb driver
-   `commit <https://pagure.io/freeipa/c/6da070e655c5d084a825607ed3be604c809b12f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da070e655c5d084a825607ed3be604c809b12f0>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add a unit test for libpwquality-based password policy
-   `commit <https://pagure.io/freeipa/c/46d0096218488a961125b6d97a9210b68e5434e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46d0096218488a961125b6d97a9210b68e5434e5>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Extend password policy to evaluate passwords using libpwpolicy
-   `commit <https://pagure.io/freeipa/c/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Require libpwolicy and configure it in the build system
-   `commit <https://pagure.io/freeipa/c/3fc2eda4e15e9592132062036d70acad3bab401c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fc2eda4e15e9592132062036d70acad3bab401c>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add new pwpolicy objectclass to test_xmprpc/objectclasses.py
-   `commit <https://pagure.io/freeipa/c/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Extend IPA pwquality plugin to include libpwquality support
-   `commit <https://pagure.io/freeipa/c/6b452e54045bb957e6f787209b4498eefc5df779>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b452e54045bb957e6f787209b4498eefc5df779>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add LDAP schema for new libpwquality attributes
-   `commit <https://pagure.io/freeipa/c/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Don't restart certmonger after stopping tracking in uninstall
-   `commit <https://pagure.io/freeipa/c/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
    `#8533 <https://pagure.io/freeipa/issue/8533>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
-   `commit <https://pagure.io/freeipa/c/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Test that ccaches are cleaned up during installation
-   `commit <https://pagure.io/freeipa/c/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
-   `commit <https://pagure.io/freeipa/c/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Require a matching server package for the selinux subpackage
-   `commit <https://pagure.io/freeipa/c/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
    `#8511 <https://pagure.io/freeipa/issue/8511>`__
 -  Add index for more trust-related attributes
-   `commit <https://pagure.io/freeipa/c/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  ipatests: Add tests for checking available memory
-   `commit <https://pagure.io/freeipa/c/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
-   `commit <https://pagure.io/freeipa/c/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
-   `commit <https://pagure.io/freeipa/c/2e4431af7066ce298008973b6caddc170645c98d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e4431af7066ce298008973b6caddc170645c98d>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  Use ACI class set_permissions() method to set permissions
-   `commit <https://pagure.io/freeipa/c/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  De-duplicate ACI attributes and permissions
-   `commit <https://pagure.io/freeipa/c/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
-   `commit <https://pagure.io/freeipa/c/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
-   `commit <https://pagure.io/freeipa/c/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Set the certmonger subject with a string, not an object
-   `commit <https://pagure.io/freeipa/c/f249c51bf4342341378e63953386e9ac4070be54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f249c51bf4342341378e63953386e9ac4070be54>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
-   `commit <https://pagure.io/freeipa/c/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  cli: When parsing options require name/value pairs
-   `commit <https://pagure.io/freeipa/c/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
-   `commit <https://pagure.io/freeipa/c/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 -  ipatests: stop the CA during healthcheck expiration test
-   `commit <https://pagure.io/freeipa/c/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
    `#8463 <https://pagure.io/freeipa/issue/8463>`__
 -  Improve performance of ipa-server-guard
-   `commit <https://pagure.io/freeipa/c/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
    `#8425 <https://pagure.io/freeipa/issue/8425>`__
 -  ipatests: Add test for is_ipa_configured
-   `commit <https://pagure.io/freeipa/c/25e042d3d1e04972d4536b1fa793811e6b047559>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25e042d3d1e04972d4536b1fa793811e6b047559>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Use is_ipa_configured from ipalib.facts
-   `commit <https://pagure.io/freeipa/c/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Fall back to old server installation detection when needed
-   `commit <https://pagure.io/freeipa/c/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
-   `commit <https://pagure.io/freeipa/c/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
 -  Added negative test case for --list-sources option
-   `commit <https://pagure.io/freeipa/c/143dea18fe9bc2ebc65a8dbdcfa44d331adc161c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/143dea18fe9bc2ebc65a8dbdcfa44d331adc161c>`__
 -  ipatests: CLI validation of ipa-healthcheck command
-   `commit <https://pagure.io/freeipa/c/c5853768a778069945237e0a039715d89e16a94e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5853768a778069945237e0a039715d89e16a94e>`__
 -  IPA-EPN: Test that users without givenname and/or mail are handled
-   `commit <https://pagure.io/freeipa/c/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
 -  Address legacy pylint issues in sysrestore.py
-   `commit <https://pagure.io/freeipa/c/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Update check_client_configuration to use new client fact
-   `commit <https://pagure.io/freeipa/c/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Don't use the has_files() to know if client/server is configured
-   `commit <https://pagure.io/freeipa/c/5e027134815512862ad6ae77867e74a83aee2b59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e027134815512862ad6ae77867e74a83aee2b59>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
-   `commit <https://pagure.io/freeipa/c/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if IPA client configuration is complete
-   `commit <https://pagure.io/freeipa/c/4758db121ea0c555dab89bc1781c8752f188e414>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4758db121ea0c555dab89bc1781c8752f188e414>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if an IPA server installation is complete
-   `commit <https://pagure.io/freeipa/c/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
-   `commit <https://pagure.io/freeipa/c/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
-   `commit <https://pagure.io/freeipa/c/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  ipatests: Test healthcheck revocation checker
-   `commit <https://pagure.io/freeipa/c/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
-   `commit <https://pagure.io/freeipa/c/61c71e4a62347cd7188e407acc69ce8362857cb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61c71e4a62347cd7188e407acc69ce8362857cb4>`__
 -  ipatests: lib389 is now providing healthchecks, update naming
-   `commit <https://pagure.io/freeipa/c/d238fb4f2bb6525367a73c42a8a238843d5c8b43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d238fb4f2bb6525367a73c42a8a238843d5c8b43>`__
 -  ipatests: verify that all services can be detected by healthcheck
-   `commit <https://pagure.io/freeipa/c/e1027cc8b14b5ae0bdcc265c640f802800fa8b2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1027cc8b14b5ae0bdcc265c640f802800fa8b2a>`__
 -  ipatests: Add healthcheck test for FileSystemSpaceCheck
-   `commit <https://pagure.io/freeipa/c/07bc5e2598abfd97ac182acef40c3a08e0477009>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07bc5e2598abfd97ac182acef40c3a08e0477009>`__
 -  ipatests: Test that healthcheck detects and reports expiration
-   `commit <https://pagure.io/freeipa/c/c84b1db80954c4a963f268c62924b69d8ab5c1a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c84b1db80954c4a963f268c62924b69d8ab5c1a2>`__
 -  ipatests: Test cases for healthcheck File checker(s)
-   `commit <https://pagure.io/freeipa/c/550fbc0b9ff682d15a4f4a89974d0e506430fa8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/550fbc0b9ff682d15a4f4a89974d0e506430fa8e>`__
 -  Replace SSLCertVerificationError with CertificateError for py36
-   `commit <https://pagure.io/freeipa/c/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
-   `commit <https://pagure.io/freeipa/c/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
    `#8429 <https://pagure.io/freeipa/issue/8429>`__
 -  Don't delegate the TGT in ipa-join
-   `commit <https://pagure.io/freeipa/c/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
    `#8405 <https://pagure.io/freeipa/issue/8405>`__
 -  IPA-EPN: Don't treat givenname differently
-   `commit <https://pagure.io/freeipa/c/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
-   `commit <https://pagure.io/freeipa/c/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
-   `commit <https://pagure.io/freeipa/c/3b266d39570f447db0f571a8b8085eb6c0403509>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b266d39570f447db0f571a8b8085eb6c0403509>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
-   `commit <https://pagure.io/freeipa/c/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
-   `commit <https://pagure.io/freeipa/c/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: test using SSL against port 465
-   `commit <https://pagure.io/freeipa/c/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add test for starttls mode
-   `commit <https://pagure.io/freeipa/c/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
-   `commit <https://pagure.io/freeipa/c/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
-   `commit <https://pagure.io/freeipa/c/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add index for krbPasswordExpiration for EPN
-   `commit <https://pagure.io/freeipa/c/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add a jinja2 e-mail template for EPN
-   `commit <https://pagure.io/freeipa/c/03caa7f965d889848675158503286cde00d635c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03caa7f965d889848675158503286cde00d635c9>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Perform baseline healthcheck
-   `commit <https://pagure.io/freeipa/c/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
 -  Test that pwpolicy only applied on Kerberos entries
-   `commit <https://pagure.io/freeipa/c/89066892151e1da5c2557d8eb76c2b04dbd61979>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89066892151e1da5c2557d8eb76c2b04dbd61979>`__
 -  Add ability to change a user password as the Directory Manager
-   `commit <https://pagure.io/freeipa/c/ff6984e2eea0f54851db796c8b3ad29c54a4e325>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff6984e2eea0f54851db796c8b3ad29c54a4e325>`__
 -  Don't save password history on non-Kerberos accounts
-   `commit <https://pagure.io/freeipa/c/132a0f8771edd3a741bc60e6bc4c9b56cb172e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132a0f8771edd3a741bc60e6bc4c9b56cb172e4a>`__
 -  Test that ipa-healthcheck human output translates error strings
-   `commit <https://pagure.io/freeipa/c/4a3b7baed785f7492e8404dac3eee8a8ce9fd937>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a3b7baed785f7492e8404dac3eee8a8ce9fd937>`__
 -  Move execution of ipa-healthcheck to a separate function
-   `commit <https://pagure.io/freeipa/c/44e73428441a070f26a791ee2816f2989713ba8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44e73428441a070f26a791ee2816f2989713ba8d>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
-   `commit <https://pagure.io/freeipa/c/f589a8952c33a25794e577077bb3c0bda740667c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f589a8952c33a25794e577077bb3c0bda740667c>`__
    `#8135 <https://pagure.io/freeipa/issue/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/e4966f9c3f9566603be24e09f4803b3183898272>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4966f9c3f9566603be24e09f4803b3183898272>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  Add tests for ipa-cacert-manage delete command
-   `commit <https://pagure.io/freeipa/c/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
-   `commit <https://pagure.io/freeipa/c/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
-   `commit <https://pagure.io/freeipa/c/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
-   `commit <https://pagure.io/freeipa/c/02ce407f5e10e670d4788778037892b58f80adc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02ce407f5e10e670d4788778037892b58f80adc0>`__
 -  Add integration test for Kerberos ticket policy
-   `commit <https://pagure.io/freeipa/c/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Conditionally restart certmonger after client installation
-   `commit <https://pagure.io/freeipa/c/3593e5362206fd9287e97fe2cee229a1117811ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3593e5362206fd9287e97fe2cee229a1117811ff>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Add conditional restart (try-restart) capability to services
-   `commit <https://pagure.io/freeipa/c/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Enable AES SHA 256 and 384-bit enctypes in Kerberos
-   `commit <https://pagure.io/freeipa/c/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
    `#8110 <https://pagure.io/freeipa/issue/8110>`__
 -  Disable dogtag cert publishing
-   `commit <https://pagure.io/freeipa/c/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
    `#7522 <https://pagure.io/freeipa/issue/7522>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
-   `commit <https://pagure.io/freeipa/c/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 -  Report if a certmonger CA is missing
-   `commit <https://pagure.io/freeipa/c/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
    `#7870 <https://pagure.io/freeipa/issue/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
-   `commit <https://pagure.io/freeipa/c/ffb4b624fc8bfd870958976ec25b74677e740841>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffb4b624fc8bfd870958976ec25b74677e740841>`__
    `#8034 <https://pagure.io/freeipa/issue/8034>`__
 -  Don't log host passwords when they are set/modified
-   `commit <https://pagure.io/freeipa/c/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  Skip lock and fork in ipa-server-guard on unsupported ops
-   `commit <https://pagure.io/freeipa/c/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
 -  Defer initializing the API in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/0770254ce347c9892f6b143bb5f48fb1b0826e2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0770254ce347c9892f6b143bb5f48fb1b0826e2a>`__
 -  Add missing timeout option to logging statement
-   `commit <https://pagure.io/freeipa/c/5db48f151ba4aef2baebc40a4d357403a922d362>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5db48f151ba4aef2baebc40a4d357403a922d362>`__
 -  Log dogtag auth timeout in install, provide hint to increase it
-   `commit <https://pagure.io/freeipa/c/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Log the replication wait timeout for debugging purposes
-   `commit <https://pagure.io/freeipa/c/54035982e5850ec59611798a9e172a044969106f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54035982e5850ec59611798a9e172a044969106f>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Replace replication_wait_timeout with certmonger_wait_timeout
-   `commit <https://pagure.io/freeipa/c/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Use tasks to configure automount nsswitch settings
-   `commit <https://pagure.io/freeipa/c/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
 -  Move ipachangeconf from ipaclient.install to ipapython
-   `commit <https://pagure.io/freeipa/c/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
-   `commit <https://pagure.io/freeipa/c/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  httpinstance: add pinfile when tracking certificate
-   `commit <https://pagure.io/freeipa/c/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  Remove posixAccount from service_find search filter
-   `commit <https://pagure.io/freeipa/c/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
    `#8013 <https://pagure.io/freeipa/issue/8013>`__
 
 
@@ -4574,41 +4574,41 @@ Robbie Harwood (17)
 ----------------------------------------------------------------------------------------------
 
 -  Fix krbtpolicy tests
-   `commit <https://pagure.io/freeipa/c/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
    `#8590 <https://pagure.io/freeipa/issue/8590>`__
 -  Drop upper bound on krb5 version in freeipa.spec
-   `commit <https://pagure.io/freeipa/c/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
 -  ipa-kdb: implement AS-REQ lifetime jitter
-   `commit <https://pagure.io/freeipa/c/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
    `#8010 <https://pagure.io/freeipa/issue/8010>`__
 -  Update kdcpolicy design doc for jitter implementation
-   `commit <https://pagure.io/freeipa/c/249097c62414abc99256af9dc622c284745081e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/249097c62414abc99256af9dc622c284745081e4>`__
 -  Drop support for DAL version 5.0
-   `commit <https://pagure.io/freeipa/c/93e81cfd0c1d4d759985ed1ce3f4aa540dcf438e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93e81cfd0c1d4d759985ed1ce3f4aa540dcf438e>`__
 -  Support DAL version 8.0
-   `commit <https://pagure.io/freeipa/c/ff10f3fa18948971912bab9ad5bfbc3d36133a3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff10f3fa18948971912bab9ad5bfbc3d36133a3b>`__
 -  Handle the removal of KRB5_KDB_FLAG_ALIAS_OK
-   `commit <https://pagure.io/freeipa/c/1c787cc36c42f05fe945c4a8ae8551832e0e2c1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c787cc36c42f05fe945c4a8ae8551832e0e2c1d>`__
 -  Fix several leaks in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/df6a89be51fa8bbc9ce292c9730f20a1e34674ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df6a89be51fa8bbc9ce292c9730f20a1e34674ac>`__
 -  Use separate variable for client fetch in kdcpolicy
-   `commit <https://pagure.io/freeipa/c/ab4e910c52ae4bdf75eca85f8ff54508f6974fc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab4e910c52ae4bdf75eca85f8ff54508f6974fc3>`__
 -  Make the coding style explicit
-   `commit <https://pagure.io/freeipa/c/3ccf73bfd6f87d7be1a156d276c22a81d1fac6b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ccf73bfd6f87d7be1a156d276c22a81d1fac6b4>`__
 -  Provide modern example enctypes in ipa-getkeytab(1)
-   `commit <https://pagure.io/freeipa/c/3cb9444c4c9af126c0559d4f1cb6c58aece78b19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cb9444c4c9af126c0559d4f1cb6c58aece78b19>`__
 -  Fix segfault in ipadb_parse_ldap_entry()
-   `commit <https://pagure.io/freeipa/c/c11fd328bc4d175308e58cd7a0c72dcb8d16bfdf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c11fd328bc4d175308e58cd7a0c72dcb8d16bfdf>`__
 -  Add a skeleton kdcpolicy plugin
-   `commit <https://pagure.io/freeipa/c/179c8f4009adc30b9b3c497855f15927016c84db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/179c8f4009adc30b9b3c497855f15927016c84db>`__
 -  Move certauth configuration into a server krb5.conf template
-   `commit <https://pagure.io/freeipa/c/39e3704a0679d117f5145044e73726175a8f600b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39e3704a0679d117f5145044e73726175a8f600b>`__
 -  Enable krb5 snippet updates on client update
-   `commit <https://pagure.io/freeipa/c/c7b938a1d5c20df24a2d8a62019c5341e0f26c63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7b938a1d5c20df24a2d8a62019c5341e0f26c63>`__
 -  Fix NULL pointer dereference in maybe_require_preauth()
-   `commit <https://pagure.io/freeipa/c/45b4f5377bf3921406271148e18a3b99acfee03b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45b4f5377bf3921406271148e18a3b99acfee03b>`__
 -  Log INFO message when LDAP connection fails on startup
-   `commit <https://pagure.io/freeipa/c/9414b038e714043d87dc0646dd9af3933896a75a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9414b038e714043d87dc0646dd9af3933896a75a>`__
 
 
 
@@ -4616,7 +4616,7 @@ Rafael Guterres Jeffman (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes pylint errors introduced by version 2.4.0.
-   `commit <https://pagure.io/freeipa/c/883b44243ae005c6f2d6d5cab502083f1cc10273>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/883b44243ae005c6f2d6d5cab502083f1cc10273>`__
 
 
 
@@ -4624,17 +4624,17 @@ Rafael Guterres Jeffman (6)
 ----------------------------------------------------------------------------------------------
 
 -  Removed unnecessary imports after code review.
-   `commit <https://pagure.io/freeipa/c/73529e065c901c332caef125f1f12cba33ddaefd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73529e065c901c332caef125f1f12cba33ddaefd>`__
 -  Removes several pylint warnings.
-   `commit <https://pagure.io/freeipa/c/d4fab33605503fadd1826cd3e879d9c928b8cea9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4fab33605503fadd1826cd3e879d9c928b8cea9>`__
 -  Removed unnecessary imports after code review.
-   `commit <https://pagure.io/freeipa/c/51e0f564870b9b353f0ecf81da700f3d5d1791fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f564870b9b353f0ecf81da700f3d5d1791fb>`__
 -  Removes several pylint warnings.
-   `commit <https://pagure.io/freeipa/c/c898be1df926bd134ac4d7cd86d10a00ff5cd2ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c898be1df926bd134ac4d7cd86d10a00ff5cd2ae>`__
 -  Removes rpmlint warning on freeipa.spec.
-   `commit <https://pagure.io/freeipa/c/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
 -  Re-add function façades removed by commit 2da9088.
-   `commit <https://pagure.io/freeipa/c/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
    `#8062 <https://pagure.io/freeipa/issue/8062>`__
 
 
@@ -4643,7 +4643,7 @@ Robert Collins (1)
 ----------------------------------------------------------------------------------------------
 
 -  Note sss_cache -E.
-   `commit <https://pagure.io/freeipa/c/681f8ae5a48c39c915c12d75f2d4554b100822a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/681f8ae5a48c39c915c12d75f2d4554b100822a9>`__
 
 
 
@@ -4651,7 +4651,7 @@ Sam Bristow (1)
 ----------------------------------------------------------------------------------------------
 
 -  Workaround networking issues with Libvirt
-   `commit <https://pagure.io/freeipa/c/265d064bf890d06e64015339fb4789d8aaaec149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/265d064bf890d06e64015339fb4789d8aaaec149>`__
 
 
 
@@ -4659,7 +4659,7 @@ Sam Morris (1)
 ----------------------------------------------------------------------------------------------
 
 -  Debian: write out only one CA certificate per file
-   `commit <https://pagure.io/freeipa/c/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
    `#8106 <https://pagure.io/freeipa/issue/8106>`__
 
 
@@ -4668,10 +4668,10 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: Remove keys if password auth is disabled
-   `commit <https://pagure.io/freeipa/c/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
-   `commit <https://pagure.io/freeipa/c/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -4680,7 +4680,7 @@ Sergio Oliveira Campos (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add test for sssd ad trust lookup with dn in certmaprule
-   `commit <https://pagure.io/freeipa/c/e071933e642a83140550ddcf86d6fcb50c3e65bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e071933e642a83140550ddcf86d6fcb50c3e65bc>`__
 
 
 
@@ -4688,256 +4688,256 @@ Stanislav Levin (91)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Collect EPN log for debugging
-   `commit <https://pagure.io/freeipa/c/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
 -  EPN: Allow authentication by SMTP client's certificate
-   `commit <https://pagure.io/freeipa/c/17f430efc4cf438b6c052465b8252688bc5822f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17f430efc4cf438b6c052465b8252688bc5822f9>`__
    `#8580 <https://pagure.io/freeipa/issue/8580>`__
 -  EPN: Enable certificate validation and hostname checking
-   `commit <https://pagure.io/freeipa/c/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
    `#8579 <https://pagure.io/freeipa/issue/8579>`__
 -  test_epn: Standardize EPN configs for deduplication
-   `commit <https://pagure.io/freeipa/c/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
 -  EPN: Don't downgrade security
-   `commit <https://pagure.io/freeipa/c/94adee3c73f039fc2d985afd1681cd64ece55116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94adee3c73f039fc2d985afd1681cd64ece55116>`__
    `#8578 <https://pagure.io/freeipa/issue/8578>`__
 -  ipatests: Respect platform's openssl dir
-   `commit <https://pagure.io/freeipa/c/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
 -  dns: Make use of \`resolve_address\` of a current resolver instead of
    the global one
-   `commit <https://pagure.io/freeipa/c/b450c9bd324a3c89ea03d898592cfed832184802>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b450c9bd324a3c89ea03d898592cfed832184802>`__
 -  dnspython: Add compatibility shim
-   `commit <https://pagure.io/freeipa/c/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
    `#8383 <https://pagure.io/freeipa/issue/8383>`__
 -  tox: Don't expand symlinks
-   `commit <https://pagure.io/freeipa/c/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
    `#8475 <https://pagure.io/freeipa/issue/8475>`__
 -  Azure: Increase verbosity for Tox task
-   `commit <https://pagure.io/freeipa/c/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
-   `commit <https://pagure.io/freeipa/c/f3d10871300498150c41f3acc154688f1ee48ceb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3d10871300498150c41f3acc154688f1ee48ceb>`__
 -  nss: Raise exception earlier on unsupported DB type
-   `commit <https://pagure.io/freeipa/c/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
    `#8474 <https://pagure.io/freeipa/issue/8474>`__
 -  Azure: base: Collect both install and uninstall logs
-   `commit <https://pagure.io/freeipa/c/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
 -  Azure: Drop dependency on UsePythonVersion task
-   `commit <https://pagure.io/freeipa/c/60ff2841cd74706a5ebd40924f11ad3defaa1750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60ff2841cd74706a5ebd40924f11ad3defaa1750>`__
 -  Azure: Add Rawhide definitions
-   `commit <https://pagure.io/freeipa/c/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
 -  ipa-dnskeysyncd: Raise loglevel to DEBUG
-   `commit <https://pagure.io/freeipa/c/92157bc880600be137c634d5def788c1bf8c5e8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92157bc880600be137c634d5def788c1bf8c5e8a>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Include crypto policy in openssl config
-   `commit <https://pagure.io/freeipa/c/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Don't override custom command line options for named
-   `commit <https://pagure.io/freeipa/c/ecfaf897b937e2333296d32960b2cc13843048f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecfaf897b937e2333296d32960b2cc13843048f9>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  service: Allow service to clean up its state
-   `commit <https://pagure.io/freeipa/c/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  spec: Bump required openssl-pkcs11 and softhsm
-   `commit <https://pagure.io/freeipa/c/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Make use of 'pkcs11' OpenSSL engine for BIND on Fedora31
-   `commit <https://pagure.io/freeipa/c/721435cf7f2ed41fe807c34022fed31c792b4497>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/721435cf7f2ed41fe807c34022fed31c792b4497>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  upgrade: Handle migration of BIND OpenSSL engine
-   `commit <https://pagure.io/freeipa/c/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  DNSKeySyncInstance: Populate named/ods uid/gid on instantiation
-   `commit <https://pagure.io/freeipa/c/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Allow using of a custom OpenSSL engine for BIND
-   `commit <https://pagure.io/freeipa/c/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Remove no longer used paths
-   `commit <https://pagure.io/freeipa/c/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  spec: Require ldns-utils
-   `commit <https://pagure.io/freeipa/c/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  pylint: Ignore \`raise-missing-from\`
-   `commit <https://pagure.io/freeipa/c/8831b9b6498b834c77dce2e0b96854be105810f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8831b9b6498b834c77dce2e0b96854be105810f9>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
-   `commit <https://pagure.io/freeipa/c/ec6369ca009139af69aa4214e82fc411184b428f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec6369ca009139af69aa4214e82fc411184b428f>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
-   `commit <https://pagure.io/freeipa/c/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Teach pylint about more RRs types
-   `commit <https://pagure.io/freeipa/c/de105aa8fc8281c28c359d607c2b43154103a399>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de105aa8fc8281c28c359d607c2b43154103a399>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  spec: Move ipa-cldap plugin out to freeipa-server-trust-ad package
-   `commit <https://pagure.io/freeipa/c/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
 -  uninstall: Clean up no longer used flag
-   `commit <https://pagure.io/freeipa/c/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
-   `commit <https://pagure.io/freeipa/c/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
-   `commit <https://pagure.io/freeipa/c/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
    `#8459 <https://pagure.io/freeipa/issue/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
-   `commit <https://pagure.io/freeipa/c/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
 -  Azure: Switch to dockerhub provider
-   `commit <https://pagure.io/freeipa/c/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
-   `commit <https://pagure.io/freeipa/c/06a344a5d932db148b1921c03906d2843b3622cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a344a5d932db148b1921c03906d2843b3622cb>`__
    `#8428 <https://pagure.io/freeipa/issue/8428>`__
 -  pylint: Fix warning and error
-   `commit <https://pagure.io/freeipa/c/c81cac70acd304f34f875af5096c407a44f1395b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c81cac70acd304f34f875af5096c407a44f1395b>`__
    `#8442 <https://pagure.io/freeipa/issue/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
-   `commit <https://pagure.io/freeipa/c/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
    `#8435 <https://pagure.io/freeipa/issue/8435>`__
 -  Azure: Make dnf repos consistent
-   `commit <https://pagure.io/freeipa/c/26f96595b010396f055c7d11a645be57fc637863>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26f96595b010396f055c7d11a645be57fc637863>`__
    `#8330 <https://pagure.io/freeipa/issue/8330>`__
 -  Azure: Always update apt cache
-   `commit <https://pagure.io/freeipa/c/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
 -  Azure: Allow chronyd to sync time
-   `commit <https://pagure.io/freeipa/c/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Add custom seccomp profile
-   `commit <https://pagure.io/freeipa/c/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Increase memory limit
-   `commit <https://pagure.io/freeipa/c/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
    `#8264 <https://pagure.io/freeipa/issue/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
-   `commit <https://pagure.io/freeipa/c/63747bc0c041382536e2cad121bb591e42df3a2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63747bc0c041382536e2cad121bb591e42df3a2f>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Pretty print multihost config
-   `commit <https://pagure.io/freeipa/c/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
-   `commit <https://pagure.io/freeipa/c/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Specify shell implementation
-   `commit <https://pagure.io/freeipa/c/974395704ad3a0c992324a080e96e1160f324153>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/974395704ad3a0c992324a080e96e1160f324153>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Specify Pytest XML report schema
-   `commit <https://pagure.io/freeipa/c/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
-   `commit <https://pagure.io/freeipa/c/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
-   `commit <https://pagure.io/freeipa/c/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
-   `commit <https://pagure.io/freeipa/c/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove deprecated yield_fixture
-   `commit <https://pagure.io/freeipa/c/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Bump required Pytest
-   `commit <https://pagure.io/freeipa/c/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
-   `commit <https://pagure.io/freeipa/c/ba162b9b47004da633a2c140409982725f5e0960>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba162b9b47004da633a2c140409982725f5e0960>`__
    `#8261 <https://pagure.io/freeipa/issue/8261>`__
 -  Azure: Gather coredumps
-   `commit <https://pagure.io/freeipa/c/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
    `#8251 <https://pagure.io/freeipa/issue/8251>`__
 -  Azure: Allow distros to install Python they want
-   `commit <https://pagure.io/freeipa/c/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
    `#8254 <https://pagure.io/freeipa/issue/8254>`__
 -  pki-proxy: Don't rely on running apache until it's configured
-   `commit <https://pagure.io/freeipa/c/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
    `#8233 <https://pagure.io/freeipa/issue/8233>`__
 -  spec: Take the ownership over '/usr/libexec/ipa/custodia'
-   `commit <https://pagure.io/freeipa/c/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
 -  Azure: Report elapsed time
-   `commit <https://pagure.io/freeipa/c/0a1e98cdf055867d8a02ed6a8eb65eabe2442a67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a1e98cdf055867d8a02ed6a8eb65eabe2442a67>`__
 -  Azure: Rebalance tests
-   `commit <https://pagure.io/freeipa/c/38e0a9f4c0bd38c204be5dde2d689308d9e153d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38e0a9f4c0bd38c204be5dde2d689308d9e153d6>`__
 -  Azure: Skip tests requiring external DNS
-   `commit <https://pagure.io/freeipa/c/9203404cd5d9864bfcf6e5b1f4ae2c054464e757>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9203404cd5d9864bfcf6e5b1f4ae2c054464e757>`__
 -  Azure: Free Docker resources after usage
-   `commit <https://pagure.io/freeipa/c/e925148ad9d5d8e36a61c68d0d247283c109a37e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e925148ad9d5d8e36a61c68d0d247283c109a37e>`__
 -  Azure: Preliminary check for provided limits
-   `commit <https://pagure.io/freeipa/c/1fa033c32d4c94ea9456a2a728893e206957930e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fa033c32d4c94ea9456a2a728893e206957930e>`__
 -  Azure: Sync Gating definitions to current PR-CI
-   `commit <https://pagure.io/freeipa/c/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
 -  pylint: Run Pylint over Azure Python scripts
-   `commit <https://pagure.io/freeipa/c/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Add support for testing multi IPA environments
-   `commit <https://pagure.io/freeipa/c/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
-   `commit <https://pagure.io/freeipa/c/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  yamllint: Lint all the YAML files
-   `commit <https://pagure.io/freeipa/c/fa104daf77902172f087c7026052fd9a59b4861a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa104daf77902172f087c7026052fd9a59b4861a>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
-   `commit <https://pagure.io/freeipa/c/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to run integration tests
-   `commit <https://pagure.io/freeipa/c/879855ce705770834d0be8182818ae672bc72063>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/879855ce705770834d0be8182818ae672bc72063>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow SSH for Docker environments
-   `commit <https://pagure.io/freeipa/c/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to not provide tests to be ignored
-   `commit <https://pagure.io/freeipa/c/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  ipatests: Allow zero-length arguments
-   `commit <https://pagure.io/freeipa/c/902821e8aa47936acac713023bff9a4009d8dfb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/902821e8aa47936acac713023bff9a4009d8dfb7>`__
    `#8173 <https://pagure.io/freeipa/issue/8173>`__
 -  lint: Make Pylint-2.4 happy again
-   `commit <https://pagure.io/freeipa/c/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Clean up comment
-   `commit <https://pagure.io/freeipa/c/a309de6c08987b1cf9645111414d1c52b4525190>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a309de6c08987b1cf9645111414d1c52b4525190>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
-   `commit <https://pagure.io/freeipa/c/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Teach Pylint how to handle request.context
-   `commit <https://pagure.io/freeipa/c/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  ipatests: Properly kill gpg-agent
-   `commit <https://pagure.io/freeipa/c/19462788f162491e0aedaaf42528cae7104b8068>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19462788f162491e0aedaaf42528cae7104b8068>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
-   `commit <https://pagure.io/freeipa/c/8c7447fd42548d28df6200e354afdc03355b94b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7447fd42548d28df6200e354afdc03355b94b6>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/292d686c0b7935dd219559b10de3a393b712a990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/292d686c0b7935dd219559b10de3a393b712a990>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  Fix errors found by Pylint-2.4.3
-   `commit <https://pagure.io/freeipa/c/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
    `#8102 <https://pagure.io/freeipa/issue/8102>`__
 -  Install language packs for tests
-   `commit <https://pagure.io/freeipa/c/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
 -  Restore running of 'test_ipaserver' tests on Azure
-   `commit <https://pagure.io/freeipa/c/16149831daf12826c1c39d4109a0014b86fbb072>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16149831daf12826c1c39d4109a0014b86fbb072>`__
 -  Setup DNS for AP Docker container
-   `commit <https://pagure.io/freeipa/c/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 -  Fixed errors newly exposed by pylint 2.4.0
-   `commit <https://pagure.io/freeipa/c/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 -  Avoid use of '/tmp' for pip operations
-   `commit <https://pagure.io/freeipa/c/c7500220c443c6051178211eadd64392ca7bd08a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7500220c443c6051178211eadd64392ca7bd08a>`__
    `#8009 <https://pagure.io/freeipa/issue/8009>`__
 -  Make use of Azure Pipeline slicing
-   `commit <https://pagure.io/freeipa/c/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
    `#8008 <https://pagure.io/freeipa/issue/8008>`__
 -  Simplify ipa-run-tests script
-   `commit <https://pagure.io/freeipa/c/2312b38a678d30b73c08dae19db7f8b74361a957>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2312b38a678d30b73c08dae19db7f8b74361a957>`__
    `#8007 <https://pagure.io/freeipa/issue/8007>`__
 -  Fix \`test_webui.test_selinuxusermap\`
-   `commit <https://pagure.io/freeipa/c/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
    `#7996 <https://pagure.io/freeipa/issue/7996>`__,
    `#8005 <https://pagure.io/freeipa/issue/8005>`__
 
@@ -4947,110 +4947,110 @@ Sergey Orlov (45)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: simplify fixture
-   `commit <https://pagure.io/freeipa/c/6da5cc32d743d75b11a874a027d812603432ce45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da5cc32d743d75b11a874a027d812603432ce45>`__
 -  ipatests: refactor test for login using cifs alias principal
-   `commit <https://pagure.io/freeipa/c/4420ae81ae6c42a945d7b4d2cc6df5e381052e7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4420ae81ae6c42a945d7b4d2cc6df5e381052e7b>`__
 -  Fix password file permission
-   `commit <https://pagure.io/freeipa/c/07341990d962643e421ec1e7f6dd027cf428e0dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07341990d962643e421ec1e7f6dd027cf428e0dc>`__
 -  ipatests: mark test_trustdomain_disable test as expectedly failing
-   `commit <https://pagure.io/freeipa/c/26233c887eb50f30407c1a6eb953fd57c7fd9fb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26233c887eb50f30407c1a6eb953fd57c7fd9fb9>`__
 -  ipatests: add context manager for declaring part of test as xfail
-   `commit <https://pagure.io/freeipa/c/84c94f735004eaac3d6debd9ddebbd89a2d75f4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c94f735004eaac3d6debd9ddebbd89a2d75f4e>`__
 -  ipatests: add utility for getting sssd version on remote host
-   `commit <https://pagure.io/freeipa/c/3ae0d0d724a094d3e8251b141e2b58b024300134>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ae0d0d724a094d3e8251b141e2b58b024300134>`__
 -  update prci definitions for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/b238812b964f9526454ed7066633c73f2f596101>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b238812b964f9526454ed7066633c73f2f596101>`__
 -  ipatests: add test for sssd behavior with disabled trustdomains
-   `commit <https://pagure.io/freeipa/c/d8135b73283bc0a17df322f66e2154bec5f48170>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8135b73283bc0a17df322f66e2154bec5f48170>`__
 -  ipatests: add missing classes from test_nfs in nightly_previous run
-   `commit <https://pagure.io/freeipa/c/9b3c3202ca14da9be13bd976ea82d02f614b319c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b3c3202ca14da9be13bd976ea82d02f614b319c>`__
 -  ipatests: add missing classes from test_installation in nightly runs
-   `commit <https://pagure.io/freeipa/c/1c4aa66b3cdf56a14f01c6750c494914e4d651eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c4aa66b3cdf56a14f01c6750c494914e4d651eb>`__
 -  ipatests: run test_integration/test_cert.py in PR-CI
-   `commit <https://pagure.io/freeipa/c/99a322a4ae3c6a66d1e52517ee17c9b9c1b902e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a322a4ae3c6a66d1e52517ee17c9b9c1b902e0>`__
 -  ipatests: run all cases from test_integration/test_idviews.py in
    nightlies
-   `commit <https://pagure.io/freeipa/c/b8e1a7d5ae73bffa745e8417968cef0b77892cc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8e1a7d5ae73bffa745e8417968cef0b77892cc3>`__
 -  ipatests: explicitly save output of certutil
-   `commit <https://pagure.io/freeipa/c/98b6326a8e4c906ef267f838eb755898305186ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98b6326a8e4c906ef267f838eb755898305186ce>`__
 -  ipatests: add AD DC as a DNS forwarder before establishing trust
-   `commit <https://pagure.io/freeipa/c/a2dee05b168ca1651c145d239da7bb5c1a8b3865>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2dee05b168ca1651c145d239da7bb5c1a8b3865>`__
 -  ipatests: add test_automember to "previous" nightly run
-   `commit <https://pagure.io/freeipa/c/e927396851a2d24409ca3972d21804c83c14e502>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e927396851a2d24409ca3972d21804c83c14e502>`__
 -  ipatests: add test_fips to testing-fedora nightly run
-   `commit <https://pagure.io/freeipa/c/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
 -  ipatests: provide AD admin password when trying to establish trust
-   `commit <https://pagure.io/freeipa/c/aae30eb708b04c54807bc226b93ca14e09561b87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aae30eb708b04c54807bc226b93ca14e09561b87>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  ipatests: remove test_ordering
-   `commit <https://pagure.io/freeipa/c/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
 -  ipatests: add test for SSSD updating expired cache items
-   `commit <https://pagure.io/freeipa/c/8dd663e0c2cbc6c6fec43ffcc09259f9be336429>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8dd663e0c2cbc6c6fec43ffcc09259f9be336429>`__
 -  ipatests: provide docstrings instead of imporperly placed comments
-   `commit <https://pagure.io/freeipa/c/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
 -  ipatests: remove invalid parameter from sssd.conf
-   `commit <https://pagure.io/freeipa/c/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
-   `commit <https://pagure.io/freeipa/c/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: replace utility for editing sssd.conf
-   `commit <https://pagure.io/freeipa/c/9450aef75f2ac064ea182c942d39400287a38bab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9450aef75f2ac064ea182c942d39400287a38bab>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
-   `commit <https://pagure.io/freeipa/c/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
 -  ipatests: add test_trust suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
 -  ipatests: add check for output contents of ipa-client-samba
-   `commit <https://pagure.io/freeipa/c/15fd36612ea451cec2e1302a462fa440663fcc74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15fd36612ea451cec2e1302a462fa440663fcc74>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
-   `commit <https://pagure.io/freeipa/c/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 -  ipatests: enable test_smb.py in gating.yaml
-   `commit <https://pagure.io/freeipa/c/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
 -  ipatests: replace ad hoc backup with FileBackup helper
-   `commit <https://pagure.io/freeipa/c/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: refactor FileBackup helper
-   `commit <https://pagure.io/freeipa/c/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: in DNS zone file add A record for name server
-   `commit <https://pagure.io/freeipa/c/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
 -  ipatests: strip newline character when getting name of temp file
-   `commit <https://pagure.io/freeipa/c/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
-   `commit <https://pagure.io/freeipa/c/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
    `#7995 <https://pagure.io/freeipa/issue/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
-   `commit <https://pagure.io/freeipa/c/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
 -  ipatests: add tests for cached_auth_timeout in sssd.conf
-   `commit <https://pagure.io/freeipa/c/4ab2842b76ffc9cffd931bf652d211ca34b4d1d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ab2842b76ffc9cffd931bf652d211ca34b4d1d8>`__
 -  ipatests: refactoring: use library function to check if selinux is
    enabled
-   `commit <https://pagure.io/freeipa/c/4ea9aead5cab96ed9454facdb6d22bdfe514a09b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ea9aead5cab96ed9454facdb6d22bdfe514a09b>`__
 -  ipatests: add new utilities for file management
-   `commit <https://pagure.io/freeipa/c/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
 -  ipatests: refactor and extend tests for IPA-Samba integration
-   `commit <https://pagure.io/freeipa/c/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipatests: modify run_command to allow specify successful return codes
-   `commit <https://pagure.io/freeipa/c/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
 -  ipatests: add utility functions related to using and managing user
    accounts
-   `commit <https://pagure.io/freeipa/c/3fa7865ff8c48a35d0d120c74da76ea4076a6aa4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fa7865ff8c48a35d0d120c74da76ea4076a6aa4>`__
 -  ipatests: allow to pass additional options for clients installation
-   `commit <https://pagure.io/freeipa/c/074bf285f185d96d67cf9f410f1e8935078d15eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/074bf285f185d96d67cf9f410f1e8935078d15eb>`__
 -  ipatests: new test for trust with partially unreachable AD topology
-   `commit <https://pagure.io/freeipa/c/843f57abe431bcf493e0bcce8ef07255be986435>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/843f57abe431bcf493e0bcce8ef07255be986435>`__
 -  ipatests: mark test_domain_resolution_order as expectedly failing
-   `commit <https://pagure.io/freeipa/c/4740655260caa7baee4473b0d35840a4c0da3dac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4740655260caa7baee4473b0d35840a4c0da3dac>`__
 -  ipatests: add test for sudo with runAsUser and domain resolution
    order.
-   `commit <https://pagure.io/freeipa/c/0d15eb78d4178bea6057e4d32b234c592ca80fa7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d15eb78d4178bea6057e4d32b234c592ca80fa7>`__
 
 
 
@@ -5061,22 +5061,22 @@ Sumedh Sidhaye (6)
    test_cert.py::TestCertmongerRekey which needs more time to execute.
    Adding additional 30 mins to the timeout in order to complete the
    test run
-   `commit <https://pagure.io/freeipa/c/3f5f68e770bc720b130a8f7fb6d54d2ae62e6f4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f5f68e770bc720b130a8f7fb6d54d2ae62e6f4c>`__
 -  Test for removing a subgroup
-   `commit <https://pagure.io/freeipa/c/47bddf4f458699f46b398d0969d5e3a348feed52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47bddf4f458699f46b398d0969d5e3a348feed52>`__
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
-   `commit <https://pagure.io/freeipa/c/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
-   `commit <https://pagure.io/freeipa/c/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
-   `commit <https://pagure.io/freeipa/c/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
 -  Test: To check ipa replica-manage del does not fail
-   `commit <https://pagure.io/freeipa/c/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
    `#7929 <https://pagure.io/freeipa/issue/7929>`__
 
 
@@ -5085,7 +5085,7 @@ Simo Sorce (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure to have storage space for tag
-   `commit <https://pagure.io/freeipa/c/4abd2f76d76c4c1a1ec5087ec447f4515b63c2c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4abd2f76d76c4c1a1ec5087ec447f4515b63c2c6>`__
 
 
 
@@ -5093,7 +5093,7 @@ Stasiek Michalski (1)
 ----------------------------------------------------------------------------------------------
 
 -  Support for SUSE/openSUSE ipaplatform
-   `commit <https://pagure.io/freeipa/c/3e8c51922b404bf2406ead09376e3e89f0624cdf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e8c51922b404bf2406ead09376e3e89f0624cdf>`__
 
 
 
@@ -5102,94 +5102,94 @@ Serhii Tsymbaliuk (28)
 
 -  WebUI tests: Add simple test to check topology graph page is
    available
-   `commit <https://pagure.io/freeipa/c/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
    `#8523 <https://pagure.io/freeipa/issue/8523>`__
 -  WebUI: Fix topology graph navigation crash
-   `commit <https://pagure.io/freeipa/c/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
    `#8523 <https://pagure.io/freeipa/issue/8523>`__
 -  WebUI: Fix jQuery DOM manipulation issues
-   `commit <https://pagure.io/freeipa/c/29b41aef0a49d5460631a8543f0f6620d4696790>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29b41aef0a49d5460631a8543f0f6620d4696790>`__
    `#8507 <https://pagure.io/freeipa/issue/8507>`__
 -  WebUI tests: Add test case to cover user ID override feature
-   `commit <https://pagure.io/freeipa/c/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
-   `commit <https://pagure.io/freeipa/c/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
-   `commit <https://pagure.io/freeipa/c/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
-   `commit <https://pagure.io/freeipa/c/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
-   `commit <https://pagure.io/freeipa/c/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
-   `commit <https://pagure.io/freeipa/c/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
    `#8325 <https://pagure.io/freeipa/issue/8325>`__
 -  WebUI tests: Test all available fields on "Kerberos Ticket Policy"
    page
-   `commit <https://pagure.io/freeipa/c/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
    `#8207 <https://pagure.io/freeipa/issue/8207>`__
 -  WebUI: Add authentication indicator specific fields to "Kerberos
    Ticket Policy" page
-   `commit <https://pagure.io/freeipa/c/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
    `#8207 <https://pagure.io/freeipa/issue/8207>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
-   `commit <https://pagure.io/freeipa/c/3645854c11b0489215a27077a633755638f00268>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3645854c11b0489215a27077a633755638f00268>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
-   `commit <https://pagure.io/freeipa/c/33ca0745585ae3fcd466631a069e244bea74be88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33ca0745585ae3fcd466631a069e244bea74be88>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI tests: cover membership management with UI tests
-   `commit <https://pagure.io/freeipa/c/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
    `#8298 <https://pagure.io/freeipa/issue/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
    `#8284 <https://pagure.io/freeipa/issue/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
-   `commit <https://pagure.io/freeipa/c/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
    `#8222 <https://pagure.io/freeipa/issue/8222>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
    `#8239 <https://pagure.io/freeipa/issue/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
-   `commit <https://pagure.io/freeipa/c/a4634a59c98ae922708f9211786b67505dada736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4634a59c98ae922708f9211786b67505dada736>`__
    `#8157 <https://pagure.io/freeipa/issue/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
-   `commit <https://pagure.io/freeipa/c/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
    `#8169 <https://pagure.io/freeipa/issue/8169>`__
 -  WebUI: Fix notification area layout
-   `commit <https://pagure.io/freeipa/c/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
-   `commit <https://pagure.io/freeipa/c/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
    `#8123 <https://pagure.io/freeipa/issue/8123>`__
 -  WebUI: Fix new test initialization on "HBAC Test" page
-   `commit <https://pagure.io/freeipa/c/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
    `#8031 <https://pagure.io/freeipa/issue/8031>`__
 -  WebUI: Fix changing category on HBAC/Sudo/etc Rule pages
-   `commit <https://pagure.io/freeipa/c/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
    `#7961 <https://pagure.io/freeipa/issue/7961>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
-   `commit <https://pagure.io/freeipa/c/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
    `#5062 <https://pagure.io/freeipa/issue/5062>`__
 -  WebUI tests: Fix login screen loading issue
-   `commit <https://pagure.io/freeipa/c/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
    `#8053 <https://pagure.io/freeipa/issue/8053>`__
 -  WebUI tests: Fix request timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/f16ea8e652a3a3b555087646b9887bc77934d175>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16ea8e652a3a3b555087646b9887bc77934d175>`__
    `#8024 <https://pagure.io/freeipa/issue/8024>`__
 -  WebUI: Add PKINIT status field to 'Configuration' page
-   `commit <https://pagure.io/freeipa/c/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
    `#7305 <https://pagure.io/freeipa/issue/7305>`__
 -  WebUI tests: Fix timeout issues for reset password tests
-   `commit <https://pagure.io/freeipa/c/6316a006327426af9365f865633cf6767ff699a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6316a006327426af9365f865633cf6767ff699a9>`__
    `#8012 <https://pagure.io/freeipa/issue/8012>`__
 
 
@@ -5198,89 +5198,89 @@ Sudhir Menon (36)
 ----------------------------------------------------------------------------------------------
 
 -  Modified YAML files
-   `commit <https://pagure.io/freeipa/c/184fa80917b120f5aef07e523e993cc012446a84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/184fa80917b120f5aef07e523e993cc012446a84>`__
 -  ipatests: Test for IPATrustDomainsCheck with external trust to AD
-   `commit <https://pagure.io/freeipa/c/d41bfea4b67701ac2de8a0dc46fe7466423ffece>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d41bfea4b67701ac2de8a0dc46fe7466423ffece>`__
 -  ipatests: support subordinate upn suffixes
-   `commit <https://pagure.io/freeipa/c/7e605e958ef6d41584afc238433669c15458ac67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e605e958ef6d41584afc238433669c15458ac67>`__
 -  ipatests: Tests for ipahealthcheck.ds.nss_ssl
-   `commit <https://pagure.io/freeipa/c/46f114d9e751b2a092b975b909f0e890257a507d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46f114d9e751b2a092b975b909f0e890257a507d>`__
 -  Added nsslapd-logging-hr-timestamps-enabled attribute in
    \_SINGLE_VALUE_OVERRIDE table
-   `commit <https://pagure.io/freeipa/c/617f7824ca56c040bd5c5ad60dc23f228df70b63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/617f7824ca56c040bd5c5ad60dc23f228df70b63>`__
 -  ipatests: ipa-healthcheck tests for DS checks
-   `commit <https://pagure.io/freeipa/c/b7be1a2470c220da30154305e869149d808c0ec2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7be1a2470c220da30154305e869149d808c0ec2>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_riplugincheck
-   `commit <https://pagure.io/freeipa/c/2b1230e5b083084eecf3aeb027223d5501a45924>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b1230e5b083084eecf3aeb027223d5501a45924>`__
    `#8563 <https://pagure.io/freeipa/issue/8563>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_encryption
-   `commit <https://pagure.io/freeipa/c/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
    `#8560 <https://pagure.io/freeipa/issue/8560>`__
 -  ipatests: ipa-healthcheck test for DS RIPluginCheck
-   `commit <https://pagure.io/freeipa/c/686414d2017b8122df04b04493909a12db8ccd66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/686414d2017b8122df04b04493909a12db8ccd66>`__
 -  ipatests: ipa-healthcheck test for EncryptionCheck
-   `commit <https://pagure.io/freeipa/c/b8a2a0f3013139574ac42ae69eb3e37c9ff56fba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8a2a0f3013139574ac42ae69eb3e37c9ff56fba>`__
 -  ipatests: ipa-healthcheck test for DS BackendsCheck
-   `commit <https://pagure.io/freeipa/c/9a41966a250a97e7df204b4e66a4e7e9546d78aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a41966a250a97e7df204b4e66a4e7e9546d78aa>`__
 -  ipatests: ipa-healthcheck fixes for tests running on RHEL
-   `commit <https://pagure.io/freeipa/c/abefd6e19b5f6b1f5defe613d8bccd5292c65ea4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abefd6e19b5f6b1f5defe613d8bccd5292c65ea4>`__
 -  ipatests: ipa-healthcheck test fixes running on RHEL
-   `commit <https://pagure.io/freeipa/c/01c6b8a8475fbb62249b70a8fb51ee6f5ec4fe67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01c6b8a8475fbb62249b70a8fb51ee6f5ec4fe67>`__
 -  ipatests: Install healthcheck pkg for TestIpaHealthCheckWithADtrust
-   `commit <https://pagure.io/freeipa/c/15f168c10342a48c67e6f37737b60bab05dad04a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15f168c10342a48c67e6f37737b60bab05dad04a>`__
 -  Modified nightly YAML files to include ipa-healthcheck ExternalCA
    Tests
-   `commit <https://pagure.io/freeipa/c/7642ce35828025cd292f0e7785b93455ae4684d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7642ce35828025cd292f0e7785b93455ae4684d2>`__
 -  ipatests: Tests for ipahealthcheck tool with IPA external
-   `commit <https://pagure.io/freeipa/c/400ef3aa2c1ea74da22547aa7ca1c20fdc6cb211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/400ef3aa2c1ea74da22547aa7ca1c20fdc6cb211>`__
 -  ipatests: Test IPACertNSSTrust check when trust attributes is
    modified for specific cert
-   `commit <https://pagure.io/freeipa/c/bb2dfbbf0b0e3daf7207bf6605b9f23edb115be5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb2dfbbf0b0e3daf7207bf6605b9f23edb115be5>`__
 -  ipatests: Test to check IPACAChainExpirationCheck when IPA cacrt is
    renamed
-   `commit <https://pagure.io/freeipa/c/fcc99813f58825efb093f477544076e272c62ea9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fcc99813f58825efb093f477544076e272c62ea9>`__
 -  ipatests: Test for ipa-nis-manage CLI tool.
-   `commit <https://pagure.io/freeipa/c/6ff31dbf55cfea509289c72c6f97f945fb934f6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ff31dbf55cfea509289c72c6f97f945fb934f6c>`__
 -  ipatests: Increase timeout value in
    test_getcert_list_profile_using_subca
-   `commit <https://pagure.io/freeipa/c/04d25dd2866c74b23b16172411d5cfaa83d0b726>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04d25dd2866c74b23b16172411d5cfaa83d0b726>`__
 -  ipatests: Tests to check profile is displayed for getcert request.
-   `commit <https://pagure.io/freeipa/c/8e05a8a8da6eea7dcad48ec5b77631e4495e4879>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e05a8a8da6eea7dcad48ec5b77631e4495e4879>`__
 -  Modified YAML to include healthcheck AD tests
-   `commit <https://pagure.io/freeipa/c/f1b2d7b6fcda02f79db8eb00085d980c56ccc314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1b2d7b6fcda02f79db8eb00085d980c56ccc314>`__
 -  ipatests: Tests to check ipahealthcheck tool with IPA-AD trust
    scenario
-   `commit <https://pagure.io/freeipa/c/769c87f5e737174c771338fc2af1bd31304a689c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/769c87f5e737174c771338fc2af1bd31304a689c>`__
 -  ipatests: Test to check warning state for TomcatFileCheck in
    ipahealthcheck.ipa.files
-   `commit <https://pagure.io/freeipa/c/0d0dc73ae1fd640841a4b15ed83edc44096859e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d0dc73ae1fd640841a4b15ed83edc44096859e3>`__
 -  ipatests: Test for ipahealthcheck.ipa.files for TomcatFilecheck
-   `commit <https://pagure.io/freeipa/c/ddd061c0b71b27d2193f83a3695ff6ade9ccc256>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddd061c0b71b27d2193f83a3695ff6ade9ccc256>`__
 -  ipatests: Test for ipahealthcheck DogtagCertsConnectivityCheck
-   `commit <https://pagure.io/freeipa/c/6a7fa03f91955cc999b9ae143647071fc35e3793>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a7fa03f91955cc999b9ae143647071fc35e3793>`__
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
-   `commit <https://pagure.io/freeipa/c/555f8a038dae139ad161c5dab51e2378f8894b81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/555f8a038dae139ad161c5dab51e2378f8894b81>`__
    `#8066 <https://pagure.io/freeipa/issue/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
-   `commit <https://pagure.io/freeipa/c/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
-   `commit <https://pagure.io/freeipa/c/29fd9602c66133603c9723a4918cda0bcc8b5c53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29fd9602c66133603c9723a4918cda0bcc8b5c53>`__
 -  Test for ipahealthcheck.ipa.idns check when integrated DNS is setup
-   `commit <https://pagure.io/freeipa/c/fd9f1b3d5bf35f8286505d1ed0971a42349a476b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd9f1b3d5bf35f8286505d1ed0971a42349a476b>`__
 -  ipatests: Added testcase to check logrotate is added for healthcheck
    tool
-   `commit <https://pagure.io/freeipa/c/c77f4213e9ae78e76c5eee88ffc1cbffbb5556e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c77f4213e9ae78e76c5eee88ffc1cbffbb5556e8>`__
 -  ipatests: check that ipa-healthcheck warns if no dna range is set
-   `commit <https://pagure.io/freeipa/c/4e3a2bd6bff79c17bc439555dcf41a11d0569e6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e3a2bd6bff79c17bc439555dcf41a11d0569e6f>`__
 -  Adding back temp config definition removed
-   `commit <https://pagure.io/freeipa/c/d7830d900d85e936263bb0be9d5f364ba86d874f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7830d900d85e936263bb0be9d5f364ba86d874f>`__
 -  Nightly definition for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/000703c89f18a190e5cac17ad7113a2ed067c35b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/000703c89f18a190e5cac17ad7113a2ed067c35b>`__
 -  Tier-1 test for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
 -  Added testcase to check capitalization fix while running ipa user-mod
-   `commit <https://pagure.io/freeipa/c/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
    `#5879 <https://pagure.io/freeipa/issue/5879>`__
 
 
@@ -5289,17 +5289,17 @@ Tibor Dudlák (5)
 ----------------------------------------------------------------------------------------------
 
 -  Add container environment check to replicainstall
-   `commit <https://pagure.io/freeipa/c/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
    `#6210 <https://pagure.io/freeipa/issue/6210>`__
 -  Increase ntp_options test timeout
-   `commit <https://pagure.io/freeipa/c/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
 -  ipatests: refactor TestNTPoptions
-   `commit <https://pagure.io/freeipa/c/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
 -  ipatests: Add tests for interactive chronyd config
-   `commit <https://pagure.io/freeipa/c/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 -  ipatests: Update test tasks for client to be interactive
-   `commit <https://pagure.io/freeipa/c/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 
 
@@ -5308,13 +5308,13 @@ Tomas Halman (4)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: add extdom protocol documentation
-   `commit <https://pagure.io/freeipa/c/bddf64b9da2df21a14022109ae989bd5408bf14b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddf64b9da2df21a14022109ae989bd5408bf14b>`__
 -  extdom: use sss_nss_*_timeout calls
-   `commit <https://pagure.io/freeipa/c/84b6c0f53b9ebdd4c01181898499bb6992aa9e8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84b6c0f53b9ebdd4c01181898499bb6992aa9e8a>`__
 -  extdom: plugin doesn't use timeout in blocking call
-   `commit <https://pagure.io/freeipa/c/5f898c3c614f4165f0eb15c3aad2157689fbbcfe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f898c3c614f4165f0eb15c3aad2157689fbbcfe>`__
 -  extdom: plugin doesn't allow @ in group name
-   `commit <https://pagure.io/freeipa/c/e5f04258b5b3fb6c04c28ddd38ae251c822e80bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5f04258b5b3fb6c04c28ddd38ae251c822e80bc>`__
 
 
 
@@ -5322,24 +5322,24 @@ Timo Aaltonen (9)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform: Use gpg instead of gpg2
-   `commit <https://pagure.io/freeipa/c/b46fa4e4b30743836b612785031e345fe15ed94f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b46fa4e4b30743836b612785031e345fe15ed94f>`__
 -  Debian: Fix chrony service name
-   `commit <https://pagure.io/freeipa/c/efe767c4a40adce54407502f93a693c9f698e421>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efe767c4a40adce54407502f93a693c9f698e421>`__
 -  Debian: Fix paths and service names for bind 9.16
-   `commit <https://pagure.io/freeipa/c/38cb763d3d981e3f4e45643b805b4f42429359d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38cb763d3d981e3f4e45643b805b4f42429359d3>`__
 -  ipatests/test_installation: Use knownservices to map the service
    name.
-   `commit <https://pagure.io/freeipa/c/2e85b4809afb4757fd7b81868709ced4f211d7b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e85b4809afb4757fd7b81868709ced4f211d7b4>`__
 -  ipatests/test_commands: Check sssd version like on test_sssd
-   `commit <https://pagure.io/freeipa/c/158257c4b3f0eb58db73ac667aae4feaef21b58b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/158257c4b3f0eb58db73ac667aae4feaef21b58b>`__
 -  Debian: Use parse_ipa_version from redhat.
-   `commit <https://pagure.io/freeipa/c/7ed5374c91dd7e69b2ac0222cf7dc5d48df75c19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ed5374c91dd7e69b2ac0222cf7dc5d48df75c19>`__
 -  Debian: Use enable/disable_ldap_automount() from base
-   `commit <https://pagure.io/freeipa/c/7d657c6faa4f090d5f672502f9f62d64e74c355d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d657c6faa4f090d5f672502f9f62d64e74c355d>`__
 -  Debian: Fix font-awesome path.
-   `commit <https://pagure.io/freeipa/c/04bb8ef2f5a95d752dd41f4bc575d22ae6f7e9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04bb8ef2f5a95d752dd41f4bc575d22ae6f7e9d1>`__
 -  install: Add missing scripts to app_DATA.
-   `commit <https://pagure.io/freeipa/c/0000fe0502e75fcc68c6b9a8bc5b2b5a79fb4888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0000fe0502e75fcc68c6b9a8bc5b2b5a79fb4888>`__
 
 
 
@@ -5348,15 +5348,15 @@ Thorsten Scherf (5)
 
 -  Corrected some typos and added improvements to some setup
    instructions
-   `commit <https://pagure.io/freeipa/c/416d87b9bd4261ed30285a95ce3fec442822b3a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/416d87b9bd4261ed30285a95ce3fec442822b3a7>`__
 -  Module added about ssh pubkey management
-   `commit <https://pagure.io/freeipa/c/c14042dc322192204507676dc0c975822773f0ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c14042dc322192204507676dc0c975822773f0ee>`__
 -  Added bash-completion rpm to build instructions.
-   `commit <https://pagure.io/freeipa/c/7f187146c75330a15572b69da1633b4a6cffb383>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f187146c75330a15572b69da1633b4a6cffb383>`__
 -  Added --mkhomedir option for server and replica.
-   `commit <https://pagure.io/freeipa/c/0db3a5693316d4166b5920e2df3560c5c38a6dbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0db3a5693316d4166b5920e2df3560c5c38a6dbd>`__
 -  Added vagrant-libvirt-doc rpm and polkit rule
-   `commit <https://pagure.io/freeipa/c/49c48aa9537c6eccf3a6b610ef7472a51f7eb3b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49c48aa9537c6eccf3a6b610ef7472a51f7eb3b3>`__
 
 
 
@@ -5364,7 +5364,7 @@ Theodor van Nahl (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix UnboundLocalError in ipa-replica-manage on errors
-   `commit <https://pagure.io/freeipa/c/adcf04255cb24564230604469ae34c180e057dfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adcf04255cb24564230604469ae34c180e057dfa>`__
 
 
 
@@ -5373,15 +5373,15 @@ Thomas Woerner (4)
 
 -  ipaserver/plugins/hbacrule: Add HBAC to memberservice_hbacsvc\*
    labels
-   `commit <https://pagure.io/freeipa/c/51fcca535236e309dc6431ad68bad36bf8f56823>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51fcca535236e309dc6431ad68bad36bf8f56823>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
-   `commit <https://pagure.io/freeipa/c/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
    `#8150 <https://pagure.io/freeipa/issue/8150>`__
 -  Enable TestInstallMasterDNSRepeatedly in prci_definitions
-   `commit <https://pagure.io/freeipa/c/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
 -  Test repeated installation of the primary with DNS enabled and domain
    set
-   `commit <https://pagure.io/freeipa/c/d070c5957791d19ece22082dbd69a319975a4b54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d070c5957791d19ece22082dbd69a319975a4b54>`__
 
 
 
@@ -5389,7 +5389,7 @@ Viktor Ashirov (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update ACIs with the correct syntax
-   `commit <https://pagure.io/freeipa/c/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
    `#8301 <https://pagure.io/freeipa/issue/8301>`__
 
 
@@ -5398,16 +5398,16 @@ Vit Mojzis (5)
 ----------------------------------------------------------------------------------------------
 
 -  selinux: Fix/waive issues reported by SELint
-   `commit <https://pagure.io/freeipa/c/e2f9912b78d723441f241abb453971dd78cf5d6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2f9912b78d723441f241abb453971dd78cf5d6e>`__
 -  selinux: disable ipa_custodia when installing custom policy
-   `commit <https://pagure.io/freeipa/c/3aad16a75ef06d20d111773268df30ee04274db7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3aad16a75ef06d20d111773268df30ee04274db7>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  selinux: Remove obsolete memcached access
-   `commit <https://pagure.io/freeipa/c/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
 -  selinux: move BUILD_SELINUX_POLICY definition
-   `commit <https://pagure.io/freeipa/c/0c9949e8983e4befacbd4a40b5440008474a75a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c9949e8983e4befacbd4a40b5440008474a75a3>`__
 -  Add freeipa-selinux subpackage
-   `commit <https://pagure.io/freeipa/c/5b573bb9a34fec5d34a4509c68015951ec6669b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b573bb9a34fec5d34a4509c68015951ec6669b9>`__
 
 
 
@@ -5415,9 +5415,9 @@ Yuri Chornoivan (2)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/abc416407ebd1e9136436395638e6f43eab4e1b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abc416407ebd1e9136436395638e6f43eab4e1b0>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/a330adae8a1814f1f0e2482354189a3b59ad88fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a330adae8a1814f1f0e2482354189a3b59ad88fd>`__
 
 
 
@@ -5425,15 +5425,15 @@ zdover (5)
 ----------------------------------------------------------------------------------------------
 
 -  100 percent complete edit
-   `commit <https://pagure.io/freeipa/c/39d1715c54e03c61a8a34837b465d7cef8c6adfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39d1715c54e03c61a8a34837b465d7cef8c6adfc>`__
 -  sixty percent edited
-   `commit <https://pagure.io/freeipa/c/e8c9efed0d43b36042b86896e02ed4b186b04457>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8c9efed0d43b36042b86896e02ed4b186b04457>`__
 -  thirty percent edited
-   `commit <https://pagure.io/freeipa/c/2012713c24d1bce974f2c53691d2977427c8f862>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2012713c24d1bce974f2c53691d2977427c8f862>`__
 -  first tranche of edits
-   `commit <https://pagure.io/freeipa/c/dd22a3c29924f56a044f1c549ff8db02b0b2788f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd22a3c29924f56a044f1c549ff8db02b0b2788f>`__
 -  making a list's items agree with one another
-   `commit <https://pagure.io/freeipa/c/37b38eadc509d34b6b67a61e71cda74d2ff34a94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37b38eadc509d34b6b67a61e71cda74d2ff34a94>`__
 
 
 
@@ -5441,7 +5441,7 @@ Zdenek Pytela (2)
 ----------------------------------------------------------------------------------------------
 
 -  Add ipa_pki_retrieve_key_exec() interface
-   `commit <https://pagure.io/freeipa/c/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  Allow ipa-adtrust-install restart sssd and dirsrv services
-   `commit <https://pagure.io/freeipa/c/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__

--- a/src/page/Releases/4.9.0rc1.rst
+++ b/src/page/Releases/4.9.0rc1.rst
@@ -1420,59 +1420,59 @@ Armando Neto (25)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Update PRCI Fedora 32 templates
-   `commit <https://pagure.io/freeipa/c/3722013dcd6d03d3adbdfb518c733b1a90e5af39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3722013dcd6d03d3adbdfb518c733b1a90e5af39>`__
 -  ipatests: Add nightly definitions for enforcing mode
-   `commit <https://pagure.io/freeipa/c/26ae95f4b492b98078b5deb16825df3fd525f305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26ae95f4b492b98078b5deb16825df3fd525f305>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/21186540f0425840e544a3cead8da909744aeac0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21186540f0425840e544a3cead8da909744aeac0>`__
    `#8473 <https://pagure.io/freeipa/issue/8473>`__
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/7de20e8e07306d7a7f751283f257f544b24a0eef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de20e8e07306d7a7f751283f257f544b24a0eef>`__
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/67d4517f7321f363e785937a23fe521ccee76d52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67d4517f7321f363e785937a23fe521ccee76d52>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/cc624fb178291062e30a11b8dc6a6b67cbe5dea8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc624fb178291062e30a11b8dc6a6b67cbe5dea8>`__
 -  ipatests: bump prci templates
-   `commit <https://pagure.io/freeipa/c/04ce1a415b33a95ad5bd65cb93e511a16940b123>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04ce1a415b33a95ad5bd65cb93e511a16940b123>`__
 -  prci: update templates for new Fedora release
-   `commit <https://pagure.io/freeipa/c/40b8174c347ff49df0d83d3aaf9b6f19c5f3461c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b8174c347ff49df0d83d3aaf9b6f19c5f3461c>`__
 -  Update instructions for Fedora 28 / FreeIPA 4.6.90
-   `commit <https://pagure.io/freeipa/c/33cd0bb625d3aa2cede2b7bbe6cd49d4a0db5f29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33cd0bb625d3aa2cede2b7bbe6cd49d4a0db5f29>`__
 -  prci: bump version for latest and previous templates
-   `commit <https://pagure.io/freeipa/c/132ef03acbe15f02fd2a2212741bdc1fa030fc84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132ef03acbe15f02fd2a2212741bdc1fa030fc84>`__
 -  prci: Bump version of all templates
-   `commit <https://pagure.io/freeipa/c/19f0142e792c5da783312eb7c67fd3999883b38d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19f0142e792c5da783312eb7c67fd3999883b38d>`__
 -  prci: update packages for rawhide nightly runs
-   `commit <https://pagure.io/freeipa/c/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
-   `commit <https://pagure.io/freeipa/c/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: Improve test_commands reliability
-   `commit <https://pagure.io/freeipa/c/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
 -  travis: Remove CI integration
-   `commit <https://pagure.io/freeipa/c/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
    `#7323 <https://pagure.io/freeipa/issue/7323>`__
 -  prci: bump template version for temp_commit and nightly_latest
-   `commit <https://pagure.io/freeipa/c/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
 -  prci: bump fedora release
-   `commit <https://pagure.io/freeipa/c/99d6845dbe803bd81badc0e064fe3578886377cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99d6845dbe803bd81badc0e064fe3578886377cd>`__
 -  prci: rename definitions files and jobs to change how fedora releases
    are referenced
-   `commit <https://pagure.io/freeipa/c/c62bd1608e3a4aea27751826d7b8790367b1b5e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c62bd1608e3a4aea27751826d7b8790367b1b5e3>`__
 -  prci: increase timeout argument for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/3d8a444f624b431706838f243fc19f92e8fbc63e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d8a444f624b431706838f243fc19f92e8fbc63e>`__
 -  prci: increase timeout for jobs that required AD
-   `commit <https://pagure.io/freeipa/c/a4ca34261a55af96e3428822f08f8b2292e6234a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4ca34261a55af96e3428822f08f8b2292e6234a>`__
 -  prci: update packages for pki and testing nightly runs
-   `commit <https://pagure.io/freeipa/c/98ee5f247252041c5135b00a55daa765072fb6d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98ee5f247252041c5135b00a55daa765072fb6d5>`__
 -  Update definitions for nightly tests
-   `commit <https://pagure.io/freeipa/c/78d27f8252c9bd7a3f1ac9a4fbe4d10c8c5d02ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78d27f8252c9bd7a3f1ac9a4fbe4d10c8c5d02ad>`__
 -  prci: fix typo on nightly test definitions
-   `commit <https://pagure.io/freeipa/c/2e0850e70e87a1affd78ae9544f5767cb5e13c5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e0850e70e87a1affd78ae9544f5767cb5e13c5a>`__
 -  prci: update test definitions
-   `commit <https://pagure.io/freeipa/c/481c540000f3c6546e00a8117919e8bbe72db2f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/481c540000f3c6546e00a8117919e8bbe72db2f1>`__
 
 
 
@@ -1480,373 +1480,373 @@ Alexander Bokovoy (140)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.0 release candidate 1
-   `commit <https://pagure.io/freeipa/c/a1f3e3b836f357cd3fe8698a4ecdc92c919a6306>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1f3e3b836f357cd3fe8698a4ecdc92c919a6306>`__
 -  Translations: update translations template
-   `commit <https://pagure.io/freeipa/c/038645d8c24c67b9136859b6b9d7c159c33148f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/038645d8c24c67b9136859b6b9d7c159c33148f5>`__
 -  Add contributors from translations project at Weblate
-   `commit <https://pagure.io/freeipa/c/ff79c0cea54c0bd3ce3883927da156360f516e5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff79c0cea54c0bd3ce3883927da156360f516e5d>`__
 -  Azure CI: mask chronyd in the container
-   `commit <https://pagure.io/freeipa/c/f977629182324d0511dfab89cebfa5decd97353e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f977629182324d0511dfab89cebfa5decd97353e>`__
 -  spec: use pkgconf to find out krb5 version
-   `commit <https://pagure.io/freeipa/c/39d0dd332c798044f95b5cc2c24b5eece57f5555>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39d0dd332c798044f95b5cc2c24b5eece57f5555>`__
 -  Azure CI: use PPA to provide newer libseccomp version
-   `commit <https://pagure.io/freeipa/c/1bf0d628281f33693a1f6c6e156b0c258eee929e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bf0d628281f33693a1f6c6e156b0c258eee929e>`__
 -  Azure CI: use Ubuntu-20.04 image by default
-   `commit <https://pagure.io/freeipa/c/6e1eaad873d69baa9b2d0250d91aaadc7c69c6a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e1eaad873d69baa9b2d0250d91aaadc7c69c6a5>`__
 -  ipa-acme-manage: user a cookie created for the communication with
    dogtag REST endpoints
-   `commit <https://pagure.io/freeipa/c/935a46158251d52b16f6e0f531a8851778795c67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/935a46158251d52b16f6e0f531a8851778795c67>`__
    `#8584 <https://pagure.io/freeipa/issue/8584>`__
 -  ipa-otpd: fix gcc complaints in Rawhide
-   `commit <https://pagure.io/freeipa/c/b36f224892152af786e69bb166497e6fd9c44cd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36f224892152af786e69bb166497e6fd9c44cd6>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-sam: fix gcc complaints on Rawhide
-   `commit <https://pagure.io/freeipa/c/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-kdb: fix gcc complaints in kdb tests
-   `commit <https://pagure.io/freeipa/c/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  ipa-kdb: fix gcc complaints
-   `commit <https://pagure.io/freeipa/c/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
    `#8585 <https://pagure.io/freeipa/issue/8585>`__
 -  wgi/plugins.py: ignore empty plugin directories
-   `commit <https://pagure.io/freeipa/c/91706690e0c894864c93716c4fbecb285722e77d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91706690e0c894864c93716c4fbecb285722e77d>`__
    `#8567 <https://pagure.io/freeipa/issue/8567>`__
 -  ipa-kdb: fix crash in MS-PAC cache init code
-   `commit <https://pagure.io/freeipa/c/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
    `#8566 <https://pagure.io/freeipa/issue/8566>`__
 -  rpcserver: fix exception handling for FAST armor failure
-   `commit <https://pagure.io/freeipa/c/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
 -  rpcserver: fallback to non-armored kinit in case of trusted domains
-   `commit <https://pagure.io/freeipa/c/b8b46779dc239cf5b007ad11b5b8c9cf51e34ed0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8b46779dc239cf5b007ad11b5b8c9cf51e34ed0>`__
 -  pylint: remove unused variable
-   `commit <https://pagure.io/freeipa/c/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
 -  ipa-kdb: support subordinate/superior UPN suffixes
-   `commit <https://pagure.io/freeipa/c/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
    `#8554 <https://pagure.io/freeipa/issue/8554>`__
 -  Pre-populate IP addresses for the name server upgrades
-   `commit <https://pagure.io/freeipa/c/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
    `#8518 <https://pagure.io/freeipa/issue/8518>`__
 -  Specify memory limits as strings for docker compose
-   `commit <https://pagure.io/freeipa/c/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
    `#8494 <https://pagure.io/freeipa/issue/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
-   `commit <https://pagure.io/freeipa/c/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
-   `commit <https://pagure.io/freeipa/c/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
    `#8490 <https://pagure.io/freeipa/issue/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
-   `commit <https://pagure.io/freeipa/c/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
    `#8344 <https://pagure.io/freeipa/issue/8344>`__
 -  Add new contributors
-   `commit <https://pagure.io/freeipa/c/11a64478b32985e3c92258aecdd97a28b2351176>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11a64478b32985e3c92258aecdd97a28b2351176>`__
 -  Add alternative email to the mailmap for myself
-   `commit <https://pagure.io/freeipa/c/4fdf69adf288102633bb733620e5009684d134ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fdf69adf288102633bb733620e5009684d134ce>`__
 -  master: update po/ipa.pot
-   `commit <https://pagure.io/freeipa/c/20ece52b9a1cad43c4fa99e37b1748608c9ce926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ece52b9a1cad43c4fa99e37b1748608c9ce926>`__
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
-   `commit <https://pagure.io/freeipa/c/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
    `#8437 <https://pagure.io/freeipa/issue/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
-   `commit <https://pagure.io/freeipa/c/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
-   `commit <https://pagure.io/freeipa/c/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
    `#8395 <https://pagure.io/freeipa/issue/8395>`__
 -  handle Y2038 in timestamp to datetime conversions
-   `commit <https://pagure.io/freeipa/c/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
    `#8378 <https://pagure.io/freeipa/issue/8378>`__
 -  update list of contributors
-   `commit <https://pagure.io/freeipa/c/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/81f7863b3f294748f6500ecbcf354ab20ef907a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81f7863b3f294748f6500ecbcf354ab20ef907a3>`__
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
-   `commit <https://pagure.io/freeipa/c/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
    `#8357 <https://pagure.io/freeipa/issue/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
-   `commit <https://pagure.io/freeipa/c/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 -  tests: account for ID overrides as members of groups and roles
-   `commit <https://pagure.io/freeipa/c/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  Support adding user ID overrides as group and role members
-   `commit <https://pagure.io/freeipa/c/bee4204039dac9cd858e823b839183ba2cdbd216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bee4204039dac9cd858e823b839183ba2cdbd216>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
-   `commit <https://pagure.io/freeipa/c/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
    `#7255 <https://pagure.io/freeipa/issue/7255>`__
 -  support using trust-related operations in the server console
-   `commit <https://pagure.io/freeipa/c/ecc0a96d161717960058e22eecad43754de06f11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecc0a96d161717960058e22eecad43754de06f11>`__
 -  Add design page for managing IPA resources as a user from a trusted
    Active Directory forest
-   `commit <https://pagure.io/freeipa/c/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
    `#7816 <https://pagure.io/freeipa/issue/7816>`__,
    `#8357 <https://pagure.io/freeipa/issue/8357>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
-   `commit <https://pagure.io/freeipa/c/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
-   `commit <https://pagure.io/freeipa/c/b9a6027410814832f9228621abd2bbd2acebb944>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9a6027410814832f9228621abd2bbd2acebb944>`__
    `#8362 <https://pagure.io/freeipa/issue/8362>`__
 -  azure: do not run test_commands due to failures in low memory cases
-   `commit <https://pagure.io/freeipa/c/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
 -  test_smb: test S4U2Self operation by IPA service
-   `commit <https://pagure.io/freeipa/c/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
-   `commit <https://pagure.io/freeipa/c/b5876f30d4000424cc8122498c411f812b3a0959>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5876f30d4000424cc8122498c411f812b3a0959>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
-   `commit <https://pagure.io/freeipa/c/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
-   `commit <https://pagure.io/freeipa/c/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
-   `commit <https://pagure.io/freeipa/c/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add asserted identity SIDs
-   `commit <https://pagure.io/freeipa/c/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
-   `commit <https://pagure.io/freeipa/c/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
-   `commit <https://pagure.io/freeipa/c/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
-   `commit <https://pagure.io/freeipa/c/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
-   `commit <https://pagure.io/freeipa/c/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
    `#8319 <https://pagure.io/freeipa/issue/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
-   `commit <https://pagure.io/freeipa/c/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
    `#8328 <https://pagure.io/freeipa/issue/8328>`__
 -  service delegation: allow to add and remove host principals
-   `commit <https://pagure.io/freeipa/c/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
    `#8289 <https://pagure.io/freeipa/issue/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
-   `commit <https://pagure.io/freeipa/c/d986e844bbd37ccc7a532175631a55acd315cda3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d986e844bbd37ccc7a532175631a55acd315cda3>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
-   `commit <https://pagure.io/freeipa/c/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
-   `commit <https://pagure.io/freeipa/c/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
    `#8291 <https://pagure.io/freeipa/issue/8291>`__
 -  Azure Pipelines: switch to Fedora 32
-   `commit <https://pagure.io/freeipa/c/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
 -  Azure Pipelines: Override services known to not work in containers
-   `commit <https://pagure.io/freeipa/c/b8a1d130ad561acd3594c269dffa126f8242bd7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8a1d130ad561acd3594c269dffa126f8242bd7a>`__
 -  Add pytest.skip_if_container()
-   `commit <https://pagure.io/freeipa/c/a009b9e0342ca2633355fb9347855676110d678c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a009b9e0342ca2633355fb9347855676110d678c>`__
 -  CVE-2020-1722: prevent use of too long passwords
-   `commit <https://pagure.io/freeipa/c/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
    `#8268 <https://pagure.io/freeipa/issue/8268>`__
 -  Allow rename of a host group
-   `commit <https://pagure.io/freeipa/c/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
    `#6783 <https://pagure.io/freeipa/issue/6783>`__
 -  Add 'api' and 'aci' targets to make
-   `commit <https://pagure.io/freeipa/c/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
 -  Remove Fedora repository fastmirror selection
-   `commit <https://pagure.io/freeipa/c/77ed0918a7e419baf99527b5b73c9ee0a56c8767>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77ed0918a7e419baf99527b5b73c9ee0a56c8767>`__
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
-   `commit <https://pagure.io/freeipa/c/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
-   `commit <https://pagure.io/freeipa/c/527f30be76f0da6d4453745ace25f64948c0504f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/527f30be76f0da6d4453745ace25f64948c0504f>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
-   `commit <https://pagure.io/freeipa/c/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
-   `commit <https://pagure.io/freeipa/c/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
    `#7181 <https://pagure.io/freeipa/issue/7181>`__
 -  Fix indentation levels
-   `commit <https://pagure.io/freeipa/c/38204856fd72e5191bae07a47907314aacf43d1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38204856fd72e5191bae07a47907314aacf43d1a>`__
 -  ipatests: always skip additional input for group-add-member
    --external
-   `commit <https://pagure.io/freeipa/c/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  po: update Chinese (China) translation
-   `commit <https://pagure.io/freeipa/c/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
 -  po: update Ukrainian translation
-   `commit <https://pagure.io/freeipa/c/9fcae1590ddb2fd240b200d0960e33323d594acb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fcae1590ddb2fd240b200d0960e33323d594acb>`__
 -  po: update Tajik translation timestamp
-   `commit <https://pagure.io/freeipa/c/e50c2500f440caa59fa78320ed669db9f0a25d10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e50c2500f440caa59fa78320ed669db9f0a25d10>`__
 -  po: update Slovak translation timestamp
-   `commit <https://pagure.io/freeipa/c/ed55c408f8599dd4c0be8261c34930b9c7416171>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed55c408f8599dd4c0be8261c34930b9c7416171>`__
 -  po: update Russian translation
-   `commit <https://pagure.io/freeipa/c/ad3ef9de44f41051fed8f743fb4bc7cf2e896ea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3ef9de44f41051fed8f743fb4bc7cf2e896ea7>`__
 -  po: update Portuguese (Brazil) translation timestamp
-   `commit <https://pagure.io/freeipa/c/45dede73c7106b234f0c1d022bd20260d9c7c7fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45dede73c7106b234f0c1d022bd20260d9c7c7fa>`__
 -  po: update Portuguese translation timestamp
-   `commit <https://pagure.io/freeipa/c/baf1a7217d35c2142953a098f4caf88f181e42b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/baf1a7217d35c2142953a098f4caf88f181e42b0>`__
 -  po: update Polish translation
-   `commit <https://pagure.io/freeipa/c/047c8cc55d0845123160e94c69bf0f4efe47059e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/047c8cc55d0845123160e94c69bf0f4efe47059e>`__
 -  po: update Punjabi translation timestamp
-   `commit <https://pagure.io/freeipa/c/3e636959ff14e454329a6806bf4fe4f560ccf398>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e636959ff14e454329a6806bf4fe4f560ccf398>`__
 -  po: update Dutch translation timestamp
-   `commit <https://pagure.io/freeipa/c/7f3cc11a20ad1705cb62ec0075d1e7ec863fced7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f3cc11a20ad1705cb62ec0075d1e7ec863fced7>`__
 -  po: update Marathi translation timestamp
-   `commit <https://pagure.io/freeipa/c/0c9066e8f3b7b78fb7cf4763fa51919aa6c4965c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c9066e8f3b7b78fb7cf4763fa51919aa6c4965c>`__
 -  po: update Kannada translation timestamp
-   `commit <https://pagure.io/freeipa/c/1c30d18611519aca5244b2315a5d8a3e198eea38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c30d18611519aca5244b2315a5d8a3e198eea38>`__
 -  po: update Japanese translation timestamp
-   `commit <https://pagure.io/freeipa/c/60d69a8755d3f32d6fed70ba541f70e4069e0647>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60d69a8755d3f32d6fed70ba541f70e4069e0647>`__
 -  po: update Indonesian translation timestamp
-   `commit <https://pagure.io/freeipa/c/347d9c78b17176e7677995c2ecbbfc7b13d50dcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/347d9c78b17176e7677995c2ecbbfc7b13d50dcc>`__
 -  po: update Hungarian translation timestamp
-   `commit <https://pagure.io/freeipa/c/f18a4f8dd34134b3c08b1169ba42ebcffa49ac72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f18a4f8dd34134b3c08b1169ba42ebcffa49ac72>`__
 -  po: update Hindi translation timestamp
-   `commit <https://pagure.io/freeipa/c/35c1da8346c1b671b1a1bffa51199324c3947d9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35c1da8346c1b671b1a1bffa51199324c3947d9f>`__
 -  po: update French translation
-   `commit <https://pagure.io/freeipa/c/1a0232a6938c64277c4b8f2cdc35be650da644cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a0232a6938c64277c4b8f2cdc35be650da644cc>`__
 -  po: update Basque translation timestamp
-   `commit <https://pagure.io/freeipa/c/e6574914ade837f1d49579394437dfe720b55b22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6574914ade837f1d49579394437dfe720b55b22>`__
 -  po: update Spanish translation
-   `commit <https://pagure.io/freeipa/c/2859216b4cbb763a25792cffe6204da8edb4a232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2859216b4cbb763a25792cffe6204da8edb4a232>`__
 -  po: update English (United Kingdom) translation timestamp
-   `commit <https://pagure.io/freeipa/c/439c488f04b857cfb83f779e450c34b93f7c38bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/439c488f04b857cfb83f779e450c34b93f7c38bb>`__
 -  po: update German translation
-   `commit <https://pagure.io/freeipa/c/117893f03e4f26044e7b15053e336b8d42b4f180>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/117893f03e4f26044e7b15053e336b8d42b4f180>`__
 -  po: update Czech translation timestamp
-   `commit <https://pagure.io/freeipa/c/68cc049124f2acf66b4fdd4588e1fb25d50a9364>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68cc049124f2acf66b4fdd4588e1fb25d50a9364>`__
 -  po: update Catalan translation timestamp
-   `commit <https://pagure.io/freeipa/c/6cd244da6be890e577bf381c6303363e2a6f237f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cd244da6be890e577bf381c6303363e2a6f237f>`__
 -  po: update Bengali translation timestamp
-   `commit <https://pagure.io/freeipa/c/0be22a6ae71a3261c9e9333a01dc028f55554924>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be22a6ae71a3261c9e9333a01dc028f55554924>`__
 -  po: update ipa.pot template
-   `commit <https://pagure.io/freeipa/c/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
 -  Update translation infrastructure
-   `commit <https://pagure.io/freeipa/c/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Keep ipa.pot translation file in git for weblate
-   `commit <https://pagure.io/freeipa/c/92e36258cee838a378729d06fc4134b5c4428f87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92e36258cee838a378729d06fc4134b5c4428f87>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Do not force any particular sphinx theme
-   `commit <https://pagure.io/freeipa/c/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
 -  Override master document for ReadTheDocs
-   `commit <https://pagure.io/freeipa/c/34b961dc2032f56ccf1f8d905de42649d7ff7d3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34b961dc2032f56ccf1f8d905de42649d7ff7d3e>`__
 -  Move workshop documents to doc/workshop
-   `commit <https://pagure.io/freeipa/c/c6a379c432c7bc1a1a009fdc081db1470562ed8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6a379c432c7bc1a1a009fdc081db1470562ed8d>`__
 -  Add unit 11: Kerberos ticket policy
-   `commit <https://pagure.io/freeipa/c/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
 -  Prevent adding IPA objects as external members of external groups
-   `commit <https://pagure.io/freeipa/c/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
    `#8236 <https://pagure.io/freeipa/issue/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
-   `commit <https://pagure.io/freeipa/c/ec73de969f55b7a005b6401029f87fe6a225a417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec73de969f55b7a005b6401029f87fe6a225a417>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Tighten permissions on PKI proxy configuration
-   `commit <https://pagure.io/freeipa/c/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
    `#8221 <https://pagure.io/freeipa/issue/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
-   `commit <https://pagure.io/freeipa/c/ba904672a21add3b0ab1808c5640ac786f194aad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba904672a21add3b0ab1808c5640ac786f194aad>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
-   `commit <https://pagure.io/freeipa/c/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
    `#8200 <https://pagure.io/freeipa/issue/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
-   `commit <https://pagure.io/freeipa/c/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
    `#8192 <https://pagure.io/freeipa/issue/8192>`__
 -  Update Azure Pipelines to use Fedora 31
-   `commit <https://pagure.io/freeipa/c/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
 -  install/updates: move external members past schema compat update
-   `commit <https://pagure.io/freeipa/c/ff547a2777d63609faba42101e9802f5e988fa00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff547a2777d63609faba42101e9802f5e988fa00>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Reset per-indicator Kerberos policy
-   `commit <https://pagure.io/freeipa/c/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
    `#8153 <https://pagure.io/freeipa/issue/8153>`__
 -  ipa-client-samba: map domain sid of trust domain properly for display
-   `commit <https://pagure.io/freeipa/c/3d402b69eb484a14944ccc23fcf945963977e348>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d402b69eb484a14944ccc23fcf945963977e348>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
-   `commit <https://pagure.io/freeipa/c/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
-   `commit <https://pagure.io/freeipa/c/e9dd757763c76402e07f533f19e269eeebc554fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9dd757763c76402e07f533f19e269eeebc554fa>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  covscan: free encryption types in case there is an error
-   `commit <https://pagure.io/freeipa/c/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
    `#8131 <https://pagure.io/freeipa/issue/8131>`__
 -  Add Authentication Indicator Kerberos ticket policy options
-   `commit <https://pagure.io/freeipa/c/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Allow presence of LDAP attribute options
-   `commit <https://pagure.io/freeipa/c/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
-   `commit <https://pagure.io/freeipa/c/ba466a802129cbe61964653fdfddacd5d43f6771>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba466a802129cbe61964653fdfddacd5d43f6771>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/d243c188f26c50a056be5e88554daec6116f5f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d243c188f26c50a056be5e88554daec6116f5f8f>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/d317fd4de7b16dd2f50a360d7f8d2954b975fe1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d317fd4de7b16dd2f50a360d7f8d2954b975fe1e>`__
 -  Add local helpers to handle unixid structure
-   `commit <https://pagure.io/freeipa/c/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
 -  adtrust: add default read_keys permission for TDO objects
-   `commit <https://pagure.io/freeipa/c/0be98884991ff14720dfce428e4f23ebc4a42311>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be98884991ff14720dfce428e4f23ebc4a42311>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  add default access control when migrating trust objects
-   `commit <https://pagure.io/freeipa/c/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
    `#8067 <https://pagure.io/freeipa/issue/8067>`__
 -  adtrust: avoid using timestamp in klist output
-   `commit <https://pagure.io/freeipa/c/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
    `#8066 <https://pagure.io/freeipa/issue/8066>`__
 -  Mark failing test as xfail for use of python-dns make_ds method
-   `commit <https://pagure.io/freeipa/c/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
-   `commit <https://pagure.io/freeipa/c/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
 -  Update translations
-   `commit <https://pagure.io/freeipa/c/661804b748bc09b0a619416af896ee83007f9229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/661804b748bc09b0a619416af896ee83007f9229>`__
 -  Add Theodor van Nahl to the Contributors.txt
-   `commit <https://pagure.io/freeipa/c/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
 -  Restore SELinux context for p11-kit config overrides
-   `commit <https://pagure.io/freeipa/c/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
    `#7810 <https://pagure.io/freeipa/issue/7810>`__
 -  Change RA agent certificate profile to caSubsystemCert
-   `commit <https://pagure.io/freeipa/c/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
 -  certmaprule: add negative test for altSecurityIdentities
-   `commit <https://pagure.io/freeipa/c/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__
 -  certmap rules: altSecurityIdentities should only be used for trusted
    domains
-   `commit <https://pagure.io/freeipa/c/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__
 -  Create indexes for altSecurityIdentities and ipaCertmapData
    attributes
-   `commit <https://pagure.io/freeipa/c/725899595f42b607989db96d849e1b4f01de7faa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/725899595f42b607989db96d849e1b4f01de7faa>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__,
    `#7933 <https://pagure.io/freeipa/issue/7933>`__
 -  Add altSecurityIdentities attribute from MS-WSPP schema definition
-   `commit <https://pagure.io/freeipa/c/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
    `#7932 <https://pagure.io/freeipa/issue/7932>`__,
    `#7933 <https://pagure.io/freeipa/issue/7933>`__
 -  Use stage and phase attempt counters when saving test artifacts
-   `commit <https://pagure.io/freeipa/c/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
 -  Use any nodejs version instead of forcing a version before nodejs 11
-   `commit <https://pagure.io/freeipa/c/d55c9b6d7f0eefa5648fec5c0fb05ca475acd4fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d55c9b6d7f0eefa5648fec5c0fb05ca475acd4fd>`__
 -  Fix rpmlint errors for Rawhide
-   `commit <https://pagure.io/freeipa/c/5530911f20a7a6d2831c9ce35948d63b226f212f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5530911f20a7a6d2831c9ce35948d63b226f212f>`__
 -  Set git master to 4.9.0
-   `commit <https://pagure.io/freeipa/c/56b1b5ac5b3a2aad9cf005ac9d5c720c2a9fca0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56b1b5ac5b3a2aad9cf005ac9d5c720c2a9fca0e>`__
 -  Changing IPA master back to git snapshots
-   `commit <https://pagure.io/freeipa/c/21a5938a3e6a02b140dd0df64abde63f4df1d777>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21a5938a3e6a02b140dd0df64abde63f4df1d777>`__
 
 
 
@@ -1854,7 +1854,7 @@ Abhijeet (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update workshop.rst
-   `commit <https://pagure.io/freeipa/c/4a48fe3102040d164e9a4247f1b8539ccd8ef295>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a48fe3102040d164e9a4247f1b8539ccd8ef295>`__
 
 
 
@@ -1862,10 +1862,10 @@ Alexandre Mulatinho (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-join: allowing call with jsonrpc into freeipa API
-   `commit <https://pagure.io/freeipa/c/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-scripts: fix all ipa command line scripts to operate with -I
-   `commit <https://pagure.io/freeipa/c/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
    `#7987 <https://pagure.io/freeipa/issue/7987>`__
 
 
@@ -1875,46 +1875,46 @@ Anuja More (18)
 
 -  ipatests: cleanup in
    test_subdomain_lookup_with_certmaprule_containing_dn
-   `commit <https://pagure.io/freeipa/c/ea7b8d66536e388152619c99f8cc83e3fd7e92b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea7b8d66536e388152619c99f8cc83e3fd7e92b8>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/4247fb9c73e940f459ab62dcd32157e6148c319e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4247fb9c73e940f459ab62dcd32157e6148c319e>`__
 -  ipatests : Test to verify override_gid works with subdomain.
-   `commit <https://pagure.io/freeipa/c/0dfb44c3c793623686258794c3c8fc8ec6216e29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dfb44c3c793623686258794c3c8fc8ec6216e29>`__
 -  ipatests: xfail test with older versions of sssd
-   `commit <https://pagure.io/freeipa/c/d39786c0514b124f0e11a3fbcfef104d1eccea3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d39786c0514b124f0e11a3fbcfef104d1eccea3b>`__
 -  ipatests: Test that trusted AD users should not lose their AD
    domains.
-   `commit <https://pagure.io/freeipa/c/0cb0056fd6fc3f8665b11a196d8c613926d40a95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cb0056fd6fc3f8665b11a196d8c613926d40a95>`__
 -  Mark test to skip sssd-2.2.2
-   `commit <https://pagure.io/freeipa/c/6018ccaa8dfeccf27494369a8ba9a6c670779e2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6018ccaa8dfeccf27494369a8ba9a6c670779e2e>`__
 -  ipatests: User and group with same name should not break reading AD
    user data.
-   `commit <https://pagure.io/freeipa/c/b2ab2863ca121d94e7519cd53a9fdbb43b6c5d27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2ab2863ca121d94e7519cd53a9fdbb43b6c5d27>`__
 -  ipatests: Added test when 2FA prompting configurations is set.
-   `commit <https://pagure.io/freeipa/c/8007cec855fedc89593b0af92be282aa0e65e5c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8007cec855fedc89593b0af92be282aa0e65e5c6>`__
 -  ipatests: SSSD should fetch external groups without any limit.
-   `commit <https://pagure.io/freeipa/c/87a1d34c3bf1e86ff6ac0fe0a3c26f0709893476>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87a1d34c3bf1e86ff6ac0fe0a3c26f0709893476>`__
 -  Update topology for test_integration/test_sssd.py
-   `commit <https://pagure.io/freeipa/c/0a4bec2a1f2a1fbf6b6b05a5cdbdf5bf08d66344>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a4bec2a1f2a1fbf6b6b05a5cdbdf5bf08d66344>`__
 -  ipatests: Add test for ipa-extdom-extop plugin should allow @ in
    group name
-   `commit <https://pagure.io/freeipa/c/4f09416f2f01cee03213f7d5186fe1a7104e6d66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f09416f2f01cee03213f7d5186fe1a7104e6d66>`__
 -  After mounting "Unspecified GSS failure" should not be in logs.
-   `commit <https://pagure.io/freeipa/c/ab1999deb687f77fcad6c466ab3d472c8417d6ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab1999deb687f77fcad6c466ab3d472c8417d6ee>`__
 -  Add xmlrpc test with input validation check for kerberos ticket
    policy.
-   `commit <https://pagure.io/freeipa/c/f35738ef22aac54c09d64e3a7985298faf9ac1eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f35738ef22aac54c09d64e3a7985298faf9ac1eb>`__
 -  Fix fedora version for xfail for sssd test
-   `commit <https://pagure.io/freeipa/c/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
 -  Add integration test for otp kerberos ticket policy.
-   `commit <https://pagure.io/freeipa/c/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  ipatests: filter_users should be applied correctly.
-   `commit <https://pagure.io/freeipa/c/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
 -  ipatests : Login via ssh using private-key for ipa-user should work.
-   `commit <https://pagure.io/freeipa/c/836b90f65244a0407e74627b550297d0962d882e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/836b90f65244a0407e74627b550297d0962d882e>`__
 -  Extdom plugin should not return error (32)/'No such object'
-   `commit <https://pagure.io/freeipa/c/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -1923,7 +1923,7 @@ Andika Triwidada (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/5915031830125246b51346dddcadc8fc892e1793>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5915031830125246b51346dddcadc8fc892e1793>`__
 
 
 
@@ -1931,7 +1931,7 @@ Ariel O. Barria (1)
 ----------------------------------------------------------------------------------------------
 
 -  vagrant user does not have permission to write to /etc/resolv.conf
-   `commit <https://pagure.io/freeipa/c/2f9c9c8757d3d31860adbee0a68a6466e33643dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f9c9c8757d3d31860adbee0a68a6466e33643dc>`__
 
 
 
@@ -1939,13 +1939,13 @@ Alexander Scheel (3)
 ----------------------------------------------------------------------------------------------
 
 -  Specify cert_paths when calling PKIConnection
-   `commit <https://pagure.io/freeipa/c/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
    `#8379 <https://pagure.io/freeipa/issue/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
-   `commit <https://pagure.io/freeipa/c/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
    `#8372 <https://pagure.io/freeipa/issue/8372>`__
 -  Clarify AJP connector creation process
-   `commit <https://pagure.io/freeipa/c/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
 
 
 
@@ -1953,103 +1953,103 @@ Peter Keresztes Schmidt (33)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Unify adapter property definition for state evaluators
-   `commit <https://pagure.io/freeipa/c/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
-   `commit <https://pagure.io/freeipa/c/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 -  ipa-backup/restore: remove remaining chdir calls
-   `commit <https://pagure.io/freeipa/c/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
    `#7416 <https://pagure.io/freeipa/issue/7416>`__
 -  ipa-join: handle JSON-RPC error codes
-   `commit <https://pagure.io/freeipa/c/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
    `#8408 <https://pagure.io/freeipa/issue/8408>`__
 -  ipa-join: extract common JSON-RPC response parsing to common function
-   `commit <https://pagure.io/freeipa/c/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
    `#8408 <https://pagure.io/freeipa/issue/8408>`__
 -  ipa-join: Generalize XML-RPC references in man page
-   `commit <https://pagure.io/freeipa/c/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: Use bool type where appropriate
-   `commit <https://pagure.io/freeipa/c/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: select {JSON,XML}-RPC at build time
-   `commit <https://pagure.io/freeipa/c/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: implement JSON-RPC based unenrollment
-   `commit <https://pagure.io/freeipa/c/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: extract unenrollment code common to JSON and XML-RPC to
    separate function
-   `commit <https://pagure.io/freeipa/c/677659c8da27de7b256b7067e513f089892d05b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/677659c8da27de7b256b7067e513f089892d05b8>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: switch to jansson for json handling
-   `commit <https://pagure.io/freeipa/c/25205f44a10b9e4846121d1a9b05aafa74485292>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25205f44a10b9e4846121d1a9b05aafa74485292>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: buffer curl response before parsing json
-   `commit <https://pagure.io/freeipa/c/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: improve curl error handling in JSON-RPC code
-   `commit <https://pagure.io/freeipa/c/c197918e8d220f10676f42b3589e47599b7a11e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c197918e8d220f10676f42b3589e47599b7a11e5>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  ipa-join: don't set TLS related curl options for JSON-RPC
-   `commit <https://pagure.io/freeipa/c/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
    `#7966 <https://pagure.io/freeipa/issue/7966>`__
 -  Populate nshardwareplatform and nsosversion during join operation
-   `commit <https://pagure.io/freeipa/c/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
    `#8370 <https://pagure.io/freeipa/issue/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
-   `commit <https://pagure.io/freeipa/c/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
    `#8396 <https://pagure.io/freeipa/issue/8396>`__
 -  Unify spelling of "One-Time Password"
-   `commit <https://pagure.io/freeipa/c/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
 -  WebUI: reword OTP info message displayed during PW reset
-   `commit <https://pagure.io/freeipa/c/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
-   `commit <https://pagure.io/freeipa/c/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__
 -  Split named custom config to allow changes in options stanza
-   `commit <https://pagure.io/freeipa/c/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
    `#8287 <https://pagure.io/freeipa/issue/8287>`__
 -  lite-server: Fix werkzeug deprecation warnings
-   `commit <https://pagure.io/freeipa/c/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
    `#8360 <https://pagure.io/freeipa/issue/8360>`__
 -  util: replace NSS usage with OpenSSL
-   `commit <https://pagure.io/freeipa/c/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  util: add unit test for pw hashing
-   `commit <https://pagure.io/freeipa/c/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  po: remove zanata config since translation was moved to weblate
-   `commit <https://pagure.io/freeipa/c/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  Remove unused support for dm_password arg from ldapupdate.connect
-   `commit <https://pagure.io/freeipa/c/0f232a30116751f38722c65ae607c6e6958c8061>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f232a30116751f38722c65ae607c6e6958c8061>`__
    `#7610 <https://pagure.io/freeipa/issue/7610>`__
 -  Use ipaldap exceptions rather than ldap error codes in LDAP updater
-   `commit <https://pagure.io/freeipa/c/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
    `#7610 <https://pagure.io/freeipa/issue/7610>`__
 -  Specify min and max values for TTL of a DNS record
-   `commit <https://pagure.io/freeipa/c/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
    `#8358 <https://pagure.io/freeipa/issue/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
-   `commit <https://pagure.io/freeipa/c/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
 -  WebUI: Expose TTL of DNS records
-   `commit <https://pagure.io/freeipa/c/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
    `#3827 <https://pagure.io/freeipa/issue/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
-   `commit <https://pagure.io/freeipa/c/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
    `#8359 <https://pagure.io/freeipa/issue/8359>`__
 -  WebUI: Use data adapter to load facet header data
-   `commit <https://pagure.io/freeipa/c/517c7ab2153e701355732bc8d49076653e090a01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/517c7ab2153e701355732bc8d49076653e090a01>`__
    `#8339 <https://pagure.io/freeipa/issue/8339>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
-   `commit <https://pagure.io/freeipa/c/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
    `#8338 <https://pagure.io/freeipa/issue/8338>`__
 -  Remove remains of unused config options
-   `commit <https://pagure.io/freeipa/c/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
    `#6708 <https://pagure.io/freeipa/issue/6708>`__
 
 
@@ -2058,488 +2058,488 @@ Christian Heimes (181)
 ----------------------------------------------------------------------------------------------
 
 -  Easier to use ipa_gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/727a2ffb9336a050c26c790989edaf41864c6911>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/727a2ffb9336a050c26c790989edaf41864c6911>`__
 -  Update debug strings to reflect new calls
-   `commit <https://pagure.io/freeipa/c/3d796a7e5102eded524e4847f8f9dd26f508ae94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d796a7e5102eded524e4847f8f9dd26f508ae94>`__
 -  Remove problematic optimization from gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
 -  Replace nodename with ipa_gethostfqdn()
-   `commit <https://pagure.io/freeipa/c/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  Unify access to FQDN
-   `commit <https://pagure.io/freeipa/c/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  Reuse main LDAP connection
-   `commit <https://pagure.io/freeipa/c/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Speed up cainstance.migrate_profiles_to_ldap
-   `commit <https://pagure.io/freeipa/c/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__,
    `#8522 <https://pagure.io/freeipa/issue/8522>`__
 -  Lookup ipa-ca record with NSS
-   `commit <https://pagure.io/freeipa/c/731c5b211041ee18940082b29e6a21b3f084fc57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/731c5b211041ee18940082b29e6a21b3f084fc57>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__,
    `#8521 <https://pagure.io/freeipa/issue/8521>`__,
    `#8529 <https://pagure.io/freeipa/issue/8529>`__
 -  Simplify update code
-   `commit <https://pagure.io/freeipa/c/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Don't add 127.0.0.1 to resolv.conf twice
-   `commit <https://pagure.io/freeipa/c/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Require(post) systemd with resolved enabled on F33
-   `commit <https://pagure.io/freeipa/c/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Replace sudo with runuser
-   `commit <https://pagure.io/freeipa/c/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  Use separate install logs for AD and DNS instance
-   `commit <https://pagure.io/freeipa/c/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
    `#8528 <https://pagure.io/freeipa/issue/8528>`__
 -  Spawn PKI: Execute more steps early
-   `commit <https://pagure.io/freeipa/c/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Dogtag: Remove set_audit_renewal step
-   `commit <https://pagure.io/freeipa/c/8882680ee167c535e7539fe0452892aae617aac3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8882680ee167c535e7539fe0452892aae617aac3>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Skip offline dse.ldif patching by default
-   `commit <https://pagure.io/freeipa/c/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Remove magic sleep from create_index_task
-   `commit <https://pagure.io/freeipa/c/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Remove root-autobind configuration
-   `commit <https://pagure.io/freeipa/c/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Verify freeipa-selinux's ipa module is loaded
-   `commit <https://pagure.io/freeipa/c/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
 -  Check ca_wrapped in ipa-custodia-check
-   `commit <https://pagure.io/freeipa/c/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  Retry chronyc waitsync only once
-   `commit <https://pagure.io/freeipa/c/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  configure_dns_resolver: call self.restore_context
-   `commit <https://pagure.io/freeipa/c/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
    `#8518 <https://pagure.io/freeipa/issue/8518>`__
 -  Drop unused extended sleep feature from Sleeper
-   `commit <https://pagure.io/freeipa/c/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Faster certmonger wait_for_request()
-   `commit <https://pagure.io/freeipa/c/b79191f7107fbc1890631f4c65be48b646798131>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b79191f7107fbc1890631f4c65be48b646798131>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Add helper for poll/sleep loops with timeout
-   `commit <https://pagure.io/freeipa/c/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
    `#8521 <https://pagure.io/freeipa/issue/8521>`__
 -  Add missing fedora_container platform members
-   `commit <https://pagure.io/freeipa/c/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
    `#8519 <https://pagure.io/freeipa/issue/8519>`__
 -  Add more indices
-   `commit <https://pagure.io/freeipa/c/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
 -  Use single update LDIF for indices
-   `commit <https://pagure.io/freeipa/c/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
    `#8493 <https://pagure.io/freeipa/issue/8493>`__
 -  Also backup DNS config drop-ins
-   `commit <https://pagure.io/freeipa/c/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Ensure that resolved.conf.d is accessible
-   `commit <https://pagure.io/freeipa/c/34e47778b47748e94792455699b35e8c126c5db7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34e47778b47748e94792455699b35e8c126c5db7>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Fix compiler warning in ipa-kdb
-   `commit <https://pagure.io/freeipa/c/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
 -  Fix compiler warnings in libotp
-   `commit <https://pagure.io/freeipa/c/7de2c9bc82c5ffb5ab68adbf13a130aac009ff11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7de2c9bc82c5ffb5ab68adbf13a130aac009ff11>`__
 -  Fix compiler warning in ipa-pwd-extop
-   `commit <https://pagure.io/freeipa/c/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
 -  trust-add: Catch correct exception when chown SSSD
-   `commit <https://pagure.io/freeipa/c/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
    `#8516 <https://pagure.io/freeipa/issue/8516>`__
 -  Fix nsslapd-db-lock tuning of BDB backend
-   `commit <https://pagure.io/freeipa/c/69ebe41525116639ec512205319197dd278e15e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ebe41525116639ec512205319197dd278e15e6>`__
    `#5914 <https://pagure.io/freeipa/issue/5914>`__,
    `#8515 <https://pagure.io/freeipa/issue/8515>`__
 -  Create systemd-resolved configuration on update
-   `commit <https://pagure.io/freeipa/c/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
 -  Configure systemd-resolved to use IPA's BIND
-   `commit <https://pagure.io/freeipa/c/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Use new API for auto-forwarders
-   `commit <https://pagure.io/freeipa/c/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Configure NetworkManager to use systemd-resolved
-   `commit <https://pagure.io/freeipa/c/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Add helpers for resolve1 and nameservers
-   `commit <https://pagure.io/freeipa/c/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
    `#8275 <https://pagure.io/freeipa/issue/8275>`__
 -  Make git a build requirement
-   `commit <https://pagure.io/freeipa/c/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
 -  Delay import of psutil to avoid AVC
-   `commit <https://pagure.io/freeipa/c/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
    `#8512 <https://pagure.io/freeipa/issue/8512>`__
 -  Add User and Group to all ipaplatform.constants
-   `commit <https://pagure.io/freeipa/c/bc128cae471dae6e070953333d5d76f211aa7688>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc128cae471dae6e070953333d5d76f211aa7688>`__
 -  Use new classes for run_command and Service
-   `commit <https://pagure.io/freeipa/c/b19d20e2db9441334ef412dcdefa06bd5c790216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b19d20e2db9441334ef412dcdefa06bd5c790216>`__
 -  Add user and group wrappers
-   `commit <https://pagure.io/freeipa/c/72fb4e60c8d8eec854b4986e00037ff3a85e4389>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72fb4e60c8d8eec854b4986e00037ff3a85e4389>`__
 -  Simplify LDAPUpdater
-   `commit <https://pagure.io/freeipa/c/99a40cbbe95b629ccfd49cb3c809889731148779>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a40cbbe95b629ccfd49cb3c809889731148779>`__
 -  Add ldap_update() helper to service class
-   `commit <https://pagure.io/freeipa/c/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
 -  Don't create DS SSCA and self-signed cert
-   `commit <https://pagure.io/freeipa/c/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
    `#8502 <https://pagure.io/freeipa/issue/8502>`__
 -  Duplicate CA CRT: ignore expected cert
-   `commit <https://pagure.io/freeipa/c/b606fa6cca87706730fa20bfa437956194398c82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b606fa6cca87706730fa20bfa437956194398c82>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Add krbPrincipalName pres index correctly
-   `commit <https://pagure.io/freeipa/c/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  Only restart DS when duplicate cacrt was found
-   `commit <https://pagure.io/freeipa/c/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
    `#7125 <https://pagure.io/freeipa/issue/7125>`__
 -  Treat container subplatforms like main platform
-   `commit <https://pagure.io/freeipa/c/e89b40071356b1c3050accee54f8332531d9bac2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e89b40071356b1c3050accee54f8332531d9bac2>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Don't configure authselect in containers
-   `commit <https://pagure.io/freeipa/c/999485909a0bc654570f05cd2127d86d14d6f25a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/999485909a0bc654570f05cd2127d86d14d6f25a>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
-   `commit <https://pagure.io/freeipa/c/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Explicitly pass keytab to ipa-join
-   `commit <https://pagure.io/freeipa/c/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
 -  Write state dir to smb.conf
-   `commit <https://pagure.io/freeipa/c/64b20aad283c6a0a9557e77993b09679a72efa88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64b20aad283c6a0a9557e77993b09679a72efa88>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
-   `commit <https://pagure.io/freeipa/c/02986ff42b97dceb689abb32cf937da993880ddd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02986ff42b97dceb689abb32cf937da993880ddd>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Allow to override ipaplatform with env var
-   `commit <https://pagure.io/freeipa/c/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
    `#8401 <https://pagure.io/freeipa/issue/8401>`__
 -  Teach pylint how dnspython 2.x works
-   `commit <https://pagure.io/freeipa/c/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
    `#8419 <https://pagure.io/freeipa/issue/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
-   `commit <https://pagure.io/freeipa/c/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
    `#8412 <https://pagure.io/freeipa/issue/8412>`__
 -  Make tab completion in console more useful
-   `commit <https://pagure.io/freeipa/c/80794f6b5e263566a1da9685aba82762208a6219>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80794f6b5e263566a1da9685aba82762208a6219>`__
 -  Add \__signature_\_ to plugins
-   `commit <https://pagure.io/freeipa/c/069f41a01e65f07367000c6d9605167242a88736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/069f41a01e65f07367000c6d9605167242a88736>`__
    `#8388 <https://pagure.io/freeipa/issue/8388>`__
 -  Run test_fips in DS and PKI nightly
-   `commit <https://pagure.io/freeipa/c/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
 -  SELinux: Backport dirsrv_systemctl interface
-   `commit <https://pagure.io/freeipa/c/b56fa015280f98d20f883b4799a91ada49413fbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b56fa015280f98d20f883b4799a91ada49413fbc>`__
 -  RHEL 8.3 has KRB5 1.18 with KDB 8.0
-   `commit <https://pagure.io/freeipa/c/1144da5d94aa75e882929e136d7d322dc4a93732>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1144da5d94aa75e882929e136d7d322dc4a93732>`__
 -  Terminology improvements: use block list
-   `commit <https://pagure.io/freeipa/c/3ec1b77f6a03886936299a9d34ed8fd640c3984d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ec1b77f6a03886936299a9d34ed8fd640c3984d>`__
 -  Terminology improvements: use allow list
-   `commit <https://pagure.io/freeipa/c/3ce816ba772ffae6b0bd05e4589727513fa76e3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ce816ba772ffae6b0bd05e4589727513fa76e3c>`__
 -  Grammar: whitespace is a word
-   `commit <https://pagure.io/freeipa/c/5c09dcdb981df7837ac1bb75547d23fc7d8946d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c09dcdb981df7837ac1bb75547d23fc7d8946d0>`__
 -  Terminology improvements: CA renewal
-   `commit <https://pagure.io/freeipa/c/523f70ae46127161556a0881fc9a01e138a90666>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/523f70ae46127161556a0881fc9a01e138a90666>`__
 -  Use old uglifyjs on RHEL 8
-   `commit <https://pagure.io/freeipa/c/6e3346f0a7d820cb3643044884657fa60a80f918>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e3346f0a7d820cb3643044884657fa60a80f918>`__
    `#8300 <https://pagure.io/freeipa/issue/8300>`__
 -  Build ipa-selinux package on RHEL 8
-   `commit <https://pagure.io/freeipa/c/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
 -  Prevent local account takeover
-   `commit <https://pagure.io/freeipa/c/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
    `#8326 <https://pagure.io/freeipa/issue/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
-   `commit <https://pagure.io/freeipa/c/a18d406b5631f80134e202ae3310580683937f92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a18d406b5631f80134e202ae3310580683937f92>`__
    `#8367 <https://pagure.io/freeipa/issue/8367>`__
 -  Auto-generated ipa-epn files to gitignore
-   `commit <https://pagure.io/freeipa/c/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
 -  Overhaul bind upgrade process
-   `commit <https://pagure.io/freeipa/c/f52a15b808aa4d827c1f77f807611d49c9563d03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f52a15b808aa4d827c1f77f807611d49c9563d03>`__
 -  More upgrade tests
-   `commit <https://pagure.io/freeipa/c/43dd1e8a65826898ebcf2351cd248b876c625ed1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43dd1e8a65826898ebcf2351cd248b876c625ed1>`__
 -  Fix named.conf named_conf_include_re
-   `commit <https://pagure.io/freeipa/c/996a220900502ed5b6450af14c271e4f344f8cf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/996a220900502ed5b6450af14c271e4f344f8cf6>`__
 -  Remove named_validate_dnssec update step
-   `commit <https://pagure.io/freeipa/c/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
-   `commit <https://pagure.io/freeipa/c/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
    `#8363 <https://pagure.io/freeipa/issue/8363>`__
 -  libotp: Replace NSS with OpenSSL HMAC
-   `commit <https://pagure.io/freeipa/c/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
    `#6857 <https://pagure.io/freeipa/issue/6857>`__
 -  Include named config files in backup
-   `commit <https://pagure.io/freeipa/c/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
 -  Handle DatabaseError in RPC-Server connect()
-   `commit <https://pagure.io/freeipa/c/d79a7a9696ff634141bdff3423157d08513da310>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d79a7a9696ff634141bdff3423157d08513da310>`__
    `#8352 <https://pagure.io/freeipa/issue/8352>`__
 -  Allow permissions with 'self' bindruletype
-   `commit <https://pagure.io/freeipa/c/9dda004f270f321685597be276ca51e6b32fcd59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dda004f270f321685597be276ca51e6b32fcd59>`__
    `#8348 <https://pagure.io/freeipa/issue/8348>`__
 -  make: serialize strip-po / strip-pot
-   `commit <https://pagure.io/freeipa/c/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
    `#8323 <https://pagure.io/freeipa/issue/8323>`__
 -  Remove obsolete BIND named.conf options
-   `commit <https://pagure.io/freeipa/c/f5964b71572579acad9d1731b62eb3c088358c6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5964b71572579acad9d1731b62eb3c088358c6f>`__
    `#8349 <https://pagure.io/freeipa/issue/8349>`__,
    `#8350 <https://pagure.io/freeipa/issue/8350>`__
 -  Add ipa-print-pac to gitignore
-   `commit <https://pagure.io/freeipa/c/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
 -  Allow dnsrecord-add --force on clients
-   `commit <https://pagure.io/freeipa/c/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Explain the effect of OPT_X_TLS_PROTOCOL_MIN
-   `commit <https://pagure.io/freeipa/c/f3e117156436bbf715232bea730a9172c14a8c1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3e117156436bbf715232bea730a9172c14a8c1f>`__
 -  Check for freeipa-server-dns package early
-   `commit <https://pagure.io/freeipa/c/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
    `#7577 <https://pagure.io/freeipa/issue/7577>`__
 -  Hard-code in_tree=True for tests
-   `commit <https://pagure.io/freeipa/c/0fa31ef123a544378f04a2177524c9f72181a812>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa31ef123a544378f04a2177524c9f72181a812>`__
    `#8317 <https://pagure.io/freeipa/issue/8317>`__
 -  Fix detection logic for api.env.in_tree
-   `commit <https://pagure.io/freeipa/c/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
    `#8312 <https://pagure.io/freeipa/issue/8312>`__
 -  Make api.env.mode consistent
-   `commit <https://pagure.io/freeipa/c/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
    `#8313 <https://pagure.io/freeipa/issue/8313>`__
 -  Disable password schema update on LDAP bind
-   `commit <https://pagure.io/freeipa/c/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
    `#8315 <https://pagure.io/freeipa/issue/8315>`__
 -  Use httpd 2.4 syntax for access control
-   `commit <https://pagure.io/freeipa/c/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
 -  Let GH auto-notify and auto-close stale PRs
-   `commit <https://pagure.io/freeipa/c/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
 -  Fix make devcheck
-   `commit <https://pagure.io/freeipa/c/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
    `#8307 <https://pagure.io/freeipa/issue/8307>`__
 -  Simplify pki proxy conf
-   `commit <https://pagure.io/freeipa/c/19ea1b97a1559609014e0784c6f973c0e073878a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19ea1b97a1559609014e0784c6f973c0e073878a>`__
 -  Make check_required_principal() case-insensitive
-   `commit <https://pagure.io/freeipa/c/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
    `#8308 <https://pagure.io/freeipa/issue/8308>`__
 -  Make ipaplatform a regular top-level package
-   `commit <https://pagure.io/freeipa/c/490682ac3cab8978635655bdcc880f28227e900b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/490682ac3cab8978635655bdcc880f28227e900b>`__
    `#6474 <https://pagure.io/freeipa/issue/6474>`__,
    `#8309 <https://pagure.io/freeipa/issue/8309>`__
 -  Reconfigure pycodestyle
-   `commit <https://pagure.io/freeipa/c/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Manually reformat ipapython/version.py.in
-   `commit <https://pagure.io/freeipa/c/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Silence W601 .has_key() is deprecated
-   `commit <https://pagure.io/freeipa/c/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E722 do not use bare 'except'
-   `commit <https://pagure.io/freeipa/c/186d739d7f54989e9ed6ea08371825b29f21b811>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/186d739d7f54989e9ed6ea08371825b29f21b811>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
-   `commit <https://pagure.io/freeipa/c/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E714 test for object identity should be 'is not'
-   `commit <https://pagure.io/freeipa/c/8c9bba8e1ad1def3745497de24b14786148a64af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c9bba8e1ad1def3745497de24b14786148a64af>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E713 test for membership should be 'not in'
-   `commit <https://pagure.io/freeipa/c/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E712 comparison to True / False
-   `commit <https://pagure.io/freeipa/c/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E711 comparison to None
-   `commit <https://pagure.io/freeipa/c/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Fix E266 too many leading '#' for block comment
-   `commit <https://pagure.io/freeipa/c/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
    `#8306 <https://pagure.io/freeipa/issue/8306>`__
 -  Address issues found by new pylint 2.5.0
-   `commit <https://pagure.io/freeipa/c/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
    `#8297 <https://pagure.io/freeipa/issue/8297>`__
 -  Require Sphinx >2.1
-   `commit <https://pagure.io/freeipa/c/b7415c3ddcdbd826bc25761d78840c4417381571>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7415c3ddcdbd826bc25761d78840c4417381571>`__
 -  Fix /doc/workshop subtree merge
-   `commit <https://pagure.io/freeipa/c/d34db063774952814e0cae7e4499c7462ef04687>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d34db063774952814e0cae7e4499c7462ef04687>`__
 -  Create ipasphinx package for Sphinx plugins
-   `commit <https://pagure.io/freeipa/c/e00dc40feadf7be9d5b1aec995d59cadb83b5b92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e00dc40feadf7be9d5b1aec995d59cadb83b5b92>`__
 -  Add skip_if_platform marker
-   `commit <https://pagure.io/freeipa/c/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
 -  Define default password policy for sysaccounts
-   `commit <https://pagure.io/freeipa/c/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Use api.env.container_sysaccounts
-   `commit <https://pagure.io/freeipa/c/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
    `#8276 <https://pagure.io/freeipa/issue/8276>`__
 -  Fix exception escape warning
-   `commit <https://pagure.io/freeipa/c/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
 -  Fix APIVersion.__getnewargs_\_
-   `commit <https://pagure.io/freeipa/c/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
 -  servrole: takes_params must be a tuple
-   `commit <https://pagure.io/freeipa/c/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
    `#8290 <https://pagure.io/freeipa/issue/8290>`__
 -  Improve Sphinx building and linting
-   `commit <https://pagure.io/freeipa/c/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
 -  Fix various OpenDNSSEC 2.1 issues
-   `commit <https://pagure.io/freeipa/c/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
    `#8283 <https://pagure.io/freeipa/issue/8283>`__
 -  Use /run and /run/lock instead of /var
-   `commit <https://pagure.io/freeipa/c/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
    `#8272 <https://pagure.io/freeipa/issue/8272>`__
 -  po: fix LINGUAS to use whitespace separation
-   `commit <https://pagure.io/freeipa/c/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
    `#8159 <https://pagure.io/freeipa/issue/8159>`__
 -  SELinux: apache_manage_pid_files for F30
-   `commit <https://pagure.io/freeipa/c/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
    `#8241 <https://pagure.io/freeipa/issue/8241>`__
 -  Add pytest OpenSSH transport with password
-   `commit <https://pagure.io/freeipa/c/e8602b158680a92903b930a9d9a25e9c2c458685>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8602b158680a92903b930a9d9a25e9c2c458685>`__
 -  Add explicit syntax language to code blocks
-   `commit <https://pagure.io/freeipa/c/9f2553c64f06ac496b0063239942443b8f6c435d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f2553c64f06ac496b0063239942443b8f6c435d>`__
 -  Use m2r instead of recommonmark
-   `commit <https://pagure.io/freeipa/c/a9a225d7153474331933213db0ee8cf8470e5020>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9a225d7153474331933213db0ee8cf8470e5020>`__
 -  Include workshop in sphinx build
-   `commit <https://pagure.io/freeipa/c/145afd68e504a817a87448395c206be89cac6d22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/145afd68e504a817a87448395c206be89cac6d22>`__
 -  Fix codestyle
-   `commit <https://pagure.io/freeipa/c/c4a55522eed2165d550f6f1c93bb20e902348149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4a55522eed2165d550f6f1c93bb20e902348149>`__
 -  Test documentation builds in Azure
-   `commit <https://pagure.io/freeipa/c/a4efb3028b933e0dce1da907c6a6f1a30ce41269>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4efb3028b933e0dce1da907c6a6f1a30ce41269>`__
 -  Include design documentation
-   `commit <https://pagure.io/freeipa/c/a4456b010a4eeaa3225426a0ade67e1461613d18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4456b010a4eeaa3225426a0ade67e1461613d18>`__
 -  Introduce FreeIPA
-   `commit <https://pagure.io/freeipa/c/d267d43447a00aa96c14c4f8853e0c0793757c2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d267d43447a00aa96c14c4f8853e0c0793757c2c>`__
 -  Bootstrap Sphinx documentation
-   `commit <https://pagure.io/freeipa/c/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
 -  Move freeipa-selinux dependency to freeipa-common
-   `commit <https://pagure.io/freeipa/c/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate ipa_custodia policy
-   `commit <https://pagure.io/freeipa/c/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Allow hosts to read DNS records for IP SAN
-   `commit <https://pagure.io/freeipa/c/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
    `#8098 <https://pagure.io/freeipa/issue/8098>`__
 -  Cleanup SELinux policy
-   `commit <https://pagure.io/freeipa/c/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  Integrate SELinux policy into build system
-   `commit <https://pagure.io/freeipa/c/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
 -  dnsrecord: Treat empty list arguments correctly
-   `commit <https://pagure.io/freeipa/c/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
    `#8196 <https://pagure.io/freeipa/issue/8196>`__
 -  Remove dependency on custodia package
-   `commit <https://pagure.io/freeipa/c/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
 -  lite-setup: configure lite-server test env
-   `commit <https://pagure.io/freeipa/c/e9ae7c4b898e570440245714cf20f03d8ee35159>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9ae7c4b898e570440245714cf20f03d8ee35159>`__
 -  Add tracemalloc support to profile memory usage
-   `commit <https://pagure.io/freeipa/c/0a55e82d916b38472bd38032946ea9b249a765f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a55e82d916b38472bd38032946ea9b249a765f2>`__
 -  Make assert_error compatible with Python 3.6
-   `commit <https://pagure.io/freeipa/c/10b62ad6bc967e022202d657b7493440fb5cf736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10b62ad6bc967e022202d657b7493440fb5cf736>`__
    `#8179 <https://pagure.io/freeipa/issue/8179>`__
 -  Print LDAP diagnostic messages on error
-   `commit <https://pagure.io/freeipa/c/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
 -  Fix get_trusted_domain_object_from_sid()
-   `commit <https://pagure.io/freeipa/c/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
    `#7958 <https://pagure.io/freeipa/issue/7958>`__
 -  Check valid before/after of external certs
-   `commit <https://pagure.io/freeipa/c/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix service ldap_disable()
-   `commit <https://pagure.io/freeipa/c/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
    `#8143 <https://pagure.io/freeipa/issue/8143>`__
 -  Require idstart to be larger than UID_MAX
-   `commit <https://pagure.io/freeipa/c/44b3791bc3a14ede0708538347954871df6496fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44b3791bc3a14ede0708538347954871df6496fa>`__
    `#8137 <https://pagure.io/freeipa/issue/8137>`__
 -  Fix lite-server to work with GSS_NAME
-   `commit <https://pagure.io/freeipa/c/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
 -  Fix logic of check_client_configuration
-   `commit <https://pagure.io/freeipa/c/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
    `#8133 <https://pagure.io/freeipa/issue/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
-   `commit <https://pagure.io/freeipa/c/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
    `#8134 <https://pagure.io/freeipa/issue/8134>`__
 -  Don't run test_smb in gating tests
-   `commit <https://pagure.io/freeipa/c/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
 -  Don't hard-code client's TLS versions and ciphers
-   `commit <https://pagure.io/freeipa/c/639bb71940daddd15efb3b4fa922d185235c0b33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/639bb71940daddd15efb3b4fa922d185235c0b33>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
-   `commit <https://pagure.io/freeipa/c/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Enable TLS 1.3 support on the server
-   `commit <https://pagure.io/freeipa/c/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
    `#8125 <https://pagure.io/freeipa/issue/8125>`__
 -  Skip paramiko tests in FIPS mode
-   `commit <https://pagure.io/freeipa/c/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  FIPS: server key has different name in FIPS mode
-   `commit <https://pagure.io/freeipa/c/d153957990b7456d53af5903a0e62b2716f61183>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d153957990b7456d53af5903a0e62b2716f61183>`__
 -  Remove FIPS noise from SSHd
-   `commit <https://pagure.io/freeipa/c/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
 -  Fix otptoken_sync plugin
-   `commit <https://pagure.io/freeipa/c/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Add test case for OTP login
-   `commit <https://pagure.io/freeipa/c/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
    `#7804 <https://pagure.io/freeipa/issue/7804>`__
 -  Show group-add/remove-member-manager failures
-   `commit <https://pagure.io/freeipa/c/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
    `#8122 <https://pagure.io/freeipa/issue/8122>`__
 -  Test installation with (fake) userspace FIPS
-   `commit <https://pagure.io/freeipa/c/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
    `#8118 <https://pagure.io/freeipa/issue/8118>`__
 -  Use default ssh host key algorithms
-   `commit <https://pagure.io/freeipa/c/97a31e69e8399933d45006c744ddafcf036eca5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97a31e69e8399933d45006c744ddafcf036eca5f>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 -  Add tests for member management
-   `commit <https://pagure.io/freeipa/c/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
 -  Add group membership management
-   `commit <https://pagure.io/freeipa/c/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
    `#8114 <https://pagure.io/freeipa/issue/8114>`__
 -  Skip commented lines after substitution
-   `commit <https://pagure.io/freeipa/c/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
    `#8111 <https://pagure.io/freeipa/issue/8111>`__
 -  Block camellia in krbenctypes update in FIPS
-   `commit <https://pagure.io/freeipa/c/bc56642bf9e59821322903e7470be6ec1d857034>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc56642bf9e59821322903e7470be6ec1d857034>`__
    `#8111 <https://pagure.io/freeipa/issue/8111>`__
 -  Don't install a preexec_fn by default
-   `commit <https://pagure.io/freeipa/c/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
 -  Don't create log files from help scripts
-   `commit <https://pagure.io/freeipa/c/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
    `#8075 <https://pagure.io/freeipa/issue/8075>`__
 -  Add new env vars to pylint plugin
-   `commit <https://pagure.io/freeipa/c/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  Fix wrong use of identity operation
-   `commit <https://pagure.io/freeipa/c/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  Enable literal-comparison linter again
-   `commit <https://pagure.io/freeipa/c/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  Replace %{_libdir} macro in BuildRequires
-   `commit <https://pagure.io/freeipa/c/51836c0594d9f97ace8392c03d47aae883b87724>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51836c0594d9f97ace8392c03d47aae883b87724>`__
    `#8056 <https://pagure.io/freeipa/issue/8056>`__
 -  Fix ca_initialize_hsm_state
-   `commit <https://pagure.io/freeipa/c/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__
 -  Store HSM token and state
-   `commit <https://pagure.io/freeipa/c/076d955b9373ad8603f3885ea6841d367f866327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/076d955b9373ad8603f3885ea6841d367f866327>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__
 -  Allow insecure binds for migration
-   `commit <https://pagure.io/freeipa/c/a36556e1064900af7a75ca6f07aba66212cf321a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a36556e1064900af7a75ca6f07aba66212cf321a>`__
    `#8040 <https://pagure.io/freeipa/issue/8040>`__
 -  Don't move keys when key backup is disabled
-   `commit <https://pagure.io/freeipa/c/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
    `#7677 <https://pagure.io/freeipa/issue/7677>`__
 -  Update comments to explain caSubsystemCert switch
-   `commit <https://pagure.io/freeipa/c/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
 -  Test external CA with DNS name constraints
-   `commit <https://pagure.io/freeipa/c/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
 -  Add PKCS#11 module name to p11helper errors
-   `commit <https://pagure.io/freeipa/c/94b4af55b0b4f376e687fae777c51678b99816f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94b4af55b0b4f376e687fae777c51678b99816f3>`__
    `#8015 <https://pagure.io/freeipa/issue/8015>`__
 -  Use nis-domainname.service on all RH platforms
-   `commit <https://pagure.io/freeipa/c/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
    `#8004 <https://pagure.io/freeipa/issue/8004>`__
 
 
@@ -2548,12 +2548,12 @@ Cédric Jeanneret (3)
 ----------------------------------------------------------------------------------------------
 
 -  Update selinux-policy minimal requirement
-   `commit <https://pagure.io/freeipa/c/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
 -  Prevents DNS Amplification Attack and allow to customize named
-   `commit <https://pagure.io/freeipa/c/6c2710446718828e6840ac34ea6fc704ae6790db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c2710446718828e6840ac34ea6fc704ae6790db>`__
    `#8079 <https://pagure.io/freeipa/issue/8079>`__
 -  Add new tip for dependencies
-   `commit <https://pagure.io/freeipa/c/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
 
 
 
@@ -2561,19 +2561,19 @@ Changmin Teng (5)
 ----------------------------------------------------------------------------------------------
 
 -  Add design document
-   `commit <https://pagure.io/freeipa/c/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Modify webUI to adhere to new IPA server API
-   `commit <https://pagure.io/freeipa/c/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Implement user pre-authentication control with kdcpolicy plugin
-   `commit <https://pagure.io/freeipa/c/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Extend the list of supported pre-auth mechanisms in IPA server API
-   `commit <https://pagure.io/freeipa/c/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Add new authentication indicators in kdc.conf.template
-   `commit <https://pagure.io/freeipa/c/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 
 
@@ -2582,7 +2582,7 @@ Daniel Lara Souza (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/11828cf87ca3def972839cdec290d0ea91df4733>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11828cf87ca3def972839cdec290d0ea91df4733>`__
 
 
 
@@ -2590,7 +2590,7 @@ Dinesh Prasanth M K (1)
 ----------------------------------------------------------------------------------------------
 
 -  Adding auto COPR builds
-   `commit <https://pagure.io/freeipa/c/df59f09eed698b76a9089614a170c771c9dfb7b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df59f09eed698b76a9089614a170c771c9dfb7b6>`__
 
 
 
@@ -2598,7 +2598,7 @@ Endi Sukma Dewata (1)
 ----------------------------------------------------------------------------------------------
 
 -  Removed hard-coded default profile subsystem class name
-   `commit <https://pagure.io/freeipa/c/edfe95b120edd4794c7d1e1290c99116fac3b194>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edfe95b120edd4794c7d1e1290c99116fac3b194>`__
 
 
 
@@ -2606,7 +2606,7 @@ Emilio Herrera (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/4cc9c942d121e06edfca734b5e69c035dff7c9c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cc9c942d121e06edfca734b5e69c035dff7c9c5>`__
 
 
 
@@ -2614,272 +2614,272 @@ François Cami (93)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: run freeipa-healthcheck on hidden replica
-   `commit <https://pagure.io/freeipa/c/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
    `#8536 <https://pagure.io/freeipa/issue/8536>`__
 -  ipatests: tasks: add user_del
-   `commit <https://pagure.io/freeipa/c/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
    `#8536 <https://pagure.io/freeipa/issue/8536>`__
 -  ipatests: kinit_as_user improvements
-   `commit <https://pagure.io/freeipa/c/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: create_active_user improvements
-   `commit <https://pagure.io/freeipa/c/e0586f33a60a44e340889ec5adea0800bde21592>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0586f33a60a44e340889ec5adea0800bde21592>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: add get_kdcinfo
-   `commit <https://pagure.io/freeipa/c/884e0d36e9f655d0456229d0e259592e65714660>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/884e0d36e9f655d0456229d0e259592e65714660>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  ipatests: add check_if_sssd_is_online
-   `commit <https://pagure.io/freeipa/c/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
    `#8510 <https://pagure.io/freeipa/issue/8510>`__
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
-   `commit <https://pagure.io/freeipa/c/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
    `#8513 <https://pagure.io/freeipa/issue/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
-   `commit <https://pagure.io/freeipa/c/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
-   `commit <https://pagure.io/freeipa/c/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
-   `commit <https://pagure.io/freeipa/c/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
-   `commit <https://pagure.io/freeipa/c/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
-   `commit <https://pagure.io/freeipa/c/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
-   `commit <https://pagure.io/freeipa/c/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
-   `commit <https://pagure.io/freeipa/c/7823da0630379d642f4a19b3ae0c063963041a82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7823da0630379d642f4a19b3ae0c063963041a82>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
-   `commit <https://pagure.io/freeipa/c/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  ipatests: check that pkispawn log is not empty
-   `commit <https://pagure.io/freeipa/c/c31bf3d430763ef5b0ef28510995af48dccde287>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c31bf3d430763ef5b0ef28510995af48dccde287>`__
    `#8503 <https://pagure.io/freeipa/issue/8503>`__
 -  SELinux Policy: let custodia replicate keys
-   `commit <https://pagure.io/freeipa/c/68328299c881df497dab32b145157d6e0e42d6c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68328299c881df497dab32b145157d6e0e42d6c6>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  ipatests: test_epn: update error messages
-   `commit <https://pagure.io/freeipa/c/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  IPA-EPN: enhance input validation
-   `commit <https://pagure.io/freeipa/c/97006786dfed7947aaa96737201ef7e0e53dd952>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97006786dfed7947aaa96737201ef7e0e53dd952>`__
    `#8444 <https://pagure.io/freeipa/issue/8444>`__
 -  IPA-EPN: Fix SMTP connection error handling
-   `commit <https://pagure.io/freeipa/c/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
-   `commit <https://pagure.io/freeipa/c/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
    `#8445 <https://pagure.io/freeipa/issue/8445>`__
 -  IPA-EPN: fix configuration file typo
-   `commit <https://pagure.io/freeipa/c/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
-   `commit <https://pagure.io/freeipa/c/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
-   `commit <https://pagure.io/freeipa/c/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
-   `commit <https://pagure.io/freeipa/c/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
    `#8449 <https://pagure.io/freeipa/issue/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/763d3b059bccc37744764985b57d97554a2a6947>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/763d3b059bccc37744764985b57d97554a2a6947>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
-   `commit <https://pagure.io/freeipa/c/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
-   `commit <https://pagure.io/freeipa/c/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  tasks: add run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
    `#8129 <https://pagure.io/freeipa/issue/8129>`__
 -  ipatests: test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
-   `commit <https://pagure.io/freeipa/c/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
    `#8151 <https://pagure.io/freeipa/issue/8151>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
-   `commit <https://pagure.io/freeipa/c/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
    `#8432 <https://pagure.io/freeipa/issue/8432>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
-   `commit <https://pagure.io/freeipa/c/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
-   `commit <https://pagure.io/freeipa/c/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
    `#8391 <https://pagure.io/freeipa/issue/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
-   `commit <https://pagure.io/freeipa/c/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
-   `commit <https://pagure.io/freeipa/c/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
-   `commit <https://pagure.io/freeipa/c/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
 -  EPN: ship the configuration file.
-   `commit <https://pagure.io/freeipa/c/6efe9917970f81a400793d4339d6826d8350ec55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6efe9917970f81a400793d4339d6826d8350ec55>`__
    `#8374 <https://pagure.io/freeipa/issue/8374>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
-   `commit <https://pagure.io/freeipa/c/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
    `#8377 <https://pagure.io/freeipa/issue/8377>`__
 -  .mailmap: add fcami
-   `commit <https://pagure.io/freeipa/c/533ec75494127694692a46503e031df51a83f0c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/533ec75494127694692a46503e031df51a83f0c2>`__
 -  IPA-EPN: Test suite.
-   `commit <https://pagure.io/freeipa/c/3805eff4178285f0189c355d17594b5e09dce9b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3805eff4178285f0189c355d17594b5e09dce9b0>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: First version.
-   `commit <https://pagure.io/freeipa/c/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
-   `commit <https://pagure.io/freeipa/c/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
-   `commit <https://pagure.io/freeipa/c/e7319f628fd70bb7abc77aff1a819326bf52cb5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7319f628fd70bb7abc77aff1a819326bf52cb5c>`__
 -  tox.ini: switch from W503 to W504
-   `commit <https://pagure.io/freeipa/c/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
 -  IPA-EPN: Add design draft
-   `commit <https://pagure.io/freeipa/c/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  doc/Makefile: use sphinx-build -W by default
-   `commit <https://pagure.io/freeipa/c/7558e1413dca240a77893352b5bb62bd21103b46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7558e1413dca240a77893352b5bb62bd21103b46>`__
 -  Makefile.am: add doclint to fastcheck
-   `commit <https://pagure.io/freeipa/c/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
 -  ipatests: increase test_webui_server timeout
-   `commit <https://pagure.io/freeipa/c/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
    `#8266 <https://pagure.io/freeipa/issue/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
-   `commit <https://pagure.io/freeipa/c/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
    `#8262 <https://pagure.io/freeipa/issue/8262>`__
 -  ipatests: move ipa_backup to tasks
-   `commit <https://pagure.io/freeipa/c/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  pr-ci templates: update test_fips timeouts
-   `commit <https://pagure.io/freeipa/c/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
    `#8247 <https://pagure.io/freeipa/issue/8247>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
-   `commit <https://pagure.io/freeipa/c/3665ba928b25c017465588bd505e93d15d72290f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3665ba928b25c017465588bd505e93d15d72290f>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  test_backup_and_restore: add server role verification steps
-   `commit <https://pagure.io/freeipa/c/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
-   `commit <https://pagure.io/freeipa/c/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
    `#8217 <https://pagure.io/freeipa/issue/8217>`__
 -  pr-ci templates: update test_fips timeouts
-   `commit <https://pagure.io/freeipa/c/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
    `#8247 <https://pagure.io/freeipa/issue/8247>`__
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
-   `commit <https://pagure.io/freeipa/c/f9804558bbe745df1141c84f00be83edcbe06c91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9804558bbe745df1141c84f00be83edcbe06c91>`__
    `#8240 <https://pagure.io/freeipa/issue/8240>`__
 -  8-sudorule.rst: add sudo and su-l as services for bob's HBAC rule.
-   `commit <https://pagure.io/freeipa/c/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
 -  ipa-restore: restart services at the end
-   `commit <https://pagure.io/freeipa/c/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
    `#8226 <https://pagure.io/freeipa/issue/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
-   `commit <https://pagure.io/freeipa/c/5f9d5281848a4de3acd669caa277d1b830722b71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f9d5281848a4de3acd669caa277d1b830722b71>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipa-client-automount: call save_domain() for each change
-   `commit <https://pagure.io/freeipa/c/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
    `#8190 <https://pagure.io/freeipa/issue/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
-   `commit <https://pagure.io/freeipa/c/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
-   `commit <https://pagure.io/freeipa/c/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
    `#7938 <https://pagure.io/freeipa/issue/7938>`__
 -  ipatests/test_nfs.py: wait before umount
-   `commit <https://pagure.io/freeipa/c/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
    `#8144 <https://pagure.io/freeipa/issue/8144>`__
 -  ipatests: fix pr-ci templates' indentation
-   `commit <https://pagure.io/freeipa/c/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
-   `commit <https://pagure.io/freeipa/c/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
    `#8148 <https://pagure.io/freeipa/issue/8148>`__
 -  DSU: add Design for Disable Stale Users
-   `commit <https://pagure.io/freeipa/c/438094f868e1a96444e148d9a2481b559cab9a11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/438094f868e1a96444e148d9a2481b559cab9a11>`__
    `#8104 <https://pagure.io/freeipa/issue/8104>`__
 -  ipatests: nightly_f29: disable TestIpaClientAutomountFileRestore
-   `commit <https://pagure.io/freeipa/c/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
    `#8063 <https://pagure.io/freeipa/issue/8063>`__
 -  ipatests: temporarily remove test_smb from gating
-   `commit <https://pagure.io/freeipa/c/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
 -  ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)
-   `commit <https://pagure.io/freeipa/c/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
 -  ipapython/ipachangeconf.py: change "is not 0" for "!= 0"
-   `commit <https://pagure.io/freeipa/c/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  authconfig.py: restore user-nsswitch.conf at uninstall time
-   `commit <https://pagure.io/freeipa/c/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
    `#8054 <https://pagure.io/freeipa/issue/8054>`__
 -  ipatests: remove xfail in TestIpaClientAutomountFileRestore
-   `commit <https://pagure.io/freeipa/c/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
 -  ipa-client-automount: always restore nsswitch.conf at uninstall time
-   `commit <https://pagure.io/freeipa/c/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
    `#8038 <https://pagure.io/freeipa/issue/8038>`__
 -  ipatests: check that ipa-client-automount restores nsswitch.conf at
    uninstall time
-   `commit <https://pagure.io/freeipa/c/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
 -  travis-ci: make dnf invocations more resilient
-   `commit <https://pagure.io/freeipa/c/c709f131712370d567064bb286d32d36f2307e0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c709f131712370d567064bb286d32d36f2307e0f>`__
    `#8048 <https://pagure.io/freeipa/issue/8048>`__
 -  azure-pipelines.yml: switch to Python 3.7
-   `commit <https://pagure.io/freeipa/c/70b96d76cb97b386da27e05d81240f946b206378>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70b96d76cb97b386da27e05d81240f946b206378>`__
    `#8030 <https://pagure.io/freeipa/issue/8030>`__
 -  test_nfs.py: switch to master_3repl
-   `commit <https://pagure.io/freeipa/c/80561224abcdc738a127e1ad70f3966cbb955c66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80561224abcdc738a127e1ad70f3966cbb955c66>`__
    `#8027 <https://pagure.io/freeipa/issue/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
-   `commit <https://pagure.io/freeipa/c/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
    `#7949 <https://pagure.io/freeipa/issue/7949>`__
 -  prci_definitions: add master_3client topology
-   `commit <https://pagure.io/freeipa/c/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
    `#8026 <https://pagure.io/freeipa/issue/8026>`__
 -  ipapython/admintool.py: use SERVER_NOT_CONFIGURED
-   `commit <https://pagure.io/freeipa/c/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
 -  ipa-client-samba: remove state on uninstall
-   `commit <https://pagure.io/freeipa/c/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
    `#8021 <https://pagure.io/freeipa/issue/8021>`__
 -  ipatests: test ipa-client-samba after --uninstall
-   `commit <https://pagure.io/freeipa/c/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
 -  ipa-client-samba: remove and restore smb.conf only on first uninstall
-   `commit <https://pagure.io/freeipa/c/5b65551b3107e46853afcc4901a60ea6e661a511>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b65551b3107e46853afcc4901a60ea6e661a511>`__
    `#8019 <https://pagure.io/freeipa/issue/8019>`__
 -  ipatests: test multiple invocations of ipa-client-samba --uninstall
-   `commit <https://pagure.io/freeipa/c/68b85703d8ab2ede823d96e317dd106de27b108b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68b85703d8ab2ede823d96e317dd106de27b108b>`__
 -  ipatests/azure: display actual dnf repo URLs
-   `commit <https://pagure.io/freeipa/c/be7f54d40c33d147fdaf0d3cd65b56452a4f001a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be7f54d40c33d147fdaf0d3cd65b56452a4f001a>`__
 
 
 
@@ -2888,266 +2888,266 @@ Florence Blanc-Renaud (89)
 
 -  ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst
    from gating
-   `commit <https://pagure.io/freeipa/c/a33530f2f6cc7933edc537eb5055d4f147741654>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a33530f2f6cc7933edc537eb5055d4f147741654>`__
    `#8496 <https://pagure.io/freeipa/issue/8496>`__
 -  ipatests: ipa-acme-manage status returns 3 on a CA-less server
-   `commit <https://pagure.io/freeipa/c/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
    `#8572 <https://pagure.io/freeipa/issue/8572>`__
 -  ipatests: IPADNSSystemRecordsCheck also checks for AAAA records
-   `commit <https://pagure.io/freeipa/c/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
    `#8573 <https://pagure.io/freeipa/issue/8573>`__
 -  ipatests: curl outputs the cookie in stderr and not in sdtout
-   `commit <https://pagure.io/freeipa/c/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
    `#8559 <https://pagure.io/freeipa/issue/8559>`__
 -  ipatests: properly handle journalctl return code
-   `commit <https://pagure.io/freeipa/c/cb7d09642205cba07ef614065d106f7f84d8921b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb7d09642205cba07ef614065d106f7f84d8921b>`__
    `#8541 <https://pagure.io/freeipa/issue/8541>`__
 -  rpmspec: ensure ipa snippet for sshd is always included
-   `commit <https://pagure.io/freeipa/c/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
    `#8535 <https://pagure.io/freeipa/issue/8535>`__
 -  ipatests: add tests to 389ds regression
-   `commit <https://pagure.io/freeipa/c/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
 -  test_smb: skip test_smb_service_s4u2self for fed31
-   `commit <https://pagure.io/freeipa/c/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
    `#8505 <https://pagure.io/freeipa/issue/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
-   `commit <https://pagure.io/freeipa/c/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
    `#8481 <https://pagure.io/freeipa/issue/8481>`__
 -  ipatests: fix bind service name
-   `commit <https://pagure.io/freeipa/c/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
    `#8482 <https://pagure.io/freeipa/issue/8482>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
-   `commit <https://pagure.io/freeipa/c/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
-   `commit <https://pagure.io/freeipa/c/ec67022af204f1d34bb2da302aa0e3b874812399>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec67022af204f1d34bb2da302aa0e3b874812399>`__
    `#8472 <https://pagure.io/freeipa/issue/8472>`__
 -  ipatests: remove xfail from test_dnssec
-   `commit <https://pagure.io/freeipa/c/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
-   `commit <https://pagure.io/freeipa/c/f2711321679f99be9a8521f07c81e715bad74b06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2711321679f99be9a8521f07c81e715bad74b06>`__
    `#8447 <https://pagure.io/freeipa/issue/8447>`__
 -  ipatests: collect IPA_RENEWAL_LOCK file
-   `commit <https://pagure.io/freeipa/c/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
-   `commit <https://pagure.io/freeipa/c/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
    `#8439 <https://pagure.io/freeipa/issue/8439>`__
 -  ipatests: check KDC cert permissions in CA less install
-   `commit <https://pagure.io/freeipa/c/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  CAless installation: set the perms on KDC cert file
-   `commit <https://pagure.io/freeipa/c/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
    `#8440 <https://pagure.io/freeipa/issue/8440>`__
 -  ipatests: increase test_trust timeout
-   `commit <https://pagure.io/freeipa/c/0a3c98d236758274a719c2beeca2080df1390594>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a3c98d236758274a719c2beeca2080df1390594>`__
 -  ipatests: fix test_authselect
-   `commit <https://pagure.io/freeipa/c/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
-   `commit <https://pagure.io/freeipa/c/aac570bb4558798ef0b868a88a3b796361c400ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aac570bb4558798ef0b868a88a3b796361c400ba>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
-   `commit <https://pagure.io/freeipa/c/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
    `#8189 <https://pagure.io/freeipa/issue/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
-   `commit <https://pagure.io/freeipa/c/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
    `#8414 <https://pagure.io/freeipa/issue/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
-   `commit <https://pagure.io/freeipa/c/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
    `#8413 <https://pagure.io/freeipa/issue/8413>`__
 -  sshd template must be part of client package
-   `commit <https://pagure.io/freeipa/c/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
    `#8400 <https://pagure.io/freeipa/issue/8400>`__
 -  Add test_dnssec to 389ds nightly tests
-   `commit <https://pagure.io/freeipa/c/17cf8edb4073fb1db67e5541409dd28943909750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17cf8edb4073fb1db67e5541409dd28943909750>`__
 -  ipa cert-show: fix the code setting revocation reason
-   `commit <https://pagure.io/freeipa/c/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
    `#8394 <https://pagure.io/freeipa/issue/8394>`__
 -  Bump requires for selinux-policy
-   `commit <https://pagure.io/freeipa/c/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
 -  ipatests: fix the method adding ifp to sssd.conf
-   `commit <https://pagure.io/freeipa/c/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
    `#8371 <https://pagure.io/freeipa/issue/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
-   `commit <https://pagure.io/freeipa/c/dc11b98e4a6650040731405a0e954e20be12afa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc11b98e4a6650040731405a0e954e20be12afa6>`__
    `#5628 <https://pagure.io/freeipa/issue/5628>`__,
    `#8381 <https://pagure.io/freeipa/issue/8381>`__
 -  client install: fix broken sshd config
-   `commit <https://pagure.io/freeipa/c/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
-   `commit <https://pagure.io/freeipa/c/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
    `#8304 <https://pagure.io/freeipa/issue/8304>`__
 -  ipatests: Update the pki-master-f32 image version
-   `commit <https://pagure.io/freeipa/c/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
-   `commit <https://pagure.io/freeipa/c/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
-   `commit <https://pagure.io/freeipa/c/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
    `#8366 <https://pagure.io/freeipa/issue/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
-   `commit <https://pagure.io/freeipa/c/14876657794949e8acfeb63e7ccaa512becde7e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14876657794949e8acfeb63e7ccaa512becde7e1>`__
    `#8364 <https://pagure.io/freeipa/issue/8364>`__
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
-   `commit <https://pagure.io/freeipa/c/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
    `#6884 <https://pagure.io/freeipa/issue/6884>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
-   `commit <https://pagure.io/freeipa/c/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
    `#8311 <https://pagure.io/freeipa/issue/8311>`__
 -  Man pages: fix syntax issues
-   `commit <https://pagure.io/freeipa/c/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
    `#8273 <https://pagure.io/freeipa/issue/8273>`__
 -  ipatests: wait for SSSD to become online in backup/restore tests
-   `commit <https://pagure.io/freeipa/c/3753862401b8500b7498d2723ccb727b5dd6263e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3753862401b8500b7498d2723ccb727b5dd6263e>`__
    `#8228 <https://pagure.io/freeipa/issue/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
-   `commit <https://pagure.io/freeipa/c/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  idviews: prevent applying to a master
-   `commit <https://pagure.io/freeipa/c/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
    `#5662 <https://pagure.io/freeipa/issue/5662>`__
 -  opendnssec2.1 support: move all ods tasks to specific file
-   `commit <https://pagure.io/freeipa/c/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
-   `commit <https://pagure.io/freeipa/c/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
-   `commit <https://pagure.io/freeipa/c/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  With opendnssec 2, read the zone list from file
-   `commit <https://pagure.io/freeipa/c/b857828180c650d7b2db17663a9413323eaef73d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b857828180c650d7b2db17663a9413323eaef73d>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Remove the from opendnssec conf
-   `commit <https://pagure.io/freeipa/c/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  Support opendnssec 2.1.6
-   `commit <https://pagure.io/freeipa/c/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
    `#8214 <https://pagure.io/freeipa/issue/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
-   `commit <https://pagure.io/freeipa/c/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
-   `commit <https://pagure.io/freeipa/c/233a18b2a24d814518a119bd3f1688a0eb361917>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/233a18b2a24d814518a119bd3f1688a0eb361917>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
-   `commit <https://pagure.io/freeipa/c/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
-   `commit <https://pagure.io/freeipa/c/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
-   `commit <https://pagure.io/freeipa/c/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
    `#7600 <https://pagure.io/freeipa/issue/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
-   `commit <https://pagure.io/freeipa/c/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/9eb1be875276c61127663c3860228f03a66ebfbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9eb1be875276c61127663c3860228f03a66ebfbd>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  ipatests: fix modify_sssd_conf()
-   `commit <https://pagure.io/freeipa/c/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
 -  ipatests: update packages for rawhide and updates-testing nightlies
-   `commit <https://pagure.io/freeipa/c/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
 -  ipatests: fix backup and restore
-   `commit <https://pagure.io/freeipa/c/ae140ae40692154ce692c03901f6e17c0e227498>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae140ae40692154ce692c03901f6e17c0e227498>`__
    `#8170 <https://pagure.io/freeipa/issue/8170>`__
 -  AD user without override receive InternalServerError with API
-   `commit <https://pagure.io/freeipa/c/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 -  ipa-cacert-manage man page: fix indentation
-   `commit <https://pagure.io/freeipa/c/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
    `#8138 <https://pagure.io/freeipa/issue/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
-   `commit <https://pagure.io/freeipa/c/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
-   `commit <https://pagure.io/freeipa/c/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
 -  ipatests: fix test_crlgen_manage
-   `commit <https://pagure.io/freeipa/c/b3d650370cfa181a68c7ce332a0013ef2e23ad21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3d650370cfa181a68c7ce332a0013ef2e23ad21>`__
 -  ipatests: fix teardown
-   `commit <https://pagure.io/freeipa/c/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
 -  ipatests: generic uninstall should call ipa server-del
-   `commit <https://pagure.io/freeipa/c/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
    `#7985 <https://pagure.io/freeipa/issue/7985>`__
 -  Nightly definition: use right template for krbtpolicy
-   `commit <https://pagure.io/freeipa/c/094cf629b338b78d13b15b87b4844c487c150e39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/094cf629b338b78d13b15b87b4844c487c150e39>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  test_ipalib: add test for DNParam class
-   `commit <https://pagure.io/freeipa/c/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  XMLRPCtest: add a test for add-certmapdata with multiple
    subject/issuer
-   `commit <https://pagure.io/freeipa/c/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  DNParam: raise Exception when multiple values provided to a 1-val
    param
-   `commit <https://pagure.io/freeipa/c/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
    `#8097 <https://pagure.io/freeipa/issue/8097>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
-   `commit <https://pagure.io/freeipa/c/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
    `#8113 <https://pagure.io/freeipa/issue/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
-   `commit <https://pagure.io/freeipa/c/921f500240fc0861e099a97a2b412e8610eaf198>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/921f500240fc0861e099a97a2b412e8610eaf198>`__
    `#8099 <https://pagure.io/freeipa/issue/8099>`__
 -  ipa-server-certinstall manpage: add missing options
-   `commit <https://pagure.io/freeipa/c/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
    `#8086 <https://pagure.io/freeipa/issue/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
-   `commit <https://pagure.io/freeipa/c/121971a51e6a652f3bc0c8c481a361954bab886e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/121971a51e6a652f3bc0c8c481a361954bab886e>`__
    `#8070 <https://pagure.io/freeipa/issue/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
-   `commit <https://pagure.io/freeipa/c/387ee6e60f398efcdaf91c8097794ed24179150d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/387ee6e60f398efcdaf91c8097794ed24179150d>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
-   `commit <https://pagure.io/freeipa/c/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
    `#4972 <https://pagure.io/freeipa/issue/4972>`__
 -  ipatests: fix fedora29 nightly definition
-   `commit <https://pagure.io/freeipa/c/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
 -  replica install: enforce --server arg
-   `commit <https://pagure.io/freeipa/c/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
-   `commit <https://pagure.io/freeipa/c/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
-   `commit <https://pagure.io/freeipa/c/055ea253dfe0182671cba16916840a013daa8b74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/055ea253dfe0182671cba16916840a013daa8b74>`__
    `#8073 <https://pagure.io/freeipa/issue/8073>`__
 -  ipatests: enable 389-ds audit log and collect audit file
-   `commit <https://pagure.io/freeipa/c/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
    `#8064 <https://pagure.io/freeipa/issue/8064>`__
 -  ipatests: add nightly definition for DS integration tests
-   `commit <https://pagure.io/freeipa/c/c1af6aa27c6a3c69185507fb99da172526875db3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1af6aa27c6a3c69185507fb99da172526875db3>`__
 -  config plugin: replace 'is 0' with '== 0'
-   `commit <https://pagure.io/freeipa/c/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
    `#8057 <https://pagure.io/freeipa/issue/8057>`__
 -  ipatests: fix wrong xfail in test_domain_resolution_order
-   `commit <https://pagure.io/freeipa/c/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
    `#8052 <https://pagure.io/freeipa/issue/8052>`__
 -  Nightly test definition: add missing tests
-   `commit <https://pagure.io/freeipa/c/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
 -  xmlrpc test: add test for preserved > stage user
-   `commit <https://pagure.io/freeipa/c/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
-   `commit <https://pagure.io/freeipa/c/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
    `#7597 <https://pagure.io/freeipa/issue/7597>`__
 -  test_xmlrpc: fix
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
-   `commit <https://pagure.io/freeipa/c/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
    `#7902 <https://pagure.io/freeipa/issue/7902>`__
 -  Azure pipeline: report failure in prepare-build step
-   `commit <https://pagure.io/freeipa/c/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
    `#8022 <https://pagure.io/freeipa/issue/8022>`__
 -  upgrade: remove ipaCert and key from /etc/httpd/alias
-   `commit <https://pagure.io/freeipa/c/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
    `#7329 <https://pagure.io/freeipa/issue/7329>`__
 
 
@@ -3156,9 +3156,9 @@ Francisco Trivino (2)
 ----------------------------------------------------------------------------------------------
 
 -  prci: bump template version and fix test_smb gating definition
-   `commit <https://pagure.io/freeipa/c/cd887a48b510fe17ed181d61d4fc69eb978c771d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd887a48b510fe17ed181d61d4fc69eb978c771d>`__
 -  prci: increase gating tasks priority
-   `commit <https://pagure.io/freeipa/c/991d508a5c9ec6b19e9a937864fd24b765dff7f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/991d508a5c9ec6b19e9a937864fd24b765dff7f2>`__
 
 
 
@@ -3166,368 +3166,368 @@ Fraser Tweedale (141)
 ----------------------------------------------------------------------------------------------
 
 -  mailmap: add ftweedal
-   `commit <https://pagure.io/freeipa/c/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
 -  dns: allow PTR records in arbitrary zones
-   `commit <https://pagure.io/freeipa/c/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
    `#5566 <https://pagure.io/freeipa/issue/5566>`__
 -  ipa_sam: do not modify static buffer holding fqdn
-   `commit <https://pagure.io/freeipa/c/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
    `#8501 <https://pagure.io/freeipa/issue/8501>`__
 -  spec: require pki-acme if pki-ca >= 10.10
-   `commit <https://pagure.io/freeipa/c/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
 -  install: simplify host name verification
-   `commit <https://pagure.io/freeipa/c/9094dfc294ff0fc85e153bd7ae2cdbcbac423c3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9094dfc294ff0fc85e153bd7ae2cdbcbac423c3b>`__
 -  delete unused subroutine get_host_name()
-   `commit <https://pagure.io/freeipa/c/b54d936487202a16031e5fdc23f5dfabde28af58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b54d936487202a16031e5fdc23f5dfabde28af58>`__
 -  certupdate: update config after deployment becomes CA-ful
-   `commit <https://pagure.io/freeipa/c/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  cainstance: extract function import_ra_key
-   `commit <https://pagure.io/freeipa/c/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  cainstance.update_ipa_conf: allow specifying ca_host
-   `commit <https://pagure.io/freeipa/c/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
    `#7188 <https://pagure.io/freeipa/issue/7188>`__
 -  acme: delete ACME RA account on server uninstall
-   `commit <https://pagure.io/freeipa/c/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: enable mod_md tests on Fedora
-   `commit <https://pagure.io/freeipa/c/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certbot dns-01 test
-   `commit <https://pagure.io/freeipa/c/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certbot dns script
-   `commit <https://pagure.io/freeipa/c/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add revocation test
-   `commit <https://pagure.io/freeipa/c/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: handle alternative schema ldif location
-   `commit <https://pagure.io/freeipa/c/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add mod_md integration test
-   `commit <https://pagure.io/freeipa/c/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration tests to gating
-   `commit <https://pagure.io/freeipa/c/bb6d84903967bc6176d8a0817b602ba314129417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb6d84903967bc6176d8a0817b602ba314129417>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration test to nightly CI
-   `commit <https://pagure.io/freeipa/c/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add integration test
-   `commit <https://pagure.io/freeipa/c/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add ipa-acme-manage command
-   `commit <https://pagure.io/freeipa/c/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: configure engine.conf and disable by default
-   `commit <https://pagure.io/freeipa/c/00a84464eae31150714f667df67774ebe34b8514>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00a84464eae31150714f667df67774ebe34b8514>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: configure ACME service on upgrade
-   `commit <https://pagure.io/freeipa/c/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add certificate profile
-   `commit <https://pagure.io/freeipa/c/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: add Dogtag ACL to allow ACME agents to revoke certs
-   `commit <https://pagure.io/freeipa/c/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: create ACME RA account
-   `commit <https://pagure.io/freeipa/c/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  dogtaginstance: add ensure_group method
-   `commit <https://pagure.io/freeipa/c/a21823da7fcce521838764df5280295ccbdb8157>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a21823da7fcce521838764df5280295ccbdb8157>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  dogtaginstance: extract user creation to subroutine.
-   `commit <https://pagure.io/freeipa/c/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: set up ACME service when configuring CA
-   `commit <https://pagure.io/freeipa/c/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  acme: ipa-pki-proxy: proxy /acme to Dogtag
-   `commit <https://pagure.io/freeipa/c/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  certupdate: only add LWCA tracking requests on CA servers
-   `commit <https://pagure.io/freeipa/c/e4462a94433e75da622118873d300d61a8e5f53f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4462a94433e75da622118873d300d61a8e5f53f>`__
    `#8399 <https://pagure.io/freeipa/issue/8399>`__
 -  tests: fix cleanup for CATracker
-   `commit <https://pagure.io/freeipa/c/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  ca plugin: improve doc
-   `commit <https://pagure.io/freeipa/c/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  ca-del: require CA to already be disabled
-   `commit <https://pagure.io/freeipa/c/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
-   `commit <https://pagure.io/freeipa/c/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
 -  ra.get_certificate: use REST API
-   `commit <https://pagure.io/freeipa/c/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
    `#3473 <https://pagure.io/freeipa/issue/3473>`__,
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  extract virtual operation access check subroutine
-   `commit <https://pagure.io/freeipa/c/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__,
    `#6423 <https://pagure.io/freeipa/issue/6423>`__
 -  Define errors_by_code in ipalib.errors
-   `commit <https://pagure.io/freeipa/c/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
    `#5011 <https://pagure.io/freeipa/issue/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
-   `commit <https://pagure.io/freeipa/c/68ada5f2040bb207a5402220fb93e360bae215fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68ada5f2040bb207a5402220fb93e360bae215fe>`__
    `#8368 <https://pagure.io/freeipa/issue/8368>`__
 -  fix cert-find errors in CA-less deployment
-   `commit <https://pagure.io/freeipa/c/19544d53aeada733eb63d596be0a8576b17b9d04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19544d53aeada733eb63d596be0a8576b17b9d04>`__
    `#8369 <https://pagure.io/freeipa/issue/8369>`__
 -  upgrade: avoid stopping certmonger when fixing requests
-   `commit <https://pagure.io/freeipa/c/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
-   `commit <https://pagure.io/freeipa/c/9d9012f682a2dcff7676580fbc622771b427fcef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d9012f682a2dcff7676580fbc622771b427fcef>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
-   `commit <https://pagure.io/freeipa/c/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
-   `commit <https://pagure.io/freeipa/c/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
-   `commit <https://pagure.io/freeipa/c/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
-   `commit <https://pagure.io/freeipa/c/f7c45641fe356364175899399b51b07987b44a1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7c45641fe356364175899399b51b07987b44a1b>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
-   `commit <https://pagure.io/freeipa/c/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: support dnsname as request search criterion
-   `commit <https://pagure.io/freeipa/c/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: move 'criteria' description to module docstring
-   `commit <https://pagure.io/freeipa/c/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  certmonger: avoid mutable default argument
-   `commit <https://pagure.io/freeipa/c/0711c4a0d45f9e28459596552ca751890b13c265>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0711c4a0d45f9e28459596552ca751890b13c265>`__
    `#8186 <https://pagure.io/freeipa/issue/8186>`__
 -  add resources section
-   `commit <https://pagure.io/freeipa/c/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/a2f3088a21b9db2e79a717c9b4afae04fafc658e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2f3088a21b9db2e79a717c9b4afae04fafc658e>`__
 -  suggest \`ipa help topics\`
-   `commit <https://pagure.io/freeipa/c/8e0d4bcccecc7dd405c8d71895c95d4a1a2eddd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e0d4bcccecc7dd405c8d71895c95d4a1a2eddd2>`__
 -  lots of minor tweaks and updates
-   `commit <https://pagure.io/freeipa/c/3a0f8a114b72936e74cac7ad5ce8def1ca0299f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a0f8a114b72936e74cac7ad5ce8def1ca0299f6>`__
 -  rename certificates module
-   `commit <https://pagure.io/freeipa/c/0678ed564992879e1f70429e51554fec2380dc8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0678ed564992879e1f70429e51554fec2380dc8b>`__
 -  Vagrantfile: set DNS configuration in network-scripts
-   `commit <https://pagure.io/freeipa/c/345850eb6cdcf5ca608ed0b3508a78da6bd908ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/345850eb6cdcf5ca608ed0b3508a78da6bd908ef>`__
 -  add more prerequisites and fix some links
-   `commit <https://pagure.io/freeipa/c/bc1c5a84bda16e6ed19a4226519c994a483568ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc1c5a84bda16e6ed19a4226519c994a483568ea>`__
 -  add inter-module links
-   `commit <https://pagure.io/freeipa/c/66ff3675c898daeffac6b675cceef0c0edc91b1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66ff3675c898daeffac6b675cceef0c0edc91b1a>`__
 -  split workshop into separate files
-   `commit <https://pagure.io/freeipa/c/b6c50da05942ba8703aa296c3e0de8369ecf9581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6c50da05942ba8703aa296c3e0de8369ecf9581>`__
 -  add sudorule and selinux units to TOC
-   `commit <https://pagure.io/freeipa/c/a097485eb155b199159196fb30d57e0101af4599>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a097485eb155b199159196fb30d57e0101af4599>`__
 -  add selinuxusermap unit
-   `commit <https://pagure.io/freeipa/c/7a6b914747440e7c266d0eb54f90c22cf3ffcae8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a6b914747440e7c266d0eb54f90c22cf3ffcae8>`__
 -  add sudorule unit
-   `commit <https://pagure.io/freeipa/c/d14dc294005596b86cdfab69df94c238dcce47d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d14dc294005596b86cdfab69df94c238dcce47d0>`__
 -  minor editoral improvements
-   `commit <https://pagure.io/freeipa/c/0f7a460fea88ae83f4b657ac52f2f3d64a38984f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f7a460fea88ae83f4b657ac52f2f3d64a38984f>`__
 -  Change workshop "Modules" to "Units"
-   `commit <https://pagure.io/freeipa/c/77eea677053f8865ce6d5e082f513c44d6e738ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77eea677053f8865ce6d5e082f513c44d6e738ad>`__
 -  prep: updates for f24, box version 0.0.7
-   `commit <https://pagure.io/freeipa/c/44b6c2bedcec01d34adad08f20fa77a08d15274a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44b6c2bedcec01d34adad08f20fa77a08d15274a>`__
 -  certs: request SAN DNS name
-   `commit <https://pagure.io/freeipa/c/3be3ca97f6099d30dd9299ff825f065452203146>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3be3ca97f6099d30dd9299ff825f065452203146>`__
 -  updates for FreeIPA 4.3
-   `commit <https://pagure.io/freeipa/c/65489291894a45d1af4bb1cdd5bdeae2d13a7501>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65489291894a45d1af4bb1cdd5bdeae2d13a7501>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/18c0ef421bfac1a20e127696c46988f4c4d10131>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18c0ef421bfac1a20e127696c46988f4c4d10131>`__
 -  add facilitator notes; remove feedback link
-   `commit <https://pagure.io/freeipa/c/9cf596564aa27d482b866475a5c40d4d4def1953>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cf596564aa27d482b866475a5c40d4d4def1953>`__
 -  building: note disk and memory requirements
-   `commit <https://pagure.io/freeipa/c/ae56b9a276bb729fdbe9b987bfcc288628ef0330>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae56b9a276bb729fdbe9b987bfcc288628ef0330>`__
 -  bump libvirt vm mem to 1G; other fixes
-   `commit <https://pagure.io/freeipa/c/f8d94388d4b43843fcc5de7bcb514dda29820299>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8d94388d4b43843fcc5de7bcb514dda29820299>`__
 -  update feedback url
-   `commit <https://pagure.io/freeipa/c/73d8f7bb450e55bb2d443a1eb3182d65fbd3ae0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73d8f7bb450e55bb2d443a1eb3182d65fbd3ae0a>`__
 -  update clone url
-   `commit <https://pagure.io/freeipa/c/1e1de65e03947971b1ded64cef917dac900f8530>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e1de65e03947971b1ded64cef917dac900f8530>`__
 -  add internal links to modules
-   `commit <https://pagure.io/freeipa/c/88b7708069e8c84cbae043ef9acc866c8b223e12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88b7708069e8c84cbae043ef9acc866c8b223e12>`__
 -  symlink README to workshop.rst
-   `commit <https://pagure.io/freeipa/c/73b1b05a3a3b0a3d118db621d45967932636f0f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73b1b05a3a3b0a3d118db621d45967932636f0f7>`__
 -  add replica installation module
-   `commit <https://pagure.io/freeipa/c/40f6a1b7beee2c87d9cbc13b1211f5f1de43f328>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40f6a1b7beee2c87d9cbc13b1211f5f1de43f328>`__
 -  update to f23
-   `commit <https://pagure.io/freeipa/c/25e55198b4c14704afa917d436ceca3334cdd7c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25e55198b4c14704afa917d436ceca3334cdd7c0>`__
 -  add vagrant box building instructions
-   `commit <https://pagure.io/freeipa/c/05ab50a127b001ed2e59328445829d8270323d0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05ab50a127b001ed2e59328445829d8270323d0c>`__
 -  workshop: remove references to freeipa-workshop-vagrantfile repo
-   `commit <https://pagure.io/freeipa/c/17b87fbc3b948c534e83a0b95498d783139bd948>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17b87fbc3b948c534e83a0b95498d783139bd948>`__
 -  enable and start httpd on client
-   `commit <https://pagure.io/freeipa/c/08a96bdf81a323aa79431a8900be7f07708d9317>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08a96bdf81a323aa79431a8900be7f07708d9317>`__
 -  typospotting
-   `commit <https://pagure.io/freeipa/c/3ed5610f6418f20b0bae32bfca8f2a07b8be1d49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ed5610f6418f20b0bae32bfca8f2a07b8be1d49>`__
 -  initial commit
-   `commit <https://pagure.io/freeipa/c/638d98625c26293a404903730cbd2326123790a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/638d98625c26293a404903730cbd2326123790a6>`__
 -  remove proposal
-   `commit <https://pagure.io/freeipa/c/73da58024d8aa11dcdf2beb0b90039540eaf58f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73da58024d8aa11dcdf2beb0b90039540eaf58f6>`__
 -  add copyright notice
-   `commit <https://pagure.io/freeipa/c/fb5ab1d4af8c3c716fa80ee3f5a9ea5dc1dd0fc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb5ab1d4af8c3c716fa80ee3f5a9ea5dc1dd0fc0>`__
 -  freeipa-workshop: fix mod_authnz_pam link
-   `commit <https://pagure.io/freeipa/c/1723910accba6f2e39327ccc2eab59ed143798ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1723910accba6f2e39327ccc2eab59ed143798ab>`__
 -  merge (most of) zdover's edits
-   `commit <https://pagure.io/freeipa/c/df3115680e143dac9d9f94bf7ea44909dc03eb25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df3115680e143dac9d9f94bf7ea44909dc03eb25>`__
 -  20151029-osdc-freeipa-workshop: add app.py
-   `commit <https://pagure.io/freeipa/c/a209cb9d373997586610e93cd05370f53e031b84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a209cb9d373997586610e93cd05370f53e031b84>`__
 -  osdc-freeipa-workshop: add certificate management module
-   `commit <https://pagure.io/freeipa/c/32b37185ba5acda95fc983e54e94f4368f0d37ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32b37185ba5acda95fc983e54e94f4368f0d37ed>`__
 -  osdc-freeipa-workshop: add OS X and update Debian/Ubuntu details
-   `commit <https://pagure.io/freeipa/c/855556e06411fbee67a5c9673991c0468b3f8893>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/855556e06411fbee67a5c9673991c0468b3f8893>`__
 -  osdc-freeipa-workshop: add debian/ubuntu prep instructions
-   `commit <https://pagure.io/freeipa/c/326011dad850af390631e60b21ab98ffe8a6c73f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326011dad850af390631e60b21ab98ffe8a6c73f>`__
 -  osdc-freeipa-workshop: support vagrant-libvirt on Fedora
-   `commit <https://pagure.io/freeipa/c/9c2072c6432c04f7c3ba8846845eb743d0655b60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c2072c6432c04f7c3ba8846845eb743d0655b60>`__
 -  osdc-freeipa-workshop: presentation, minor curriculum edits
-   `commit <https://pagure.io/freeipa/c/69b2fd6f1cffe27aa75af4751b67e953e3395ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69b2fd6f1cffe27aa75af4751b67e953e3395ba5>`__
 -  osdc-freeipa-workshop: typospotting
-   `commit <https://pagure.io/freeipa/c/31676d7c9bbeb33b29a412df3a466a65866e9605>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31676d7c9bbeb33b29a412df3a466a65866e9605>`__
 -  osdc-freeipa-workshop: remove definition list of VMs
-   `commit <https://pagure.io/freeipa/c/7a865b7fbab5e014f9dd7bbd2e5cc7ea2061f099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a865b7fbab5e014f9dd7bbd2e5cc7ea2061f099>`__
 -  osdc-freeipa-workshop: add missing dnf install vagrant
-   `commit <https://pagure.io/freeipa/c/fe03beb0e7a81d83f7bcf04ad8fb8d4ae0aca9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe03beb0e7a81d83f7bcf04ad8fb8d4ae0aca9d1>`__
 -  osdc-freeipa-workshop: clarify prep goals and VirtualBox version
-   `commit <https://pagure.io/freeipa/c/514f4c298c7a3ffc8af6431866b86ed2f653e36a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/514f4c298c7a3ffc8af6431866b86ed2f653e36a>`__
 -  osdc-freeipa-workshop: update troubleshooting doc
-   `commit <https://pagure.io/freeipa/c/e76d1726824410ef0b544b96bfe9654ac2fab349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e76d1726824410ef0b544b96bfe9654ac2fab349>`__
 -  osdc-freeipa-workshop: incorporate wibrown\'s feedback
-   `commit <https://pagure.io/freeipa/c/77cb86bcf3b7dbf522029715f724f1bdaa5160ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77cb86bcf3b7dbf522029715f724f1bdaa5160ce>`__
 -  osdc-freeipa-workshop: update f22 installation steps
-   `commit <https://pagure.io/freeipa/c/1445311e743609eab89668f6a5250e20605a3098>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1445311e743609eab89668f6a5250e20605a3098>`__
 -  osdc-freeipa-workshop: add Windows prep details
-   `commit <https://pagure.io/freeipa/c/4c5db754459a62671b8fac8cda64410d7dc5677a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c5db754459a62671b8fac8cda64410d7dc5677a>`__
 -  osdc-freeipa-workshop: add Vagrantfile clone instructions and
    curriculum overview
-   `commit <https://pagure.io/freeipa/c/c90fabd6b10cfb3a84c6cc35131a4e8a85383309>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c90fabd6b10cfb3a84c6cc35131a4e8a85383309>`__
 -  osdc-freeipa-workshop: remove vagrant-hostmanager steps, add editing
    notes
-   `commit <https://pagure.io/freeipa/c/0417063d49c83ce60026bd10b09566266ea7435e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0417063d49c83ce60026bd10b09566266ea7435e>`__
 -  osdc-freeipa-workshop: selinux and other minor fixes
-   `commit <https://pagure.io/freeipa/c/aafbbd9bcee862aa3dbed2937452a61453ffebe9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aafbbd9bcee862aa3dbed2937452a61453ffebe9>`__
 -  osdc-freeipa-workshop: add mod_lookup_identity and mod_authnz_pam
    sections
-   `commit <https://pagure.io/freeipa/c/ea16b85390b1ff81c6cdfc6adecc66d3d12db5f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea16b85390b1ff81c6cdfc6adecc66d3d12db5f3>`__
 -  osdc-freeipa-workshop: add mod_auth_gssapi section
-   `commit <https://pagure.io/freeipa/c/70ec83dd398dd5b59f9ea497fcc111a18771d38c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70ec83dd398dd5b59f9ea497fcc111a18771d38c>`__
 -  sudo make me a sandwich
-   `commit <https://pagure.io/freeipa/c/26f4be5839444bf7b04d8e743d5541281bf44bf2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26f4be5839444bf7b04d8e743d5541281bf44bf2>`__
 -  osdc-freeipa-workshop: add rpmfusion instructions
-   `commit <https://pagure.io/freeipa/c/96f93687d9e193520636bc928ca99c51a67beb88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96f93687d9e193520636bc928ca99c51a67beb88>`__
 -  osdc-freeipa-workshop: external authnz module (WIP); minor fixes
-   `commit <https://pagure.io/freeipa/c/64109d5ac4255bebf5ad29dbe87e8203c22436d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64109d5ac4255bebf5ad29dbe87e8203c22436d6>`__
 -  osdc-freeipa-workshop: add initial workshop modules
-   `commit <https://pagure.io/freeipa/c/71ec597caa783296398008fc824af0e9ed809071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71ec597caa783296398008fc824af0e9ed809071>`__
 -  fix osdc2015 and lca2016 dates
-   `commit <https://pagure.io/freeipa/c/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
 -  Do not renew externally-signed CA as self-signed
-   `commit <https://pagure.io/freeipa/c/769180c2c60205a453f87d7d1b88c27d238728db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/769180c2c60205a453f87d7d1b88c27d238728db>`__
    `#8176 <https://pagure.io/freeipa/issue/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
-   `commit <https://pagure.io/freeipa/c/2a2cc961666af1e41e127f043d571a93da800ef5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a2cc961666af1e41e127f043d571a93da800ef5>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  Fix test regressions caused by certificate validation changes
-   `commit <https://pagure.io/freeipa/c/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  ipatests: assert_error: allow regexp match
-   `commit <https://pagure.io/freeipa/c/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
    `#8142 <https://pagure.io/freeipa/issue/8142>`__
 -  removed unused function export_pem_p12
-   `commit <https://pagure.io/freeipa/c/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
 -  test_integration: add tests for custom CA subject DN
-   `commit <https://pagure.io/freeipa/c/e767386e7120be3515d6a34529b51ae658248038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e767386e7120be3515d6a34529b51ae658248038>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
-   `commit <https://pagure.io/freeipa/c/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
-   `commit <https://pagure.io/freeipa/c/326d417d98b092e175623cd28e46586df00e60a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326d417d98b092e175623cd28e46586df00e60a2>`__
    `#8084 <https://pagure.io/freeipa/issue/8084>`__
 -  Bump Dogtag min version to 10.7.3
-   `commit <https://pagure.io/freeipa/c/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  ipa-pki-retrieve-key: request AES encryption (with fallback)
-   `commit <https://pagure.io/freeipa/c/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  NSSWrappedCertDB: accept optional symmetric algorithm
-   `commit <https://pagure.io/freeipa/c/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  IPASecStore: support extra key arguments
-   `commit <https://pagure.io/freeipa/c/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
    `#8020 <https://pagure.io/freeipa/issue/8020>`__
 -  dsinstance: add proflie when tracking certificate
-   `commit <https://pagure.io/freeipa/c/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  ipatests: test ipa-server-upgrade in CA-less deployment
-   `commit <https://pagure.io/freeipa/c/65d9a9be520ea9402143d9f06878eff53647925a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65d9a9be520ea9402143d9f06878eff53647925a>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  Use RENEWAL_CA_NAME and RA_AGENT_PROFILE constants
-   `commit <https://pagure.io/freeipa/c/bb779baadf0df3333bd853599a21e81907c8c116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb779baadf0df3333bd853599a21e81907c8c116>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  cainstance: add profile to IPA RA tracking request
-   `commit <https://pagure.io/freeipa/c/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: fix spurious certmonger re-tracking
-   `commit <https://pagure.io/freeipa/c/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: log missing/misconfigured tracking requests
-   `commit <https://pagure.io/freeipa/c/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: update KRA tracking requests
-   `commit <https://pagure.io/freeipa/c/482866e47e20520fbe39ef05439badbb3069bef6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/482866e47e20520fbe39ef05439badbb3069bef6>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: always add profile to tracking requests
-   `commit <https://pagure.io/freeipa/c/4f4e2f96b022a056777fed59583f204edb797a2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f4e2f96b022a056777fed59583f204edb797a2e>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtaginstance: avoid special cases for Server-Cert
-   `commit <https://pagure.io/freeipa/c/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtag-ipa-ca-renew-agent: always use profile-based renewal
-   `commit <https://pagure.io/freeipa/c/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  certmonger: use long options when invoking dogtag-ipa-renew-agent
-   `commit <https://pagure.io/freeipa/c/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  upgrade: add profile to Dogtag tracking requests
-   `commit <https://pagure.io/freeipa/c/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  dogtaginstance: add profile to tracking requests
-   `commit <https://pagure.io/freeipa/c/3c388f5a228b767dfd92bd824dfced166acda143>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c388f5a228b767dfd92bd824dfced166acda143>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  ci: add --external-ca-profile tests to gating
-   `commit <https://pagure.io/freeipa/c/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  ci: add --external-ca-profile tests to nightly
-   `commit <https://pagure.io/freeipa/c/2c8352fe8536be0e630fdb910dc90831847ad119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c8352fe8536be0e630fdb910dc90831847ad119>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Collapse --external-ca-profile tests into single class
-   `commit <https://pagure.io/freeipa/c/80e76f094c234710ff58917e7ce4661d823c4de7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80e76f094c234710ff58917e7ce4661d823c4de7>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Add more tests for --external-ca-profile handling
-   `commit <https://pagure.io/freeipa/c/b15bd50e6db919279e25a8bed796df4836b845a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b15bd50e6db919279e25a8bed796df4836b845a8>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  Fix use of incorrect variable
-   `commit <https://pagure.io/freeipa/c/7171142aaf91d6079798d015af9862d6e5474c8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7171142aaf91d6079798d015af9862d6e5474c8c>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__,
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  install: fix --external-ca-profile option
-   `commit <https://pagure.io/freeipa/c/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
    `#5608 <https://pagure.io/freeipa/issue/5608>`__,
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 -  move MSCSTemplate classes to ipalib
-   `commit <https://pagure.io/freeipa/c/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
    `#7548 <https://pagure.io/freeipa/issue/7548>`__
 
 
@@ -3536,11 +3536,11 @@ Gaurav Talreja (3)
 ----------------------------------------------------------------------------------------------
 
 -  Normalize title of test external_ca in prci-definition
-   `commit <https://pagure.io/freeipa/c/7862e9bec5133b7416b649a84e2ef5b3d906f2ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7862e9bec5133b7416b649a84e2ef5b3d906f2ea>`__
 -  Normalize test definations titles
-   `commit <https://pagure.io/freeipa/c/4a1f56ecdc3398faf67b7a6e162cfd6b41befa5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a1f56ecdc3398faf67b7a6e162cfd6b41befa5a>`__
 -  prci: bump template version for nightly_rawhide
-   `commit <https://pagure.io/freeipa/c/775bbb919ac9967fe65ba2982e79078810849527>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/775bbb919ac9967fe65ba2982e79078810849527>`__
 
 
 
@@ -3548,9 +3548,9 @@ Isaac Boukris (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix legacy S4U2Proxy in DAL v8 support
-   `commit <https://pagure.io/freeipa/c/c940f96b700d845afda014d41a0004068d379a9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c940f96b700d845afda014d41a0004068d379a9a>`__
 -  Fix DAL v8 support
-   `commit <https://pagure.io/freeipa/c/d92f21ae1b3051f96043c64320a768551de39d5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d92f21ae1b3051f96043c64320a768551de39d5a>`__
 
 
 
@@ -3559,10 +3559,10 @@ Jeremy Frasier (2)
 
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
-   `commit <https://pagure.io/freeipa/c/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
-   `commit <https://pagure.io/freeipa/c/12529d7ef184846ca3852821b813c725b22e11c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12529d7ef184846ca3852821b813c725b22e11c6>`__
    `#8403 <https://pagure.io/freeipa/issue/8403>`__
 
 
@@ -3571,13 +3571,13 @@ Jayesh Garg (4)
 ----------------------------------------------------------------------------------------------
 
 -  Nightly definations commit
-   `commit <https://pagure.io/freeipa/c/fb3c2c140220b7d6d88558f9bb0a485f47079a5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb3c2c140220b7d6d88558f9bb0a485f47079a5e>`__
 -  Test for ipa-ca-install on replica
-   `commit <https://pagure.io/freeipa/c/ad3bf5042d35b2d16646170b09489fb964fbdb93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad3bf5042d35b2d16646170b09489fb964fbdb93>`__
 -  Test ipa-getkeytab quiet mode, encryptons
-   `commit <https://pagure.io/freeipa/c/09a5192f252635d58b205946384cb29c033441f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09a5192f252635d58b205946384cb29c033441f6>`__
 -  Test if ipactl starts services stopped by systemctl
-   `commit <https://pagure.io/freeipa/c/d7b3aafc638353880045faf41b0fb647d174f3e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7b3aafc638353880045faf41b0fb647d174f3e6>`__
 
 
 
@@ -3585,7 +3585,7 @@ Julian Gethmann (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix typo in idrange.py docstring
-   `commit <https://pagure.io/freeipa/c/273ff2708cb99dded5e7ef51504cc8de9a4496db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273ff2708cb99dded5e7ef51504cc8de9a4496db>`__
 
 
 
@@ -3593,14 +3593,14 @@ Kaleemullah Siddiqui (4)
 ----------------------------------------------------------------------------------------------
 
 -  Tests for fake_mname parameter setup
-   `commit <https://pagure.io/freeipa/c/592f3fe65986077ec0a19158d061a371c86307c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/592f3fe65986077ec0a19158d061a371c86307c7>`__
 -  Test for check of HostKeyAlgorithms option in ssh_config
-   `commit <https://pagure.io/freeipa/c/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
    `#8082 <https://pagure.io/freeipa/issue/8082>`__
 -  Fix for regression from PR#3962
-   `commit <https://pagure.io/freeipa/c/939ee59c2716aa2abf93ac78d44df937105b430d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/939ee59c2716aa2abf93ac78d44df937105b430d>`__
 -  Tests for backup-restore when pkg required is missing
-   `commit <https://pagure.io/freeipa/c/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
    `#7630 <https://pagure.io/freeipa/issue/7630>`__
 
 
@@ -3609,7 +3609,7 @@ Christian Hermann (1)
 ----------------------------------------------------------------------------------------------
 
 -  configure.ac: don't rely on bashisms
-   `commit <https://pagure.io/freeipa/c/9a440ae8855a5bc7b49ffe43c4a6654b17eed0a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a440ae8855a5bc7b49ffe43c4a6654b17eed0a9>`__
 
 
 
@@ -3617,7 +3617,7 @@ Miro Hrončok (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix a syntax typo
-   `commit <https://pagure.io/freeipa/c/35e1ebb2f3eb2d46f4080860ebe4e71421f80b54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35e1ebb2f3eb2d46f4080860ebe4e71421f80b54>`__
 
 
 
@@ -3626,7 +3626,7 @@ MIZUTA Takeshi (1)
 
 -  Add config that maintains existing content to ipa-client-install
    manpage
-   `commit <https://pagure.io/freeipa/c/650db3b80d5f1ec68131d0e17993fb31f9488d7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/650db3b80d5f1ec68131d0e17993fb31f9488d7c>`__
 
 
 
@@ -3634,25 +3634,25 @@ Michal Polovka (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_epn: test_EPN_config_file: Package name fix
-   `commit <https://pagure.io/freeipa/c/147b808ffb58217443562ade56da212829539817>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/147b808ffb58217443562ade56da212829539817>`__
 -  ipatests: test_epn: Fix package installation
-   `commit <https://pagure.io/freeipa/c/3c18f94b29b15cf652c14e3dd828a27827dad239>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c18f94b29b15cf652c14e3dd828a27827dad239>`__
 -  Test for healthcheck being run on replica with stopped master
-   `commit <https://pagure.io/freeipa/c/3a64ac08e1b3202bb469fcf0f2a17bd5114bab8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a64ac08e1b3202bb469fcf0f2a17bd5114bab8f>`__
 -  Test for output being indented by default value if not stated
    implicitly.
-   `commit <https://pagure.io/freeipa/c/f5f960ed2ab08208b52260ab2dbe99da500ee04e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5f960ed2ab08208b52260ab2dbe99da500ee04e>`__
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
-   `commit <https://pagure.io/freeipa/c/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
    `#2018 <https://pagure.io/freeipa/issue/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
-   `commit <https://pagure.io/freeipa/c/253779afc4432d02aa37b44dda789c4b152568fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/253779afc4432d02aa37b44dda789c4b152568fb>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__,
    `#8055 <https://pagure.io/freeipa/issue/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
-   `commit <https://pagure.io/freeipa/c/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
    `#6843 <https://pagure.io/freeipa/issue/6843>`__
 
 
@@ -3661,16 +3661,16 @@ Mark Reynolds (4)
 ----------------------------------------------------------------------------------------------
 
 -  Reorder creation of the CA mapping tree and database backend
-   `commit <https://pagure.io/freeipa/c/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
    `#8558 <https://pagure.io/freeipa/issue/8558>`__
 -  Increase replication changelog trimming to 30 days
-   `commit <https://pagure.io/freeipa/c/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
    `#8464 <https://pagure.io/freeipa/issue/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
-   `commit <https://pagure.io/freeipa/c/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
    `#8456 <https://pagure.io/freeipa/issue/8456>`__
 -  Issue 8407 - Support changelog integration into main database
-   `commit <https://pagure.io/freeipa/c/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
    `#8407 <https://pagure.io/freeipa/issue/8407>`__
 
 
@@ -3679,75 +3679,75 @@ Mohammad Rizwan (28)
 ----------------------------------------------------------------------------------------------
 
 -  Move acme client installation part to classmethod
-   `commit <https://pagure.io/freeipa/c/c4a6b0e5662f539b8438cdbc593eb713ea8c6da2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4a6b0e5662f539b8438cdbc593eb713ea8c6da2>`__
 -  PEP8 fixes for test_acme.py
-   `commit <https://pagure.io/freeipa/c/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
 -  External-CA scenarios for ACME service
-   `commit <https://pagure.io/freeipa/c/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 -  ipatests: Check if ACME is enabled on all CA servers
-   `commit <https://pagure.io/freeipa/c/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  PEP8 fixes
-   `commit <https://pagure.io/freeipa/c/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
 -  ipatests: add --skip-overlap-check option to prepare_reverse_zone()
-   `commit <https://pagure.io/freeipa/c/bddbfb79e4749713dd2b22445fb95e3e53d080e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddbfb79e4749713dd2b22445fb95e3e53d080e8>`__
 -  ipatests: Add PTR record for IP SAN
-   `commit <https://pagure.io/freeipa/c/b3d7a70ee00bb5e8a0f1781a378dc169ee455624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3d7a70ee00bb5e8a0f1781a378dc169ee455624>`__
 -  ipatests: Test certmonger rekey command works fine
-   `commit <https://pagure.io/freeipa/c/abd0cbfcfdb913e4576721bc9c5acd43bdd2bae2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abd0cbfcfdb913e4576721bc9c5acd43bdd2bae2>`__
 -  Xfail test for sssd < 2.3.0
-   `commit <https://pagure.io/freeipa/c/32a5359ece5b449b1cedb700d79cfa2744a288cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32a5359ece5b449b1cedb700d79cfa2744a288cb>`__
 -  ipatests: Test ipa user login with wrong password
-   `commit <https://pagure.io/freeipa/c/e33ffab534c9ecce26fbd069956d15da182ce6ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e33ffab534c9ecce26fbd069956d15da182ce6ed>`__
 -  WebUI tests: fix PEP8 issues in test_webui/test_user.py
-   `commit <https://pagure.io/freeipa/c/0c02920529306aaa1a8be1fae185390e2e115859>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c02920529306aaa1a8be1fae185390e2e115859>`__
 -  webui: check if notification area doesn't intercept menu button
-   `commit <https://pagure.io/freeipa/c/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  ipatests: Test deletion of required principal throws proper error
-   `commit <https://pagure.io/freeipa/c/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  Display principal name while del required principal
-   `commit <https://pagure.io/freeipa/c/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
    `#7695 <https://pagure.io/freeipa/issue/7695>`__
 -  ipatests: Test to check password leak in apache error log
-   `commit <https://pagure.io/freeipa/c/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
-   `commit <https://pagure.io/freeipa/c/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
    `#8163 <https://pagure.io/freeipa/issue/8163>`__
 -  ipatests: Skip test using paramiko when FIPS is enabled
-   `commit <https://pagure.io/freeipa/c/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if schema-compat-entry-attribute is set
-   `commit <https://pagure.io/freeipa/c/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
    `#8193 <https://pagure.io/freeipa/issue/8193>`__
 -  Test if getcert creates cacert file with -F option
-   `commit <https://pagure.io/freeipa/c/9bcc57d9e01625a122811a50f78acde247b5791d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bcc57d9e01625a122811a50f78acde247b5791d>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Move wait_for_request() method to tasks.py
-   `commit <https://pagure.io/freeipa/c/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
 -  Test if server installer lock Bind9 recursion
-   `commit <https://pagure.io/freeipa/c/1556f3f767c3fab7634b46a9193e363887558db0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1556f3f767c3fab7634b46a9193e363887558db0>`__
    `#8079 <https://pagure.io/freeipa/issue/8079>`__
 -  Add certmonger wait_for_request that uses run_command
-   `commit <https://pagure.io/freeipa/c/806795422934c3220856bcaaf8810cdebd782fd4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/806795422934c3220856bcaaf8810cdebd782fd4>`__
 -  Test if certmonger reads the token in HSM
-   `commit <https://pagure.io/freeipa/c/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
-   `commit <https://pagure.io/freeipa/c/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
    `#8110 <https://pagure.io/freeipa/issue/8110>`__
 -  Add test to nightly yamls
-   `commit <https://pagure.io/freeipa/c/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
 -  Installation of replica against a specific server
-   `commit <https://pagure.io/freeipa/c/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
    `#7566 <https://pagure.io/freeipa/issue/7566>`__
 -  Check file ownership and permission for dirsrv log instance
-   `commit <https://pagure.io/freeipa/c/7aec6f10374129d75cd99a4012980516ca535551>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7aec6f10374129d75cd99a4012980516ca535551>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 
 
@@ -3756,7 +3756,7 @@ ndehadra (1)
 ----------------------------------------------------------------------------------------------
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
-   `commit <https://pagure.io/freeipa/c/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
    `#7307 <https://pagure.io/freeipa/issue/7307>`__
 
 
@@ -3765,13 +3765,13 @@ Weblate (4)
 ----------------------------------------------------------------------------------------------
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/afa0f5d1877d297a455d1dfec7e0304031ad5078>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afa0f5d1877d297a455d1dfec7e0304031ad5078>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/90c1a00f046b7cd2e54c27039db98ac795595304>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90c1a00f046b7cd2e54c27039db98ac795595304>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/89d85182667d137c2ee8d68b2f1b8d6f7d1da38e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d85182667d137c2ee8d68b2f1b8d6f7d1da38e>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/a2f7e917a13a99bcdc7daa5171fe234a971e913c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2f7e917a13a99bcdc7daa5171fe234a971e913c>`__
 
 
 
@@ -3779,9 +3779,9 @@ Oğuz Ersen (2)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Turkish)
-   `commit <https://pagure.io/freeipa/c/0464a5ffff35fbb37e7d0561c39d9d8e8c65b496>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0464a5ffff35fbb37e7d0561c39d9d8e8c65b496>`__
 -  Translated using Weblate (Turkish)
-   `commit <https://pagure.io/freeipa/c/54dff05cd29dc8ef473a7c6a3056d30d5cb1982d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54dff05cd29dc8ef473a7c6a3056d30d5cb1982d>`__
 
 
 
@@ -3789,7 +3789,7 @@ Spencer E. Olson (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes debian path for IPA_CUSTODIA_HANDLER
-   `commit <https://pagure.io/freeipa/c/73796c779758fdd8f3c2d8ede3ef24d5b7d025e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73796c779758fdd8f3c2d8ede3ef24d5b7d025e7>`__
 
 
 
@@ -3797,7 +3797,7 @@ Piotr Drąg (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/a96b89388d222db607edd57486b5dde16568fdda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a96b89388d222db607edd57486b5dde16568fdda>`__
 
 
 
@@ -3805,9 +3805,9 @@ Petr Voborník (2)
 ----------------------------------------------------------------------------------------------
 
 -  baseuser: fix ipanthomedirectorydrive option name
-   `commit <https://pagure.io/freeipa/c/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
 -  webui: hide user attributes for SMB services section if empty
-   `commit <https://pagure.io/freeipa/c/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
    `#8336 <https://pagure.io/freeipa/issue/8336>`__
 
 
@@ -3816,7 +3816,7 @@ Rafael Fontenelle (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/1eaa5974e4cd03724f8a43a59a5de4ab1568f769>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1eaa5974e4cd03724f8a43a59a5de4ab1568f769>`__
 
 
 
@@ -3824,369 +3824,369 @@ Rob Crittenden (116)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test that password reset unlocks users too
-   `commit <https://pagure.io/freeipa/c/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
    `#8551 <https://pagure.io/freeipa/issue/8551>`__
 -  On password reset also set krbLastAdminUnlock to unlock account
-   `commit <https://pagure.io/freeipa/c/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
    `#8551 <https://pagure.io/freeipa/issue/8551>`__
 -  Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test
-   `commit <https://pagure.io/freeipa/c/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Catch EmptyResult exception in update_idranges
-   `commit <https://pagure.io/freeipa/c/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  Test that ipapwpolicy objectclass is added on upgrade
-   `commit <https://pagure.io/freeipa/c/f86250a9a592f2549bc1446c8e3493b256618107>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f86250a9a592f2549bc1446c8e3493b256618107>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  Add ipwpwdpolicy objectclass to all policies on upgrade
-   `commit <https://pagure.io/freeipa/c/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
    `#8555 <https://pagure.io/freeipa/issue/8555>`__
 -  ipatests: Add tests for requiring ipa-ca SAN when ACME is enabled
-   `commit <https://pagure.io/freeipa/c/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  Change the return codes of ipa-acme-manage
-   `commit <https://pagure.io/freeipa/c/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  Require an ipa-ca SAN on 3rd party certs if ACME is enabled
-   `commit <https://pagure.io/freeipa/c/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
    `#8498 <https://pagure.io/freeipa/issue/8498>`__
 -  ipatests: Collect the let's encrypt log
-   `commit <https://pagure.io/freeipa/c/d4ef64b229541200564131e927cd0b4b32662fe2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ef64b229541200564131e927cd0b4b32662fe2>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Add a status option to ipa-acme-manage
-   `commit <https://pagure.io/freeipa/c/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Don't install ACME if full support is not available
-   `commit <https://pagure.io/freeipa/c/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Centralize enable/disable of the ACME service
-   `commit <https://pagure.io/freeipa/c/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Let dogtag.py be imported if the api is not initialized
-   `commit <https://pagure.io/freeipa/c/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Enable importing LDIF files not shipped by IPA
-   `commit <https://pagure.io/freeipa/c/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__
 -  Use a state to determine if a 389-ds upgrade is in progress
-   `commit <https://pagure.io/freeipa/c/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
    `#7534 <https://pagure.io/freeipa/issue/7534>`__
 -  ipatests: Add test_pwpolicy to nightly runs
-   `commit <https://pagure.io/freeipa/c/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Requirements and design for libpwquality integration
-   `commit <https://pagure.io/freeipa/c/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add SELinux policy so kadmind can read the crackdb dictionary
-   `commit <https://pagure.io/freeipa/c/68aa7c05542422aca05bec4967133be09a32496e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68aa7c05542422aca05bec4967133be09a32496e>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  ipatests: add test for password policies
-   `commit <https://pagure.io/freeipa/c/fe44835970eca197543eb3c908c51a240204d846>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe44835970eca197543eb3c908c51a240204d846>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add a raiseonerr option to ldappasswd_user_change
-   `commit <https://pagure.io/freeipa/c/be2efc12d37018794200fee874f27d83e0442ea4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be2efc12d37018794200fee874f27d83e0442ea4>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Pass the user to the password policy check in the kdb driver
-   `commit <https://pagure.io/freeipa/c/6da070e655c5d084a825607ed3be604c809b12f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da070e655c5d084a825607ed3be604c809b12f0>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add a unit test for libpwquality-based password policy
-   `commit <https://pagure.io/freeipa/c/46d0096218488a961125b6d97a9210b68e5434e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46d0096218488a961125b6d97a9210b68e5434e5>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Extend password policy to evaluate passwords using libpwpolicy
-   `commit <https://pagure.io/freeipa/c/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Require libpwolicy and configure it in the build system
-   `commit <https://pagure.io/freeipa/c/3fc2eda4e15e9592132062036d70acad3bab401c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fc2eda4e15e9592132062036d70acad3bab401c>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add new pwpolicy objectclass to test_xmprpc/objectclasses.py
-   `commit <https://pagure.io/freeipa/c/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Extend IPA pwquality plugin to include libpwquality support
-   `commit <https://pagure.io/freeipa/c/6b452e54045bb957e6f787209b4498eefc5df779>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b452e54045bb957e6f787209b4498eefc5df779>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Add LDAP schema for new libpwquality attributes
-   `commit <https://pagure.io/freeipa/c/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
    `#2445 <https://pagure.io/freeipa/issue/2445>`__,
    `#298 <https://pagure.io/freeipa/issue/298>`__,
    `#5948 <https://pagure.io/freeipa/issue/5948>`__,
    `#6964 <https://pagure.io/freeipa/issue/6964>`__
 -  Don't restart certmonger after stopping tracking in uninstall
-   `commit <https://pagure.io/freeipa/c/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
    `#8533 <https://pagure.io/freeipa/issue/8533>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
-   `commit <https://pagure.io/freeipa/c/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Test that ccaches are cleaned up during installation
-   `commit <https://pagure.io/freeipa/c/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
-   `commit <https://pagure.io/freeipa/c/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
    `#8248 <https://pagure.io/freeipa/issue/8248>`__
 -  Require a matching server package for the selinux subpackage
-   `commit <https://pagure.io/freeipa/c/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
    `#8511 <https://pagure.io/freeipa/issue/8511>`__
 -  Add index for more trust-related attributes
-   `commit <https://pagure.io/freeipa/c/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
    `#8491 <https://pagure.io/freeipa/issue/8491>`__
 -  ipatests: Add tests for checking available memory
-   `commit <https://pagure.io/freeipa/c/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
-   `commit <https://pagure.io/freeipa/c/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
-   `commit <https://pagure.io/freeipa/c/2e4431af7066ce298008973b6caddc170645c98d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e4431af7066ce298008973b6caddc170645c98d>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  Use ACI class set_permissions() method to set permissions
-   `commit <https://pagure.io/freeipa/c/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  De-duplicate ACI attributes and permissions
-   `commit <https://pagure.io/freeipa/c/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
    `#8443 <https://pagure.io/freeipa/issue/8443>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
-   `commit <https://pagure.io/freeipa/c/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
-   `commit <https://pagure.io/freeipa/c/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
    `#8446 <https://pagure.io/freeipa/issue/8446>`__
 -  Set the certmonger subject with a string, not an object
-   `commit <https://pagure.io/freeipa/c/f249c51bf4342341378e63953386e9ac4070be54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f249c51bf4342341378e63953386e9ac4070be54>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
-   `commit <https://pagure.io/freeipa/c/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
    `#8204 <https://pagure.io/freeipa/issue/8204>`__
 -  cli: When parsing options require name/value pairs
-   `commit <https://pagure.io/freeipa/c/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
-   `commit <https://pagure.io/freeipa/c/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
    `#6115 <https://pagure.io/freeipa/issue/6115>`__
 -  ipatests: stop the CA during healthcheck expiration test
-   `commit <https://pagure.io/freeipa/c/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
    `#8463 <https://pagure.io/freeipa/issue/8463>`__
 -  Improve performance of ipa-server-guard
-   `commit <https://pagure.io/freeipa/c/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
    `#8425 <https://pagure.io/freeipa/issue/8425>`__
 -  ipatests: Add test for is_ipa_configured
-   `commit <https://pagure.io/freeipa/c/25e042d3d1e04972d4536b1fa793811e6b047559>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25e042d3d1e04972d4536b1fa793811e6b047559>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Use is_ipa_configured from ipalib.facts
-   `commit <https://pagure.io/freeipa/c/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  Fall back to old server installation detection when needed
-   `commit <https://pagure.io/freeipa/c/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
    `#8458 <https://pagure.io/freeipa/issue/8458>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
-   `commit <https://pagure.io/freeipa/c/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
 -  Added negative test case for --list-sources option
-   `commit <https://pagure.io/freeipa/c/143dea18fe9bc2ebc65a8dbdcfa44d331adc161c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/143dea18fe9bc2ebc65a8dbdcfa44d331adc161c>`__
 -  ipatests: CLI validation of ipa-healthcheck command
-   `commit <https://pagure.io/freeipa/c/c5853768a778069945237e0a039715d89e16a94e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5853768a778069945237e0a039715d89e16a94e>`__
 -  IPA-EPN: Test that users without givenname and/or mail are handled
-   `commit <https://pagure.io/freeipa/c/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
 -  Address legacy pylint issues in sysrestore.py
-   `commit <https://pagure.io/freeipa/c/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Update check_client_configuration to use new client fact
-   `commit <https://pagure.io/freeipa/c/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Don't use the has_files() to know if client/server is configured
-   `commit <https://pagure.io/freeipa/c/5e027134815512862ad6ae77867e74a83aee2b59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e027134815512862ad6ae77867e74a83aee2b59>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
-   `commit <https://pagure.io/freeipa/c/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if IPA client configuration is complete
-   `commit <https://pagure.io/freeipa/c/4758db121ea0c555dab89bc1781c8752f188e414>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4758db121ea0c555dab89bc1781c8752f188e414>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  Simplify determining if an IPA server installation is complete
-   `commit <https://pagure.io/freeipa/c/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
    `#8384 <https://pagure.io/freeipa/issue/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
-   `commit <https://pagure.io/freeipa/c/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
-   `commit <https://pagure.io/freeipa/c/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
    `#8441 <https://pagure.io/freeipa/issue/8441>`__
 -  ipatests: Test healthcheck revocation checker
-   `commit <https://pagure.io/freeipa/c/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
-   `commit <https://pagure.io/freeipa/c/61c71e4a62347cd7188e407acc69ce8362857cb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61c71e4a62347cd7188e407acc69ce8362857cb4>`__
 -  ipatests: lib389 is now providing healthchecks, update naming
-   `commit <https://pagure.io/freeipa/c/d238fb4f2bb6525367a73c42a8a238843d5c8b43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d238fb4f2bb6525367a73c42a8a238843d5c8b43>`__
 -  ipatests: verify that all services can be detected by healthcheck
-   `commit <https://pagure.io/freeipa/c/e1027cc8b14b5ae0bdcc265c640f802800fa8b2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1027cc8b14b5ae0bdcc265c640f802800fa8b2a>`__
 -  ipatests: Add healthcheck test for FileSystemSpaceCheck
-   `commit <https://pagure.io/freeipa/c/07bc5e2598abfd97ac182acef40c3a08e0477009>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07bc5e2598abfd97ac182acef40c3a08e0477009>`__
 -  ipatests: Test that healthcheck detects and reports expiration
-   `commit <https://pagure.io/freeipa/c/c84b1db80954c4a963f268c62924b69d8ab5c1a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c84b1db80954c4a963f268c62924b69d8ab5c1a2>`__
 -  ipatests: Test cases for healthcheck File checker(s)
-   `commit <https://pagure.io/freeipa/c/550fbc0b9ff682d15a4f4a89974d0e506430fa8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/550fbc0b9ff682d15a4f4a89974d0e506430fa8e>`__
 -  Replace SSLCertVerificationError with CertificateError for py36
-   `commit <https://pagure.io/freeipa/c/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
-   `commit <https://pagure.io/freeipa/c/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
    `#8429 <https://pagure.io/freeipa/issue/8429>`__
 -  Don't delegate the TGT in ipa-join
-   `commit <https://pagure.io/freeipa/c/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
    `#8405 <https://pagure.io/freeipa/issue/8405>`__
 -  IPA-EPN: Don't treat givenname differently
-   `commit <https://pagure.io/freeipa/c/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
-   `commit <https://pagure.io/freeipa/c/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
-   `commit <https://pagure.io/freeipa/c/3b266d39570f447db0f571a8b8085eb6c0403509>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b266d39570f447db0f571a8b8085eb6c0403509>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
-   `commit <https://pagure.io/freeipa/c/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
-   `commit <https://pagure.io/freeipa/c/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: test using SSL against port 465
-   `commit <https://pagure.io/freeipa/c/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add test for starttls mode
-   `commit <https://pagure.io/freeipa/c/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
-   `commit <https://pagure.io/freeipa/c/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
-   `commit <https://pagure.io/freeipa/c/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add index for krbPasswordExpiration for EPN
-   `commit <https://pagure.io/freeipa/c/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Add a jinja2 e-mail template for EPN
-   `commit <https://pagure.io/freeipa/c/03caa7f965d889848675158503286cde00d635c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03caa7f965d889848675158503286cde00d635c9>`__
    `#3687 <https://pagure.io/freeipa/issue/3687>`__
 -  Perform baseline healthcheck
-   `commit <https://pagure.io/freeipa/c/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
 -  Test that pwpolicy only applied on Kerberos entries
-   `commit <https://pagure.io/freeipa/c/89066892151e1da5c2557d8eb76c2b04dbd61979>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89066892151e1da5c2557d8eb76c2b04dbd61979>`__
 -  Add ability to change a user password as the Directory Manager
-   `commit <https://pagure.io/freeipa/c/ff6984e2eea0f54851db796c8b3ad29c54a4e325>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff6984e2eea0f54851db796c8b3ad29c54a4e325>`__
 -  Don't save password history on non-Kerberos accounts
-   `commit <https://pagure.io/freeipa/c/132a0f8771edd3a741bc60e6bc4c9b56cb172e4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132a0f8771edd3a741bc60e6bc4c9b56cb172e4a>`__
 -  Test that ipa-healthcheck human output translates error strings
-   `commit <https://pagure.io/freeipa/c/4a3b7baed785f7492e8404dac3eee8a8ce9fd937>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a3b7baed785f7492e8404dac3eee8a8ce9fd937>`__
 -  Move execution of ipa-healthcheck to a separate function
-   `commit <https://pagure.io/freeipa/c/44e73428441a070f26a791ee2816f2989713ba8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44e73428441a070f26a791ee2816f2989713ba8d>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
-   `commit <https://pagure.io/freeipa/c/f589a8952c33a25794e577077bb3c0bda740667c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f589a8952c33a25794e577077bb3c0bda740667c>`__
    `#8135 <https://pagure.io/freeipa/issue/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
-   `commit <https://pagure.io/freeipa/c/e4966f9c3f9566603be24e09f4803b3183898272>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4966f9c3f9566603be24e09f4803b3183898272>`__
    `#8201 <https://pagure.io/freeipa/issue/8201>`__
 -  Add tests for ipa-cacert-manage delete command
-   `commit <https://pagure.io/freeipa/c/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
-   `commit <https://pagure.io/freeipa/c/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
-   `commit <https://pagure.io/freeipa/c/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
    `#8124 <https://pagure.io/freeipa/issue/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
-   `commit <https://pagure.io/freeipa/c/02ce407f5e10e670d4788778037892b58f80adc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02ce407f5e10e670d4788778037892b58f80adc0>`__
 -  Add integration test for Kerberos ticket policy
-   `commit <https://pagure.io/freeipa/c/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  Conditionally restart certmonger after client installation
-   `commit <https://pagure.io/freeipa/c/3593e5362206fd9287e97fe2cee229a1117811ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3593e5362206fd9287e97fe2cee229a1117811ff>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Add conditional restart (try-restart) capability to services
-   `commit <https://pagure.io/freeipa/c/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
    `#8105 <https://pagure.io/freeipa/issue/8105>`__
 -  Enable AES SHA 256 and 384-bit enctypes in Kerberos
-   `commit <https://pagure.io/freeipa/c/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
    `#8110 <https://pagure.io/freeipa/issue/8110>`__
 -  Disable dogtag cert publishing
-   `commit <https://pagure.io/freeipa/c/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
    `#7522 <https://pagure.io/freeipa/issue/7522>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
-   `commit <https://pagure.io/freeipa/c/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
    `#7725 <https://pagure.io/freeipa/issue/7725>`__
 -  Report if a certmonger CA is missing
-   `commit <https://pagure.io/freeipa/c/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
    `#7870 <https://pagure.io/freeipa/issue/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
-   `commit <https://pagure.io/freeipa/c/ffb4b624fc8bfd870958976ec25b74677e740841>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffb4b624fc8bfd870958976ec25b74677e740841>`__
    `#8034 <https://pagure.io/freeipa/issue/8034>`__
 -  Don't log host passwords when they are set/modified
-   `commit <https://pagure.io/freeipa/c/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
    `#8017 <https://pagure.io/freeipa/issue/8017>`__
 -  Skip lock and fork in ipa-server-guard on unsupported ops
-   `commit <https://pagure.io/freeipa/c/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
 -  Defer initializing the API in dogtag-ipa-ca-renew-agent-submit
-   `commit <https://pagure.io/freeipa/c/0770254ce347c9892f6b143bb5f48fb1b0826e2a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0770254ce347c9892f6b143bb5f48fb1b0826e2a>`__
 -  Add missing timeout option to logging statement
-   `commit <https://pagure.io/freeipa/c/5db48f151ba4aef2baebc40a4d357403a922d362>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5db48f151ba4aef2baebc40a4d357403a922d362>`__
 -  Log dogtag auth timeout in install, provide hint to increase it
-   `commit <https://pagure.io/freeipa/c/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Log the replication wait timeout for debugging purposes
-   `commit <https://pagure.io/freeipa/c/54035982e5850ec59611798a9e172a044969106f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54035982e5850ec59611798a9e172a044969106f>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Replace replication_wait_timeout with certmonger_wait_timeout
-   `commit <https://pagure.io/freeipa/c/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
    `#7971 <https://pagure.io/freeipa/issue/7971>`__
 -  Use tasks to configure automount nsswitch settings
-   `commit <https://pagure.io/freeipa/c/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
 -  Move ipachangeconf from ipaclient.install to ipapython
-   `commit <https://pagure.io/freeipa/c/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
-   `commit <https://pagure.io/freeipa/c/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  httpinstance: add pinfile when tracking certificate
-   `commit <https://pagure.io/freeipa/c/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
    `#7991 <https://pagure.io/freeipa/issue/7991>`__
 -  Remove posixAccount from service_find search filter
-   `commit <https://pagure.io/freeipa/c/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
    `#8013 <https://pagure.io/freeipa/issue/8013>`__
 
 
@@ -4195,38 +4195,38 @@ Robbie Harwood (16)
 ----------------------------------------------------------------------------------------------
 
 -  Drop upper bound on krb5 version in freeipa.spec
-   `commit <https://pagure.io/freeipa/c/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
 -  ipa-kdb: implement AS-REQ lifetime jitter
-   `commit <https://pagure.io/freeipa/c/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
    `#8010 <https://pagure.io/freeipa/issue/8010>`__
 -  Update kdcpolicy design doc for jitter implementation
-   `commit <https://pagure.io/freeipa/c/249097c62414abc99256af9dc622c284745081e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/249097c62414abc99256af9dc622c284745081e4>`__
 -  Drop support for DAL version 5.0
-   `commit <https://pagure.io/freeipa/c/93e81cfd0c1d4d759985ed1ce3f4aa540dcf438e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93e81cfd0c1d4d759985ed1ce3f4aa540dcf438e>`__
 -  Support DAL version 8.0
-   `commit <https://pagure.io/freeipa/c/ff10f3fa18948971912bab9ad5bfbc3d36133a3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff10f3fa18948971912bab9ad5bfbc3d36133a3b>`__
 -  Handle the removal of KRB5_KDB_FLAG_ALIAS_OK
-   `commit <https://pagure.io/freeipa/c/1c787cc36c42f05fe945c4a8ae8551832e0e2c1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c787cc36c42f05fe945c4a8ae8551832e0e2c1d>`__
 -  Fix several leaks in ipadb_find_principal
-   `commit <https://pagure.io/freeipa/c/df6a89be51fa8bbc9ce292c9730f20a1e34674ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df6a89be51fa8bbc9ce292c9730f20a1e34674ac>`__
 -  Use separate variable for client fetch in kdcpolicy
-   `commit <https://pagure.io/freeipa/c/ab4e910c52ae4bdf75eca85f8ff54508f6974fc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab4e910c52ae4bdf75eca85f8ff54508f6974fc3>`__
 -  Make the coding style explicit
-   `commit <https://pagure.io/freeipa/c/3ccf73bfd6f87d7be1a156d276c22a81d1fac6b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ccf73bfd6f87d7be1a156d276c22a81d1fac6b4>`__
 -  Provide modern example enctypes in ipa-getkeytab(1)
-   `commit <https://pagure.io/freeipa/c/3cb9444c4c9af126c0559d4f1cb6c58aece78b19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cb9444c4c9af126c0559d4f1cb6c58aece78b19>`__
 -  Fix segfault in ipadb_parse_ldap_entry()
-   `commit <https://pagure.io/freeipa/c/c11fd328bc4d175308e58cd7a0c72dcb8d16bfdf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c11fd328bc4d175308e58cd7a0c72dcb8d16bfdf>`__
 -  Add a skeleton kdcpolicy plugin
-   `commit <https://pagure.io/freeipa/c/179c8f4009adc30b9b3c497855f15927016c84db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/179c8f4009adc30b9b3c497855f15927016c84db>`__
 -  Move certauth configuration into a server krb5.conf template
-   `commit <https://pagure.io/freeipa/c/39e3704a0679d117f5145044e73726175a8f600b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39e3704a0679d117f5145044e73726175a8f600b>`__
 -  Enable krb5 snippet updates on client update
-   `commit <https://pagure.io/freeipa/c/c7b938a1d5c20df24a2d8a62019c5341e0f26c63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7b938a1d5c20df24a2d8a62019c5341e0f26c63>`__
 -  Fix NULL pointer dereference in maybe_require_preauth()
-   `commit <https://pagure.io/freeipa/c/45b4f5377bf3921406271148e18a3b99acfee03b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45b4f5377bf3921406271148e18a3b99acfee03b>`__
 -  Log INFO message when LDAP connection fails on startup
-   `commit <https://pagure.io/freeipa/c/9414b038e714043d87dc0646dd9af3933896a75a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9414b038e714043d87dc0646dd9af3933896a75a>`__
 
 
 
@@ -4234,7 +4234,7 @@ Rafael Guterres Jeffman (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes pylint errors introduced by version 2.4.0.
-   `commit <https://pagure.io/freeipa/c/883b44243ae005c6f2d6d5cab502083f1cc10273>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/883b44243ae005c6f2d6d5cab502083f1cc10273>`__
 
 
 
@@ -4242,17 +4242,17 @@ Rafael Guterres Jeffman (6)
 ----------------------------------------------------------------------------------------------
 
 -  Removed unnecessary imports after code review.
-   `commit <https://pagure.io/freeipa/c/73529e065c901c332caef125f1f12cba33ddaefd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73529e065c901c332caef125f1f12cba33ddaefd>`__
 -  Removes several pylint warnings.
-   `commit <https://pagure.io/freeipa/c/d4fab33605503fadd1826cd3e879d9c928b8cea9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4fab33605503fadd1826cd3e879d9c928b8cea9>`__
 -  Removed unnecessary imports after code review.
-   `commit <https://pagure.io/freeipa/c/51e0f564870b9b353f0ecf81da700f3d5d1791fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f564870b9b353f0ecf81da700f3d5d1791fb>`__
 -  Removes several pylint warnings.
-   `commit <https://pagure.io/freeipa/c/c898be1df926bd134ac4d7cd86d10a00ff5cd2ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c898be1df926bd134ac4d7cd86d10a00ff5cd2ae>`__
 -  Removes rpmlint warning on freeipa.spec.
-   `commit <https://pagure.io/freeipa/c/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
 -  Re-add function façades removed by commit 2da9088.
-   `commit <https://pagure.io/freeipa/c/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
    `#8062 <https://pagure.io/freeipa/issue/8062>`__
 
 
@@ -4261,7 +4261,7 @@ Robert Collins (1)
 ----------------------------------------------------------------------------------------------
 
 -  Note sss_cache -E.
-   `commit <https://pagure.io/freeipa/c/681f8ae5a48c39c915c12d75f2d4554b100822a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/681f8ae5a48c39c915c12d75f2d4554b100822a9>`__
 
 
 
@@ -4269,7 +4269,7 @@ Sam Bristow (1)
 ----------------------------------------------------------------------------------------------
 
 -  Workaround networking issues with Libvirt
-   `commit <https://pagure.io/freeipa/c/265d064bf890d06e64015339fb4789d8aaaec149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/265d064bf890d06e64015339fb4789d8aaaec149>`__
 
 
 
@@ -4277,7 +4277,7 @@ Sam Morris (1)
 ----------------------------------------------------------------------------------------------
 
 -  Debian: write out only one CA certificate per file
-   `commit <https://pagure.io/freeipa/c/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
    `#8106 <https://pagure.io/freeipa/issue/8106>`__
 
 
@@ -4286,10 +4286,10 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: Remove keys if password auth is disabled
-   `commit <https://pagure.io/freeipa/c/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
-   `commit <https://pagure.io/freeipa/c/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
    `#8044 <https://pagure.io/freeipa/issue/8044>`__
 
 
@@ -4298,7 +4298,7 @@ Sergio Oliveira Campos (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add test for sssd ad trust lookup with dn in certmaprule
-   `commit <https://pagure.io/freeipa/c/e071933e642a83140550ddcf86d6fcb50c3e65bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e071933e642a83140550ddcf86d6fcb50c3e65bc>`__
 
 
 
@@ -4306,256 +4306,256 @@ Stanislav Levin (91)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Collect EPN log for debugging
-   `commit <https://pagure.io/freeipa/c/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
 -  EPN: Allow authentication by SMTP client's certificate
-   `commit <https://pagure.io/freeipa/c/17f430efc4cf438b6c052465b8252688bc5822f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17f430efc4cf438b6c052465b8252688bc5822f9>`__
    `#8580 <https://pagure.io/freeipa/issue/8580>`__
 -  EPN: Enable certificate validation and hostname checking
-   `commit <https://pagure.io/freeipa/c/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
    `#8579 <https://pagure.io/freeipa/issue/8579>`__
 -  test_epn: Standardize EPN configs for deduplication
-   `commit <https://pagure.io/freeipa/c/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
 -  EPN: Don't downgrade security
-   `commit <https://pagure.io/freeipa/c/94adee3c73f039fc2d985afd1681cd64ece55116>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94adee3c73f039fc2d985afd1681cd64ece55116>`__
    `#8578 <https://pagure.io/freeipa/issue/8578>`__
 -  ipatests: Respect platform's openssl dir
-   `commit <https://pagure.io/freeipa/c/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
 -  dns: Make use of \`resolve_address\` of a current resolver instead of
    the global one
-   `commit <https://pagure.io/freeipa/c/b450c9bd324a3c89ea03d898592cfed832184802>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b450c9bd324a3c89ea03d898592cfed832184802>`__
 -  dnspython: Add compatibility shim
-   `commit <https://pagure.io/freeipa/c/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
    `#8383 <https://pagure.io/freeipa/issue/8383>`__
 -  tox: Don't expand symlinks
-   `commit <https://pagure.io/freeipa/c/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
    `#8475 <https://pagure.io/freeipa/issue/8475>`__
 -  Azure: Increase verbosity for Tox task
-   `commit <https://pagure.io/freeipa/c/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
-   `commit <https://pagure.io/freeipa/c/f3d10871300498150c41f3acc154688f1ee48ceb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3d10871300498150c41f3acc154688f1ee48ceb>`__
 -  nss: Raise exception earlier on unsupported DB type
-   `commit <https://pagure.io/freeipa/c/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
    `#8474 <https://pagure.io/freeipa/issue/8474>`__
 -  Azure: base: Collect both install and uninstall logs
-   `commit <https://pagure.io/freeipa/c/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
 -  Azure: Drop dependency on UsePythonVersion task
-   `commit <https://pagure.io/freeipa/c/60ff2841cd74706a5ebd40924f11ad3defaa1750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60ff2841cd74706a5ebd40924f11ad3defaa1750>`__
 -  Azure: Add Rawhide definitions
-   `commit <https://pagure.io/freeipa/c/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
 -  ipa-dnskeysyncd: Raise loglevel to DEBUG
-   `commit <https://pagure.io/freeipa/c/92157bc880600be137c634d5def788c1bf8c5e8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92157bc880600be137c634d5def788c1bf8c5e8a>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Include crypto policy in openssl config
-   `commit <https://pagure.io/freeipa/c/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Don't override custom command line options for named
-   `commit <https://pagure.io/freeipa/c/ecfaf897b937e2333296d32960b2cc13843048f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecfaf897b937e2333296d32960b2cc13843048f9>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  service: Allow service to clean up its state
-   `commit <https://pagure.io/freeipa/c/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  spec: Bump required openssl-pkcs11 and softhsm
-   `commit <https://pagure.io/freeipa/c/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Make use of 'pkcs11' OpenSSL engine for BIND on Fedora31
-   `commit <https://pagure.io/freeipa/c/721435cf7f2ed41fe807c34022fed31c792b4497>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/721435cf7f2ed41fe807c34022fed31c792b4497>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  upgrade: Handle migration of BIND OpenSSL engine
-   `commit <https://pagure.io/freeipa/c/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  DNSKeySyncInstance: Populate named/ods uid/gid on instantiation
-   `commit <https://pagure.io/freeipa/c/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Allow using of a custom OpenSSL engine for BIND
-   `commit <https://pagure.io/freeipa/c/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  named: Remove no longer used paths
-   `commit <https://pagure.io/freeipa/c/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  spec: Require ldns-utils
-   `commit <https://pagure.io/freeipa/c/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
    `#8094 <https://pagure.io/freeipa/issue/8094>`__
 -  pylint: Ignore \`raise-missing-from\`
-   `commit <https://pagure.io/freeipa/c/8831b9b6498b834c77dce2e0b96854be105810f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8831b9b6498b834c77dce2e0b96854be105810f9>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
-   `commit <https://pagure.io/freeipa/c/ec6369ca009139af69aa4214e82fc411184b428f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec6369ca009139af69aa4214e82fc411184b428f>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
-   `commit <https://pagure.io/freeipa/c/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  pylint: Teach pylint about more RRs types
-   `commit <https://pagure.io/freeipa/c/de105aa8fc8281c28c359d607c2b43154103a399>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de105aa8fc8281c28c359d607c2b43154103a399>`__
    `#8468 <https://pagure.io/freeipa/issue/8468>`__
 -  spec: Move ipa-cldap plugin out to freeipa-server-trust-ad package
-   `commit <https://pagure.io/freeipa/c/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
 -  uninstall: Clean up no longer used flag
-   `commit <https://pagure.io/freeipa/c/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
-   `commit <https://pagure.io/freeipa/c/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
    `#8461 <https://pagure.io/freeipa/issue/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
-   `commit <https://pagure.io/freeipa/c/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
    `#8459 <https://pagure.io/freeipa/issue/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
-   `commit <https://pagure.io/freeipa/c/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
 -  Azure: Switch to dockerhub provider
-   `commit <https://pagure.io/freeipa/c/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
-   `commit <https://pagure.io/freeipa/c/06a344a5d932db148b1921c03906d2843b3622cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a344a5d932db148b1921c03906d2843b3622cb>`__
    `#8428 <https://pagure.io/freeipa/issue/8428>`__
 -  pylint: Fix warning and error
-   `commit <https://pagure.io/freeipa/c/c81cac70acd304f34f875af5096c407a44f1395b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c81cac70acd304f34f875af5096c407a44f1395b>`__
    `#8442 <https://pagure.io/freeipa/issue/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
-   `commit <https://pagure.io/freeipa/c/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
    `#8435 <https://pagure.io/freeipa/issue/8435>`__
 -  Azure: Make dnf repos consistent
-   `commit <https://pagure.io/freeipa/c/26f96595b010396f055c7d11a645be57fc637863>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26f96595b010396f055c7d11a645be57fc637863>`__
    `#8330 <https://pagure.io/freeipa/issue/8330>`__
 -  Azure: Always update apt cache
-   `commit <https://pagure.io/freeipa/c/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
 -  Azure: Allow chronyd to sync time
-   `commit <https://pagure.io/freeipa/c/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Add custom seccomp profile
-   `commit <https://pagure.io/freeipa/c/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
    `#8316 <https://pagure.io/freeipa/issue/8316>`__
 -  Azure: Increase memory limit
-   `commit <https://pagure.io/freeipa/c/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
    `#8264 <https://pagure.io/freeipa/issue/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
-   `commit <https://pagure.io/freeipa/c/63747bc0c041382536e2cad121bb591e42df3a2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63747bc0c041382536e2cad121bb591e42df3a2f>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Pretty print multihost config
-   `commit <https://pagure.io/freeipa/c/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
-   `commit <https://pagure.io/freeipa/c/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
    `#8265 <https://pagure.io/freeipa/issue/8265>`__
 -  ipatests: Specify shell implementation
-   `commit <https://pagure.io/freeipa/c/974395704ad3a0c992324a080e96e1160f324153>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/974395704ad3a0c992324a080e96e1160f324153>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Specify Pytest XML report schema
-   `commit <https://pagure.io/freeipa/c/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
-   `commit <https://pagure.io/freeipa/c/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
-   `commit <https://pagure.io/freeipa/c/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
-   `commit <https://pagure.io/freeipa/c/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Remove deprecated yield_fixture
-   `commit <https://pagure.io/freeipa/c/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Bump required Pytest
-   `commit <https://pagure.io/freeipa/c/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
    `#8101 <https://pagure.io/freeipa/issue/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
-   `commit <https://pagure.io/freeipa/c/ba162b9b47004da633a2c140409982725f5e0960>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba162b9b47004da633a2c140409982725f5e0960>`__
    `#8261 <https://pagure.io/freeipa/issue/8261>`__
 -  Azure: Gather coredumps
-   `commit <https://pagure.io/freeipa/c/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
    `#8251 <https://pagure.io/freeipa/issue/8251>`__
 -  Azure: Allow distros to install Python they want
-   `commit <https://pagure.io/freeipa/c/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
    `#8254 <https://pagure.io/freeipa/issue/8254>`__
 -  pki-proxy: Don't rely on running apache until it's configured
-   `commit <https://pagure.io/freeipa/c/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
    `#8233 <https://pagure.io/freeipa/issue/8233>`__
 -  spec: Take the ownership over '/usr/libexec/ipa/custodia'
-   `commit <https://pagure.io/freeipa/c/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
 -  Azure: Report elapsed time
-   `commit <https://pagure.io/freeipa/c/0a1e98cdf055867d8a02ed6a8eb65eabe2442a67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a1e98cdf055867d8a02ed6a8eb65eabe2442a67>`__
 -  Azure: Rebalance tests
-   `commit <https://pagure.io/freeipa/c/38e0a9f4c0bd38c204be5dde2d689308d9e153d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38e0a9f4c0bd38c204be5dde2d689308d9e153d6>`__
 -  Azure: Skip tests requiring external DNS
-   `commit <https://pagure.io/freeipa/c/9203404cd5d9864bfcf6e5b1f4ae2c054464e757>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9203404cd5d9864bfcf6e5b1f4ae2c054464e757>`__
 -  Azure: Free Docker resources after usage
-   `commit <https://pagure.io/freeipa/c/e925148ad9d5d8e36a61c68d0d247283c109a37e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e925148ad9d5d8e36a61c68d0d247283c109a37e>`__
 -  Azure: Preliminary check for provided limits
-   `commit <https://pagure.io/freeipa/c/1fa033c32d4c94ea9456a2a728893e206957930e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fa033c32d4c94ea9456a2a728893e206957930e>`__
 -  Azure: Sync Gating definitions to current PR-CI
-   `commit <https://pagure.io/freeipa/c/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
 -  pylint: Run Pylint over Azure Python scripts
-   `commit <https://pagure.io/freeipa/c/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Add support for testing multi IPA environments
-   `commit <https://pagure.io/freeipa/c/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
-   `commit <https://pagure.io/freeipa/c/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  yamllint: Lint all the YAML files
-   `commit <https://pagure.io/freeipa/c/fa104daf77902172f087c7026052fd9a59b4861a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa104daf77902172f087c7026052fd9a59b4861a>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
-   `commit <https://pagure.io/freeipa/c/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to run integration tests
-   `commit <https://pagure.io/freeipa/c/879855ce705770834d0be8182818ae672bc72063>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/879855ce705770834d0be8182818ae672bc72063>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow SSH for Docker environments
-   `commit <https://pagure.io/freeipa/c/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  Azure: Allow to not provide tests to be ignored
-   `commit <https://pagure.io/freeipa/c/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
    `#8202 <https://pagure.io/freeipa/issue/8202>`__
 -  ipatests: Allow zero-length arguments
-   `commit <https://pagure.io/freeipa/c/902821e8aa47936acac713023bff9a4009d8dfb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/902821e8aa47936acac713023bff9a4009d8dfb7>`__
    `#8173 <https://pagure.io/freeipa/issue/8173>`__
 -  lint: Make Pylint-2.4 happy again
-   `commit <https://pagure.io/freeipa/c/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Clean up comment
-   `commit <https://pagure.io/freeipa/c/a309de6c08987b1cf9645111414d1c52b4525190>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a309de6c08987b1cf9645111414d1c52b4525190>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
-   `commit <https://pagure.io/freeipa/c/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  pylint: Teach Pylint how to handle request.context
-   `commit <https://pagure.io/freeipa/c/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
    `#8116 <https://pagure.io/freeipa/issue/8116>`__
 -  ipatests: Properly kill gpg-agent
-   `commit <https://pagure.io/freeipa/c/19462788f162491e0aedaaf42528cae7104b8068>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19462788f162491e0aedaaf42528cae7104b8068>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
-   `commit <https://pagure.io/freeipa/c/8c7447fd42548d28df6200e354afdc03355b94b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7447fd42548d28df6200e354afdc03355b94b6>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
-   `commit <https://pagure.io/freeipa/c/292d686c0b7935dd219559b10de3a393b712a990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/292d686c0b7935dd219559b10de3a393b712a990>`__
    `#7989 <https://pagure.io/freeipa/issue/7989>`__
 -  Fix errors found by Pylint-2.4.3
-   `commit <https://pagure.io/freeipa/c/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
    `#8102 <https://pagure.io/freeipa/issue/8102>`__
 -  Install language packs for tests
-   `commit <https://pagure.io/freeipa/c/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
 -  Restore running of 'test_ipaserver' tests on Azure
-   `commit <https://pagure.io/freeipa/c/16149831daf12826c1c39d4109a0014b86fbb072>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16149831daf12826c1c39d4109a0014b86fbb072>`__
 -  Setup DNS for AP Docker container
-   `commit <https://pagure.io/freeipa/c/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 -  Fixed errors newly exposed by pylint 2.4.0
-   `commit <https://pagure.io/freeipa/c/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
    `#8077 <https://pagure.io/freeipa/issue/8077>`__
 -  Avoid use of '/tmp' for pip operations
-   `commit <https://pagure.io/freeipa/c/c7500220c443c6051178211eadd64392ca7bd08a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7500220c443c6051178211eadd64392ca7bd08a>`__
    `#8009 <https://pagure.io/freeipa/issue/8009>`__
 -  Make use of Azure Pipeline slicing
-   `commit <https://pagure.io/freeipa/c/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
    `#8008 <https://pagure.io/freeipa/issue/8008>`__
 -  Simplify ipa-run-tests script
-   `commit <https://pagure.io/freeipa/c/2312b38a678d30b73c08dae19db7f8b74361a957>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2312b38a678d30b73c08dae19db7f8b74361a957>`__
    `#8007 <https://pagure.io/freeipa/issue/8007>`__
 -  Fix \`test_webui.test_selinuxusermap\`
-   `commit <https://pagure.io/freeipa/c/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
    `#7996 <https://pagure.io/freeipa/issue/7996>`__,
    `#8005 <https://pagure.io/freeipa/issue/8005>`__
 
@@ -4565,110 +4565,110 @@ Sergey Orlov (45)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: simplify fixture
-   `commit <https://pagure.io/freeipa/c/6da5cc32d743d75b11a874a027d812603432ce45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6da5cc32d743d75b11a874a027d812603432ce45>`__
 -  ipatests: refactor test for login using cifs alias principal
-   `commit <https://pagure.io/freeipa/c/4420ae81ae6c42a945d7b4d2cc6df5e381052e7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4420ae81ae6c42a945d7b4d2cc6df5e381052e7b>`__
 -  Fix password file permission
-   `commit <https://pagure.io/freeipa/c/07341990d962643e421ec1e7f6dd027cf428e0dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07341990d962643e421ec1e7f6dd027cf428e0dc>`__
 -  ipatests: mark test_trustdomain_disable test as expectedly failing
-   `commit <https://pagure.io/freeipa/c/26233c887eb50f30407c1a6eb953fd57c7fd9fb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26233c887eb50f30407c1a6eb953fd57c7fd9fb9>`__
 -  ipatests: add context manager for declaring part of test as xfail
-   `commit <https://pagure.io/freeipa/c/84c94f735004eaac3d6debd9ddebbd89a2d75f4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c94f735004eaac3d6debd9ddebbd89a2d75f4e>`__
 -  ipatests: add utility for getting sssd version on remote host
-   `commit <https://pagure.io/freeipa/c/3ae0d0d724a094d3e8251b141e2b58b024300134>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ae0d0d724a094d3e8251b141e2b58b024300134>`__
 -  update prci definitions for test_sssd.py
-   `commit <https://pagure.io/freeipa/c/b238812b964f9526454ed7066633c73f2f596101>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b238812b964f9526454ed7066633c73f2f596101>`__
 -  ipatests: add test for sssd behavior with disabled trustdomains
-   `commit <https://pagure.io/freeipa/c/d8135b73283bc0a17df322f66e2154bec5f48170>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8135b73283bc0a17df322f66e2154bec5f48170>`__
 -  ipatests: add missing classes from test_nfs in nightly_previous run
-   `commit <https://pagure.io/freeipa/c/9b3c3202ca14da9be13bd976ea82d02f614b319c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b3c3202ca14da9be13bd976ea82d02f614b319c>`__
 -  ipatests: add missing classes from test_installation in nightly runs
-   `commit <https://pagure.io/freeipa/c/1c4aa66b3cdf56a14f01c6750c494914e4d651eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c4aa66b3cdf56a14f01c6750c494914e4d651eb>`__
 -  ipatests: run test_integration/test_cert.py in PR-CI
-   `commit <https://pagure.io/freeipa/c/99a322a4ae3c6a66d1e52517ee17c9b9c1b902e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a322a4ae3c6a66d1e52517ee17c9b9c1b902e0>`__
 -  ipatests: run all cases from test_integration/test_idviews.py in
    nightlies
-   `commit <https://pagure.io/freeipa/c/b8e1a7d5ae73bffa745e8417968cef0b77892cc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8e1a7d5ae73bffa745e8417968cef0b77892cc3>`__
 -  ipatests: explicitly save output of certutil
-   `commit <https://pagure.io/freeipa/c/98b6326a8e4c906ef267f838eb755898305186ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98b6326a8e4c906ef267f838eb755898305186ce>`__
 -  ipatests: add AD DC as a DNS forwarder before establishing trust
-   `commit <https://pagure.io/freeipa/c/a2dee05b168ca1651c145d239da7bb5c1a8b3865>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2dee05b168ca1651c145d239da7bb5c1a8b3865>`__
 -  ipatests: add test_automember to "previous" nightly run
-   `commit <https://pagure.io/freeipa/c/e927396851a2d24409ca3972d21804c83c14e502>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e927396851a2d24409ca3972d21804c83c14e502>`__
 -  ipatests: add test_fips to testing-fedora nightly run
-   `commit <https://pagure.io/freeipa/c/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
 -  ipatests: provide AD admin password when trying to establish trust
-   `commit <https://pagure.io/freeipa/c/aae30eb708b04c54807bc226b93ca14e09561b87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aae30eb708b04c54807bc226b93ca14e09561b87>`__
    `#7895 <https://pagure.io/freeipa/issue/7895>`__
 -  ipatests: remove test_ordering
-   `commit <https://pagure.io/freeipa/c/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
 -  ipatests: add test for SSSD updating expired cache items
-   `commit <https://pagure.io/freeipa/c/8dd663e0c2cbc6c6fec43ffcc09259f9be336429>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8dd663e0c2cbc6c6fec43ffcc09259f9be336429>`__
 -  ipatests: provide docstrings instead of imporperly placed comments
-   `commit <https://pagure.io/freeipa/c/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
 -  ipatests: remove invalid parameter from sssd.conf
-   `commit <https://pagure.io/freeipa/c/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
-   `commit <https://pagure.io/freeipa/c/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: replace utility for editing sssd.conf
-   `commit <https://pagure.io/freeipa/c/9450aef75f2ac064ea182c942d39400287a38bab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9450aef75f2ac064ea182c942d39400287a38bab>`__
    `#8219 <https://pagure.io/freeipa/issue/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
-   `commit <https://pagure.io/freeipa/c/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
 -  ipatests: add test_trust suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
 -  ipatests: add check for output contents of ipa-client-samba
-   `commit <https://pagure.io/freeipa/c/15fd36612ea451cec2e1302a462fa440663fcc74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15fd36612ea451cec2e1302a462fa440663fcc74>`__
    `#8149 <https://pagure.io/freeipa/issue/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
-   `commit <https://pagure.io/freeipa/c/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
-   `commit <https://pagure.io/freeipa/c/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
    `#6951 <https://pagure.io/freeipa/issue/6951>`__
 -  ipatests: enable test_smb.py in gating.yaml
-   `commit <https://pagure.io/freeipa/c/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
 -  ipatests: replace ad hoc backup with FileBackup helper
-   `commit <https://pagure.io/freeipa/c/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: refactor FileBackup helper
-   `commit <https://pagure.io/freeipa/c/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
    `#8115 <https://pagure.io/freeipa/issue/8115>`__
 -  ipatests: in DNS zone file add A record for name server
-   `commit <https://pagure.io/freeipa/c/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
 -  ipatests: strip newline character when getting name of temp file
-   `commit <https://pagure.io/freeipa/c/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
-   `commit <https://pagure.io/freeipa/c/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
    `#7995 <https://pagure.io/freeipa/issue/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
-   `commit <https://pagure.io/freeipa/c/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
 -  ipatests: add tests for cached_auth_timeout in sssd.conf
-   `commit <https://pagure.io/freeipa/c/4ab2842b76ffc9cffd931bf652d211ca34b4d1d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ab2842b76ffc9cffd931bf652d211ca34b4d1d8>`__
 -  ipatests: refactoring: use library function to check if selinux is
    enabled
-   `commit <https://pagure.io/freeipa/c/4ea9aead5cab96ed9454facdb6d22bdfe514a09b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ea9aead5cab96ed9454facdb6d22bdfe514a09b>`__
 -  ipatests: add new utilities for file management
-   `commit <https://pagure.io/freeipa/c/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
 -  ipatests: refactor and extend tests for IPA-Samba integration
-   `commit <https://pagure.io/freeipa/c/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
    `#3999 <https://pagure.io/freeipa/issue/3999>`__
 -  ipatests: modify run_command to allow specify successful return codes
-   `commit <https://pagure.io/freeipa/c/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
 -  ipatests: add utility functions related to using and managing user
    accounts
-   `commit <https://pagure.io/freeipa/c/3fa7865ff8c48a35d0d120c74da76ea4076a6aa4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fa7865ff8c48a35d0d120c74da76ea4076a6aa4>`__
 -  ipatests: allow to pass additional options for clients installation
-   `commit <https://pagure.io/freeipa/c/074bf285f185d96d67cf9f410f1e8935078d15eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/074bf285f185d96d67cf9f410f1e8935078d15eb>`__
 -  ipatests: new test for trust with partially unreachable AD topology
-   `commit <https://pagure.io/freeipa/c/843f57abe431bcf493e0bcce8ef07255be986435>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/843f57abe431bcf493e0bcce8ef07255be986435>`__
 -  ipatests: mark test_domain_resolution_order as expectedly failing
-   `commit <https://pagure.io/freeipa/c/4740655260caa7baee4473b0d35840a4c0da3dac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4740655260caa7baee4473b0d35840a4c0da3dac>`__
 -  ipatests: add test for sudo with runAsUser and domain resolution
    order.
-   `commit <https://pagure.io/freeipa/c/0d15eb78d4178bea6057e4d32b234c592ca80fa7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d15eb78d4178bea6057e4d32b234c592ca80fa7>`__
 
 
 
@@ -4679,22 +4679,22 @@ Sumedh Sidhaye (6)
    test_cert.py::TestCertmongerRekey which needs more time to execute.
    Adding additional 30 mins to the timeout in order to complete the
    test run
-   `commit <https://pagure.io/freeipa/c/3f5f68e770bc720b130a8f7fb6d54d2ae62e6f4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f5f68e770bc720b130a8f7fb6d54d2ae62e6f4c>`__
 -  Test for removing a subgroup
-   `commit <https://pagure.io/freeipa/c/47bddf4f458699f46b398d0969d5e3a348feed52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47bddf4f458699f46b398d0969d5e3a348feed52>`__
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
-   `commit <https://pagure.io/freeipa/c/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
    `#8164 <https://pagure.io/freeipa/issue/8164>`__
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
-   `commit <https://pagure.io/freeipa/c/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
    `#8029 <https://pagure.io/freeipa/issue/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
-   `commit <https://pagure.io/freeipa/c/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
 -  Test: To check ipa replica-manage del does not fail
-   `commit <https://pagure.io/freeipa/c/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
    `#7929 <https://pagure.io/freeipa/issue/7929>`__
 
 
@@ -4703,7 +4703,7 @@ Simo Sorce (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make sure to have storage space for tag
-   `commit <https://pagure.io/freeipa/c/4abd2f76d76c4c1a1ec5087ec447f4515b63c2c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4abd2f76d76c4c1a1ec5087ec447f4515b63c2c6>`__
 
 
 
@@ -4711,7 +4711,7 @@ Stasiek Michalski (1)
 ----------------------------------------------------------------------------------------------
 
 -  Support for SUSE/openSUSE ipaplatform
-   `commit <https://pagure.io/freeipa/c/3e8c51922b404bf2406ead09376e3e89f0624cdf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e8c51922b404bf2406ead09376e3e89f0624cdf>`__
 
 
 
@@ -4720,94 +4720,94 @@ Serhii Tsymbaliuk (28)
 
 -  WebUI tests: Add simple test to check topology graph page is
    available
-   `commit <https://pagure.io/freeipa/c/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
    `#8523 <https://pagure.io/freeipa/issue/8523>`__
 -  WebUI: Fix topology graph navigation crash
-   `commit <https://pagure.io/freeipa/c/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
    `#8523 <https://pagure.io/freeipa/issue/8523>`__
 -  WebUI: Fix jQuery DOM manipulation issues
-   `commit <https://pagure.io/freeipa/c/29b41aef0a49d5460631a8543f0f6620d4696790>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29b41aef0a49d5460631a8543f0f6620d4696790>`__
    `#8507 <https://pagure.io/freeipa/issue/8507>`__
 -  WebUI tests: Add test case to cover user ID override feature
-   `commit <https://pagure.io/freeipa/c/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
-   `commit <https://pagure.io/freeipa/c/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
    `#8416 <https://pagure.io/freeipa/issue/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
-   `commit <https://pagure.io/freeipa/c/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
-   `commit <https://pagure.io/freeipa/c/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
    `#7137 <https://pagure.io/freeipa/issue/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
-   `commit <https://pagure.io/freeipa/c/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
    `#8335 <https://pagure.io/freeipa/issue/8335>`__
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
-   `commit <https://pagure.io/freeipa/c/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
    `#8325 <https://pagure.io/freeipa/issue/8325>`__
 -  WebUI tests: Test all available fields on "Kerberos Ticket Policy"
    page
-   `commit <https://pagure.io/freeipa/c/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
    `#8207 <https://pagure.io/freeipa/issue/8207>`__
 -  WebUI: Add authentication indicator specific fields to "Kerberos
    Ticket Policy" page
-   `commit <https://pagure.io/freeipa/c/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
    `#8207 <https://pagure.io/freeipa/issue/8207>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
-   `commit <https://pagure.io/freeipa/c/3645854c11b0489215a27077a633755638f00268>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3645854c11b0489215a27077a633755638f00268>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
-   `commit <https://pagure.io/freeipa/c/33ca0745585ae3fcd466631a069e244bea74be88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33ca0745585ae3fcd466631a069e244bea74be88>`__
    `#8322 <https://pagure.io/freeipa/issue/8322>`__
 -  WebUI tests: cover membership management with UI tests
-   `commit <https://pagure.io/freeipa/c/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
    `#8298 <https://pagure.io/freeipa/issue/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
    `#8284 <https://pagure.io/freeipa/issue/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
-   `commit <https://pagure.io/freeipa/c/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
    `#8222 <https://pagure.io/freeipa/issue/8222>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
-   `commit <https://pagure.io/freeipa/c/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
    `#8239 <https://pagure.io/freeipa/issue/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
-   `commit <https://pagure.io/freeipa/c/a4634a59c98ae922708f9211786b67505dada736>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4634a59c98ae922708f9211786b67505dada736>`__
    `#8157 <https://pagure.io/freeipa/issue/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
-   `commit <https://pagure.io/freeipa/c/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
    `#8169 <https://pagure.io/freeipa/issue/8169>`__
 -  WebUI: Fix notification area layout
-   `commit <https://pagure.io/freeipa/c/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
    `#8120 <https://pagure.io/freeipa/issue/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
-   `commit <https://pagure.io/freeipa/c/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
    `#8123 <https://pagure.io/freeipa/issue/8123>`__
 -  WebUI: Fix new test initialization on "HBAC Test" page
-   `commit <https://pagure.io/freeipa/c/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
    `#8031 <https://pagure.io/freeipa/issue/8031>`__
 -  WebUI: Fix changing category on HBAC/Sudo/etc Rule pages
-   `commit <https://pagure.io/freeipa/c/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
    `#7961 <https://pagure.io/freeipa/issue/7961>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
-   `commit <https://pagure.io/freeipa/c/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
    `#5062 <https://pagure.io/freeipa/issue/5062>`__
 -  WebUI tests: Fix login screen loading issue
-   `commit <https://pagure.io/freeipa/c/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
    `#8053 <https://pagure.io/freeipa/issue/8053>`__
 -  WebUI tests: Fix request timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/f16ea8e652a3a3b555087646b9887bc77934d175>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16ea8e652a3a3b555087646b9887bc77934d175>`__
    `#8024 <https://pagure.io/freeipa/issue/8024>`__
 -  WebUI: Add PKINIT status field to 'Configuration' page
-   `commit <https://pagure.io/freeipa/c/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
    `#7305 <https://pagure.io/freeipa/issue/7305>`__
 -  WebUI tests: Fix timeout issues for reset password tests
-   `commit <https://pagure.io/freeipa/c/6316a006327426af9365f865633cf6767ff699a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6316a006327426af9365f865633cf6767ff699a9>`__
    `#8012 <https://pagure.io/freeipa/issue/8012>`__
 
 
@@ -4817,80 +4817,80 @@ Sudhir Menon (32)
 
 -  Added nsslapd-logging-hr-timestamps-enabled attribute in
    \_SINGLE_VALUE_OVERRIDE table
-   `commit <https://pagure.io/freeipa/c/617f7824ca56c040bd5c5ad60dc23f228df70b63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/617f7824ca56c040bd5c5ad60dc23f228df70b63>`__
 -  ipatests: ipa-healthcheck tests for DS checks
-   `commit <https://pagure.io/freeipa/c/b7be1a2470c220da30154305e869149d808c0ec2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7be1a2470c220da30154305e869149d808c0ec2>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_riplugincheck
-   `commit <https://pagure.io/freeipa/c/2b1230e5b083084eecf3aeb027223d5501a45924>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b1230e5b083084eecf3aeb027223d5501a45924>`__
    `#8563 <https://pagure.io/freeipa/issue/8563>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_encryption
-   `commit <https://pagure.io/freeipa/c/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
    `#8560 <https://pagure.io/freeipa/issue/8560>`__
 -  ipatests: ipa-healthcheck test for DS RIPluginCheck
-   `commit <https://pagure.io/freeipa/c/686414d2017b8122df04b04493909a12db8ccd66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/686414d2017b8122df04b04493909a12db8ccd66>`__
 -  ipatests: ipa-healthcheck test for EncryptionCheck
-   `commit <https://pagure.io/freeipa/c/b8a2a0f3013139574ac42ae69eb3e37c9ff56fba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8a2a0f3013139574ac42ae69eb3e37c9ff56fba>`__
 -  ipatests: ipa-healthcheck test for DS BackendsCheck
-   `commit <https://pagure.io/freeipa/c/9a41966a250a97e7df204b4e66a4e7e9546d78aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a41966a250a97e7df204b4e66a4e7e9546d78aa>`__
 -  ipatests: ipa-healthcheck fixes for tests running on RHEL
-   `commit <https://pagure.io/freeipa/c/abefd6e19b5f6b1f5defe613d8bccd5292c65ea4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abefd6e19b5f6b1f5defe613d8bccd5292c65ea4>`__
 -  ipatests: ipa-healthcheck test fixes running on RHEL
-   `commit <https://pagure.io/freeipa/c/01c6b8a8475fbb62249b70a8fb51ee6f5ec4fe67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01c6b8a8475fbb62249b70a8fb51ee6f5ec4fe67>`__
 -  ipatests: Install healthcheck pkg for TestIpaHealthCheckWithADtrust
-   `commit <https://pagure.io/freeipa/c/15f168c10342a48c67e6f37737b60bab05dad04a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15f168c10342a48c67e6f37737b60bab05dad04a>`__
 -  Modified nightly YAML files to include ipa-healthcheck ExternalCA
    Tests
-   `commit <https://pagure.io/freeipa/c/7642ce35828025cd292f0e7785b93455ae4684d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7642ce35828025cd292f0e7785b93455ae4684d2>`__
 -  ipatests: Tests for ipahealthcheck tool with IPA external
-   `commit <https://pagure.io/freeipa/c/400ef3aa2c1ea74da22547aa7ca1c20fdc6cb211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/400ef3aa2c1ea74da22547aa7ca1c20fdc6cb211>`__
 -  ipatests: Test IPACertNSSTrust check when trust attributes is
    modified for specific cert
-   `commit <https://pagure.io/freeipa/c/bb2dfbbf0b0e3daf7207bf6605b9f23edb115be5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb2dfbbf0b0e3daf7207bf6605b9f23edb115be5>`__
 -  ipatests: Test to check IPACAChainExpirationCheck when IPA cacrt is
    renamed
-   `commit <https://pagure.io/freeipa/c/fcc99813f58825efb093f477544076e272c62ea9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fcc99813f58825efb093f477544076e272c62ea9>`__
 -  ipatests: Test for ipa-nis-manage CLI tool.
-   `commit <https://pagure.io/freeipa/c/6ff31dbf55cfea509289c72c6f97f945fb934f6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ff31dbf55cfea509289c72c6f97f945fb934f6c>`__
 -  ipatests: Increase timeout value in
    test_getcert_list_profile_using_subca
-   `commit <https://pagure.io/freeipa/c/04d25dd2866c74b23b16172411d5cfaa83d0b726>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04d25dd2866c74b23b16172411d5cfaa83d0b726>`__
 -  ipatests: Tests to check profile is displayed for getcert request.
-   `commit <https://pagure.io/freeipa/c/8e05a8a8da6eea7dcad48ec5b77631e4495e4879>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e05a8a8da6eea7dcad48ec5b77631e4495e4879>`__
 -  Modified YAML to include healthcheck AD tests
-   `commit <https://pagure.io/freeipa/c/f1b2d7b6fcda02f79db8eb00085d980c56ccc314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1b2d7b6fcda02f79db8eb00085d980c56ccc314>`__
 -  ipatests: Tests to check ipahealthcheck tool with IPA-AD trust
    scenario
-   `commit <https://pagure.io/freeipa/c/769c87f5e737174c771338fc2af1bd31304a689c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/769c87f5e737174c771338fc2af1bd31304a689c>`__
 -  ipatests: Test to check warning state for TomcatFileCheck in
    ipahealthcheck.ipa.files
-   `commit <https://pagure.io/freeipa/c/0d0dc73ae1fd640841a4b15ed83edc44096859e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d0dc73ae1fd640841a4b15ed83edc44096859e3>`__
 -  ipatests: Test for ipahealthcheck.ipa.files for TomcatFilecheck
-   `commit <https://pagure.io/freeipa/c/ddd061c0b71b27d2193f83a3695ff6ade9ccc256>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddd061c0b71b27d2193f83a3695ff6ade9ccc256>`__
 -  ipatests: Test for ipahealthcheck DogtagCertsConnectivityCheck
-   `commit <https://pagure.io/freeipa/c/6a7fa03f91955cc999b9ae143647071fc35e3793>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a7fa03f91955cc999b9ae143647071fc35e3793>`__
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
-   `commit <https://pagure.io/freeipa/c/555f8a038dae139ad161c5dab51e2378f8894b81>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/555f8a038dae139ad161c5dab51e2378f8894b81>`__
    `#8066 <https://pagure.io/freeipa/issue/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
-   `commit <https://pagure.io/freeipa/c/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
-   `commit <https://pagure.io/freeipa/c/29fd9602c66133603c9723a4918cda0bcc8b5c53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29fd9602c66133603c9723a4918cda0bcc8b5c53>`__
 -  Test for ipahealthcheck.ipa.idns check when integrated DNS is setup
-   `commit <https://pagure.io/freeipa/c/fd9f1b3d5bf35f8286505d1ed0971a42349a476b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd9f1b3d5bf35f8286505d1ed0971a42349a476b>`__
 -  ipatests: Added testcase to check logrotate is added for healthcheck
    tool
-   `commit <https://pagure.io/freeipa/c/c77f4213e9ae78e76c5eee88ffc1cbffbb5556e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c77f4213e9ae78e76c5eee88ffc1cbffbb5556e8>`__
 -  ipatests: check that ipa-healthcheck warns if no dna range is set
-   `commit <https://pagure.io/freeipa/c/4e3a2bd6bff79c17bc439555dcf41a11d0569e6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e3a2bd6bff79c17bc439555dcf41a11d0569e6f>`__
 -  Adding back temp config definition removed
-   `commit <https://pagure.io/freeipa/c/d7830d900d85e936263bb0be9d5f364ba86d874f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7830d900d85e936263bb0be9d5f364ba86d874f>`__
 -  Nightly definition for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/000703c89f18a190e5cac17ad7113a2ed067c35b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/000703c89f18a190e5cac17ad7113a2ed067c35b>`__
 -  Tier-1 test for ipa-healthcheck tool
-   `commit <https://pagure.io/freeipa/c/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
 -  Added testcase to check capitalization fix while running ipa user-mod
-   `commit <https://pagure.io/freeipa/c/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
    `#5879 <https://pagure.io/freeipa/issue/5879>`__
 
 
@@ -4899,17 +4899,17 @@ Tibor Dudlák (5)
 ----------------------------------------------------------------------------------------------
 
 -  Add container environment check to replicainstall
-   `commit <https://pagure.io/freeipa/c/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
    `#6210 <https://pagure.io/freeipa/issue/6210>`__
 -  Increase ntp_options test timeout
-   `commit <https://pagure.io/freeipa/c/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
 -  ipatests: refactor TestNTPoptions
-   `commit <https://pagure.io/freeipa/c/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
 -  ipatests: Add tests for interactive chronyd config
-   `commit <https://pagure.io/freeipa/c/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 -  ipatests: Update test tasks for client to be interactive
-   `commit <https://pagure.io/freeipa/c/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
    `#7908 <https://pagure.io/freeipa/issue/7908>`__
 
 
@@ -4918,13 +4918,13 @@ Tomas Halman (4)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: add extdom protocol documentation
-   `commit <https://pagure.io/freeipa/c/bddf64b9da2df21a14022109ae989bd5408bf14b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bddf64b9da2df21a14022109ae989bd5408bf14b>`__
 -  extdom: use sss_nss_*_timeout calls
-   `commit <https://pagure.io/freeipa/c/84b6c0f53b9ebdd4c01181898499bb6992aa9e8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84b6c0f53b9ebdd4c01181898499bb6992aa9e8a>`__
 -  extdom: plugin doesn't use timeout in blocking call
-   `commit <https://pagure.io/freeipa/c/5f898c3c614f4165f0eb15c3aad2157689fbbcfe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f898c3c614f4165f0eb15c3aad2157689fbbcfe>`__
 -  extdom: plugin doesn't allow @ in group name
-   `commit <https://pagure.io/freeipa/c/e5f04258b5b3fb6c04c28ddd38ae251c822e80bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5f04258b5b3fb6c04c28ddd38ae251c822e80bc>`__
 
 
 
@@ -4933,17 +4933,17 @@ Timo Aaltonen (6)
 
 -  ipatests/test_installation: Use knownservices to map the service
    name.
-   `commit <https://pagure.io/freeipa/c/2e85b4809afb4757fd7b81868709ced4f211d7b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e85b4809afb4757fd7b81868709ced4f211d7b4>`__
 -  ipatests/test_commands: Check sssd version like on test_sssd
-   `commit <https://pagure.io/freeipa/c/158257c4b3f0eb58db73ac667aae4feaef21b58b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/158257c4b3f0eb58db73ac667aae4feaef21b58b>`__
 -  Debian: Use parse_ipa_version from redhat.
-   `commit <https://pagure.io/freeipa/c/7ed5374c91dd7e69b2ac0222cf7dc5d48df75c19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ed5374c91dd7e69b2ac0222cf7dc5d48df75c19>`__
 -  Debian: Use enable/disable_ldap_automount() from base
-   `commit <https://pagure.io/freeipa/c/7d657c6faa4f090d5f672502f9f62d64e74c355d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d657c6faa4f090d5f672502f9f62d64e74c355d>`__
 -  Debian: Fix font-awesome path.
-   `commit <https://pagure.io/freeipa/c/04bb8ef2f5a95d752dd41f4bc575d22ae6f7e9d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04bb8ef2f5a95d752dd41f4bc575d22ae6f7e9d1>`__
 -  install: Add missing scripts to app_DATA.
-   `commit <https://pagure.io/freeipa/c/0000fe0502e75fcc68c6b9a8bc5b2b5a79fb4888>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0000fe0502e75fcc68c6b9a8bc5b2b5a79fb4888>`__
 
 
 
@@ -4952,15 +4952,15 @@ Thorsten Scherf (5)
 
 -  Corrected some typos and added improvements to some setup
    instructions
-   `commit <https://pagure.io/freeipa/c/416d87b9bd4261ed30285a95ce3fec442822b3a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/416d87b9bd4261ed30285a95ce3fec442822b3a7>`__
 -  Module added about ssh pubkey management
-   `commit <https://pagure.io/freeipa/c/c14042dc322192204507676dc0c975822773f0ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c14042dc322192204507676dc0c975822773f0ee>`__
 -  Added bash-completion rpm to build instructions.
-   `commit <https://pagure.io/freeipa/c/7f187146c75330a15572b69da1633b4a6cffb383>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f187146c75330a15572b69da1633b4a6cffb383>`__
 -  Added --mkhomedir option for server and replica.
-   `commit <https://pagure.io/freeipa/c/0db3a5693316d4166b5920e2df3560c5c38a6dbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0db3a5693316d4166b5920e2df3560c5c38a6dbd>`__
 -  Added vagrant-libvirt-doc rpm and polkit rule
-   `commit <https://pagure.io/freeipa/c/49c48aa9537c6eccf3a6b610ef7472a51f7eb3b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49c48aa9537c6eccf3a6b610ef7472a51f7eb3b3>`__
 
 
 
@@ -4968,7 +4968,7 @@ Theodor van Nahl (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix UnboundLocalError in ipa-replica-manage on errors
-   `commit <https://pagure.io/freeipa/c/adcf04255cb24564230604469ae34c180e057dfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adcf04255cb24564230604469ae34c180e057dfa>`__
 
 
 
@@ -4977,15 +4977,15 @@ Thomas Woerner (4)
 
 -  ipaserver/plugins/hbacrule: Add HBAC to memberservice_hbacsvc\*
    labels
-   `commit <https://pagure.io/freeipa/c/51fcca535236e309dc6431ad68bad36bf8f56823>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51fcca535236e309dc6431ad68bad36bf8f56823>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
-   `commit <https://pagure.io/freeipa/c/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
    `#8150 <https://pagure.io/freeipa/issue/8150>`__
 -  Enable TestInstallMasterDNSRepeatedly in prci_definitions
-   `commit <https://pagure.io/freeipa/c/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
 -  Test repeated installation of the primary with DNS enabled and domain
    set
-   `commit <https://pagure.io/freeipa/c/d070c5957791d19ece22082dbd69a319975a4b54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d070c5957791d19ece22082dbd69a319975a4b54>`__
 
 
 
@@ -4993,7 +4993,7 @@ Viktor Ashirov (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update ACIs with the correct syntax
-   `commit <https://pagure.io/freeipa/c/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
    `#8301 <https://pagure.io/freeipa/issue/8301>`__
 
 
@@ -5002,14 +5002,14 @@ Vit Mojzis (4)
 ----------------------------------------------------------------------------------------------
 
 -  selinux: disable ipa_custodia when installing custom policy
-   `commit <https://pagure.io/freeipa/c/3aad16a75ef06d20d111773268df30ee04274db7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3aad16a75ef06d20d111773268df30ee04274db7>`__
    `#6891 <https://pagure.io/freeipa/issue/6891>`__
 -  selinux: Remove obsolete memcached access
-   `commit <https://pagure.io/freeipa/c/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
 -  selinux: move BUILD_SELINUX_POLICY definition
-   `commit <https://pagure.io/freeipa/c/0c9949e8983e4befacbd4a40b5440008474a75a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c9949e8983e4befacbd4a40b5440008474a75a3>`__
 -  Add freeipa-selinux subpackage
-   `commit <https://pagure.io/freeipa/c/5b573bb9a34fec5d34a4509c68015951ec6669b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b573bb9a34fec5d34a4509c68015951ec6669b9>`__
 
 
 
@@ -5017,9 +5017,9 @@ Yuri Chornoivan (2)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/abc416407ebd1e9136436395638e6f43eab4e1b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abc416407ebd1e9136436395638e6f43eab4e1b0>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/a330adae8a1814f1f0e2482354189a3b59ad88fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a330adae8a1814f1f0e2482354189a3b59ad88fd>`__
 
 
 
@@ -5027,15 +5027,15 @@ zdover (5)
 ----------------------------------------------------------------------------------------------
 
 -  100 percent complete edit
-   `commit <https://pagure.io/freeipa/c/39d1715c54e03c61a8a34837b465d7cef8c6adfc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39d1715c54e03c61a8a34837b465d7cef8c6adfc>`__
 -  sixty percent edited
-   `commit <https://pagure.io/freeipa/c/e8c9efed0d43b36042b86896e02ed4b186b04457>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8c9efed0d43b36042b86896e02ed4b186b04457>`__
 -  thirty percent edited
-   `commit <https://pagure.io/freeipa/c/2012713c24d1bce974f2c53691d2977427c8f862>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2012713c24d1bce974f2c53691d2977427c8f862>`__
 -  first tranche of edits
-   `commit <https://pagure.io/freeipa/c/dd22a3c29924f56a044f1c549ff8db02b0b2788f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd22a3c29924f56a044f1c549ff8db02b0b2788f>`__
 -  making a list's items agree with one another
-   `commit <https://pagure.io/freeipa/c/37b38eadc509d34b6b67a61e71cda74d2ff34a94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37b38eadc509d34b6b67a61e71cda74d2ff34a94>`__
 
 
 
@@ -5043,7 +5043,7 @@ Zdenek Pytela (2)
 ----------------------------------------------------------------------------------------------
 
 -  Add ipa_pki_retrieve_key_exec() interface
-   `commit <https://pagure.io/freeipa/c/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
    `#8488 <https://pagure.io/freeipa/issue/8488>`__
 -  Allow ipa-adtrust-install restart sssd and dirsrv services
-   `commit <https://pagure.io/freeipa/c/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__

--- a/src/page/Releases/4.9.0rc2.rst
+++ b/src/page/Releases/4.9.0rc2.rst
@@ -102,7 +102,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Bump PR-CI templates
-   `commit <https://pagure.io/freeipa/c/a3c5c71925b5fd8faa56379d92fa19631d230108>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3c5c71925b5fd8faa56379d92fa19631d230108>`__
 
 
 
@@ -110,16 +110,16 @@ Alexander Bokovoy (5)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.0rc2
-   `commit <https://pagure.io/freeipa/c/e74d6409902b83fb81a0aec251280375a90d6f07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e74d6409902b83fb81a0aec251280375a90d6f07>`__
 -  Update contributors
-   `commit <https://pagure.io/freeipa/c/5f36ee51e4f9d270cc65668d9ab4666e0ac8c07f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f36ee51e4f9d270cc65668d9ab4666e0ac8c07f>`__
 -  freeipa.spec.in: unify spec files across upstream RHEL, and Fedora
-   `commit <https://pagure.io/freeipa/c/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
 -  ad trust: accept subordinate domains of the forest trust root
-   `commit <https://pagure.io/freeipa/c/381cc5e8eae1b7437fc15cb699983887d398f498>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/381cc5e8eae1b7437fc15cb699983887d398f498>`__
    `#8554 <https://pagure.io/freeipa/issue/8554>`__
 -  util: Fix client-only build
-   `commit <https://pagure.io/freeipa/c/244704cc156dba0731671c55661d82073f970c9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/244704cc156dba0731671c55661d82073f970c9b>`__
    `#8587 <https://pagure.io/freeipa/issue/8587>`__
 
 
@@ -128,7 +128,7 @@ Antonio Torres Moríñigo (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-client-install manpage: add ipa.p11-kit to list of files created
-   `commit <https://pagure.io/freeipa/c/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
    `#8424 <https://pagure.io/freeipa/issue/8424>`__
 
 
@@ -137,10 +137,10 @@ Florence Blanc-Renaud (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix TestTrust::test_subordinate_suffix
-   `commit <https://pagure.io/freeipa/c/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
    `#8601 <https://pagure.io/freeipa/issue/8601>`__
 -  Always define the path DNSSEC_OPENSSL_CONF
-   `commit <https://pagure.io/freeipa/c/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
    `#8597 <https://pagure.io/freeipa/issue/8597>`__
 
 
@@ -149,7 +149,7 @@ Mark Reynolds (1)
 ----------------------------------------------------------------------------------------------
 
 -  Accept 389-ds JSON replication status messages
-   `commit <https://pagure.io/freeipa/c/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
    `#7975 <https://pagure.io/freeipa/issue/7975>`__
 
 
@@ -158,7 +158,7 @@ Mohammad Rizwan (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test certmonger IPA responder switched to JSONRPC
-   `commit <https://pagure.io/freeipa/c/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
    `#3299 <https://pagure.io/freeipa/issue/3299>`__
 
 
@@ -167,78 +167,78 @@ Rob Crittenden (25)
 ----------------------------------------------------------------------------------------------
 
 -  Skip the ACME mod_md test when the client is in enforcing mode
-   `commit <https://pagure.io/freeipa/c/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
    `#8514 <https://pagure.io/freeipa/issue/8514>`__
 -  Increase timeout for krbtpolicy to 4800
-   `commit <https://pagure.io/freeipa/c/28ed75ca0251724e34a447174ae775edca9763e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28ed75ca0251724e34a447174ae775edca9763e2>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Enable the ccache sweep systemd timer
-   `commit <https://pagure.io/freeipa/c/068d08577d97258267917f81363a1a033a681803>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/068d08577d97258267917f81363a1a033a681803>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  ipatests: test that stale caches are removed using the sweeper
-   `commit <https://pagure.io/freeipa/c/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Generate a unique cache for each connection
-   `commit <https://pagure.io/freeipa/c/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  Convert reset_to_default_policy into a pytest fixture
-   `commit <https://pagure.io/freeipa/c/848dffb59273493ef3abde2a86864e85c8d19eff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/848dffb59273493ef3abde2a86864e85c8d19eff>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 -  VERSION: back to git snapshots
-   `commit <https://pagure.io/freeipa/c/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
 -  ipatests: Test that ipa-ca.$domain can retrieve CRLs without redirect
-   `commit <https://pagure.io/freeipa/c/b478bf99d9f158dabae145169f242b2b5d26404c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b478bf99d9f158dabae145169f242b2b5d26404c>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__
 -  Allow Apache to answer to ipa-ca requests without a redirect
-   `commit <https://pagure.io/freeipa/c/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__
 -  Move where the restore state is marked during IPA server upgrade
-   `commit <https://pagure.io/freeipa/c/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
    `#7534 <https://pagure.io/freeipa/issue/7534>`__
 -  Reorder when ACME is enabled to fix failure on upgrade
-   `commit <https://pagure.io/freeipa/c/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
    `#8603 <https://pagure.io/freeipa/issue/8603>`__
 -  Remove test for minimum ACME support and rely on package deps
-   `commit <https://pagure.io/freeipa/c/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
 -  Require PKI 10.10+ for KRA profile and ACME support
-   `commit <https://pagure.io/freeipa/c/3e530e93c37ee71a560714e26285cd85e71557c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e530e93c37ee71a560714e26285cd85e71557c9>`__
    `#8524 <https://pagure.io/freeipa/issue/8524>`__,
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  Test that the KRA profiles can renewal its three certificates
-   `commit <https://pagure.io/freeipa/c/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  Change KRA profiles in certmonger tracking so they can renew
-   `commit <https://pagure.io/freeipa/c/a9e1c014f601a567f4aa5135d02883c498835268>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9e1c014f601a567f4aa5135d02883c498835268>`__
    `#8545 <https://pagure.io/freeipa/issue/8545>`__
 -  ipatests: Increase timeout for ACME in gating.yaml
-   `commit <https://pagure.io/freeipa/c/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: honor class inheritance in TestACMEwithExternalCA
-   `commit <https://pagure.io/freeipa/c/75ad5757528491616f7f4e596bb9f6b152944d99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75ad5757528491616f7f4e596bb9f6b152944d99>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: configure MDStoreDir for mod_md ACME test
-   `commit <https://pagure.io/freeipa/c/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Clean up existing ACME registration and certs
-   `commit <https://pagure.io/freeipa/c/5d286e79515c8a6c856a5acde6300271422acfac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d286e79515c8a6c856a5acde6300271422acfac>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Configure a replica in TestACMEwithExternalCA
-   `commit <https://pagure.io/freeipa/c/de5baf8516cde060f1606070b2a8824f71178f16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de5baf8516cde060f1606070b2a8824f71178f16>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: call the CALess install method to generate the CA
-   `commit <https://pagure.io/freeipa/c/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
    `#8581 <https://pagure.io/freeipa/issue/8581>`__
 -  ipatests: Test that Match ProxyCommand masks on no shell exec
-   `commit <https://pagure.io/freeipa/c/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
    `#7676 <https://pagure.io/freeipa/issue/7676>`__
 -  Create IPA ssh client configuration and move ProxyCommand
-   `commit <https://pagure.io/freeipa/c/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
    `#7676 <https://pagure.io/freeipa/issue/7676>`__
 -  ipatests: Test that ipa-certupdate can run without credentials
-   `commit <https://pagure.io/freeipa/c/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
    `#8531 <https://pagure.io/freeipa/issue/8531>`__
 -  Use host keytab to obtain credentials needed for ipa-certupdate
-   `commit <https://pagure.io/freeipa/c/1a09ce9f3fa503eeefe394856be538892652accf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a09ce9f3fa503eeefe394856be538892652accf>`__
    `#8531 <https://pagure.io/freeipa/issue/8531>`__
 
 
@@ -247,7 +247,7 @@ Robbie Harwood (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix krbtpolicy tests
-   `commit <https://pagure.io/freeipa/c/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
    `#8590 <https://pagure.io/freeipa/issue/8590>`__
 
 
@@ -256,6 +256,6 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: support subordinate upn suffixes
-   `commit <https://pagure.io/freeipa/c/7e605e958ef6d41584afc238433669c15458ac67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e605e958ef6d41584afc238433669c15458ac67>`__
 -  ipatests: Tests for ipahealthcheck.ds.nss_ssl
-   `commit <https://pagure.io/freeipa/c/46f114d9e751b2a092b975b909f0e890257a507d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46f114d9e751b2a092b975b909f0e890257a507d>`__

--- a/src/page/Releases/4.9.0rc3.rst
+++ b/src/page/Releases/4.9.0rc3.rst
@@ -68,22 +68,22 @@ Alexander Bokovoy (6)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.0rc3
-   `commit <https://pagure.io/freeipa/c/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
 -  systemd: enforce en_US.UTF-8 locale in systemd units
-   `commit <https://pagure.io/freeipa/c/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
    `#8617 <https://pagure.io/freeipa/issue/8617>`__
 -  upgrade: provide DOMAIN to the server upgrade dictionary
-   `commit <https://pagure.io/freeipa/c/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
    `#8595 <https://pagure.io/freeipa/issue/8595>`__,
    `#8615 <https://pagure.io/freeipa/issue/8615>`__
 -  Allow mod_auth_gssapi to create and access ccaches in
    /run/ipa/ccaches
-   `commit <https://pagure.io/freeipa/c/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
    `#8613 <https://pagure.io/freeipa/issue/8613>`__
 -  Correct SELinux policy requirements
-   `commit <https://pagure.io/freeipa/c/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/77674077b4e1e6ff2d2608ad0661704d4a47ac41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77674077b4e1e6ff2d2608ad0661704d4a47ac41>`__
 
 
 
@@ -91,11 +91,11 @@ Florence Blanc-Renaud (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add test for PKI subsystem detection
-   `commit <https://pagure.io/freeipa/c/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
    `#8596 <https://pagure.io/freeipa/issue/8596>`__
 -  Improve PKI subsystem detection
-   `commit <https://pagure.io/freeipa/c/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
    `#8596 <https://pagure.io/freeipa/issue/8596>`__
 -  xmlrpctests: remove harcoded expiration date from test_user_plugin
-   `commit <https://pagure.io/freeipa/c/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
    `#8616 <https://pagure.io/freeipa/issue/8616>`__

--- a/src/page/Releases/4.9.1.rst
+++ b/src/page/Releases/4.9.1.rst
@@ -238,7 +238,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Update PR-CI definitions for ipa-4-9
-   `commit <https://pagure.io/freeipa/c/ccdecaa984ef6ebcc63d754e896b2229bcba3b88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ccdecaa984ef6ebcc63d754e896b2229bcba3b88>`__
 
 
 
@@ -246,92 +246,92 @@ Alexander Bokovoy (30)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.1
-   `commit <https://pagure.io/freeipa/c/aa58fad8eb98b0e8e248eb76b107b5e1faac4aeb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa58fad8eb98b0e8e248eb76b107b5e1faac4aeb>`__
 -  Force-update translation po/uk.po
-   `commit <https://pagure.io/freeipa/c/a97967ff3b56ba3c3894a5aadffbef68961b3581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a97967ff3b56ba3c3894a5aadffbef68961b3581>`__
 -  Force-update translation po/ipa.pot
-   `commit <https://pagure.io/freeipa/c/cb583ac18e33698f9bd950490482a722cc993a06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb583ac18e33698f9bd950490482a722cc993a06>`__
 -  Force-update translation po/hu.po
-   `commit <https://pagure.io/freeipa/c/a1c43ac3c91ae045f402610c88141d7f3d387011>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1c43ac3c91ae045f402610c88141d7f3d387011>`__
 -  Force-update translation po/de.po
-   `commit <https://pagure.io/freeipa/c/6f6dd6240c91b8a4a6c9e6f1090db33ec37c7857>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f6dd6240c91b8a4a6c9e6f1090db33ec37c7857>`__
 -  Update contributors list
-   `commit <https://pagure.io/freeipa/c/2ac8028e1f8dca4b8bc37bd4995043da647dbfb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ac8028e1f8dca4b8bc37bd4995043da647dbfb8>`__
 -  baseldap: allow rejecting unknown objects instead of adding to an
    external attr
-   `commit <https://pagure.io/freeipa/c/51ca38772f41d3a26a4253a732338d09a69f9647>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51ca38772f41d3a26a4253a732338d09a69f9647>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  ipatests: when talking to AD DCs, use FQDN credentials
-   `commit <https://pagure.io/freeipa/c/64b70be65698b12927795a7a8b79ef7aada010b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64b70be65698b12927795a7a8b79ef7aada010b8>`__
    `#8678 <https://pagure.io/freeipa/issue/8678>`__
 -  test_trust: add tests for using AD users and groups in SUDO rules
-   `commit <https://pagure.io/freeipa/c/a7c56fde7727bfad3f885cf50e21182cdc46024e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7c56fde7727bfad3f885cf50e21182cdc46024e>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  ipatests: fix test_sudorule_plugin's wrong argument use
-   `commit <https://pagure.io/freeipa/c/f4d3c91e7f80659268e006dffa5f064b29b45c98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4d3c91e7f80659268e006dffa5f064b29b45c98>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  sudorule runAs: allow to add users and groups from trusted domains
    directly
-   `commit <https://pagure.io/freeipa/c/78043bfb5e2a3b1fc0fae6d55ba605ba469ce5ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78043bfb5e2a3b1fc0fae6d55ba605ba469ce5ae>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  sudorule-add-user: allow to reference users and groups from trusted
    domains directly
-   `commit <https://pagure.io/freeipa/c/054a068f4705cd715789ceda75fa709404d5f884>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/054a068f4705cd715789ceda75fa709404d5f884>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  idviews: add extended validator for users from trusted domains
-   `commit <https://pagure.io/freeipa/c/a3563d1c35fbe9e6e96199ead211ec3b4ff1d2d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3563d1c35fbe9e6e96199ead211ec3b4ff1d2d2>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  baseldap: when adding external objects, differentiate between them
    and failures
-   `commit <https://pagure.io/freeipa/c/ffc2edf61efccbcbd4294fbc8a8613decea299a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffc2edf61efccbcbd4294fbc8a8613decea299a3>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  baseldap: refactor validator support in add_external_pre_callback
-   `commit <https://pagure.io/freeipa/c/132d7fb0ed21e2e7cc69366e2141ae69e7864afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/132d7fb0ed21e2e7cc69366e2141ae69e7864afb>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  Add design document for using AD users/groups in SUDO rules
-   `commit <https://pagure.io/freeipa/c/16b30cbe5e4f1fd8965ed27ba2ca9b4b7b295e9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16b30cbe5e4f1fd8965ed27ba2ca9b4b7b295e9c>`__
    `#3226 <https://pagure.io/freeipa/issue/3226>`__
 -  use a constant instead of /var/lib/sss/keytabs
-   `commit <https://pagure.io/freeipa/c/9f63afb4408e308c2ee972a72875525afefa5d54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f63afb4408e308c2ee972a72875525afefa5d54>`__
 -  trust-fetch-domains: use custom krb5.conf overlay for all trust
    operations
-   `commit <https://pagure.io/freeipa/c/c842d4b5c2404d263d56aa0c4ba33fe32b2ca61e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c842d4b5c2404d263d56aa0c4ba33fe32b2ca61e>`__
    `#8655 <https://pagure.io/freeipa/issue/8655>`__,
    `#8664 <https://pagure.io/freeipa/issue/8664>`__
 -  ipaserver/dcerpc: store forest topology as a blob in ipasam
-   `commit <https://pagure.io/freeipa/c/3d706b6f57309ec394df617cecb9a73d021fc2f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d706b6f57309ec394df617cecb9a73d021fc2f7>`__
    `#8576 <https://pagure.io/freeipa/issue/8576>`__
 -  ipasam: derive parent domain for subdomains automatically
-   `commit <https://pagure.io/freeipa/c/f103172954c259443f0c5b4ac89474e66cf3a1d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f103172954c259443f0c5b4ac89474e66cf3a1d6>`__
    `#8576 <https://pagure.io/freeipa/issue/8576>`__
 -  ipasam: free trusted domain context on failure
-   `commit <https://pagure.io/freeipa/c/e8f927db7da00d1671f871d3b2e89429aec3beb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8f927db7da00d1671f871d3b2e89429aec3beb9>`__
    `#8576 <https://pagure.io/freeipa/issue/8576>`__
 -  ipasam: allow search of users by user principal name (UPN)
-   `commit <https://pagure.io/freeipa/c/2e8eb0f5fe82be58be88fa0d9b07ee7af69d8829>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e8eb0f5fe82be58be88fa0d9b07ee7af69d8829>`__
    `#8661 <https://pagure.io/freeipa/issue/8661>`__
 -  ipasam: implement PASSDB getgrnam call
-   `commit <https://pagure.io/freeipa/c/962052a0567b6878843272b1882d0a0b3b2debd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/962052a0567b6878843272b1882d0a0b3b2debd1>`__
    `#8660 <https://pagure.io/freeipa/issue/8660>`__
 -  ipa-kdb: provide correct logon time in MS-PAC from authentication
    time
-   `commit <https://pagure.io/freeipa/c/f8bf37422b7c49a4a39b4704b18158b37ee9ef80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8bf37422b7c49a4a39b4704b18158b37ee9ef80>`__
    `#8659 <https://pagure.io/freeipa/issue/8659>`__
 -  ipaserver/dcerpc.py: enforce SMB encryption on LSA pipe if available
-   `commit <https://pagure.io/freeipa/c/3fa07a108030265dc89921a37216a1184e1e7516>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fa07a108030265dc89921a37216a1184e1e7516>`__
    `#8655 <https://pagure.io/freeipa/issue/8655>`__
 -  ipaserver/dcerpc.py: use Kerberos authentication for discovery
-   `commit <https://pagure.io/freeipa/c/8ab9bf68a4d12c8763c1669d0c14b7771a3289da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ab9bf68a4d12c8763c1669d0c14b7771a3289da>`__
    `#8655 <https://pagure.io/freeipa/issue/8655>`__
 -  ipaserver/dcerpc: use Samba-provided trust helper to establish trust
-   `commit <https://pagure.io/freeipa/c/753246f4e82af5697ee51bdc7f667959e1824be1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/753246f4e82af5697ee51bdc7f667959e1824be1>`__
    `#8655 <https://pagure.io/freeipa/issue/8655>`__
 -  ipatests: fix race condition in finalizer of encrypted backup test
-   `commit <https://pagure.io/freeipa/c/6fe573b3d953913bc94fd06c230703dac70f0e8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fe573b3d953913bc94fd06c230703dac70f0e8d>`__
 -  ipaplatform: add constant for systemd-run binary
-   `commit <https://pagure.io/freeipa/c/8c7d1fbad15c5a906ffa261329dd49be048549ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7d1fbad15c5a906ffa261329dd49be048549ed>`__
 -  Get back to git snapshots
-   `commit <https://pagure.io/freeipa/c/0fd4a8936f5b41e83ffdbe00f88309e5a2e94f9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fd4a8936f5b41e83ffdbe00f88309e5a2e94f9f>`__
 
 
 
@@ -339,10 +339,10 @@ Antonio Torres (2)
 ----------------------------------------------------------------------------------------------
 
 -  Check that IPA cert is added to trust store after server install
-   `commit <https://pagure.io/freeipa/c/2715fbd4a73115949264298858ed0835fe982164>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2715fbd4a73115949264298858ed0835fe982164>`__
    `#8614 <https://pagure.io/freeipa/issue/8614>`__
 -  Test that IPA certs are removed on server uninstall
-   `commit <https://pagure.io/freeipa/c/2a86a93e560e1d9ade2f78b0cf82d93b8833eb39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a86a93e560e1d9ade2f78b0cf82d93b8833eb39>`__
    `#8614 <https://pagure.io/freeipa/issue/8614>`__
 
 
@@ -352,9 +352,9 @@ Antonio Torres Moríñigo (2)
 
 -  ipatests: test that trailing/leading whitespaces in passwords are
    allowed
-   `commit <https://pagure.io/freeipa/c/3f3762ef92a809059f196e5553f1c31e9f1180e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f3762ef92a809059f196e5553f1c31e9f1180e7>`__
 -  Allow leading/trailing whitespaces in passwords
-   `commit <https://pagure.io/freeipa/c/89eba7d38db2f510554b3365f9d099190ce80c51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89eba7d38db2f510554b3365f9d099190ce80c51>`__
    `#7599 <https://pagure.io/freeipa/issue/7599>`__
 
 
@@ -363,7 +363,7 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add ccache sweeper files to gitignore
-   `commit <https://pagure.io/freeipa/c/56b84973b9f02e74f2518bd58694b673f88f8d5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56b84973b9f02e74f2518bd58694b673f88f8d5e>`__
    `#8589 <https://pagure.io/freeipa/issue/8589>`__
 
 
@@ -372,7 +372,7 @@ François Cami (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_ipahealthcheck: fix units
-   `commit <https://pagure.io/freeipa/c/34add4a2e091dc7bc6031f8fc6cc80904b1bea20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34add4a2e091dc7bc6031f8fc6cc80904b1bea20>`__
    `#8674 <https://pagure.io/freeipa/issue/8674>`__
 
 
@@ -381,40 +381,40 @@ Florence Blanc-Renaud (12)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix discrepancies in nightly defs
-   `commit <https://pagure.io/freeipa/c/bb78693405aab603203e60a174b04cd3264e1855>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb78693405aab603203e60a174b04cd3264e1855>`__
 -  ipatests: fix expected output for ipahealthcheck.ipa.files
-   `commit <https://pagure.io/freeipa/c/dc2a52abe256d2de09eafe8a07898b0cbea3404b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc2a52abe256d2de09eafe8a07898b0cbea3404b>`__
    `#8662 <https://pagure.io/freeipa/issue/8662>`__
 -  ipatests: fix healthcheck test for ipahealthcheck.ds.encryption
-   `commit <https://pagure.io/freeipa/c/2a207918521b474a39c1689837db146800624af8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a207918521b474a39c1689837db146800624af8>`__
    `#8670 <https://pagure.io/freeipa/issue/8670>`__
 -  ipatests: fix expected errmsg in
    TestTrust::test_ipa_commands_run_as_aduser
-   `commit <https://pagure.io/freeipa/c/bd3bad88ee4d4535416ad5fc5f97b55a939534ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd3bad88ee4d4535416ad5fc5f97b55a939534ef>`__
    `#8668 <https://pagure.io/freeipa/issue/8668>`__
 -  ipatest: fix test_upgrade.py::TestUpgrade::()::test_kra_detection
-   `commit <https://pagure.io/freeipa/c/0db289695c8225cad5c17c6a5846ff0a373c3ce6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0db289695c8225cad5c17c6a5846ff0a373c3ce6>`__
    `#8596 <https://pagure.io/freeipa/issue/8596>`__,
    `#8653 <https://pagure.io/freeipa/issue/8653>`__
 -  selinux: modify policy to allow one-way trust
-   `commit <https://pagure.io/freeipa/c/952b6bdcceda9f460e17075404084f1f3ddb5eaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/952b6bdcceda9f460e17075404084f1f3ddb5eaa>`__
    `#8508 <https://pagure.io/freeipa/issue/8508>`__
 -  ipatests: add test_ipa_cert_fix to the nightly definitions
-   `commit <https://pagure.io/freeipa/c/7f2be8a45a1d4baff0074cf4d8c446e3d08db795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f2be8a45a1d4baff0074cf4d8c446e3d08db795>`__
    `#8618 <https://pagure.io/freeipa/issue/8618>`__
 -  ipa-cert-fix: do not fail when CSR is missing from CS.cfg
-   `commit <https://pagure.io/freeipa/c/eb711f781322657b0b3d77332f2462ecfb27db95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb711f781322657b0b3d77332f2462ecfb27db95>`__
    `#8618 <https://pagure.io/freeipa/issue/8618>`__
 -  ipatests: add a test for ipa-cert-fix
-   `commit <https://pagure.io/freeipa/c/f36e518b5704b02b81a4b80a1b84c429594cf5ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f36e518b5704b02b81a4b80a1b84c429594cf5ce>`__
    `#8618 <https://pagure.io/freeipa/issue/8618>`__
 -  ipatests: clear initgroups cache in clear_sssd_cache
-   `commit <https://pagure.io/freeipa/c/286d0680a6d4ae53b79596e545f9291791e36aa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/286d0680a6d4ae53b79596e545f9291791e36aa5>`__
 -  ipatests: remove test_acme from gating
-   `commit <https://pagure.io/freeipa/c/dd1b596b5711aefd87fd6ec340c3713ee5932425>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd1b596b5711aefd87fd6ec340c3713ee5932425>`__
    `#8602 <https://pagure.io/freeipa/issue/8602>`__
 -  ipatests: fix expected error message in test_commands
-   `commit <https://pagure.io/freeipa/c/8bc341868f9154a625b7aae2604a7aa7b6cd0696>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8bc341868f9154a625b7aae2604a7aa7b6cd0696>`__
    `#8631 <https://pagure.io/freeipa/issue/8631>`__
 
 
@@ -423,7 +423,7 @@ JoeDrane (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update ipa_sam.c
-   `commit <https://pagure.io/freeipa/c/b53592492879f87465774eb9a4d6c02a8ba26a5e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b53592492879f87465774eb9a4d6c02a8ba26a5e>`__
 
 
 
@@ -431,48 +431,48 @@ Rob Crittenden (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test the cgroup v2 memory restrictions
-   `commit <https://pagure.io/freeipa/c/85d944cea13725511973fa00c9db6a1ebeb90efa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85d944cea13725511973fa00c9db6a1ebeb90efa>`__
    `#8635 <https://pagure.io/freeipa/issue/8635>`__
 -  Add support for cgroup v2 to the installer memory checker
-   `commit <https://pagure.io/freeipa/c/1dd4501a9fe1e83964b1f008b91d20b4afe5051a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1dd4501a9fe1e83964b1f008b91d20b4afe5051a>`__
    `#8635 <https://pagure.io/freeipa/issue/8635>`__
 -  ipa-rmkeytab: Check return value of krb5_kt_(start|end)_seq_get
-   `commit <https://pagure.io/freeipa/c/7b380969241b7f28b2aa275ff1a71fdf78912580>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b380969241b7f28b2aa275ff1a71fdf78912580>`__
    `#8658 <https://pagure.io/freeipa/issue/8658>`__
 -  ipa-rmkeytab: convert numeric return values to #defines
-   `commit <https://pagure.io/freeipa/c/06ffc7aae7f37bbd03dbd145e30c13f2234ed071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06ffc7aae7f37bbd03dbd145e30c13f2234ed071>`__
    `#8658 <https://pagure.io/freeipa/issue/8658>`__
 -  ipa_pwd: Remove unnecessary conditional
-   `commit <https://pagure.io/freeipa/c/f6cfbffc8f2e45d0e8e6057e6ead6d35e99bf48a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6cfbffc8f2e45d0e8e6057e6ead6d35e99bf48a>`__
 -  ipa_kdb: Fix memory leak
-   `commit <https://pagure.io/freeipa/c/df0c2d7e0ca8c3620093a47c9592de4f37e86608>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df0c2d7e0ca8c3620093a47c9592de4f37e86608>`__
 -  ipa-kdb: Fix logic to prevent NULL pointer dereference
-   `commit <https://pagure.io/freeipa/c/93f8840ed8f484c7880534b86aaad3d1f8fb0d2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93f8840ed8f484c7880534b86aaad3d1f8fb0d2e>`__
 -  ipa-kdb: Change mspac base RID logic from OR to AND
-   `commit <https://pagure.io/freeipa/c/f0de557063b6db143fd0d2ff47b08610edb39706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0de557063b6db143fd0d2ff47b08610edb39706>`__
 -  Add missing break statement to password quality switch
-   `commit <https://pagure.io/freeipa/c/ec4511ec12dfeff2cc2f3a23171089bd32c5add0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec4511ec12dfeff2cc2f3a23171089bd32c5add0>`__
 -  Revert "Remove test for minimum ACME support and rely on package
    deps"
-   `commit <https://pagure.io/freeipa/c/3aeb9b8e40cc526fd5c5162158b9cc5755670f66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3aeb9b8e40cc526fd5c5162158b9cc5755670f66>`__
    `#8634 <https://pagure.io/freeipa/issue/8634>`__
 -  ipatests: See if nologin supports -c before asserting message
-   `commit <https://pagure.io/freeipa/c/ca9f8d1c9feda6fd58220f1424970dcca5b730e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca9f8d1c9feda6fd58220f1424970dcca5b730e0>`__
    `#7676 <https://pagure.io/freeipa/issue/7676>`__
 -  ipatests: test that modifying a permission attrs handles failure
-   `commit <https://pagure.io/freeipa/c/bdc383a1a906f97c06b2bfa281a4b290fb4b04b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdc383a1a906f97c06b2bfa281a4b290fb4b04b3>`__
    `#8646 <https://pagure.io/freeipa/issue/8646>`__
 -  Remove virtual attributes before rolling back a permission
-   `commit <https://pagure.io/freeipa/c/9ae744254dd845f9a459601cb8a1468aeaad028a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ae744254dd845f9a459601cb8a1468aeaad028a>`__
    `#8646 <https://pagure.io/freeipa/issue/8646>`__
 -  Remove invalid test case for DNS SRV priority
-   `commit <https://pagure.io/freeipa/c/071b71290601d4a5f6a65adf2b55c34d3865172d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/071b71290601d4a5f6a65adf2b55c34d3865172d>`__
    `#8650 <https://pagure.io/freeipa/issue/8650>`__
 -  ipatests: test that no errors are reported after ipa-certupdate
-   `commit <https://pagure.io/freeipa/c/ad1764a1fff885e1c386b0a9f50517b2e0725e03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ad1764a1fff885e1c386b0a9f50517b2e0725e03>`__
    `#8644 <https://pagure.io/freeipa/issue/8644>`__
 -  Don't change the CA profile when modifying request in ipa_certupdate
-   `commit <https://pagure.io/freeipa/c/10ba43ad35acecdd1c4b7981db31a90cce1b9fab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10ba43ad35acecdd1c4b7981db31a90cce1b9fab>`__
    `#8644 <https://pagure.io/freeipa/issue/8644>`__
 
 
@@ -481,7 +481,7 @@ Robbie Harwood (1)
 ----------------------------------------------------------------------------------------------
 
 -  Set client keytab location for 389ds
-   `commit <https://pagure.io/freeipa/c/df411f00a3d1db2fcb0d122a54b9e13a57e35f3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df411f00a3d1db2fcb0d122a54b9e13a57e35f3f>`__
    `#8656 <https://pagure.io/freeipa/issue/8656>`__
 
 
@@ -490,10 +490,10 @@ Stanislav Levin (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Don't assume sshd flush its logs immediately
-   `commit <https://pagure.io/freeipa/c/cbe7d2258d6c900b2e02b2373e720275d9917316>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbe7d2258d6c900b2e02b2373e720275d9917316>`__
    `#8682 <https://pagure.io/freeipa/issue/8682>`__
 -  ipatests: Raise log level of 389-ds replication
-   `commit <https://pagure.io/freeipa/c/41a9cc637b4ea8794fc17f9fc06c6cf8d3a31caa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41a9cc637b4ea8794fc17f9fc06c6cf8d3a31caa>`__
 
 
 
@@ -502,9 +502,9 @@ Sergey Orlov (2)
 
 -  ipatests: use fully qualified name for AD admin when establishing
    trust
-   `commit <https://pagure.io/freeipa/c/dc16c2484c1006bc249848383d86ef828abd921a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc16c2484c1006bc249848383d86ef828abd921a>`__
 -  ipatests: do not set dns_lookup to true
-   `commit <https://pagure.io/freeipa/c/8d7697af269e68e051ce969ae9cc835f5ba6a3b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d7697af269e68e051ce969ae9cc835f5ba6a3b7>`__
 
 
 
@@ -512,6 +512,6 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test for IPATrustControllerPrincipalCheck
-   `commit <https://pagure.io/freeipa/c/2035ba9925ae738d2dbdd1274168cb99a2364db0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2035ba9925ae738d2dbdd1274168cb99a2364db0>`__
 -  ipatests: ipahealthcheck remove test skipped in pytest run
-   `commit <https://pagure.io/freeipa/c/27cc011ac286db20a4cd9dbdd65d4a8fd1cb7e3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27cc011ac286db20a4cd9dbdd65d4a8fd1cb7e3a>`__

--- a/src/page/Releases/4.9.10.rst
+++ b/src/page/Releases/4.9.10.rst
@@ -204,9 +204,9 @@ Armando Neto (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: bump pr-ci templates
-   `commit <https://pagure.io/freeipa/c/f3255393188dbfb32f74150243b0e7f2c6ba4dc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3255393188dbfb32f74150243b0e7f2c6ba4dc9>`__
 -  workshop: Update docs and support default cloud image
-   `commit <https://pagure.io/freeipa/c/42afcc95be0292dd0dbdf955dbe0e8e3a683782e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42afcc95be0292dd0dbdf955dbe0e8e3a683782e>`__
 
 
 
@@ -215,88 +215,88 @@ Alexander Bokovoy (29)
 
 -  idviews: use cached ipaOriginalUid value when resolving ID override
    anchor
-   `commit <https://pagure.io/freeipa/c/cfca49c469e822199cbdccd05d4c4a4cbf281448>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfca49c469e822199cbdccd05d4c4a4cbf281448>`__
    `#9178 <https://pagure.io/freeipa/issue/9178>`__
 -  ipaldap: fix conversion from boolean OID to Python
-   `commit <https://pagure.io/freeipa/c/faeb656c77adf27a49ccaceb57fc1ba44e11cc1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faeb656c77adf27a49ccaceb57fc1ba44e11cc1d>`__
    `#9171 <https://pagure.io/freeipa/issue/9171>`__
 -  ipa-kdb: avoid additional checks for a well-known anonymous principal
-   `commit <https://pagure.io/freeipa/c/6c6fc7db61d83e01a4913d22dfb178af43d30d8b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c6fc7db61d83e01a4913d22dfb178af43d30d8b>`__
    `#9165 <https://pagure.io/freeipa/issue/9165>`__
 -  Ignore dnssec-enable-related named-checkonf errors in test
-   `commit <https://pagure.io/freeipa/c/35c720cab0d91e730e94d95abfdd54d7882987d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35c720cab0d91e730e94d95abfdd54d7882987d0>`__
    `#9157 <https://pagure.io/freeipa/issue/9157>`__
 -  Support dnssec utils from bind 9.17.2+
-   `commit <https://pagure.io/freeipa/c/1c6bdf97598984e74318061449f7906e487cd034>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c6bdf97598984e74318061449f7906e487cd034>`__
    `#9157 <https://pagure.io/freeipa/issue/9157>`__
 -  ipa-kdb: apply per-indicator settings from inherited ticket policy
-   `commit <https://pagure.io/freeipa/c/a2baae42f8cff025521df19eed793f8184ce5974>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2baae42f8cff025521df19eed793f8184ce5974>`__
    `#9121 <https://pagure.io/freeipa/issue/9121>`__
 -  freeipa.spec.in: Depend on sssd-idp directly to help RHEL
    BaseOS/AppStream repository split
-   `commit <https://pagure.io/freeipa/c/979163bff2e689c46ff67d6976f7927f0d81f9cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/979163bff2e689c46ff67d6976f7927f0d81f9cd>`__
    `#9155 <https://pagure.io/freeipa/issue/9155>`__
 -  docs: tune RTD to display lists with disc and left margin
-   `commit <https://pagure.io/freeipa/c/40a257f1e682616c66c77c86be14437dbcad8a8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40a257f1e682616c66c77c86be14437dbcad8a8c>`__
 -  workshop: add chapter 12: External IdP support
-   `commit <https://pagure.io/freeipa/c/5f9e0d3ff3bd80b75bc9f5de97e7e086ba0a31e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f9e0d3ff3bd80b75bc9f5de97e7e086ba0a31e3>`__
 -  freeipa.spec.in: use SSSD 2.7.0 to add IdP pre-auth mechanism
-   `commit <https://pagure.io/freeipa/c/d49aa7103bacba60bae28f32bd76d9d35853626b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d49aa7103bacba60bae28f32bd76d9d35853626b>`__
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
 -  doc/workshop: document use of pam_sss_gss PAM module
-   `commit <https://pagure.io/freeipa/c/d0eab8fe7609fea0b46ea863db1822eca1daac63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0eab8fe7609fea0b46ea863db1822eca1daac63>`__
 -  External IdP: initial SELinux policy
-   `commit <https://pagure.io/freeipa/c/660c3dc2491fc2ee01031c1c59db6e0bb025bf93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/660c3dc2491fc2ee01031c1c59db6e0bb025bf93>`__
 -  External IdP: add Web UI to manage IdP references
-   `commit <https://pagure.io/freeipa/c/51a4e42dd777661addd4f2fed1654ee978e8a4d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51a4e42dd777661addd4f2fed1654ee978e8a4d7>`__
 -  KDB: support external IdP configuration
-   `commit <https://pagure.io/freeipa/c/673478b1cf9950aed755a6a9ae8f81cb323932b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/673478b1cf9950aed755a6a9ae8f81cb323932b3>`__
    `#8804 <https://pagure.io/freeipa/issue/8804>`__
 -  ipa-otpd: add support for SSSD OIDC helper
-   `commit <https://pagure.io/freeipa/c/bf8e2bb99f1c09ced820bd4bf6e9d7832db2caea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf8e2bb99f1c09ced820bd4bf6e9d7832db2caea>`__
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
 -  external-idp: add XMLRPC tests for External IdP objects and idp
    indicator
-   `commit <https://pagure.io/freeipa/c/b77015b7a3b627282560253cf2cd579c89f02923>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b77015b7a3b627282560253cf2cd579c89f02923>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__
 -  external-idp: add support to manage external IdP objects
-   `commit <https://pagure.io/freeipa/c/2136bd5d00f7aed5ae722ff8253c2b74ba444972>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2136bd5d00f7aed5ae722ff8253c2b74ba444972>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__
 -  external-idp: add LDAP schema, indices and other LDAP objects
-   `commit <https://pagure.io/freeipa/c/1df7b82ac188650775703dc95530017c969d0bff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1df7b82ac188650775703dc95530017c969d0bff>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__
 -  doc/designs: add External IdP support design documents
-   `commit <https://pagure.io/freeipa/c/8d81338cb94a2d850f53629ebba98a1f1ec90d1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d81338cb94a2d850f53629ebba98a1f1ec90d1e>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__,
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
 -  js tests: use latest grunt
-   `commit <https://pagure.io/freeipa/c/ea0275f6113854feb02715265a5a85904023816d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea0275f6113854feb02715265a5a85904023816d>`__
 -  Azure CI: don't force non-existing OpenSSL configuration anymore
-   `commit <https://pagure.io/freeipa/c/c2434c4e52fa2121331ab358325345b308fbc3dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2434c4e52fa2121331ab358325345b308fbc3dd>`__
 -  Azure CI: temporarily add libldap_r.so symlink for python-ldap PIP
    use
-   `commit <https://pagure.io/freeipa/c/137e62cc2faade831abc4b1955a0c0319f2d8a0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/137e62cc2faade831abc4b1955a0c0319f2d8a0f>`__
 -  Switch Azure CI to Fedora 36 pre-release
-   `commit <https://pagure.io/freeipa/c/1e882144bb5c5661906eeaefa6ce6f511005bfb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e882144bb5c5661906eeaefa6ce6f511005bfb2>`__
 -  web ui: do not provide Remove button in subid page
-   `commit <https://pagure.io/freeipa/c/59cf9017a009bb5eb4f6ef0ed07aa21e60614ab3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59cf9017a009bb5eb4f6ef0ed07aa21e60614ab3>`__
    `#9150 <https://pagure.io/freeipa/issue/9150>`__
 -  docs: force sphinx version above 3.0 to avoid caching in RTD
-   `commit <https://pagure.io/freeipa/c/5ea1866f1bdea4e20894906e7dbdbde27f9715cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ea1866f1bdea4e20894906e7dbdbde27f9715cd>`__
 -  docs: update Sphinx requirements in ipasphinx package
-   `commit <https://pagure.io/freeipa/c/ffd8f14af2a1d2d1bce9011473449706902d884d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffd8f14af2a1d2d1bce9011473449706902d884d>`__
    `#9148 <https://pagure.io/freeipa/issue/9148>`__
 -  docs: add the readthedocs configuration
-   `commit <https://pagure.io/freeipa/c/68c20846cf80eb2d46a05e0f8879ddfbd19fbbec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68c20846cf80eb2d46a05e0f8879ddfbd19fbbec>`__
    `#9148 <https://pagure.io/freeipa/issue/9148>`__
 -  docs: add plantuml and use virtual environment to generate docs
-   `commit <https://pagure.io/freeipa/c/7ddef72fbbf779da32660d54389d68a7c3b35a1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ddef72fbbf779da32660d54389d68a7c3b35a1a>`__
    `#9148 <https://pagure.io/freeipa/issue/9148>`__
 -  doc: migrate to m2r2 and newer sphinx, add plantuml to venv
-   `commit <https://pagure.io/freeipa/c/de918aea190401183da4742fc9d56101a13f1b17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de918aea190401183da4742fc9d56101a13f1b17>`__
    `#9148 <https://pagure.io/freeipa/issue/9148>`__
 
 
@@ -305,9 +305,9 @@ Anuja More (2)
 ----------------------------------------------------------------------------------------------
 
 -  pr-ci definitions: add external idp related jobs.
-   `commit <https://pagure.io/freeipa/c/b39f9336fa12e7f28ce0a5c51677983bc9b72621>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b39f9336fa12e7f28ce0a5c51677983bc9b72621>`__
 -  ipatests: Add integration tests for External IdP support
-   `commit <https://pagure.io/freeipa/c/b979dd91f149fd1f4fc1f48466a26f575eae0ae4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b979dd91f149fd1f4fc1f48466a26f575eae0ae4>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__,
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
@@ -318,7 +318,7 @@ Antonio Torres (1)
 ----------------------------------------------------------------------------------------------
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/0cdbe00a72eeb8b1f18a37ca75fb16eea5b25119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cdbe00a72eeb8b1f18a37ca75fb16eea5b25119>`__
 
 
 
@@ -326,7 +326,7 @@ Matthew Davis (1)
 ----------------------------------------------------------------------------------------------
 
 -  Create missing SSSD_PUBCONF_KRB5_INCLUDE_D_DIR
-   `commit <https://pagure.io/freeipa/c/70d23b225d11a6c8c16bd94faa8891100b83c1ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70d23b225d11a6c8c16bd94faa8891100b83c1ac>`__
    `#9174 <https://pagure.io/freeipa/issue/9174>`__
 
 
@@ -335,41 +335,41 @@ Florence Blanc-Renaud (12)
 ----------------------------------------------------------------------------------------------
 
 -  ACI: define "Read DNS entries from a zone" aci during install
-   `commit <https://pagure.io/freeipa/c/4b8b032ed5dd33662032e82ba4e296e7b0700c17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b8b032ed5dd33662032e82ba4e296e7b0700c17>`__
    `#9173 <https://pagure.io/freeipa/issue/9173>`__
 -  ipatests: update expected output for boolean attribute
-   `commit <https://pagure.io/freeipa/c/c6bc8fd4c80d7ab9cd369ffce521d52c0eabe4cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6bc8fd4c80d7ab9cd369ffce521d52c0eabe4cb>`__
    `#9171 <https://pagure.io/freeipa/issue/9171>`__
 -  ipa-replica-install: nsds5replicaUpdateInProgress is a Boolean
-   `commit <https://pagure.io/freeipa/c/23d56bb95229756054df72de4d50fead8fc6116e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23d56bb95229756054df72de4d50fead8fc6116e>`__
    `#9171 <https://pagure.io/freeipa/issue/9171>`__
 -  ipatest: update expected out for ipa-healthcheck's
    DogtagCertsConnectivityCheck
-   `commit <https://pagure.io/freeipa/c/6147f877a57dab33cccea08cc57fcb7b82d4a602>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6147f877a57dab33cccea08cc57fcb7b82d4a602>`__
    `#9175 <https://pagure.io/freeipa/issue/9175>`__
 -  ipatests: add new test with --subid installer option
-   `commit <https://pagure.io/freeipa/c/0193498f682eb3efa9cbdf82af215eaa854f466a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0193498f682eb3efa9cbdf82af215eaa854f466a>`__
    `#9159 <https://pagure.io/freeipa/issue/9159>`__
 -  man pages: document the --subid installer option
-   `commit <https://pagure.io/freeipa/c/e10f3385d0bbb4100a8220ce372dc2748f8b329e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e10f3385d0bbb4100a8220ce372dc2748f8b329e>`__
    `#9159 <https://pagure.io/freeipa/issue/9159>`__
 -  Installer: add --subid option to select the sssd profile with-subid
-   `commit <https://pagure.io/freeipa/c/74b2fd06d978d56137ccfde310f9c64187e0a5a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74b2fd06d978d56137ccfde310f9c64187e0a5a3>`__
    `#9159 <https://pagure.io/freeipa/issue/9159>`__
 -  client uninstall: handle uninstall with authconfig
-   `commit <https://pagure.io/freeipa/c/d39e232e9ee28da5d4488135d264d2d1b9e671ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d39e232e9ee28da5d4488135d264d2d1b9e671ba>`__
    `#9147 <https://pagure.io/freeipa/issue/9147>`__
 -  ipatests: --no-dnssec-validation requires --setup-dns
-   `commit <https://pagure.io/freeipa/c/7f814d9f54207a53c99155e542cc5b210707d0fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f814d9f54207a53c99155e542cc5b210707d0fd>`__
    `#9152 <https://pagure.io/freeipa/issue/9152>`__
 -  ipatests: remove test_rekey_keytype_DSA
-   `commit <https://pagure.io/freeipa/c/b3093d9c3990f8e899487087965f008607a519c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3093d9c3990f8e899487087965f008607a519c6>`__
    `#9140 <https://pagure.io/freeipa/issue/9140>`__
 -  ipatests: update the expected sha256sum of epn.conf file
-   `commit <https://pagure.io/freeipa/c/5877c4e17a92c73aa68b8ba3c7a47555e32a13ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5877c4e17a92c73aa68b8ba3c7a47555e32a13ca>`__
    `#9146 <https://pagure.io/freeipa/issue/9146>`__
 -  EPN: document missing option msg_subject
-   `commit <https://pagure.io/freeipa/c/d37d1f717ec725726d770ea73b4ab2e418c485e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d37d1f717ec725726d770ea73b4ab2e418c485e2>`__
    `#9145 <https://pagure.io/freeipa/issue/9145>`__
 
 
@@ -378,12 +378,12 @@ Francisco Trivino (3)
 ----------------------------------------------------------------------------------------------
 
 -  Update subordinate design doc
-   `commit <https://pagure.io/freeipa/c/8abc0a22a8866e82776afbd7c3bc5e3195c43115>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8abc0a22a8866e82776afbd7c3bc5e3195c43115>`__
 -  Update ipa-replica-install replication agreement error message
-   `commit <https://pagure.io/freeipa/c/c03a8c3c06562c128aac6be506274995cea74948>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c03a8c3c06562c128aac6be506274995cea74948>`__
    `#9162 <https://pagure.io/freeipa/issue/9162>`__
 -  ipatests: Bump PR-CI latest templates to Fedora 36
-   `commit <https://pagure.io/freeipa/c/9ae6ef549fe51457a6f505f3c0ea6a7804e9bcd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ae6ef549fe51457a6f505f3c0ea6a7804e9bcd2>`__
 
 
 
@@ -391,7 +391,7 @@ Matthew Davis (1)
 ----------------------------------------------------------------------------------------------
 
 -  Suse compatibility fix
-   `commit <https://pagure.io/freeipa/c/fe048d83cb88593e490af8b95c12917071683b4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe048d83cb88593e490af8b95c12917071683b4c>`__
    `#9174 <https://pagure.io/freeipa/issue/9174>`__
 
 
@@ -401,15 +401,15 @@ Michal Polovka (4)
 
 -  ipatests: xfail for test_ipahealthcheck_hidden_replica to respect pki
    version
-   `commit <https://pagure.io/freeipa/c/60739ce483e897cbd85575304dfb7562066189e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60739ce483e897cbd85575304dfb7562066189e4>`__
    `#8582 <https://pagure.io/freeipa/issue/8582>`__
 -  ipatests: tasks: add ipactl start, stop and restart
-   `commit <https://pagure.io/freeipa/c/58ddcffc412f7dd5cc762bd6f80faa07fcedf7ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58ddcffc412f7dd5cc762bd6f80faa07fcedf7ec>`__
 -  ipatests: RFE: Improve ipa-replica-install error message
-   `commit <https://pagure.io/freeipa/c/352b9dfb49bdf1c70a8de9ed7287387417580c86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/352b9dfb49bdf1c70a8de9ed7287387417580c86>`__
    `#9162 <https://pagure.io/freeipa/issue/9162>`__
 -  ipatests: test_subids: test subid-match shows UID of the owner
-   `commit <https://pagure.io/freeipa/c/ab0e67d1f51c2db620de002d5f61425e0a65c9aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab0e67d1f51c2db620de002d5f61425e0a65c9aa>`__
    `#8977 <https://pagure.io/freeipa/issue/8977>`__
 
 
@@ -418,46 +418,46 @@ Rob Crittenden (14)
 ----------------------------------------------------------------------------------------------
 
 -  Add switch for LDAP cache debug output
-   `commit <https://pagure.io/freeipa/c/d062dc9da891cbb3b0ab04291d89afddf140c560>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d062dc9da891cbb3b0ab04291d89afddf140c560>`__
    `#9180 <https://pagure.io/freeipa/issue/9180>`__
 -  Remove extraneous AJP secret from server.xml on upgrades
-   `commit <https://pagure.io/freeipa/c/deaaaaf1492410269c1f66f8d4bb57e41b99d87c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deaaaaf1492410269c1f66f8d4bb57e41b99d87c>`__
    `#9176 <https://pagure.io/freeipa/issue/9176>`__
 -  graceperiod: ignore case when checking for missing objectclass
-   `commit <https://pagure.io/freeipa/c/e6cc41094b2bc526e9f8e87229e8f83a74cfc263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6cc41094b2bc526e9f8e87229e8f83a74cfc263>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  Set default LDAP password grace period to -1
-   `commit <https://pagure.io/freeipa/c/9b0fbdc37b92981d541a4152fdfeb0964692878f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b0fbdc37b92981d541a4152fdfeb0964692878f>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  doc: Design document for LDAP graceperiod
-   `commit <https://pagure.io/freeipa/c/d2b296454c57ab639b8e023050dabc193693c42f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2b296454c57ab639b8e023050dabc193693c42f>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  Don't duplicate the LDAP gracelimit set in the previous test
-   `commit <https://pagure.io/freeipa/c/8b2edd5b4e13cb7a8b9b9eec4a0e194b4e6ca71b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b2edd5b4e13cb7a8b9b9eec4a0e194b4e6ca71b>`__
    `#9167 <https://pagure.io/freeipa/issue/9167>`__
 -  Configure and enable the graceperiod plugin on upgrades
-   `commit <https://pagure.io/freeipa/c/62bafcc53d4f45b28eb9a541e5385c2f1e7a3f97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62bafcc53d4f45b28eb9a541e5385c2f1e7a3f97>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  dnssec daemons: read the dns context config file for debug state
-   `commit <https://pagure.io/freeipa/c/c00286462196026337600113119eb5522b96141a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c00286462196026337600113119eb5522b96141a>`__
    `#9128 <https://pagure.io/freeipa/issue/9128>`__
 -  healthcheck: add tests for setting cli options in config file
-   `commit <https://pagure.io/freeipa/c/0e8350e0dd8219fd8245f57e0ebc9a096e9be84f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e8350e0dd8219fd8245f57e0ebc9a096e9be84f>`__
    `#9136 <https://pagure.io/freeipa/issue/9136>`__
 -  Exclude passwordgraceusertime from replication
-   `commit <https://pagure.io/freeipa/c/87fe3fbba6d2b5bf2a7e9a0fca91c4e588641c9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87fe3fbba6d2b5bf2a7e9a0fca91c4e588641c9c>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  Remove the replicated attribute constants
-   `commit <https://pagure.io/freeipa/c/6b3ab98b90686bb41a901af6b1cf5da99b99a148>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b3ab98b90686bb41a901af6b1cf5da99b99a148>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  Implement LDAP bind grace period 389-ds plugin
-   `commit <https://pagure.io/freeipa/c/4fcbf2ded2563ff5151edee9384d793ad38f6dae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fcbf2ded2563ff5151edee9384d793ad38f6dae>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  If the password auth type is enabled also enable the hardened policy
-   `commit <https://pagure.io/freeipa/c/300f1301bbbe8a62183819f4350f47e3f182b7f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/300f1301bbbe8a62183819f4350f47e3f182b7f1>`__
    `#9121 <https://pagure.io/freeipa/issue/9121>`__
 -  kdb: The jitter offset should always be positive
-   `commit <https://pagure.io/freeipa/c/ed1447ab612e5445a76e979fb059825bab84d1df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed1447ab612e5445a76e979fb059825bab84d1df>`__
    `#9121 <https://pagure.io/freeipa/issue/9121>`__
 
 
@@ -467,9 +467,9 @@ Sudhir Menon (2)
 
 -  ipatests: ipahealthcheck tests to check change in permission of
    ipaserver log files
-   `commit <https://pagure.io/freeipa/c/3488276649861563471398b3747224ca54875861>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3488276649861563471398b3747224ca54875861>`__
 -  ipatests: Adding --no-dnssec-validation option for healthcheck
-   `commit <https://pagure.io/freeipa/c/f11b7b3bf50f7ccf4689b1b0f80894b0b1247983>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f11b7b3bf50f7ccf4689b1b0f80894b0b1247983>`__
    `#9151 <https://pagure.io/freeipa/issue/9151>`__
 
 
@@ -478,6 +478,6 @@ Thorsten Scherf (2)
 ----------------------------------------------------------------------------------------------
 
 -  workshop: add freeipa version requirements
-   `commit <https://pagure.io/freeipa/c/84c88b69fe250bbff32e2c9abcf1d118e883eb22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c88b69fe250bbff32e2c9abcf1d118e883eb22>`__
 -  workshop: add freeipa version requirements
-   `commit <https://pagure.io/freeipa/c/7e596fd16c5056815bce9e7ae15b58dd3fd25e7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e596fd16c5056815bce9e7ae15b58dd3fd25e7e>`__

--- a/src/page/Releases/4.9.11.rst
+++ b/src/page/Releases/4.9.11.rst
@@ -188,7 +188,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  webui: Do not allow empty pagination size
-   `commit <https://pagure.io/freeipa/c/991849cf58fa990ad4540a61214b5ab4fcd4baa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/991849cf58fa990ad4540a61214b5ab4fcd4baa1>`__
    `#9192 <https://pagure.io/freeipa/issue/9192>`__
 
 
@@ -198,33 +198,33 @@ Alexander Bokovoy (10)
 
 -  ipa-kdb: for delegation check, use different error codes before and
    after krb5 1.20
-   `commit <https://pagure.io/freeipa/c/e12aa8bb782e1f3722ae93d63632cd93df06faab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e12aa8bb782e1f3722ae93d63632cd93df06faab>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: fix comment to make sure we talk about krb5 1.20 or later
-   `commit <https://pagure.io/freeipa/c/a35cac3d6fa80d259240b0eb1d4952c321be9e92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a35cac3d6fa80d259240b0eb1d4952c321be9e92>`__
 -  ipa-kdb: fix PAC requester check
-   `commit <https://pagure.io/freeipa/c/7e504647dd00202c02cd203ca3474a332d1e413e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e504647dd00202c02cd203ca3474a332d1e413e>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: handle empty S4U proxy in allowed_to_delegate
-   `commit <https://pagure.io/freeipa/c/4755bd42c0f4c8fcda6131ee89b6fa8308d8a75c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4755bd42c0f4c8fcda6131ee89b6fa8308d8a75c>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: handle cross-realm TGT entries when generating PAC
-   `commit <https://pagure.io/freeipa/c/0dd3315afb1056e3ca5bfd6af161793b5a5b8d86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dd3315afb1056e3ca5bfd6af161793b5a5b8d86>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: add krb5 1.20 support
-   `commit <https://pagure.io/freeipa/c/a0d840347b453bda141691ac587bc2ec851f15a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0d840347b453bda141691ac587bc2ec851f15a5>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipa-kdb: refactor MS-PAC processing to prepare for krb5 1.20
-   `commit <https://pagure.io/freeipa/c/9efa8fe49c08fc584189b9d9ab24dfa8560db824>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9efa8fe49c08fc584189b9d9ab24dfa8560db824>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  ipaclient: do not set TLS CA options in ldap.conf anymore
-   `commit <https://pagure.io/freeipa/c/d9a56b51bbb350219d0f5cb0ea6b3cc00230d437>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9a56b51bbb350219d0f5cb0ea6b3cc00230d437>`__
    `#9258 <https://pagure.io/freeipa/issue/9258>`__
 -  fix canonicalization issue in Web UI
-   `commit <https://pagure.io/freeipa/c/109cd579e3b089b7fad4c92bf25594eba1af8a21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/109cd579e3b089b7fad4c92bf25594eba1af8a21>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 -  ipa-otpd: initialize local pointers and handle gcc 10
-   `commit <https://pagure.io/freeipa/c/9290aa5500f752d0eedabdfc92c9fe6c0ee743b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9290aa5500f752d0eedabdfc92c9fe6c0ee743b8>`__
    `#9230 <https://pagure.io/freeipa/issue/9230>`__
 
 
@@ -233,15 +233,15 @@ Anuja More (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests : Test query to AD specific attributes is successful.
-   `commit <https://pagure.io/freeipa/c/21cb86a8e571ac7aa0304c57961881ca9c4aeacb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21cb86a8e571ac7aa0304c57961881ca9c4aeacb>`__
    `#9127 <https://pagure.io/freeipa/issue/9127>`__
 -  ipatests: Fix install_master for test_idp.py
-   `commit <https://pagure.io/freeipa/c/15f454f6f8d25275c9570e2cc3a97c4e030fc581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15f454f6f8d25275c9570e2cc3a97c4e030fc581>`__
    `#9189 <https://pagure.io/freeipa/issue/9189>`__
 -  ipatests: update prci definitions for test_idp.py
-   `commit <https://pagure.io/freeipa/c/50b4d9ab3fcb2e63edc8d20346e4a8a79f15692d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50b4d9ab3fcb2e63edc8d20346e4a8a79f15692d>`__
 -  Add end to end integration tests for external IdP
-   `commit <https://pagure.io/freeipa/c/857713c5a9c8e0b62c06dd92e69c09eeb34b2e99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/857713c5a9c8e0b62c06dd92e69c09eeb34b2e99>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__,
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
@@ -252,15 +252,15 @@ Antonio Torres (5)
 ----------------------------------------------------------------------------------------------
 
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/4f3dd0538af82bc81b146b03f03743e5ccfc516d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f3dd0538af82bc81b146b03f03743e5ccfc516d>`__
 -  Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/59bfe9d87c01f6a73fa359be700847b9f1bb616d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59bfe9d87c01f6a73fa359be700847b9f1bb616d>`__
 -  Add basic API usage guide
-   `commit <https://pagure.io/freeipa/c/76aa6d2a4293e5d492a7cc087b17603b6d28e34e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76aa6d2a4293e5d492a7cc087b17603b6d28e34e>`__
 -  doc: generate API Reference
-   `commit <https://pagure.io/freeipa/c/beaab476903b2f182a722f45bf8af8fee611f0b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/beaab476903b2f182a722f45bf8af8fee611f0b7>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/3e90842b3d94268f2ccd42c8decd0eecbcf88f1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e90842b3d94268f2ccd42c8decd0eecbcf88f1f>`__
 
 
 
@@ -269,12 +269,12 @@ Alexey Tikhonov (3)
 
 -  extdom: avoid sss_nss_getorigby*() calls when get*_r_wrapper()
    returns object from a wrong domain (performance optimization)
-   `commit <https://pagure.io/freeipa/c/a07cece0c006b3a89fc467284244f979d39f0209>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a07cece0c006b3a89fc467284244f979d39f0209>`__
 -  extdom: make sure result doesn't miss domain part
-   `commit <https://pagure.io/freeipa/c/3de618f75416afd6c087c243fe35755739d229a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3de618f75416afd6c087c243fe35755739d229a4>`__
    `#9245 <https://pagure.io/freeipa/issue/9245>`__
 -  extdom: internal functions should be static
-   `commit <https://pagure.io/freeipa/c/666357649f4dfb8254cb3707e97e12c69e6714f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/666357649f4dfb8254cb3707e97e12c69e6714f7>`__
 
 
 
@@ -282,31 +282,31 @@ Carla Martinez (9)
 ----------------------------------------------------------------------------------------------
 
 -  webui: Add name to 'Certificates' table
-   `commit <https://pagure.io/freeipa/c/76c8b47e4fb249db0b7c6185afcc0d11b78c5824>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76c8b47e4fb249db0b7c6185afcc0d11b78c5824>`__
    `#8946 <https://pagure.io/freeipa/issue/8946>`__
 -  webui: Add label name to 'Certificates' section
-   `commit <https://pagure.io/freeipa/c/98eda97648fb0d9a7ae9aac32938d4f889f8a213>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98eda97648fb0d9a7ae9aac32938d4f889f8a213>`__
    `#8946 <https://pagure.io/freeipa/issue/8946>`__
 -  Update API and VERSION
-   `commit <https://pagure.io/freeipa/c/856edcc8d3c9fe64eff532db669536a0a78ba70d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/856edcc8d3c9fe64eff532db669536a0a78ba70d>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  webui: Set 'SOA serial' field as read-only
-   `commit <https://pagure.io/freeipa/c/9f8c9a4d96877bab1cb474615d77aca2fa586ece>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f8c9a4d96877bab1cb474615d77aca2fa586ece>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  ipatest: Remove warning message for 'idnssoaserial'
-   `commit <https://pagure.io/freeipa/c/76604df09d8b62795f4e2d1fbc99af9ed55ec5cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76604df09d8b62795f4e2d1fbc99af9ed55ec5cd>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  Set 'idnssoaserial' to deprecated
-   `commit <https://pagure.io/freeipa/c/e9048daac53e24759a33e2031c8b4224a80a0e54>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9048daac53e24759a33e2031c8b4224a80a0e54>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  webui: Show 'Sudo order' column
-   `commit <https://pagure.io/freeipa/c/0513a83a4fcd5626168cb45132af8cd1b4a9ee03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0513a83a4fcd5626168cb45132af8cd1b4a9ee03>`__
    `#9237 <https://pagure.io/freeipa/issue/9237>`__
 -  Set pkeys in test_selinuxusermap.py::test_misc::delete_record
-   `commit <https://pagure.io/freeipa/c/cefa8f1e5f5b01e6863d07e9f3849dfd4c485f22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cefa8f1e5f5b01e6863d07e9f3849dfd4c485f22>`__
    `#9161 <https://pagure.io/freeipa/issue/9161>`__
 -  webui: Allow grace login limit
-   `commit <https://pagure.io/freeipa/c/ade5093b08f92b279c200f341e96972a74f644d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ade5093b08f92b279c200f341e96972a74f644d8>`__
    `#9211 <https://pagure.io/freeipa/issue/9211>`__
 
 
@@ -315,7 +315,7 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add PKINIT support to ipa-client-install
-   `commit <https://pagure.io/freeipa/c/80da53eaada1b5ad61b8cff2f9ed1217fea600c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80da53eaada1b5ad61b8cff2f9ed1217fea600c9>`__
    `#9269 <https://pagure.io/freeipa/issue/9269>`__,
    `#9271 <https://pagure.io/freeipa/issue/9271>`__
 
@@ -325,45 +325,45 @@ Jan Kuparinen (20)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/841e0c673b222e686083cb96c210a55da6e09ff8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/841e0c673b222e686083cb96c210a55da6e09ff8>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/4d92e67a45b0caf72ce5028f8bbba06f4d63fb7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d92e67a45b0caf72ce5028f8bbba06f4d63fb7f>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e6accc7b3f39e0140e0d1dc3ee6bfcf6636d214d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6accc7b3f39e0140e0d1dc3ee6bfcf6636d214d>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/20bcd69f38fb734dc80e5052cb2ed91c19b12994>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20bcd69f38fb734dc80e5052cb2ed91c19b12994>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/49a41249e1d8cf6b349f895ba88c7490081ab462>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49a41249e1d8cf6b349f895ba88c7490081ab462>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/20269ac630c451734dffef50298cba823ffe2624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20269ac630c451734dffef50298cba823ffe2624>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/1853d934d1e93dbf07d50799406ac12995a1d977>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1853d934d1e93dbf07d50799406ac12995a1d977>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/7037e5389006f1eeea0299918cbbae57893ef125>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7037e5389006f1eeea0299918cbbae57893ef125>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/9df1672f479bee01efcd53c46e800e789762bc97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9df1672f479bee01efcd53c46e800e789762bc97>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/eb1a1f35849c1f2e43c282c555b62f7d12962e37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb1a1f35849c1f2e43c282c555b62f7d12962e37>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/216cced00a1973f2103cf678ed94ef3b6c204190>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/216cced00a1973f2103cf678ed94ef3b6c204190>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e98691b491ae2a8d41c3eb6e7028f6e731dbdbae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e98691b491ae2a8d41c3eb6e7028f6e731dbdbae>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/4d306ee7ebe90275a47b4f182f66bc87bc397170>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d306ee7ebe90275a47b4f182f66bc87bc397170>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/2203f3627f28ff4c81ab9fd24eed31669ae34ff5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2203f3627f28ff4c81ab9fd24eed31669ae34ff5>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/15457a6d9fdb19466405f6882fbbc9e29510d40e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15457a6d9fdb19466405f6882fbbc9e29510d40e>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/5dcb614691ed31a660edc936612b525b1be0ccae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5dcb614691ed31a660edc936612b525b1be0ccae>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/c2061cf9c505c4821c7812a71c464afa367300b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2061cf9c505c4821c7812a71c464afa367300b5>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/9d6d2e2dc9cfb7c1ef1e400ba90b27474866380f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d6d2e2dc9cfb7c1ef1e400ba90b27474866380f>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/6bdd02db7ace58cbb16d45d5c6dbfb1945e2bb43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bdd02db7ace58cbb16d45d5c6dbfb1945e2bb43>`__
 -  Added translation using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/6169eb47e1ea42c81ad6022ab02ef3222566f70f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6169eb47e1ea42c81ad6022ab02ef3222566f70f>`__
 
 
 
@@ -371,9 +371,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: fix prci checker target masked return code & add pylint
-   `commit <https://pagure.io/freeipa/c/6483f33389c7bb1d185f2b39d68f407e131a282c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6483f33389c7bb1d185f2b39d68f407e131a282c>`__
 -  ipatests: Checker script for prci definitions
-   `commit <https://pagure.io/freeipa/c/f33266c2ba9d794a5a1e9994e5fa029d2fa5de70>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f33266c2ba9d794a5a1e9994e5fa029d2fa5de70>`__
 
 
 
@@ -381,13 +381,13 @@ Erik Belko (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Add test for grace login limit
-   `commit <https://pagure.io/freeipa/c/fd92757fc4a20eb73ebe08573c3e7ac5fb5c6ae2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd92757fc4a20eb73ebe08573c3e7ac5fb5c6ae2>`__
    `#9211 <https://pagure.io/freeipa/issue/9211>`__
 -  ipatests: test for root using admin password in webUI
-   `commit <https://pagure.io/freeipa/c/80b18b08e8cf3aaa9f75769e703c2aab569b599e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80b18b08e8cf3aaa9f75769e703c2aab569b599e>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 -  ipatests: healthcheck: test if system is FIPS enabled
-   `commit <https://pagure.io/freeipa/c/f962a0c2832619100046c923d15f21e8c10fce96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f962a0c2832619100046c923d15f21e8c10fce96>`__
    `#8951 <https://pagure.io/freeipa/issue/8951>`__
 
 
@@ -396,46 +396,46 @@ Florence Blanc-Renaud (15)
 ----------------------------------------------------------------------------------------------
 
 -  API doc: adapt the generated doc for 4.9 branch
-   `commit <https://pagure.io/freeipa/c/e725e9954737367fd6b2e5e3566d4f19ddd36295>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e725e9954737367fd6b2e5e3566d4f19ddd36295>`__
 -  API reference: update dnszone_add generated doc
-   `commit <https://pagure.io/freeipa/c/0caa26daf2cf8f770b0111a22d89e31c763a1e89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0caa26daf2cf8f770b0111a22d89e31c763a1e89>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  API reference: update vault doc
-   `commit <https://pagure.io/freeipa/c/4d6eabd3caf629a14c801ced4ad50dd9faa8147e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d6eabd3caf629a14c801ced4ad50dd9faa8147e>`__
    `#9259 <https://pagure.io/freeipa/issue/9259>`__
 -  ipatests: update vagrant boxes
-   `commit <https://pagure.io/freeipa/c/ca486d1507a2eb0a05576f835354d8d42c178810>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca486d1507a2eb0a05576f835354d8d42c178810>`__
 -  Spec file: bump the selinux-policy version
-   `commit <https://pagure.io/freeipa/c/58ad9f2eec0afe494c57015c4449ae39748117e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58ad9f2eec0afe494c57015c4449ae39748117e4>`__
    `#9198 <https://pagure.io/freeipa/issue/9198>`__
 -  webui tests: fix test_subid suite
-   `commit <https://pagure.io/freeipa/c/58e12bd93a9b7b1c9a39981ee0c6a724040e164f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58e12bd93a9b7b1c9a39981ee0c6a724040e164f>`__
    `#9214 <https://pagure.io/freeipa/issue/9214>`__
 -  ipa man page: format the EXAMPLES section
-   `commit <https://pagure.io/freeipa/c/64ef2b9c07ec0b1b316555739ff9f98229258838>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64ef2b9c07ec0b1b316555739ff9f98229258838>`__
    `#9252 <https://pagure.io/freeipa/issue/9252>`__
 -  ipatests: add negative test for otptoken-sync
-   `commit <https://pagure.io/freeipa/c/895a800e90a34f55f5d2789ece6e7bc8e6f5c0a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/895a800e90a34f55f5d2789ece6e7bc8e6f5c0a6>`__
    `#9248 <https://pagure.io/freeipa/issue/9248>`__
 -  ipa otptoken-sync: return error when sync fails
-   `commit <https://pagure.io/freeipa/c/4cc94cd3b929ee1878767d23f98ad5e755583c6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cc94cd3b929ee1878767d23f98ad5e755583c6b>`__
    `#9248 <https://pagure.io/freeipa/issue/9248>`__
 -  gitignore: add install/oddjob/org.freeipa.server.config-enable-sid
-   `commit <https://pagure.io/freeipa/c/a7369944d8b68032eddcc4577b0cc5f9f603cda9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7369944d8b68032eddcc4577b0cc5f9f603cda9>`__
 -  ipatests: Fix expected object classes
-   `commit <https://pagure.io/freeipa/c/2385d1d90aa91d34c4b36842a17e72aa2399a733>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2385d1d90aa91d34c4b36842a17e72aa2399a733>`__
    `#9062 <https://pagure.io/freeipa/issue/9062>`__
 -  check_repl_update: in progress is a boolean
-   `commit <https://pagure.io/freeipa/c/05a298f56485222583cb7dd4f6a3a4c5c77fc8cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05a298f56485222583cb7dd4f6a3a4c5c77fc8cf>`__
    `#9218 <https://pagure.io/freeipa/issue/9218>`__
 -  azure tests: disable TestInstallDNSSECFirst
-   `commit <https://pagure.io/freeipa/c/d40fd287836dc8440f69314d77ccb461c7e6ccea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d40fd287836dc8440f69314d77ccb461c7e6ccea>`__
    `#9216 <https://pagure.io/freeipa/issue/9216>`__
 -  xmlrpc tests: updated expected output for preserved user
-   `commit <https://pagure.io/freeipa/c/4984ff210a169129e4e56b10e54e9c795520855c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4984ff210a169129e4e56b10e54e9c795520855c>`__
    `#9187 <https://pagure.io/freeipa/issue/9187>`__
 -  Preserve user: fix the confusing summary
-   `commit <https://pagure.io/freeipa/c/ff4152539b96d309dcceaf854a3e0a49f435acff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff4152539b96d309dcceaf854a3e0a49f435acff>`__
    `#9187 <https://pagure.io/freeipa/issue/9187>`__
 
 
@@ -444,7 +444,7 @@ Francisco Trivino (1)
 ----------------------------------------------------------------------------------------------
 
 -  Vault: fix interoperability issues with older RHEL systems
-   `commit <https://pagure.io/freeipa/c/c643e56e4c45b7cb61aa53989657143627c23e04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c643e56e4c45b7cb61aa53989657143627c23e04>`__
    `#9259 <https://pagure.io/freeipa/issue/9259>`__
 
 
@@ -453,10 +453,10 @@ Fraser Tweedale (2)
 ----------------------------------------------------------------------------------------------
 
 -  install: suggest --skip-mem-check when mem check fails
-   `commit <https://pagure.io/freeipa/c/cbf2614d8acc11a1b41558a45dac8ec98b032732>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbf2614d8acc11a1b41558a45dac8ec98b032732>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  man: add --skip-mem-check to man pages
-   `commit <https://pagure.io/freeipa/c/585cebb1a9673e2fc083dd3c9545a6c080e171e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/585cebb1a9673e2fc083dd3c9545a6c080e171e3>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 
 
@@ -465,7 +465,7 @@ Matthew Davis (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add missing parameter to Suse modify_nsswitch_pam_stack
-   `commit <https://pagure.io/freeipa/c/4f15804270590fdf0f339fc53ed63bf440361b7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f15804270590fdf0f339fc53ed63bf440361b7b>`__
    `#9185 <https://pagure.io/freeipa/issue/9185>`__
 
 
@@ -474,7 +474,7 @@ Jesse Sandberg (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fix ipa-ccache-sweeper activation timer and clean up service file
-   `commit <https://pagure.io/freeipa/c/358924455d87b67db6cd743f3cfe15522b4c0d91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/358924455d87b67db6cd743f3cfe15522b4c0d91>`__
    `#9231 <https://pagure.io/freeipa/issue/9231>`__
 
 
@@ -483,7 +483,7 @@ Julien Rische (1)
 ----------------------------------------------------------------------------------------------
 
 -  Generate CNAMEs for TXT+URI location krb records
-   `commit <https://pagure.io/freeipa/c/a0652f5dc8efc4580d8039e70c0e762638d3871d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0652f5dc8efc4580d8039e70c0e762638d3871d>`__
    `#9257 <https://pagure.io/freeipa/issue/9257>`__
 
 
@@ -492,12 +492,12 @@ Michal Polovka (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Healthcheck use subject base from IPA not REALM
-   `commit <https://pagure.io/freeipa/c/afa94c7995f236c5eff516652f31c1a956466cf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afa94c7995f236c5eff516652f31c1a956466cf7>`__
 -  ipatests: Healthcheck should ignore pki errors when CA is not
    configured
-   `commit <https://pagure.io/freeipa/c/206e08d811c43ba8295816e609d4cb7148a774a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/206e08d811c43ba8295816e609d4cb7148a774a3>`__
 -  ipatests: Increase expect timeout for interactive mode
-   `commit <https://pagure.io/freeipa/c/a6a6781284658e77f36c07cb7fd35b43240946a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6a6781284658e77f36c07cb7fd35b43240946a2>`__
    `#9183 <https://pagure.io/freeipa/issue/9183>`__
 
 
@@ -506,7 +506,7 @@ Marcin Stanclik (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/d198a35cb885b6cc1622bf99b8546675b98c8aed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d198a35cb885b6cc1622bf99b8546675b98c8aed>`__
 
 
 
@@ -514,7 +514,7 @@ Mohammad Rizwan (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test newly added certificate lable
-   `commit <https://pagure.io/freeipa/c/c0b438bc745666694f2c590859d4926178a0ca04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0b438bc745666694f2c590859d4926178a0ca04>`__
 
 
 
@@ -522,7 +522,7 @@ Nikola Knazekova (1)
 ----------------------------------------------------------------------------------------------
 
 -  Exclude installed policy module file from RPM verification
-   `commit <https://pagure.io/freeipa/c/c977cefa101e145b13b5c19ae5369e5ca7ef1ef8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c977cefa101e145b13b5c19ae5369e5ca7ef1ef8>`__
    `#9254 <https://pagure.io/freeipa/issue/9254>`__
 
 
@@ -531,7 +531,7 @@ Pavel Březina (1)
 ----------------------------------------------------------------------------------------------
 
 -  docs: add security section to idp
-   `commit <https://pagure.io/freeipa/c/170155b648084846111bf0c65459aba94a8e980d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/170155b648084846111bf0c65459aba94a8e980d>`__
    `#8803 <https://pagure.io/freeipa/issue/8803>`__,
    `#8804 <https://pagure.io/freeipa/issue/8804>`__,
    `#8805 <https://pagure.io/freeipa/issue/8805>`__
@@ -542,7 +542,7 @@ Piotr Drąg (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/3b0c1cafc16dc927449231a7a70b2876770ba962>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b0c1cafc16dc927449231a7a70b2876770ba962>`__
 
 
 
@@ -550,11 +550,11 @@ Hela Basa (3)
 ----------------------------------------------------------------------------------------------
 
 -  Added translation using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/0a6246ea971282a2f1fc0b5fe3f09f7d656bbf2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a6246ea971282a2f1fc0b5fe3f09f7d656bbf2f>`__
 -  Translated using Weblate (Sinhala)
-   `commit <https://pagure.io/freeipa/c/696a72f7aef3df7c0f619f0d67e5fe259cc80c37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/696a72f7aef3df7c0f619f0d67e5fe259cc80c37>`__
 -  Added translation using Weblate (Sinhala)
-   `commit <https://pagure.io/freeipa/c/f9590de2e0bc1d2dde4f6a78c72b6a69f773bd99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9590de2e0bc1d2dde4f6a78c72b6a69f773bd99>`__
 
 
 
@@ -562,40 +562,40 @@ Rob Crittenden (12)
 ----------------------------------------------------------------------------------------------
 
 -  Pass the curl write callback by name instead of address
-   `commit <https://pagure.io/freeipa/c/9d184a295b1b581f1d5e189ee810c6b08bc0550b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d184a295b1b581f1d5e189ee810c6b08bc0550b>`__
    `#9274 <https://pagure.io/freeipa/issue/9274>`__
 -  Move client certificate request after krb5.conf is created
-   `commit <https://pagure.io/freeipa/c/762d786bf7a3043fd56877949f02bccd077e2711>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/762d786bf7a3043fd56877949f02bccd077e2711>`__
    `#9246 <https://pagure.io/freeipa/issue/9246>`__
 -  Defer creating the final krb5.conf on clients
-   `commit <https://pagure.io/freeipa/c/69413325158a3ea06d1491acd77ee6e0955ee89a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69413325158a3ea06d1491acd77ee6e0955ee89a>`__
    `#9228 <https://pagure.io/freeipa/issue/9228>`__
 -  Fix upper bound of password policy grace limit
-   `commit <https://pagure.io/freeipa/c/91a02174a0a9694fd5611c071913ad4720be5ac9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91a02174a0a9694fd5611c071913ad4720be5ac9>`__
    `#9243 <https://pagure.io/freeipa/issue/9243>`__
 -  Set default on group pwpolicy with no grace limit in upgrade
-   `commit <https://pagure.io/freeipa/c/a4ddaaf3048c4e8d78a1807af7266ee40ab3a30b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4ddaaf3048c4e8d78a1807af7266ee40ab3a30b>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  Set default gracelimit on group password policies to -1
-   `commit <https://pagure.io/freeipa/c/497a57e7a6872fa30d1855a1d91a455bfdbf9300>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/497a57e7a6872fa30d1855a1d91a455bfdbf9300>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  doc: Update LDAP grace period design with default values
-   `commit <https://pagure.io/freeipa/c/434620ee342ac4767beccec647a318bfa7743dfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/434620ee342ac4767beccec647a318bfa7743dfa>`__
    `#9212 <https://pagure.io/freeipa/issue/9212>`__
 -  upgrades: Don't restart the CA on ACME and profile schema change
-   `commit <https://pagure.io/freeipa/c/aaf57185a2701b34948105e8b54075afe048ff18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aaf57185a2701b34948105e8b54075afe048ff18>`__
    `#9204 <https://pagure.io/freeipa/issue/9204>`__
 -  Disabling gracelimit does not prevent LDAP binds
-   `commit <https://pagure.io/freeipa/c/1316cd8b2252c2543cf2ef2186956a8833037b1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1316cd8b2252c2543cf2ef2186956a8833037b1e>`__
    `#9206 <https://pagure.io/freeipa/issue/9206>`__
 -  Warn for permissions with read/write/search/compare and no attrs
-   `commit <https://pagure.io/freeipa/c/b31631ad69f72fb42b5091375df8021580f8139a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b31631ad69f72fb42b5091375df8021580f8139a>`__
    `#9188 <https://pagure.io/freeipa/issue/9188>`__
 -  Only calculate LDAP password grace when the password is expired
-   `commit <https://pagure.io/freeipa/c/3675bd1d7aca443832bb9bb2f521cc4d3a088aec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3675bd1d7aca443832bb9bb2f521cc4d3a088aec>`__
    `#1539 <https://pagure.io/freeipa/issue/1539>`__
 -  Fix test_secure_ajp_connector.py failing with Python 3.6.8
-   `commit <https://pagure.io/freeipa/c/de64d6724e028a1882c3a8be31c2752bebdd41fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de64d6724e028a1882c3a8be31c2752bebdd41fd>`__
    `#9190 <https://pagure.io/freeipa/issue/9190>`__
 
 
@@ -604,13 +604,13 @@ Ricky Tigg (4)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/91b63fcae0a588fc174cf865b4e0135c8c0e48ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91b63fcae0a588fc174cf865b4e0135c8c0e48ec>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e6451fe15acf406aa741d4eed296ab6eff7e9313>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6451fe15acf406aa741d4eed296ab6eff7e9313>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/3392f31afe04e5b6b0d49d4e2f2906bc90b3643c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3392f31afe04e5b6b0d49d4e2f2906bc90b3643c>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/a8a2b2cf97bbf8b2b80acce08d0903b6c91c5f98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8a2b2cf97bbf8b2b80acce08d0903b6c91c5f98>`__
 
 
 
@@ -618,7 +618,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: do not fail if certmap rule cannot be added
-   `commit <https://pagure.io/freeipa/c/e51a0c927db4a4c9b3e1ab0c6dffca545532a2b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e51a0c927db4a4c9b3e1ab0c6dffca545532a2b4>`__
 
 
 
@@ -626,93 +626,93 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/b8c39cca34b75a4ed3ed77a468836778f670027b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b8c39cca34b75a4ed3ed77a468836778f670027b>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/2c555646dd71911d1bcf860e6c3acbcfd3050ad2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c555646dd71911d1bcf860e6c3acbcfd3050ad2>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/53e4e7212b5b6fe0dceb809aaddc83158f8dfef4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53e4e7212b5b6fe0dceb809aaddc83158f8dfef4>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/29dba19aa8862ea7b3185dcc0dba789b8e4af5b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29dba19aa8862ea7b3185dcc0dba789b8e4af5b8>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/425894153a17de0cdb827a83fad599343e2d3656>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/425894153a17de0cdb827a83fad599343e2d3656>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/7f9588f36a2b82df3fd9ef7dd286886021e0ffa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f9588f36a2b82df3fd9ef7dd286886021e0ffa6>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/c07e0ec7a5acedef693b0f79fdc68529e64aa023>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c07e0ec7a5acedef693b0f79fdc68529e64aa023>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/e6e638aea7fda83beb47fa6c2f75772673d351c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6e638aea7fda83beb47fa6c2f75772673d351c2>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/994c43513950b4c82dd9e1ed38b56232f3efffaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/994c43513950b4c82dd9e1ed38b56232f3efffaa>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/fd538803cf6c098b2a3386ecc1f4b1e3a27b9a88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd538803cf6c098b2a3386ecc1f4b1e3a27b9a88>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/aef749b632fd636e6d6b920757e13d64303da9d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aef749b632fd636e6d6b920757e13d64303da9d4>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/64b2c0ebfeb7035b8c9d9e38c2a75e046e855f62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64b2c0ebfeb7035b8c9d9e38c2a75e046e855f62>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/a24adeab5ca162b3c79358128fcdee22d0bd18f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a24adeab5ca162b3c79358128fcdee22d0bd18f2>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/b70041d904926e9d33423fe1f7b48ca0c3791718>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b70041d904926e9d33423fe1f7b48ca0c3791718>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/246604ec696255674e8716610c387f0f2ef93d73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/246604ec696255674e8716610c387f0f2ef93d73>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/07a1cc5424760a4ef43ffc6734c901f1cc446909>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07a1cc5424760a4ef43ffc6734c901f1cc446909>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/e98e21709e2205c8c019cc7006d3f9ded94432ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e98e21709e2205c8c019cc7006d3f9ded94432ae>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/fe60d1f6f386734b7cb052f34fb798341130052a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe60d1f6f386734b7cb052f34fb798341130052a>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/5bd77e606cb6be3b3a133294027e284f5604b447>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bd77e606cb6be3b3a133294027e284f5604b447>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/2c0924f38694603777bcbdab804d9b3331efa239>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c0924f38694603777bcbdab804d9b3331efa239>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/067cae55eced1c1c7bcdbbb0dd56a16d7127488c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/067cae55eced1c1c7bcdbbb0dd56a16d7127488c>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/aa00e7c3cff81e79a1dfce2c1e5348af9f3a3438>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa00e7c3cff81e79a1dfce2c1e5348af9f3a3438>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/b5d6616aed77a46de2db53b3395aeaf531537df3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5d6616aed77a46de2db53b3395aeaf531537df3>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/7ca1befe7e8ca463052f8b24f6c9b37093dabbaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ca1befe7e8ca463052f8b24f6c9b37093dabbaa>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/b2cf29ae168661a12a426bf72e98f43d769fb132>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2cf29ae168661a12a426bf72e98f43d769fb132>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/8b3ceace34a55fadb560a758c02632efa87ec96f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b3ceace34a55fadb560a758c02632efa87ec96f>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/7d12b30e2c6762eda93eb66a1dab2e52770d94aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d12b30e2c6762eda93eb66a1dab2e52770d94aa>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/20006cc713c7666c373804cd7d6415f9af6a6d27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20006cc713c7666c373804cd7d6415f9af6a6d27>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/9e2f7d041c1c72b329fdacac232451e57a4d0516>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e2f7d041c1c72b329fdacac232451e57a4d0516>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/cf9f35e3eb2c90cb3b07a2c5ed33fdd2f3bfa0b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf9f35e3eb2c90cb3b07a2c5ed33fdd2f3bfa0b3>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/d6ff8af62ee12517d438d9f3ff02f25219166da4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6ff8af62ee12517d438d9f3ff02f25219166da4>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/1e65336b3513cf7c6579ac5714c50cb4a965fd96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e65336b3513cf7c6579ac5714c50cb4a965fd96>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/548afe9eed0696ceb4e8abdc3331b3f1f0fad6f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/548afe9eed0696ceb4e8abdc3331b3f1f0fad6f2>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/715043df4ea1d416e64ce50b0e141faf36f6c45d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/715043df4ea1d416e64ce50b0e141faf36f6c45d>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/18346d99b214f6060ab7f6c83e02f2c4d56ec799>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18346d99b214f6060ab7f6c83e02f2c4d56ec799>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/9658dbd3c31ad22e175e613f3c51073eb196c72c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9658dbd3c31ad22e175e613f3c51073eb196c72c>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/27dba4a7c3605a1ab03c55458ad4bb47b7c4dbc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27dba4a7c3605a1ab03c55458ad4bb47b7c4dbc7>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/d5726f04b6b73d6c1de183ee5b6b7bd96d590db5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d5726f04b6b73d6c1de183ee5b6b7bd96d590db5>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/eac046fd82d02105d3388af1f04527813546e6f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eac046fd82d02105d3388af1f04527813546e6f7>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/77feee852ed01502c0a0e48d4d4e546332827885>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/77feee852ed01502c0a0e48d4d4e546332827885>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/00eba1f70445a5faf27db461fb762a030b0b5789>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00eba1f70445a5faf27db461fb762a030b0b5789>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/101460521cb228f68a52a934acf97eddcbbb9928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/101460521cb228f68a52a934acf97eddcbbb9928>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/23fb8a4709af35db3e760159de405adad343c042>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23fb8a4709af35db3e760159de405adad343c042>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/fd81a77d78423293dee4e117b58f2f9077cb0cbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd81a77d78423293dee4e117b58f2f9077cb0cbf>`__
 
 
 
@@ -720,22 +720,22 @@ Stanislav Levin (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipapython: Support openldap 2.6
-   `commit <https://pagure.io/freeipa/c/7e93f46c589ba0a68c039d65ea3c0872644a0eb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e93f46c589ba0a68c039d65ea3c0872644a0eb0>`__
    `#9255 <https://pagure.io/freeipa/issue/9255>`__
 -  x509: Replace removed register_interface with subclassing
-   `commit <https://pagure.io/freeipa/c/89fe83b03ac3b046685389ee1059ca75c73e53b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89fe83b03ac3b046685389ee1059ca75c73e53b0>`__
    `#9160 <https://pagure.io/freeipa/issue/9160>`__
 -  ap: Constrain supported docutils
-   `commit <https://pagure.io/freeipa/c/1ada42e3bce58a729e689377b1a41b6cfa90b508>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ada42e3bce58a729e689377b1a41b6cfa90b508>`__
    `#9208 <https://pagure.io/freeipa/issue/9208>`__
 -  ap: Rearrange overloaded jobs
-   `commit <https://pagure.io/freeipa/c/b59baf31bc097821ff7787ecd75affb27ea2a7c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b59baf31bc097821ff7787ecd75affb27ea2a7c3>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 -  ap: Disable azure's security daemon
-   `commit <https://pagure.io/freeipa/c/98c6e96e8db3d5bdc0315094b8a7bf81d196479b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98c6e96e8db3d5bdc0315094b8a7bf81d196479b>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 -  ap: Raise dbus timeout
-   `commit <https://pagure.io/freeipa/c/e77b0b08d78d4d5ae7632ef23aebc577848ea507>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e77b0b08d78d4d5ae7632ef23aebc577848ea507>`__
    `#9207 <https://pagure.io/freeipa/issue/9207>`__
 
 
@@ -744,7 +744,7 @@ Scott Poore (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Rename create_quarkus to create_keycloak
-   `commit <https://pagure.io/freeipa/c/88ea19b9a53d9c209105af049a1df100d07e081a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88ea19b9a53d9c209105af049a1df100d07e081a>`__
    `#9225 <https://pagure.io/freeipa/issue/9225>`__
 
 
@@ -753,10 +753,10 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: WebUI: do not allow subid range deletion
-   `commit <https://pagure.io/freeipa/c/58b026716c973f422b1b98e27eb9536e59919d82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58b026716c973f422b1b98e27eb9536e59919d82>`__
    `#9150 <https://pagure.io/freeipa/issue/9150>`__
 -  ipatests: ipa-client-install --subid adds entry in nsswitch.conf
-   `commit <https://pagure.io/freeipa/c/a5762621ef3ed1e699306a8d2eef634bc927a6fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5762621ef3ed1e699306a8d2eef634bc927a6fc>`__
    `#9159 <https://pagure.io/freeipa/issue/9159>`__
 
 
@@ -765,9 +765,9 @@ Timo Aaltonen (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform/debian: Drop the path for ldap.so
-   `commit <https://pagure.io/freeipa/c/56c827099708d8613e194052857e121612fbd768>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56c827099708d8613e194052857e121612fbd768>`__
 -  ipaplatform/debian: Use multiarch path for libsofthsm2.so
-   `commit <https://pagure.io/freeipa/c/c39c2ee80db056296f6826746b5b7a5bf7ba7cc4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c39c2ee80db056296f6826746b5b7a5bf7ba7cc4>`__
 
 
 
@@ -775,7 +775,7 @@ Thomas Woerner (1)
 ----------------------------------------------------------------------------------------------
 
 -  DNSResolver: Fix use of nameservers with ports
-   `commit <https://pagure.io/freeipa/c/5e2e4664aec641886923c2bec61ce25b96edb62a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e2e4664aec641886923c2bec61ce25b96edb62a>`__
    `#9158 <https://pagure.io/freeipa/issue/9158>`__
 
 
@@ -784,8 +784,8 @@ Yuri Chornoivan (3)
 ----------------------------------------------------------------------------------------------
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/61dea74b405d251ea2778e209b03a167064b1bf6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61dea74b405d251ea2778e209b03a167064b1bf6>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/842a6457fda382d78a11bce626b2ef0ef3749aa0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/842a6457fda382d78a11bce626b2ef0ef3749aa0>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/6353e45b5dd446b7acc46244d8bb10c38c39f9ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6353e45b5dd446b7acc46244d8bb10c38c39f9ce>`__

--- a/src/page/Releases/4.9.12.rst
+++ b/src/page/Releases/4.9.12.rst
@@ -150,24 +150,24 @@ Alexander Bokovoy (6)
 
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
-   `commit <https://pagure.io/freeipa/c/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
    `#9355 <https://pagure.io/freeipa/issue/9355>`__
 -  Fix tox in Azure CI
-   `commit <https://pagure.io/freeipa/c/53ac81765aaad71ef18e720017454c33df0ab27c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53ac81765aaad71ef18e720017454c33df0ab27c>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Use system-wide chromium for webui tests
-   `commit <https://pagure.io/freeipa/c/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Don't fail if optional RPM macros file is missing
-   `commit <https://pagure.io/freeipa/c/801308af209167ef84351987cd894c5721e3d853>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/801308af209167ef84351987cd894c5721e3d853>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
-   `commit <https://pagure.io/freeipa/c/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
-   `commit <https://pagure.io/freeipa/c/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -176,16 +176,16 @@ Anuja More (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test that non admin user can search hbac rule.
-   `commit <https://pagure.io/freeipa/c/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
    `#5130 <https://pagure.io/freeipa/issue/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
-   `commit <https://pagure.io/freeipa/c/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
    `#6044 <https://pagure.io/freeipa/issue/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
-   `commit <https://pagure.io/freeipa/c/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  Add test for SSH with GSSAPI auth.
-   `commit <https://pagure.io/freeipa/c/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 
 
@@ -194,23 +194,23 @@ Antonio Torres (8)
 ----------------------------------------------------------------------------------------------
 
 -  Extend API documentation
-   `commit <https://pagure.io/freeipa/c/f3d5e11b979e13c40158928302ff23169cd9cc9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3d5e11b979e13c40158928302ff23169cd9cc9c>`__
 -  doc: allow notes on Param API Reference pages
-   `commit <https://pagure.io/freeipa/c/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
-   `commit <https://pagure.io/freeipa/c/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
-   `commit <https://pagure.io/freeipa/c/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
 -  API doc: add note about ipa show-mappings to usage guide
-   `commit <https://pagure.io/freeipa/c/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
 -  API doc: validate generated reference
-   `commit <https://pagure.io/freeipa/c/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
    `#9287 <https://pagure.io/freeipa/issue/9287>`__
 -  API doc: add basic user management guide
-   `commit <https://pagure.io/freeipa/c/84c4449e93d57f5236f978388cf6561a4866686a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c4449e93d57f5236f978388cf6561a4866686a>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/1b7fccd6d44361b9c175d9049313f0a5ac46bb57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b7fccd6d44361b9c175d9049313f0a5ac46bb57>`__
 
 
 
@@ -218,7 +218,7 @@ Carla Martinez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update 'Auth indicators' doc string
-   `commit <https://pagure.io/freeipa/c/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
    `#9338 <https://pagure.io/freeipa/issue/9338>`__
 
 
@@ -227,13 +227,13 @@ Christian Heimes (3)
 ----------------------------------------------------------------------------------------------
 
 -  Speed up installer by restarting DS after DNA plugin
-   `commit <https://pagure.io/freeipa/c/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
    `#9358 <https://pagure.io/freeipa/issue/9358>`__
 -  Don't block when kinit_pkinit() fails
-   `commit <https://pagure.io/freeipa/c/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
    `#9333 <https://pagure.io/freeipa/issue/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
-   `commit <https://pagure.io/freeipa/c/f3052c17599c7318c385b27795678b368906fd26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3052c17599c7318c385b27795678b368906fd26>`__
    `#9285 <https://pagure.io/freeipa/issue/9285>`__
 
 
@@ -242,7 +242,7 @@ Chris Kelley (1)
 ----------------------------------------------------------------------------------------------
 
 -  Check that CADogtagCertsConfigCheck can handle cert renewal
-   `commit <https://pagure.io/freeipa/c/bed21afd2b7bc43c5acd33ad450d284d04073a71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bed21afd2b7bc43c5acd33ad450d284d04073a71>`__
 
 
 
@@ -250,9 +250,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  doc: Use case examples for PR-CI checker tool
-   `commit <https://pagure.io/freeipa/c/faa485345cff6a4decbbd4a7542a3f640f2ca097>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faa485345cff6a4decbbd4a7542a3f640f2ca097>`__
 -  ipatests: fix (prci_checker) duplicated check & error return code
-   `commit <https://pagure.io/freeipa/c/398e091863c8d64271205fb4df26e688dddfe81e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/398e091863c8d64271205fb4df26e688dddfe81e>`__
 
 
 
@@ -261,7 +261,7 @@ Erik Belko (1)
 
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
-   `commit <https://pagure.io/freeipa/c/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -270,49 +270,49 @@ Florence Blanc-Renaud (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: increase timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: remove wrong job definition TestACMEPrune
-   `commit <https://pagure.io/freeipa/c/bdd115239adeae9f84b016207552b60985d65854>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdd115239adeae9f84b016207552b60985d65854>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  ipatests: increase timeout for test_acme
-   `commit <https://pagure.io/freeipa/c/67131ae7f93e6ceab9be06d29151c37d74024699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67131ae7f93e6ceab9be06d29151c37d74024699>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
-   `commit <https://pagure.io/freeipa/c/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
-   `commit <https://pagure.io/freeipa/c/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
    `#9310 <https://pagure.io/freeipa/issue/9310>`__
 -  Tests: force key type in ACME tests
-   `commit <https://pagure.io/freeipa/c/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
    `#9298 <https://pagure.io/freeipa/issue/9298>`__
 -  server install: remove error log about missing bkup file
-   `commit <https://pagure.io/freeipa/c/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
    `#9306 <https://pagure.io/freeipa/issue/9306>`__
 -  ipatests: mark test_smb as xfail
-   `commit <https://pagure.io/freeipa/c/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
    `#9135 <https://pagure.io/freeipa/issue/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
-   `commit <https://pagure.io/freeipa/c/f2b4d019881232833e915fedba48537548d2ef60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b4d019881232833e915fedba48537548d2ef60>`__
 -  FIPS setup: fix typo filtering camellia encryption
-   `commit <https://pagure.io/freeipa/c/f2a337caaf82fca4a8d7c347454b412ba2b4a0dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2a337caaf82fca4a8d7c347454b412ba2b4a0dd>`__
 -  cert utilities: MAC verification is incompatible with FIPS mode
-   `commit <https://pagure.io/freeipa/c/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
 -  ipatests: update the fake fips mode expected message
-   `commit <https://pagure.io/freeipa/c/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
    `#9002 <https://pagure.io/freeipa/issue/9002>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
-   `commit <https://pagure.io/freeipa/c/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
    `#9290 <https://pagure.io/freeipa/issue/9290>`__
 -  webui tests: fix assertion in test_subid.py
-   `commit <https://pagure.io/freeipa/c/3801d0c1c8a3dbec54dead29666137de2649e109>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3801d0c1c8a3dbec54dead29666137de2649e109>`__
    `#9282 <https://pagure.io/freeipa/issue/9282>`__
 -  PRCI: update memory reqs for each topology
-   `commit <https://pagure.io/freeipa/c/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
 
 
 
@@ -320,16 +320,16 @@ mbhalodi (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test for sequence processing failures with server context
-   `commit <https://pagure.io/freeipa/c/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  ipatests: add missing automember-cli tests
-   `commit <https://pagure.io/freeipa/c/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/ff50fe5f038be52207bb770179becc31fbc74e17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff50fe5f038be52207bb770179becc31fbc74e17>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 
 
@@ -338,7 +338,7 @@ Michal Polovka (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: loginscreen: do not use hardcoded password
-   `commit <https://pagure.io/freeipa/c/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 
 
@@ -347,13 +347,13 @@ Rob Crittenden (3)
 ----------------------------------------------------------------------------------------------
 
 -  Wipe the ipa-ca DNS record when updating system records
-   `commit <https://pagure.io/freeipa/c/b9387280543b86444cf4c258a7b720f492357baf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9387280543b86444cf4c258a7b720f492357baf>`__
    `#9195 <https://pagure.io/freeipa/issue/9195>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
-   `commit <https://pagure.io/freeipa/c/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
-   `commit <https://pagure.io/freeipa/c/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 
 
@@ -362,31 +362,31 @@ Stanislav Levin (9)
 ----------------------------------------------------------------------------------------------
 
 -  fastlint: Correct concatenation of file lists
-   `commit <https://pagure.io/freeipa/c/d8418ce63de206967bea5918615ee4471183cd06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8418ce63de206967bea5918615ee4471183cd06>`__
    `#9318 <https://pagure.io/freeipa/issue/9318>`__
 -  dns: Fix support for dnspython 1.1x
-   `commit <https://pagure.io/freeipa/c/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
    `#9339 <https://pagure.io/freeipa/issue/9339>`__
 -  tests: webui: Update vendored qunit
-   `commit <https://pagure.io/freeipa/c/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  AP: webui: List installed nodejs packages
-   `commit <https://pagure.io/freeipa/c/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Load qunit only once
-   `commit <https://pagure.io/freeipa/c/958a3958b4835fc2454e8bd71797638dcef9c460>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/958a3958b4835fc2454e8bd71797638dcef9c460>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Allow file access from files in tests
-   `commit <https://pagure.io/freeipa/c/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
-   `commit <https://pagure.io/freeipa/c/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
    `#9319 <https://pagure.io/freeipa/issue/9319>`__
 -  spec: Drop no longer used build dependency on paste
-   `commit <https://pagure.io/freeipa/c/ebd4096f039964cfd1d95467630c10559d051e13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebd4096f039964cfd1d95467630c10559d051e13>`__
    `#9314 <https://pagure.io/freeipa/issue/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
-   `commit <https://pagure.io/freeipa/c/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
    `#9315 <https://pagure.io/freeipa/issue/9315>`__
 
 
@@ -396,7 +396,7 @@ Sumedh Sidhaye (1)
 
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
-   `commit <https://pagure.io/freeipa/c/e8ef2c2f226704ce510525f07675107179124a95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8ef2c2f226704ce510525f07675107179124a95>`__
    `#9238 <https://pagure.io/freeipa/issue/9238>`__
 
 
@@ -405,7 +405,7 @@ Sudhir Menon (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
-   `commit <https://pagure.io/freeipa/c/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
    `#9279 <https://pagure.io/freeipa/issue/9279>`__
 
 
@@ -414,4 +414,4 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  external-idp: change idp server name to reference name
-   `commit <https://pagure.io/freeipa/c/b9c6ea67d896e52b61bd40bfd84b8d84b69ec35e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9c6ea67d896e52b61bd40bfd84b8d84b69ec35e>`__

--- a/src/page/Releases/4.9.2.rst
+++ b/src/page/Releases/4.9.2.rst
@@ -101,36 +101,36 @@ Alexander Bokovoy (14)
 ----------------------------------------------------------------------------------------------
 
 -  Back to git commits
-   `commit <https://pagure.io/freeipa/c/811d130c66880208a244741b90a5e6de2429004a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/811d130c66880208a244741b90a5e6de2429004a>`__
 -  Become IPA 4.9.2
-   `commit <https://pagure.io/freeipa/c/34600a0ecac3ad3fbe7b7b5767c3a4c1a455dc45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34600a0ecac3ad3fbe7b7b5767c3a4c1a455dc45>`__
 -  po: refresh translations to remove outdated strings
-   `commit <https://pagure.io/freeipa/c/66ffc9a612e932578b609061a5f1b38fc1c46c50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66ffc9a612e932578b609061a5f1b38fc1c46c50>`__
 -  po: update translations template
-   `commit <https://pagure.io/freeipa/c/d1313a595d63ced25b2df029029ef501e88ea596>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1313a595d63ced25b2df029029ef501e88ea596>`__
 -  test_installutils: run gpg-agent under a specific SELinux context
-   `commit <https://pagure.io/freeipa/c/7ca2797eaca963fe94f7396353569f7f8ed6d09d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ca2797eaca963fe94f7396353569f7f8ed6d09d>`__
    `#8699 <https://pagure.io/freeipa/issue/8699>`__
 -  Force-update translation after FreeIPA to IPA change: po/fr.po
-   `commit <https://pagure.io/freeipa/c/fc9652107e4424f0567bc5a010cad15047db7212>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc9652107e4424f0567bc5a010cad15047db7212>`__
 -  Force-update translation after FreeIPA to IPA change: po/es.po
-   `commit <https://pagure.io/freeipa/c/12d92fe517504ac9bec2d76bc15e7303af2f89e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12d92fe517504ac9bec2d76bc15e7303af2f89e5>`__
 -  Force-update translation po/id.po
-   `commit <https://pagure.io/freeipa/c/e77d68900a1e8d0476670b0d59b13cea6e1b7f80>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e77d68900a1e8d0476670b0d59b13cea6e1b7f80>`__
 -  Force-update translation po/fr.po
-   `commit <https://pagure.io/freeipa/c/cf054fc169879fcd3987b97ccec163402c706392>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf054fc169879fcd3987b97ccec163402c706392>`__
 -  Force-update translation po/es.po
-   `commit <https://pagure.io/freeipa/c/d8398815b10c53e678d96ea31afc9a0eb671f57b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8398815b10c53e678d96ea31afc9a0eb671f57b>`__
 -  Force-update translation po/de.po
-   `commit <https://pagure.io/freeipa/c/7d00ad4b767eb17e218e03544aa53881c9333330>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d00ad4b767eb17e218e03544aa53881c9333330>`__
 -  client: synchronize ignored return codes with ipa-rmkeytab
-   `commit <https://pagure.io/freeipa/c/5a1ad476e04859e68809435a8098beef1d38c76d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a1ad476e04859e68809435a8098beef1d38c76d>`__
    `#8658 <https://pagure.io/freeipa/issue/8658>`__
 -  ipa-sam: return NetBIOS domain name instead of DNS one
-   `commit <https://pagure.io/freeipa/c/8a4cf2187a6298a46b52ba12ff04648b73f8dd56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a4cf2187a6298a46b52ba12ff04648b73f8dd56>`__
    `#8636 <https://pagure.io/freeipa/issue/8636>`__
 -  Back to git commits
-   `commit <https://pagure.io/freeipa/c/9690659ddf57e32a9255d8eed8d27b3ffa8a90cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9690659ddf57e32a9255d8eed8d27b3ffa8a90cf>`__
 
 
 
@@ -138,15 +138,15 @@ Antonio Torres (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test addition of invalid sudo command
-   `commit <https://pagure.io/freeipa/c/029daa5ffad5ee5f7be9c3661d88c98fe20398cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/029daa5ffad5ee5f7be9c3661d88c98fe20398cb>`__
 -  sudocmd: ensure command doesn't contain trailing dot before adding it
-   `commit <https://pagure.io/freeipa/c/602a4fa321560c69407d1c6d0a04f190a5350038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/602a4fa321560c69407d1c6d0a04f190a5350038>`__
 -  WebUI: change FreeIPA naming to IPA in About dialog
-   `commit <https://pagure.io/freeipa/c/4f63dc994522243fde1cb932f6a8b5a26a171933>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f63dc994522243fde1cb932f6a8b5a26a171933>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Update samba configuration on IPA master to explicitly use 'server
    role' setting
-   `commit <https://pagure.io/freeipa/c/2b64a4e8ad5563030650f6d293d4b0537d72cd2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b64a4e8ad5563030650f6d293d4b0537d72cd2c>`__
    `#8452 <https://pagure.io/freeipa/issue/8452>`__
 
 
@@ -155,16 +155,16 @@ Christian Heimes (4)
 ----------------------------------------------------------------------------------------------
 
 -  configure: ipaplatform falls back to ID_LIKE
-   `commit <https://pagure.io/freeipa/c/55180f6e9141bca391a7e2c9d9727948624c307f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55180f6e9141bca391a7e2c9d9727948624c307f>`__
    `#8689 <https://pagure.io/freeipa/issue/8689>`__
 -  Don't install csrgen extra dependencies
-   `commit <https://pagure.io/freeipa/c/de3510211537f116a097d1212d2586f4b0726467>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de3510211537f116a097d1212d2586f4b0726467>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Ensure that KDC cert has SAN DNS entry
-   `commit <https://pagure.io/freeipa/c/5ab290a048d34b03821716b1606f9a33f62964d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ab290a048d34b03821716b1606f9a33f62964d9>`__
    `#8685 <https://pagure.io/freeipa/issue/8685>`__
 -  Fix cert_request for KDC cert
-   `commit <https://pagure.io/freeipa/c/2c48897ed1700725d3cd07a4a106e40f62d76c47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c48897ed1700725d3cd07a4a106e40f62d76c47>`__
    `#6739 <https://pagure.io/freeipa/issue/6739>`__,
    `#8686 <https://pagure.io/freeipa/issue/8686>`__
 
@@ -174,26 +174,26 @@ Florence Blanc-Renaud (8)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: update expected error message
-   `commit <https://pagure.io/freeipa/c/9854c399da83a30259ccec9cf9277ffd97f7cd67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9854c399da83a30259ccec9cf9277ffd97f7cd67>`__
    `#8704 <https://pagure.io/freeipa/issue/8704>`__
 -  xmlrpc tests: add a test for cert-remove-hold
-   `commit <https://pagure.io/freeipa/c/55c7e2121ea78eec102560d176ccb2c74146caf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/55c7e2121ea78eec102560d176ccb2c74146caf7>`__
    `#8704 <https://pagure.io/freeipa/issue/8704>`__
 -  cert plugin: propagate the error for non-existent cert
-   `commit <https://pagure.io/freeipa/c/45d7d15c1186bc563393ae0bf131ccf94b1d12c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45d7d15c1186bc563393ae0bf131ccf94b1d12c4>`__
    `#8704 <https://pagure.io/freeipa/issue/8704>`__
 -  ipatests: ipactl status now exits with 3 when a service is stopped
-   `commit <https://pagure.io/freeipa/c/8d30629801a88a8f03c94f2274ed93a1ff0a38be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d30629801a88a8f03c94f2274ed93a1ff0a38be>`__
    `#8588 <https://pagure.io/freeipa/issue/8588>`__
 -  ipatests: fix ipahealthcheck fixture \_modify_permission
-   `commit <https://pagure.io/freeipa/c/b784e1f8d4e393e31616430f74ccc3d158418619>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b784e1f8d4e393e31616430f74ccc3d158418619>`__
 -  OpenDNSSEC: fix timezone in key creation date
-   `commit <https://pagure.io/freeipa/c/2a51892ab9688b6bc5282098a426003932462549>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a51892ab9688b6bc5282098a426003932462549>`__
 -  ipatests: add a test for ZSK/KSK keytype in DNSKEY record
-   `commit <https://pagure.io/freeipa/c/dd21d068cb4500b0d8a8af14b0371f95cc40c974>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd21d068cb4500b0d8a8af14b0371f95cc40c974>`__
    `#8647 <https://pagure.io/freeipa/issue/8647>`__
 -  dnssec: fix the key type with OpenDNSSEC 2.1
-   `commit <https://pagure.io/freeipa/c/44762369fb05b67855a8dc81d647c8880d642902>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44762369fb05b67855a8dc81d647c8880d642902>`__
    `#8647 <https://pagure.io/freeipa/issue/8647>`__
 
 
@@ -202,7 +202,7 @@ Mohammad Rizwan (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test if server setup without dns uninstall properly
-   `commit <https://pagure.io/freeipa/c/85674f16a18a6d4917dcf56330dc122902b53475>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85674f16a18a6d4917dcf56330dc122902b53475>`__
    `#8630 <https://pagure.io/freeipa/issue/8630>`__
 
 
@@ -211,62 +211,62 @@ Rob Crittenden (20)
 ----------------------------------------------------------------------------------------------
 
 -  Remove the option stop_certmonger from stop_tracking\_\*
-   `commit <https://pagure.io/freeipa/c/9872610f7df6576813715f5de239957042ca2c9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9872610f7df6576813715f5de239957042ca2c9d>`__
    `#8506 <https://pagure.io/freeipa/issue/8506>`__,
    `#8533 <https://pagure.io/freeipa/issue/8533>`__
 -  Add some logging around initial ACME deployment
-   `commit <https://pagure.io/freeipa/c/6526ab48a36b068de1970a2685dcedcf4b278bd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6526ab48a36b068de1970a2685dcedcf4b278bd3>`__
    `#8712 <https://pagure.io/freeipa/issue/8712>`__
 -  Add versions to the ACME config templates and update on upgrade
-   `commit <https://pagure.io/freeipa/c/31061c60af065d7251a7aaf6d5c93e86434d12f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31061c60af065d7251a7aaf6d5c93e86434d12f2>`__
    `#8712 <https://pagure.io/freeipa/issue/8712>`__
 -  Set the ACME baseURL in order to pin a client to a single IPA server
-   `commit <https://pagure.io/freeipa/c/a16dc59447bceab9df7d0597e81af2f1a525ce4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a16dc59447bceab9df7d0597e81af2f1a525ce4c>`__
    `#8712 <https://pagure.io/freeipa/issue/8712>`__
 -  Add RHEL 9 UI branding patch reference
-   `commit <https://pagure.io/freeipa/c/dffe69573e1ee5a14af12d83c9c86084cfa3a58d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dffe69573e1ee5a14af12d83c9c86084cfa3a58d>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Force-update translation after FreeIPA to IPA change: po/ipa.pot
-   `commit <https://pagure.io/freeipa/c/936f98e93e43f1e30d3109d37009654db349a241>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/936f98e93e43f1e30d3109d37009654db349a241>`__
 -  Remove references to rjsmin in UI compile.sh
-   `commit <https://pagure.io/freeipa/c/1478db894844ca4527e0017a7204d4d6f5695752>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1478db894844ca4527e0017a7204d4d6f5695752>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Remove support for csrgen
-   `commit <https://pagure.io/freeipa/c/e35bec9a5214a836d938eae6c577a4f33fe5e4f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e35bec9a5214a836d938eae6c577a4f33fe5e4f9>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Change FreeIPA references to IPA and Identity Management
-   `commit <https://pagure.io/freeipa/c/f05ee29d10f2be294d707bd34bfc8399c06b63c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f05ee29d10f2be294d707bd34bfc8399c06b63c5>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  ipatests: Handle non-zero return code in test_ipactl_scenario_check
-   `commit <https://pagure.io/freeipa/c/00226adaa68935fbc1d85508eadafa420027edb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00226adaa68935fbc1d85508eadafa420027edb5>`__
    `#8550 <https://pagure.io/freeipa/issue/8550>`__
 -  Add exit status to the ipactl man page
-   `commit <https://pagure.io/freeipa/c/302f9377e5c760bcf38be2b0503915ccadef8b67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/302f9377e5c760bcf38be2b0503915ccadef8b67>`__
    `#8550 <https://pagure.io/freeipa/issue/8550>`__
 -  Ensure IPA is running (ideally) before uninstalling the KRA
-   `commit <https://pagure.io/freeipa/c/87ede26cc2bcbe543cb970a5e55cf1901791a100>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87ede26cc2bcbe543cb970a5e55cf1901791a100>`__
    `#8550 <https://pagure.io/freeipa/issue/8550>`__
 -  ipactl: support script status 3, program is not running
-   `commit <https://pagure.io/freeipa/c/ddb5414d56f57fdd18ad66fbc6a53410725dd9cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ddb5414d56f57fdd18ad66fbc6a53410725dd9cd>`__
    `#8588 <https://pagure.io/freeipa/issue/8588>`__
 -  Use the new API introduced in PKI 10.8
-   `commit <https://pagure.io/freeipa/c/4d26ce5061c5b7f9383286a108fc48b19b5bc65a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d26ce5061c5b7f9383286a108fc48b19b5bc65a>`__
 -  Change CA profile migration message from info to debug
-   `commit <https://pagure.io/freeipa/c/b99bc2d8b1e5226f61a7c980cfb7576dac222466>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b99bc2d8b1e5226f61a7c980cfb7576dac222466>`__
 -  Only build the UI with uglifyjs on RHEL 8
-   `commit <https://pagure.io/freeipa/c/5fb0cc43eab329e8cb0020ca96f70a05fa9bb4bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fb0cc43eab329e8cb0020ca96f70a05fa9bb4bd>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Provide more detailed logging around memory detection
-   `commit <https://pagure.io/freeipa/c/6eff5b9527d5d187922eed6f569d3e63d67e094d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6eff5b9527d5d187922eed6f569d3e63d67e094d>`__
    `#8404 <https://pagure.io/freeipa/issue/8404>`__
 -  ipatests: Update NSSDatabase DBM test on non-DBM-capable installs
-   `commit <https://pagure.io/freeipa/c/7f1849e74a7c81213ec658058aec97033c84e038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f1849e74a7c81213ec658058aec97033c84e038>`__
    `#8675 <https://pagure.io/freeipa/issue/8675>`__
 -  Ignore database errors when trying to extract ipaCert on upgrade
-   `commit <https://pagure.io/freeipa/c/348d4eef6f974c75cb546fc690bb3a20a789de28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/348d4eef6f974c75cb546fc690bb3a20a789de28>`__
    `#8675 <https://pagure.io/freeipa/issue/8675>`__
 -  Report the NSS database directory if it cannot be opened
-   `commit <https://pagure.io/freeipa/c/b71c0c678430c38cbd22663cbf48229a23f19c8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b71c0c678430c38cbd22663cbf48229a23f19c8e>`__
    `#8675 <https://pagure.io/freeipa/issue/8675>`__
 
 
@@ -275,12 +275,12 @@ Stanislav Levin (3)
 ----------------------------------------------------------------------------------------------
 
 -  rpm-spec: Require crypto-policies-scripts
-   `commit <https://pagure.io/freeipa/c/0b11a7ce5542fae4d3d2ab0584d3dfe0f67ef617>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b11a7ce5542fae4d3d2ab0584d3dfe0f67ef617>`__
 -  ipatests: Handle AAAA records in test_ipa_dns_systemrecords_check
-   `commit <https://pagure.io/freeipa/c/151fa5040af0f044fe7bf0154c2dcfc58506a499>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/151fa5040af0f044fe7bf0154c2dcfc58506a499>`__
    `#8683 <https://pagure.io/freeipa/issue/8683>`__
 -  Azure: Populate containers with self-AAAA records
-   `commit <https://pagure.io/freeipa/c/63b14839aff23db7977decbeb742949bd05a8219>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63b14839aff23db7977decbeb742949bd05a8219>`__
    `#8683 <https://pagure.io/freeipa/issue/8683>`__
 
 
@@ -290,19 +290,19 @@ Sergey Orlov (5)
 
 -  ipatests: use pexpect to control inetractive session of
    ipa-adtrust-install
-   `commit <https://pagure.io/freeipa/c/34d72d16ee3ac4e3979eed5be7ddf31997a485b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34d72d16ee3ac4e3979eed5be7ddf31997a485b8>`__
    `#8690 <https://pagure.io/freeipa/issue/8690>`__
 -  ipatests: use pexpect to invoke ktutil
-   `commit <https://pagure.io/freeipa/c/1c15447e1345a3c93932e70dea1177f6a42fb2d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c15447e1345a3c93932e70dea1177f6a42fb2d4>`__
    `#8690 <https://pagure.io/freeipa/issue/8690>`__
 -  ipatests: add a tests-oriented wrapper for pexpect module
-   `commit <https://pagure.io/freeipa/c/29377901f7bc74baceda1bf42617dd69dacf10a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29377901f7bc74baceda1bf42617dd69dacf10a2>`__
    `#8690 <https://pagure.io/freeipa/issue/8690>`__
 -  ipatests: rewrite test for requests routing to subordinate suffixes
-   `commit <https://pagure.io/freeipa/c/0d9f988f5eb5f07965582b84f1b3ac812125b63f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d9f988f5eb5f07965582b84f1b3ac812125b63f>`__
    `#8554 <https://pagure.io/freeipa/issue/8554>`__
 -  fix collecting log files which are symlinks
-   `commit <https://pagure.io/freeipa/c/5517aa691805cccfa4d19a28a6dbf3319845c4a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5517aa691805cccfa4d19a28a6dbf3319845c4a6>`__
 
 
 
@@ -310,4 +310,4 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  man: fix ipa-client-samba.1 typos
-   `commit <https://pagure.io/freeipa/c/b290bc12b25938db5e29b7742989a1a0c99f15f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b290bc12b25938db5e29b7742989a1a0c99f15f4>`__

--- a/src/page/Releases/4.9.3.rst
+++ b/src/page/Releases/4.9.3.rst
@@ -140,7 +140,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Update gating to Fedora 33
-   `commit <https://pagure.io/freeipa/c/0dfd4b7ea38ffd6f8fe7a57660ef36b225fb377a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dfd4b7ea38ffd6f8fe7a57660ef36b225fb377a>`__
 
 
 
@@ -148,27 +148,27 @@ Alexander Bokovoy (10)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.3
-   `commit <https://pagure.io/freeipa/c/dab3706c0d0bb0137ad3f742fd4a687649f5d216>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dab3706c0d0bb0137ad3f742fd4a687649f5d216>`__
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/8cb32381347e643a389ad5b0dce429087ba37bea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cb32381347e643a389ad5b0dce429087ba37bea>`__
 -  Update ipa.pot translations file
-   `commit <https://pagure.io/freeipa/c/ef4a2f30b458db9487ebf724bdd3ba1f4e7f9d99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef4a2f30b458db9487ebf724bdd3ba1f4e7f9d99>`__
 -  freeipa.spec: synchronize with Fedora for 389-ds and PKI versions
-   `commit <https://pagure.io/freeipa/c/a63c6e0252ba82233839ad33ca9331be2b7aba95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a63c6e0252ba82233839ad33ca9331be2b7aba95>`__
    `#8705 <https://pagure.io/freeipa/issue/8705>`__
 -  ipa-kdb: mark test functions as static
-   `commit <https://pagure.io/freeipa/c/2968609fd9f8f91b704dc8167d39ecc67beb8ddd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2968609fd9f8f91b704dc8167d39ecc67beb8ddd>`__
 -  ipa-kdb: reformat ipa_kdb_certauth
-   `commit <https://pagure.io/freeipa/c/f340baa4283c76957d9e0a85896c7fa3a994bba6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f340baa4283c76957d9e0a85896c7fa3a994bba6>`__
 -  ipa-kdb: add missing prototypes
-   `commit <https://pagure.io/freeipa/c/c7ce801b590e29263e9b1904995c603735007771>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7ce801b590e29263e9b1904995c603735007771>`__
 -  ipa-kdb: fix compiler warnings
-   `commit <https://pagure.io/freeipa/c/0da9de495ca41a1bf0926aef7c9c75c3e53dcd63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0da9de495ca41a1bf0926aef7c9c75c3e53dcd63>`__
 -  ipa-kdb: do not use OpenLDAP functions with NULL LDAP context
-   `commit <https://pagure.io/freeipa/c/2832810891acfaca68142df7271d6f0a50a588eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2832810891acfaca68142df7271d6f0a50a588eb>`__
    `#8681 <https://pagure.io/freeipa/issue/8681>`__
 -  Back to git commits
-   `commit <https://pagure.io/freeipa/c/811d130c66880208a244741b90a5e6de2429004a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/811d130c66880208a244741b90a5e6de2429004a>`__
 
 
 
@@ -176,35 +176,35 @@ Antonio Torres (11)
 ----------------------------------------------------------------------------------------------
 
 -  sudorule: reduce number of LDAP searches during modification
-   `commit <https://pagure.io/freeipa/c/8552faba077f5ef7ef3c6f9b2281564df553dbc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8552faba077f5ef7ef3c6f9b2281564df553dbc7>`__
    `#8780 <https://pagure.io/freeipa/issue/8780>`__
 -  ipa passwd: make help for \`--otp\` option clearer
-   `commit <https://pagure.io/freeipa/c/74638edb4387b570b545f0c0e3067a3fc10c703b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74638edb4387b570b545f0c0e3067a3fc10c703b>`__
    `#8244 <https://pagure.io/freeipa/issue/8244>`__
 -  ipatests: add test for multiple permitopen entries in SSH keys
-   `commit <https://pagure.io/freeipa/c/dc799a5f9602099be048abda319023cda9d466c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc799a5f9602099be048abda319023cda9d466c7>`__
 -  Allow multiple permitopen/permitlisten in SSH keys
-   `commit <https://pagure.io/freeipa/c/3dc58965fa7ba6080ba0c281567ac6d9b211953e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dc58965fa7ba6080ba0c281567ac6d9b211953e>`__
    `#8423 <https://pagure.io/freeipa/issue/8423>`__
 -  ipatests: add test for group creation with GID and nonposix option
-   `commit <https://pagure.io/freeipa/c/d8bc3e401ea83d845ce11b19d9b14e28676a9a33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8bc3e401ea83d845ce11b19d9b14e28676a9a33>`__
 -  Enhance error message when adding non-posix group with a GID
-   `commit <https://pagure.io/freeipa/c/28d310d5b0f84d5769c2ccada7ab48c6138b14de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28d310d5b0f84d5769c2ccada7ab48c6138b14de>`__
    `#8155 <https://pagure.io/freeipa/issue/8155>`__
 -  ipatests: expect boolean type for nsaccountlock in user module
-   `commit <https://pagure.io/freeipa/c/cfff1f6710e1c0a857e913c8545b9a4b0a0e05f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfff1f6710e1c0a857e913c8545b9a4b0a0e05f9>`__
    `#8743 <https://pagure.io/freeipa/issue/8743>`__
 -  Return nsaccountlock in user-add as boolean
-   `commit <https://pagure.io/freeipa/c/39153f9b8a9af7537cd594e5d708abecef9217c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/39153f9b8a9af7537cd594e5d708abecef9217c8>`__
    `#8743 <https://pagure.io/freeipa/issue/8743>`__
 -  Extend logging to include execution time
-   `commit <https://pagure.io/freeipa/c/e880d38beb95cd15311d49c8a1e748d5dfe45ca6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e880d38beb95cd15311d49c8a1e748d5dfe45ca6>`__
    `#8759 <https://pagure.io/freeipa/issue/8759>`__
 -  ipatests: check that zonemgr is set correctly during server install
-   `commit <https://pagure.io/freeipa/c/82043e1fd052618608d3b7786473a632478795ee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82043e1fd052618608d3b7786473a632478795ee>`__
    `#8718 <https://pagure.io/freeipa/issue/8718>`__
 -  ipaserver: don't ignore zonemgr option on install
-   `commit <https://pagure.io/freeipa/c/20bb855a57080145d0d5555294381c890ef605bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20bb855a57080145d0d5555294381c890ef605bb>`__
    `#8718 <https://pagure.io/freeipa/issue/8718>`__
 
 
@@ -213,7 +213,7 @@ Alexander Scheel (1)
 ----------------------------------------------------------------------------------------------
 
 -  Handle multiple AJP adapters during upgrade
-   `commit <https://pagure.io/freeipa/c/60389f538429c943d7b1056a3743faae2eecc59d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60389f538429c943d7b1056a3743faae2eecc59d>`__
 
 
 
@@ -221,32 +221,32 @@ François Cami (10)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: check for the "no sudo present" string absence
-   `commit <https://pagure.io/freeipa/c/4b917833fdd62cce2fd72809fd5c963194efba3e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b917833fdd62cce2fd72809fd5c963194efba3e>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  ipa-client-install: output a warning if sudo is not present (2)
-   `commit <https://pagure.io/freeipa/c/061e0b63ef3a72ba3261b42ec5f2ce290070c613>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/061e0b63ef3a72ba3261b42ec5f2ce290070c613>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  ipa-csreplica-manage, ipa-replica-manage: refactor
-   `commit <https://pagure.io/freeipa/c/25cbae4d0248fd289fb9cc6dbe55ca8fd88b5513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25cbae4d0248fd289fb9cc6dbe55ca8fd88b5513>`__
    `#8605 <https://pagure.io/freeipa/issue/8605>`__
 -  ipalib/util.py: add print_replication_status
-   `commit <https://pagure.io/freeipa/c/5f2f97a698fc8278b3bc908e9bfc0d452575afa5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5f2f97a698fc8278b3bc908e9bfc0d452575afa5>`__
 -  ipa-replica-manage: handle missing attributes
-   `commit <https://pagure.io/freeipa/c/85484d312cf0e9da563ea97166ea24dfd6833702>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85484d312cf0e9da563ea97166ea24dfd6833702>`__
    `#8605 <https://pagure.io/freeipa/issue/8605>`__
 -  ipa-replica-manage: always display nsds5replicalastinitstatus
-   `commit <https://pagure.io/freeipa/c/f6204b0d5e6f82827249e09ff2e4598ea4e7f69e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6204b0d5e6f82827249e09ff2e4598ea4e7f69e>`__
    `#8605 <https://pagure.io/freeipa/issue/8605>`__
 -  freeipa.spec: client: depend on libsss_sudo and sudo
-   `commit <https://pagure.io/freeipa/c/ee0ba2df41cf545b82d3d26e7e7e42447bb0f63e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee0ba2df41cf545b82d3d26e7e7e42447bb0f63e>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  ipa-client-install: output a warning if sudo is not present
-   `commit <https://pagure.io/freeipa/c/fe157ca349e3146a53884e90e6e588efb4e97eeb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe157ca349e3146a53884e90e6e588efb4e97eeb>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 -  ipatests: tasks: handle uninstalling packages with nodeps
-   `commit <https://pagure.io/freeipa/c/0c2741af9f353d2fbb21a5768e6433c0e99da0e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c2741af9f353d2fbb21a5768e6433c0e99da0e9>`__
 -  ipatests: add TestInstallWithoutSudo
-   `commit <https://pagure.io/freeipa/c/b590dcef10680b4ea3181ae1caec183e5967562b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b590dcef10680b4ea3181ae1caec183e5967562b>`__
    `#8530 <https://pagure.io/freeipa/issue/8530>`__
 
 
@@ -255,36 +255,36 @@ Florence Blanc-Renaud (11)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: update expected message
-   `commit <https://pagure.io/freeipa/c/c9ed627288a5319719b94dc9b8c0fea692a827b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9ed627288a5319719b94dc9b8c0fea692a827b4>`__
    `#8779 <https://pagure.io/freeipa/issue/8779>`__
 -  Adapt redhat ipaplatform to RHEL9/ELN
-   `commit <https://pagure.io/freeipa/c/8272da74041330b500425847b8f4dc84aba01b56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8272da74041330b500425847b8f4dc84aba01b56>`__
    `#8753 <https://pagure.io/freeipa/issue/8753>`__
 -  ipatests: fix TestInstalDNSSECFirst::test_resolvconf logic
-   `commit <https://pagure.io/freeipa/c/5af574326bd60c52ddcaf7f7cfe73f4e810bc04a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5af574326bd60c52ddcaf7f7cfe73f4e810bc04a>`__
    `#8695 <https://pagure.io/freeipa/issue/8695>`__
 -  ipatests: re-add test_dnssec.py::TestInstallDNSSECFirst in gating
-   `commit <https://pagure.io/freeipa/c/ab23ecdad53d2095d9534a4c941dab7e205f286c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab23ecdad53d2095d9534a4c941dab7e205f286c>`__
    `#8496 <https://pagure.io/freeipa/issue/8496>`__
 -  ipatests: filter_users belongs to nss section
-   `commit <https://pagure.io/freeipa/c/5221f4c2a08094e15f516bbef8a722c0869ba53a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5221f4c2a08094e15f516bbef8a722c0869ba53a>`__
    `#8747 <https://pagure.io/freeipa/issue/8747>`__
 -  dnssec: concurrency issue when disabling old replica key
-   `commit <https://pagure.io/freeipa/c/7616f1dad2b478c5e4f850587da1bd4e52108fa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7616f1dad2b478c5e4f850587da1bd4e52108fa1>`__
    `#8654 <https://pagure.io/freeipa/issue/8654>`__
 -  dnssec: fix ipa-ods-exporter crash when master key missing
-   `commit <https://pagure.io/freeipa/c/9cfcbc67e12c2ce6e98d3ed1645bc592a573199e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cfcbc67e12c2ce6e98d3ed1645bc592a573199e>`__
    `#8654 <https://pagure.io/freeipa/issue/8654>`__
 -  ipatests: use whole date when calling journalctl --since
-   `commit <https://pagure.io/freeipa/c/caf748860860293e010e695d72f6b3b3d8509f8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/caf748860860293e010e695d72f6b3b3d8509f8a>`__
    `#8728 <https://pagure.io/freeipa/issue/8728>`__
 -  freeipa.spec: bump the required version of 389ds
-   `commit <https://pagure.io/freeipa/c/1c1c469fc94b3c6b26a73173bfba7698108ec69c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c1c469fc94b3c6b26a73173bfba7698108ec69c>`__
    `#8496 <https://pagure.io/freeipa/issue/8496>`__
 -  ipatests: Update PRCI templates for ipa-4-9
-   `commit <https://pagure.io/freeipa/c/1bcacd800a4fdba3899bf1358bc532e717ad335c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bcacd800a4fdba3899bf1358bc532e717ad335c>`__
 -  pylint: fix inconsistent-return-statements
-   `commit <https://pagure.io/freeipa/c/2fae28f974ccdbcf021cb506b31761cf04547c64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fae28f974ccdbcf021cb506b31761cf04547c64>`__
    `#8720 <https://pagure.io/freeipa/issue/8720>`__
 
 
@@ -293,7 +293,7 @@ Fraser Tweedale (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-cert-fix: improve handling of 'pki-server cert-fix' failure
-   `commit <https://pagure.io/freeipa/c/f2b1b5b07c1b7e813ee5dbe342ff24ebbc939bb9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b1b5b07c1b7e813ee5dbe342ff24ebbc939bb9>`__
    `#8721 <https://pagure.io/freeipa/issue/8721>`__
 
 
@@ -302,7 +302,7 @@ Jan Pazdziora (1)
 ----------------------------------------------------------------------------------------------
 
 -  Avoid comparing 'max' with 'max\n'.
-   `commit <https://pagure.io/freeipa/c/44d7cce3a032b7b793708a84198414fba8a276bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44d7cce3a032b7b793708a84198414fba8a276bd>`__
 
 
 
@@ -310,7 +310,7 @@ Kaleemullah Siddiqui (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: error message check in uninstall log for KRA
-   `commit <https://pagure.io/freeipa/c/6b25cd3241a5609b4d903d5697b8947fab403c90>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b25cd3241a5609b4d903d5697b8947fab403c90>`__
    `#8550 <https://pagure.io/freeipa/issue/8550>`__
 
 
@@ -319,23 +319,23 @@ Mohammad Rizwan (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Don't rely on certmonger's assigned request id
-   `commit <https://pagure.io/freeipa/c/8defcb0cee32eedda28a0adb6d7745c6fbdbf355>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8defcb0cee32eedda28a0adb6d7745c6fbdbf355>`__
    `#8725 <https://pagure.io/freeipa/issue/8725>`__
 -  ipatests: Enable certbot test on rhel
-   `commit <https://pagure.io/freeipa/c/339152c1ca5e0d3b7f11a03390003a57328d0d6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/339152c1ca5e0d3b7f11a03390003a57328d0d6d>`__
 -  ipatests: introduce wait_for_replication in test_rolecheck_Trust
-   `commit <https://pagure.io/freeipa/c/1b8de48f1cce81277e63c104adc6c5f485e70418>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b8de48f1cce81277e63c104adc6c5f485e70418>`__
    `#8553 <https://pagure.io/freeipa/issue/8553>`__
 -  ipatests: update nightly definition for ipa_cert_fix suite
-   `commit <https://pagure.io/freeipa/c/260fbcb03297ef1ed5418b16c0df0587d2989b22>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/260fbcb03297ef1ed5418b16c0df0587d2989b22>`__
 -  ipatests: Test if ipa-cert-fix renews expired certs with kra
    installed
-   `commit <https://pagure.io/freeipa/c/c84e0547e1a693ba0e9edbfeea7bafdb2fb2b4a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c84e0547e1a693ba0e9edbfeea7bafdb2fb2b4a2>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 -  Move fixture outside the class and add setup_kra capability
-   `commit <https://pagure.io/freeipa/c/36a60dbb35cb4429f00528f79bec8b7982a30c74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36a60dbb35cb4429f00528f79bec8b7982a30c74>`__
 -  ipatests: Test if ipa-cert-fix renews expired certs
-   `commit <https://pagure.io/freeipa/c/7f30ddb1b7e30c22f9b7d14d2658b58a0ea6b459>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f30ddb1b7e30c22f9b7d14d2658b58a0ea6b459>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 
 
@@ -344,34 +344,34 @@ Rob Crittenden (11)
 ----------------------------------------------------------------------------------------------
 
 -  Increase timeout for TestIpaHealthCheck to 5400s
-   `commit <https://pagure.io/freeipa/c/d15e577bc1b6f9d98b1ac424d1c0df4ef9839c91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d15e577bc1b6f9d98b1ac424d1c0df4ef9839c91>`__
    `#8506 <https://pagure.io/freeipa/issue/8506>`__
 -  Uninstall without starting the CA in cert expiration test
-   `commit <https://pagure.io/freeipa/c/b70e30dbf011fd918c4f2955dda0fc2bc12a35ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b70e30dbf011fd918c4f2955dda0fc2bc12a35ea>`__
    `#8506 <https://pagure.io/freeipa/issue/8506>`__
 -  ipatests: Test secure_ajp_connector works with multiple connectors
-   `commit <https://pagure.io/freeipa/c/16fbe095ff54e4b560a81c0cc0453c939f2c58a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16fbe095ff54e4b560a81c0cc0453c939f2c58a8>`__
 -  Allow overriding is_newer_tomcat_version()
-   `commit <https://pagure.io/freeipa/c/d3e4bd9ec450c6ea5285c76fee60a7c6601b58f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3e4bd9ec450c6ea5285c76fee60a7c6601b58f3>`__
 -  Don't renew non-IPA issued certs in ipa-cert-fix
-   `commit <https://pagure.io/freeipa/c/f3463728f2196589d36e14cedccb26c03730a7c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3463728f2196589d36e14cedccb26c03730a7c0>`__
    `#8600 <https://pagure.io/freeipa/issue/8600>`__
 -  Set pki-core dependency to 10.3.3 for pki-server cert-fix bug
-   `commit <https://pagure.io/freeipa/c/4cb6f0ba0df928eea60b20892a6fc85373627946>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cb6f0ba0df928eea60b20892a6fc85373627946>`__
 -  ipatests: test third-party 389-ds cert with ipa-cert-fix
-   `commit <https://pagure.io/freeipa/c/660507fda2394b17d709c47a05ce5df548a47990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/660507fda2394b17d709c47a05ce5df548a47990>`__
    `#8600 <https://pagure.io/freeipa/issue/8600>`__
 -  ipa-cert-fix: Don't hardcode the NSS certificate nickname
-   `commit <https://pagure.io/freeipa/c/a0626e09b3eaf5d030982e2ff03e95841ad1b4b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0626e09b3eaf5d030982e2ff03e95841ad1b4b9>`__
    `#8600 <https://pagure.io/freeipa/issue/8600>`__
 -  Remove a remaining file used with csrgen
-   `commit <https://pagure.io/freeipa/c/fe4b1545b6f288f10aa11f4dd8ff32b14d337fc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe4b1545b6f288f10aa11f4dd8ff32b14d337fc1>`__
    `#8669 <https://pagure.io/freeipa/issue/8669>`__
 -  Don't double-report any errors from pki-spawn failures
-   `commit <https://pagure.io/freeipa/c/f1e12c75f12a739599c07ffe88aea82df635fabd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1e12c75f12a739599c07ffe88aea82df635fabd>`__
    `#8565 <https://pagure.io/freeipa/issue/8565>`__
 -  Suppress error message if the CRL directory doesn't exist
-   `commit <https://pagure.io/freeipa/c/584151d1277f60e1db116992fbd98f3421391254>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/584151d1277f60e1db116992fbd98f3421391254>`__
    `#8565 <https://pagure.io/freeipa/issue/8565>`__
 
 
@@ -380,43 +380,43 @@ Stanislav Levin (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Skip test_jsplugins in server less environments
-   `commit <https://pagure.io/freeipa/c/3eb8b304c612500218806c04486efd79b2495ba2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3eb8b304c612500218806c04486efd79b2495ba2>`__
    `#8781 <https://pagure.io/freeipa/issue/8781>`__
 -  Azure: Run Lint task as separate job
-   `commit <https://pagure.io/freeipa/c/188a279c5bf14b7cbd7cc0d65cc294fc6862b8d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/188a279c5bf14b7cbd7cc0d65cc294fc6862b8d3>`__
    `#8772 <https://pagure.io/freeipa/issue/8772>`__
 -  pylint: Fix several warnings
-   `commit <https://pagure.io/freeipa/c/2bec09aa038d2ef8f3819f11e67ba81d70cb5fe4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2bec09aa038d2ef8f3819f11e67ba81d70cb5fe4>`__
    `#8772 <https://pagure.io/freeipa/issue/8772>`__
 -  Azure: Don't install pypi's docker
-   `commit <https://pagure.io/freeipa/c/6c1dc1b226254003dda882f7856c4e3b3e5b3767>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c1dc1b226254003dda882f7856c4e3b3e5b3767>`__
 -  Azure: Disable AppArmor profile for chrony
-   `commit <https://pagure.io/freeipa/c/572f203c96baea3a086bea4e0846347b6f116bee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/572f203c96baea3a086bea4e0846347b6f116bee>`__
 -  Azure: Warn about Host's AVC and SECCOMP
-   `commit <https://pagure.io/freeipa/c/d47847b1a2b983a41099a63954df9b569d414959>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d47847b1a2b983a41099a63954df9b569d414959>`__
 -  Azure: Collect Host's systemd journal
-   `commit <https://pagure.io/freeipa/c/8cdc7bf070d90e0d641f32513c9ea3a709166d5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8cdc7bf070d90e0d641f32513c9ea3a709166d5d>`__
 -  Azure: Run chronyd in Docker
-   `commit <https://pagure.io/freeipa/c/255be047ff5ac8e79428c70c2a3b7c8ed026c965>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/255be047ff5ac8e79428c70c2a3b7c8ed026c965>`__
 -  Azure: Template docs build
-   `commit <https://pagure.io/freeipa/c/e80ff6f9d43731d8c1943cd154ef5f317f380414>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e80ff6f9d43731d8c1943cd154ef5f317f380414>`__
 -  Azure: Show disk usage
-   `commit <https://pagure.io/freeipa/c/adc4d8d7f674d159ea8f17395013859474af3290>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adc4d8d7f674d159ea8f17395013859474af3290>`__
 -  Azure: Make it possible to pass additional Pytest args
-   `commit <https://pagure.io/freeipa/c/380336d6d26228c237c1ef7e7e61ed472fd66e0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/380336d6d26228c237c1ef7e7e61ed472fd66e0d>`__
 -  Azure: Run rpmlint on Fedora
-   `commit <https://pagure.io/freeipa/c/8c38c57f77a455d6e5c257d4397011157f4f33e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c38c57f77a455d6e5c257d4397011157f4f33e3>`__
    `#8768 <https://pagure.io/freeipa/issue/8768>`__
 -  configure: Make rpmlint optional
-   `commit <https://pagure.io/freeipa/c/c441397b33fad0b5d03561763851efb6bcff4643>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c441397b33fad0b5d03561763851efb6bcff4643>`__
    `#8768 <https://pagure.io/freeipa/issue/8768>`__
 -  ipatests: Fix expectation about GSS error in test for healthcheck
-   `commit <https://pagure.io/freeipa/c/fbbfce1151b6c7dd95dea1a2438cd11c1b22e7b7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbbfce1151b6c7dd95dea1a2438cd11c1b22e7b7>`__
    `#8737 <https://pagure.io/freeipa/issue/8737>`__
 -  cleanup: Drop never used path for httpd's ccache
-   `commit <https://pagure.io/freeipa/c/99a65e3e720d0de94abfcbfa1c2619a709d3c8db>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99a65e3e720d0de94abfcbfa1c2619a709d3c8db>`__
 -  ccache_sweeper: Add gssproxy service
-   `commit <https://pagure.io/freeipa/c/cf80bb33baa79ba93987ee7e63109ece4b37bbd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf80bb33baa79ba93987ee7e63109ece4b37bbd0>`__
    `#8735 <https://pagure.io/freeipa/issue/8735>`__
 
 
@@ -425,49 +425,49 @@ Sergey Orlov (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: log command spawned by pexpect
-   `commit <https://pagure.io/freeipa/c/c52cf2130ac9610bb5ad9a964ff8ea6b86f86227>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c52cf2130ac9610bb5ad9a964ff8ea6b86f86227>`__
 -  ipatests: allocate pseudo-terminal only for specific command
-   `commit <https://pagure.io/freeipa/c/9f0c4830d0d53fda99e4a856099019efea11b177>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f0c4830d0d53fda99e4a856099019efea11b177>`__
 -  ipatests: update prci definitions for test_http_kdc_proxy
-   `commit <https://pagure.io/freeipa/c/305d6f227fd28eee16c817c5eb32a3d33a94153d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/305d6f227fd28eee16c817c5eb32a3d33a94153d>`__
 -  ipatests: add test for kdcproxy handling reply split to several TCP
    packets
-   `commit <https://pagure.io/freeipa/c/643a70a2442702d23492823ae1809d5dc392289d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/643a70a2442702d23492823ae1809d5dc392289d>`__
 -  ipatests: return result of kinit_as_user, pass raiseonerr parameter
-   `commit <https://pagure.io/freeipa/c/462dc75f8ea3435a42ad80e8fbbbe3092c706637>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/462dc75f8ea3435a42ad80e8fbbbe3092c706637>`__
 -  ipatests: use proper template for TestMaskInstall
-   `commit <https://pagure.io/freeipa/c/3ce45cec0973e88d76de6d7e16d0fa3116784c8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ce45cec0973e88d76de6d7e16d0fa3116784c8c>`__
 -  ipatests: do not configure nameserver when installing client and
    replica
-   `commit <https://pagure.io/freeipa/c/1ca7cb6585828312864eae6f5264e313be697bbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ca7cb6585828312864eae6f5264e313be697bbf>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: always try to create A records for hosts in IPA domain
-   `commit <https://pagure.io/freeipa/c/b0ee8e00aaad8d89baf3a751dd0f55f405d66394>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0ee8e00aaad8d89baf3a751dd0f55f405d66394>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: mock resolver factory
-   `commit <https://pagure.io/freeipa/c/b3abb2c696afeccd1f6eb8d3235d999cee53dfca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3abb2c696afeccd1f6eb8d3235d999cee53dfca>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: disable systemd-resolved cache
-   `commit <https://pagure.io/freeipa/c/28af45425ba2612cc0e2e612768b74bc0314d242>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28af45425ba2612cc0e2e612768b74bc0314d242>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: do not manually modify /etc/resolv.conf in tests
-   `commit <https://pagure.io/freeipa/c/f5d7f85b9280e6a0fae942e25e47db5e16ae49e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5d7f85b9280e6a0fae942e25e47db5e16ae49e4>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: setup resolvers during replica and client installations
-   `commit <https://pagure.io/freeipa/c/64f2a408ef5bc408c7c99a224c596dcf68037dd7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64f2a408ef5bc408c7c99a224c596dcf68037dd7>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: add utility for managing domain name resolvers
-   `commit <https://pagure.io/freeipa/c/1a394c6a016b21c5427fce9bad81f4c718ddeb45>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a394c6a016b21c5427fce9bad81f4c718ddeb45>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: collect config files for NetworkManager and
    systemd-resolved
-   `commit <https://pagure.io/freeipa/c/2c5b70643d5408fbe5aae1135392842824b1e49d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c5b70643d5408fbe5aae1135392842824b1e49d>`__
    `#8703 <https://pagure.io/freeipa/issue/8703>`__
 -  ipatests: test Samba mount with NTLM authentication
-   `commit <https://pagure.io/freeipa/c/80ccac79b9d123e158a5ba60f9853611d0854188>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/80ccac79b9d123e158a5ba60f9853611d0854188>`__
    `#8636 <https://pagure.io/freeipa/issue/8636>`__
 -  ipatests: skip tests for AD trust with shared secret in FIPS mode
-   `commit <https://pagure.io/freeipa/c/6d7b2d7d1b4711255ea72d62d27b5c5f4ec7c6e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d7b2d7d1b4711255ea72d62d27b5c5f4ec7c6e1>`__
    `#8715 <https://pagure.io/freeipa/issue/8715>`__
 
 
@@ -476,7 +476,7 @@ Sudhir Menon (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test to check sosreport collects healthcheck.log file
-   `commit <https://pagure.io/freeipa/c/9fb266882ea824f8b77bf1f049462850cdbdc4fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fb266882ea824f8b77bf1f049462850cdbdc4fe>`__
 
 
 
@@ -484,7 +484,7 @@ Troy Dawson (1)
 ----------------------------------------------------------------------------------------------
 
 -  platform-python only on RHEL8
-   `commit <https://pagure.io/freeipa/c/026e0ca89b48d0d2aa948c9769e6b7701906b13c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/026e0ca89b48d0d2aa948c9769e6b7701906b13c>`__
 
 
 
@@ -492,6 +492,6 @@ Thorsten Scherf (2)
 ----------------------------------------------------------------------------------------------
 
 -  Update 10-ssh-key-management.rst
-   `commit <https://pagure.io/freeipa/c/f6aac4d5cb9e2d724b71f8445a43e3c103a3f402>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f6aac4d5cb9e2d724b71f8445a43e3c103a3f402>`__
 -  Fix lgtm file classification
-   `commit <https://pagure.io/freeipa/c/cc3e3cd849f0dafed4ebc63dafe4cfdacd48ffe5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc3e3cd849f0dafed4ebc63dafe4cfdacd48ffe5>`__

--- a/src/page/Releases/4.9.4.rst
+++ b/src/page/Releases/4.9.4.rst
@@ -187,7 +187,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Bump PR-CI templates to Fedora 34
-   `commit <https://pagure.io/freeipa/c/1647afa9f7c153eea12aa4947102d1883d5be1c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1647afa9f7c153eea12aa4947102d1883d5be1c8>`__
 
 
 
@@ -195,85 +195,85 @@ Alexander Bokovoy (37)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.4
-   `commit <https://pagure.io/freeipa/c/d64d74df6fa75bea0a014083f1a9c815c6a6a3b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d64d74df6fa75bea0a014083f1a9c815c6a6a3b8>`__
 -  po/uk.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/5b6a656147612d26003fa8aab6d0d033a1dfa2ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b6a656147612d26003fa8aab6d0d033a1dfa2ac>`__
 -  po/ru.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/d6de84e711021dfd3477a5db5b7f9fde393d09d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6de84e711021dfd3477a5db5b7f9fde393d09d7>`__
 -  po/ipa.pot: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/45232145d9ad3aa3ac45e2ccf63593ca2e61e50c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45232145d9ad3aa3ac45e2ccf63593ca2e61e50c>`__
 -  po/es.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/1157c5b14f994bce1a2f31fc0e0c7da139dd14fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1157c5b14f994bce1a2f31fc0e0c7da139dd14fe>`__
 -  Depend on system-logos-ipa on RHEL/CentOS Stream
-   `commit <https://pagure.io/freeipa/c/3dd8c4d5134f7997ee75b18b282b83ff56ae5bbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3dd8c4d5134f7997ee75b18b282b83ff56ae5bbc>`__
    `#8874 <https://pagure.io/freeipa/issue/8874>`__
 -  service: enforce keytab user when retrieving the keytab
-   `commit <https://pagure.io/freeipa/c/d7f3c1ff4cbfc7840ca7c3015ca13eaeceee18ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3c1ff4cbfc7840ca7c3015ca13eaeceee18ca>`__
    `#8872 <https://pagure.io/freeipa/issue/8872>`__
 -  po/zh_CN.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/94831c341962d20c5a3ba9d5a293db9b69b7e331>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94831c341962d20c5a3ba9d5a293db9b69b7e331>`__
 -  po/tr.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/5cf1340132a4f015e28cd1325e45eba8d1c0d581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cf1340132a4f015e28cd1325e45eba8d1c0d581>`__
 -  po/tg.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/3f74383c98a367abdfcb7afd02c84299c7c0b8d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f74383c98a367abdfcb7afd02c84299c7c0b8d0>`__
 -  po/sk.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/9905e38311e9e065a98176b2f5eb71eec0fd5ef3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9905e38311e9e065a98176b2f5eb71eec0fd5ef3>`__
 -  po/ru.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/d3ef07ad5165d94bc399fb96d6b19d785e9a11ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3ef07ad5165d94bc399fb96d6b19d785e9a11ca>`__
 -  po/pt_BR.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/468c4852fee883f4769d1d4787822e5fa55f6aaf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/468c4852fee883f4769d1d4787822e5fa55f6aaf>`__
 -  po/pt.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/e7bfe72c155859b0ea315d7c24ff415fdf8f82fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7bfe72c155859b0ea315d7c24ff415fdf8f82fb>`__
 -  po/pa.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/e8ba917032624e348d3f6ec864350633abd228c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8ba917032624e348d3f6ec864350633abd228c3>`__
 -  po/nl.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/fa15bf13d56789e6250172bbe12e2af2aaea20d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa15bf13d56789e6250172bbe12e2af2aaea20d5>`__
 -  po/mr.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/a4679b8bc592af77b9619e4472ed3cf8c5f9ae2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4679b8bc592af77b9619e4472ed3cf8c5f9ae2b>`__
 -  po/kn.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/8c5ca861e15720661b9edbcc74ab2f678a407102>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c5ca861e15720661b9edbcc74ab2f678a407102>`__
 -  po/ja.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/44c57c274489a2c2da155bb58d74f6f63c07d6d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44c57c274489a2c2da155bb58d74f6f63c07d6d9>`__
 -  po/ipa.pot: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/0feda3dd7601da90109b5c303b6da0915faf6b9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0feda3dd7601da90109b5c303b6da0915faf6b9d>`__
 -  po/id.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/87150c2b6f95f34fc4efa9ffd01b716335961e24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87150c2b6f95f34fc4efa9ffd01b716335961e24>`__
 -  po/hu.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/3eca1f9127ec67c9fb94f199c36f9ee78103690a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3eca1f9127ec67c9fb94f199c36f9ee78103690a>`__
 -  po/hi.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/1de25fb8047f99fa45d9095e584086bc3ee1393b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1de25fb8047f99fa45d9095e584086bc3ee1393b>`__
 -  po/fr.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/00a0cb3abfcd9c38d202bde548868feddaee65cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00a0cb3abfcd9c38d202bde548868feddaee65cc>`__
 -  po/eu.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/4f68174c09a1bad858bde69e9170a9057c31e5e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f68174c09a1bad858bde69e9170a9057c31e5e9>`__
 -  po/es.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/f9c667e81a204c5db68ccf9276faf17d1d6d584d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9c667e81a204c5db68ccf9276faf17d1d6d584d>`__
 -  po/en_GB.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/9c34f7eac57395be459d417f58650e3ca7a1b835>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c34f7eac57395be459d417f58650e3ca7a1b835>`__
 -  po/de.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/5ed8987fba831154746f3131650f1efa83a5e7d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ed8987fba831154746f3131650f1efa83a5e7d8>`__
 -  po/cs.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/626c7f7d15de71ca78018d8ae339b35cb1af7a2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/626c7f7d15de71ca78018d8ae339b35cb1af7a2e>`__
 -  po/ca.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/7cb4ee0d1282cd1c292421585f92b07647aa2642>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cb4ee0d1282cd1c292421585f92b07647aa2642>`__
 -  po/bn_IN.po: Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/d933123eda92b7259ce8d67c6d95fa00c8f683bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d933123eda92b7259ce8d67c6d95fa00c8f683bd>`__
 -  ds: Support renaming of a replication plugin in 389-ds
-   `commit <https://pagure.io/freeipa/c/04a6583ce3c1304907d092b19e5c7cc915f6952a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04a6583ce3c1304907d092b19e5c7cc915f6952a>`__
    `#8799 <https://pagure.io/freeipa/issue/8799>`__
 -  Update IRC links to point to Libera.chat
-   `commit <https://pagure.io/freeipa/c/ab5aba2b78caace61079c229f30dd81e501446ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab5aba2b78caace61079c229f30dd81e501446ef>`__
 -  freeipa.spec: do not use jsl for linting on Fedora 34+
-   `commit <https://pagure.io/freeipa/c/18563bc87b07fd7aca6f9d3af534fdc2c42bb8aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18563bc87b07fd7aca6f9d3af534fdc2c42bb8aa>`__
    `#8847 <https://pagure.io/freeipa/issue/8847>`__
 -  ipa-otpd: handle LDAP timeout in a better way
-   `commit <https://pagure.io/freeipa/c/33404a62c01053c6a25b21445bb2731249064618>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33404a62c01053c6a25b21445bb2731249064618>`__
    `#6587 <https://pagure.io/freeipa/issue/6587>`__
 -  ipaserver/install/dns: handle SERVFAIL when checking reverse zone
-   `commit <https://pagure.io/freeipa/c/aea2c9fb02e07935524c7998ff265a22057eceb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aea2c9fb02e07935524c7998ff265a22057eceb5>`__
    `#8794 <https://pagure.io/freeipa/issue/8794>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/50d986b98196c540d38916b0410910e5450f4871>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50d986b98196c540d38916b0410910e5450f4871>`__
 
 
 
@@ -281,7 +281,7 @@ Antonio Torres (1)
 ----------------------------------------------------------------------------------------------
 
 -  hbacrule: reduce number of LDAP searches during deletion
-   `commit <https://pagure.io/freeipa/c/046012ecfa9731bc98ef2103645ad99cfd0baa32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/046012ecfa9731bc98ef2103645ad99cfd0baa32>`__
    `#8784 <https://pagure.io/freeipa/issue/8784>`__
 
 
@@ -290,7 +290,7 @@ Carl George (1)
 ----------------------------------------------------------------------------------------------
 
 -  Also use uglifyjs on CentOS Stream 8
-   `commit <https://pagure.io/freeipa/c/a8c3f5f4374fdcdcca05ece7cdbcd8a769cc7c55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8c3f5f4374fdcdcca05ece7cdbcd8a769cc7c55>`__
 
 
 
@@ -298,24 +298,24 @@ Christian Heimes (7)
 ----------------------------------------------------------------------------------------------
 
 -  Move constants, document timeout loop
-   `commit <https://pagure.io/freeipa/c/7e9407d9d6c3d09263c70f805f360c6894a72262>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e9407d9d6c3d09263c70f805f360c6894a72262>`__
 -  Fix update_dna_shared_config to wait for both entries
-   `commit <https://pagure.io/freeipa/c/74889cf3ffa39e7988ebf7fc9c4480c3a0346a20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74889cf3ffa39e7988ebf7fc9c4480c3a0346a20>`__
    `#8831 <https://pagure.io/freeipa/issue/8831>`__
 -  Constrain pylint to supported versions
-   `commit <https://pagure.io/freeipa/c/35198bedf42f7142df3986b3ddef1d22029fbcab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35198bedf42f7142df3986b3ddef1d22029fbcab>`__
    `#8818 <https://pagure.io/freeipa/issue/8818>`__
 -  Add max/min safe integer
-   `commit <https://pagure.io/freeipa/c/0c3a2dbfeaa73db868bacd4042de02a20b714d05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c3a2dbfeaa73db868bacd4042de02a20b714d05>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__,
    `#8802 <https://pagure.io/freeipa/issue/8802>`__
 -  Use PyCA crypto provider for KRAClient
-   `commit <https://pagure.io/freeipa/c/0244a060f2a521548bae0f8fb1287bbed14b8653>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0244a060f2a521548bae0f8fb1287bbed14b8653>`__
    `#8814 <https://pagure.io/freeipa/issue/8814>`__
 -  Improve wsgi app loading
-   `commit <https://pagure.io/freeipa/c/b7700b9c5e2cf156fbecb15201ab26d562302b3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7700b9c5e2cf156fbecb15201ab26d562302b3b>`__
 -  Better mod_wsgi configuration
-   `commit <https://pagure.io/freeipa/c/07fe32e2ada5dae5e218b0a0ca9962fd42fd698d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07fe32e2ada5dae5e218b0a0ca9962fd42fd698d>`__
 
 
 
@@ -323,26 +323,26 @@ François Cami (7)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: mark test_ipahealthcheck_hidden_replica as expected failure
-   `commit <https://pagure.io/freeipa/c/0ffaf29a370d42d62ae4701fe7c1f5f885a7df2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ffaf29a370d42d62ae4701fe7c1f5f885a7df2c>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__,
    `#8582 <https://pagure.io/freeipa/issue/8582>`__
 -  ipatests: hidden replica: misc fixes
-   `commit <https://pagure.io/freeipa/c/45fa10434e1ee4c36ef0e3a0c3f88d447c71ba35>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45fa10434e1ee4c36ef0e3a0c3f88d447c71ba35>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 -  ipatests: hidden replica: use dns_update_system_records
-   `commit <https://pagure.io/freeipa/c/b1fef6b80a2102b2a28ab33e84e1bb827fddeeac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1fef6b80a2102b2a28ab33e84e1bb827fddeeac>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 -  ipatests: use wait_for_replication for hidden replica checks
-   `commit <https://pagure.io/freeipa/c/834adfc2b1cfcdb3486da2eabf0e9a1ee1ad96cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/834adfc2b1cfcdb3486da2eabf0e9a1ee1ad96cc>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 -  ipatests: hiddenreplica: use wait_for_ipa_to_start after restore
-   `commit <https://pagure.io/freeipa/c/9ad9c38ee00e46444e54c73b7ec5da16c66d4b93>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ad9c38ee00e46444e54c73b7ec5da16c66d4b93>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 -  ipatests: tasks.py: add dns_update_system_records
-   `commit <https://pagure.io/freeipa/c/18b03506d3f1f85656219699a0e9dda305b6885b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18b03506d3f1f85656219699a0e9dda305b6885b>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 -  ipatests: tasks.py: add wait_for_ipa_to_start
-   `commit <https://pagure.io/freeipa/c/7f598c8d8306f847c0c9ded165d33b8c6435d759>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f598c8d8306f847c0c9ded165d33b8c6435d759>`__
    `#8534 <https://pagure.io/freeipa/issue/8534>`__
 
 
@@ -351,39 +351,39 @@ Florence Blanc-Renaud (12)
 ----------------------------------------------------------------------------------------------
 
 -  pkispawn: override AJP connector address
-   `commit <https://pagure.io/freeipa/c/986e2d7d78d0026f01269b192770a45dc5f1b772>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/986e2d7d78d0026f01269b192770a45dc5f1b772>`__
    `#8851 <https://pagure.io/freeipa/issue/8851>`__
 -  Spec file: bump augeas-libs version
-   `commit <https://pagure.io/freeipa/c/4dd9d079fbc190ebcce54c427898c67d83066d1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4dd9d079fbc190ebcce54c427898c67d83066d1e>`__
    `#8676 <https://pagure.io/freeipa/issue/8676>`__
 -  xmlrpc tests: add test for idrange auto-private-groups option
-   `commit <https://pagure.io/freeipa/c/7ddc191491f9d06ebe28688fe9fb2d1dd80b711e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ddc191491f9d06ebe28688fe9fb2d1dd80b711e>`__
    `#8807 <https://pagure.io/freeipa/issue/8807>`__
 -  Trust: add auto private groups option
-   `commit <https://pagure.io/freeipa/c/cada918c7849dfff61eeef0c6ef1de420288bff0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cada918c7849dfff61eeef0c6ef1de420288bff0>`__
    `#8807 <https://pagure.io/freeipa/issue/8807>`__
 -  LDAP schema: new attribute ipaautoprivategroups
-   `commit <https://pagure.io/freeipa/c/42b8fa60cfbf1551e916816b6d738b44fdff509a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42b8fa60cfbf1551e916816b6d738b44fdff509a>`__
    `#8807 <https://pagure.io/freeipa/issue/8807>`__
 -  Design doc for idrange option "auto-private-groups"
-   `commit <https://pagure.io/freeipa/c/9d3414287068189be896c280f9ea1a6c8bc9d32d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d3414287068189be896c280f9ea1a6c8bc9d32d>`__
    `#8807 <https://pagure.io/freeipa/issue/8807>`__
 -  ipatests: check that the output of sudo -V is not displayed
-   `commit <https://pagure.io/freeipa/c/3499fdeec2391b9d2d06a6c073ac0cc2b5f02989>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3499fdeec2391b9d2d06a6c073ac0cc2b5f02989>`__
    `#8767 <https://pagure.io/freeipa/issue/8767>`__
 -  client install: do not capture sudo -V stdout
-   `commit <https://pagure.io/freeipa/c/7fa80acf5fda9ba06c81bed97f1a0c33346574a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fa80acf5fda9ba06c81bed97f1a0c33346574a6>`__
    `#8767 <https://pagure.io/freeipa/issue/8767>`__
 -  Bumps openssl requires
-   `commit <https://pagure.io/freeipa/c/de5fffd3c34560bd51d78deabcdf35529ca90a32>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de5fffd3c34560bd51d78deabcdf35529ca90a32>`__
    `#8632 <https://pagure.io/freeipa/issue/8632>`__
 -  ipatests: TestIpaHealthCheck now needs 1 client
-   `commit <https://pagure.io/freeipa/c/03dfd01ee78c495c0ee21c6ea9fcef1148eb1053>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03dfd01ee78c495c0ee21c6ea9fcef1148eb1053>`__
 -  ipatests: call server-del before replica uninstall
-   `commit <https://pagure.io/freeipa/c/c7271ea2ba40a4d0ff0d4d0b9bac9a237b747ef0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7271ea2ba40a4d0ff0d4d0b9bac9a237b747ef0>`__
    `#8792 <https://pagure.io/freeipa/issue/8792>`__
 -  ipatests: collect PKI config files and NSSDB
-   `commit <https://pagure.io/freeipa/c/4334438136dbc3dfcfb07f60f50dfb5a63c0618e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4334438136dbc3dfcfb07f60f50dfb5a63c0618e>`__
 
 
 
@@ -391,22 +391,22 @@ MIZUTA Takeshi (8)
 ----------------------------------------------------------------------------------------------
 
 -  Add --keyfile option to ipa-otptoken-import.1
-   `commit <https://pagure.io/freeipa/c/519328382b678ae2b3330c4dfd7460768aa6121e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/519328382b678ae2b3330c4dfd7460768aa6121e>`__
 -  Add argument for --entry option in ipa-managed-entries.1
-   `commit <https://pagure.io/freeipa/c/9a9373d5dce2610cee6e1b74c348138407bc8789>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a9373d5dce2610cee6e1b74c348138407bc8789>`__
 -  Remove -s option from ipa-ldap-updater usage
-   `commit <https://pagure.io/freeipa/c/25e0f4af667de5a665bc6702927d25ef58d4a22c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25e0f4af667de5a665bc6702927d25ef58d4a22c>`__
 -  Add argument for --schema-file option in ipa-ldap-updater.1
-   `commit <https://pagure.io/freeipa/c/190f8b62cddae49eeecf84728ec08e74e6dae7ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/190f8b62cddae49eeecf84728ec08e74e6dae7ae>`__
 -  Add arguments to the description of OPTIONS in ipa-winsync-migrate.1
-   `commit <https://pagure.io/freeipa/c/25c4da9e89fd70a257e91ec35fb70e41cff37dd9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25c4da9e89fd70a257e91ec35fb70e41cff37dd9>`__
 -  Fix the option to match in the ipa-client-automount usage and
    man-page
-   `commit <https://pagure.io/freeipa/c/7c17e27b7ff728a034863ac353602f75ebf82e41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c17e27b7ff728a034863ac353602f75ebf82e41>`__
 -  Add -d option to match in the ipa-client-samba usage and man-page
-   `commit <https://pagure.io/freeipa/c/8799df5383c5e93a014f05dd6d3befddefa49173>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8799df5383c5e93a014f05dd6d3befddefa49173>`__
 -  man: fix typos in ipa-epn.1
-   `commit <https://pagure.io/freeipa/c/9d37d077fd16871b15e2c39ca586e0eb9cc8403a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d37d077fd16871b15e2c39ca586e0eb9cc8403a>`__
 
 
 
@@ -414,16 +414,16 @@ Michal Polovka (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_installation: add install test scenarios
-   `commit <https://pagure.io/freeipa/c/a21311095d3b918fcb0f5fe28669e385103c31eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a21311095d3b918fcb0f5fe28669e385103c31eb>`__
    `#2575 <https://pagure.io/freeipa/issue/2575>`__,
    `#2692 <https://pagure.io/freeipa/issue/2692>`__,
    `#4011 <https://pagure.io/freeipa/issue/4011>`__,
    `#4166 <https://pagure.io/freeipa/issue/4166>`__
 -  WebUI: Handle assertion if multiple notifications are present
-   `commit <https://pagure.io/freeipa/c/bd2a14a2e8d36735d5c2051a06fb62f3f1c6c682>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd2a14a2e8d36735d5c2051a06fb62f3f1c6c682>`__
    `#8641 <https://pagure.io/freeipa/issue/8641>`__
 -  WebUI: test_user: test if user is enabled by default
-   `commit <https://pagure.io/freeipa/c/b3488b21319ad6ec800796313fdb7cd23ae17c23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3488b21319ad6ec800796313fdb7cd23ae17c23>`__
    `#8203 <https://pagure.io/freeipa/issue/8203>`__
 
 
@@ -432,7 +432,7 @@ Mohammad Rizwan (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test if ACME renews the issued cert with cerbot
-   `commit <https://pagure.io/freeipa/c/a7ff4089437ee20bbce7fc55d43a7702dd7540a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7ff4089437ee20bbce7fc55d43a7702dd7540a7>`__
    `#4751 <https://pagure.io/freeipa/issue/4751>`__
 
 
@@ -441,49 +441,49 @@ Rob Crittenden (15)
 ----------------------------------------------------------------------------------------------
 
 -  Catch ValueError when trying to retrieve existing credentials
-   `commit <https://pagure.io/freeipa/c/63d20c44760849a7ef65b234e7e231f9a073f61f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63d20c44760849a7ef65b234e7e231f9a073f61f>`__
    `#8873 <https://pagure.io/freeipa/issue/8873>`__
 -  ipatests: kinit on server for test_proxycommand_invalid_shell
-   `commit <https://pagure.io/freeipa/c/bfd7b6e00d00efea637f0f575570ac7abd6c5fbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfd7b6e00d00efea637f0f575570ac7abd6c5fbc>`__
    `#8785 <https://pagure.io/freeipa/issue/8785>`__
 -  Add ability to search on certificate revocation status
-   `commit <https://pagure.io/freeipa/c/6031b8a2109ab1963d395a63541ddb3a8799fd9f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6031b8a2109ab1963d395a63541ddb3a8799fd9f>`__
    `#7835 <https://pagure.io/freeipa/issue/7835>`__
 -  Load dogtag RA plugin in installers so profiles can be loaded
-   `commit <https://pagure.io/freeipa/c/7239864be38f13b5d6968552ea565a8dfedcf0dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7239864be38f13b5d6968552ea565a8dfedcf0dd>`__
    `#8738 <https://pagure.io/freeipa/issue/8738>`__
 -  Parse the debugging cache log to determine the read savings
-   `commit <https://pagure.io/freeipa/c/0307d222acb8a6c675b985463f56f1071a4e5364>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0307d222acb8a6c675b985463f56f1071a4e5364>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Add a unit test for the LDAP cache layer
-   `commit <https://pagure.io/freeipa/c/951720d4e66d313c537b003200efc3b33fe4b045>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/951720d4e66d313c537b003200efc3b33fe4b045>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Add LDAP cache options to the default.conf man page
-   `commit <https://pagure.io/freeipa/c/00c99cceb43d97a5331e0407337e845c710a51d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00c99cceb43d97a5331e0407337e845c710a51d4>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Implement simple LDAP cache layer
-   `commit <https://pagure.io/freeipa/c/b37d679f1dad9fc93f2a8431b4aa62b25f48bcb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b37d679f1dad9fc93f2a8431b4aa62b25f48bcb7>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Unify installer context to be 'installer'
-   `commit <https://pagure.io/freeipa/c/63767ec067a63811bf73a7314786123b2e89d5ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/63767ec067a63811bf73a7314786123b2e89d5ff>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Call the LDAPClient layer when modifying values
-   `commit <https://pagure.io/freeipa/c/d6637b2feb2008b4a9538518d5d08a0de79c5a68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6637b2feb2008b4a9538518d5d08a0de79c5a68>`__
    `#8798 <https://pagure.io/freeipa/issue/8798>`__
 -  Only attempt to upgrade ACME configuration files if deployed
-   `commit <https://pagure.io/freeipa/c/1aa3f7a7fd24c651aafde150351328148fd517be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1aa3f7a7fd24c651aafde150351328148fd517be>`__
    `#8832 <https://pagure.io/freeipa/issue/8832>`__
 -  Parse Apache log etime and display average per command
-   `commit <https://pagure.io/freeipa/c/bae02a7edad6cb291d7610fae3465119a3b72b65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bae02a7edad6cb291d7610fae3465119a3b72b65>`__
    `#8809 <https://pagure.io/freeipa/issue/8809>`__
 -  Retrieve the user objectclasses when checking for existence
-   `commit <https://pagure.io/freeipa/c/58c73a71ba296380e10ffc28a2c360ef8341d53d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58c73a71ba296380e10ffc28a2c360ef8341d53d>`__
    `#8801 <https://pagure.io/freeipa/issue/8801>`__
 -  Cache the value of ca_is_enabled in the request context
-   `commit <https://pagure.io/freeipa/c/74130f863f76c11b6705cde886804a60ea11f64f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74130f863f76c11b6705cde886804a60ea11f64f>`__
    `#8797 <https://pagure.io/freeipa/issue/8797>`__
 -  Add pkey_only to the service_find calls in host del and disable
-   `commit <https://pagure.io/freeipa/c/7e0626a922f63779836026f5aa7872177be08eef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e0626a922f63779836026f5aa7872177be08eef>`__
    `#8787 <https://pagure.io/freeipa/issue/8787>`__
 
 
@@ -492,66 +492,66 @@ Stanislav Levin (27)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fetch sudo rules without time offset
-   `commit <https://pagure.io/freeipa/c/8e05170f82c00d7873564cd6e811430a9fdc32da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e05170f82c00d7873564cd6e811430a9fdc32da>`__
    `#8844 <https://pagure.io/freeipa/issue/8844>`__
 -  azure: Make it possible to adjust Docker resources per test env
-   `commit <https://pagure.io/freeipa/c/391ca8b90b6610b16023602a30b451bdcb5a1e6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/391ca8b90b6610b16023602a30b451bdcb5a1e6f>`__
 -  azure: coredump: Wait for systemd fully booted
-   `commit <https://pagure.io/freeipa/c/692f42dc7d887d3f89a0915529aed4d5380079ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/692f42dc7d887d3f89a0915529aed4d5380079ea>`__
 -  azure: Re-balance tests envs
-   `commit <https://pagure.io/freeipa/c/d4d27947a80c8b530ae8b4b962543929db4a8999>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4d27947a80c8b530ae8b4b962543929db4a8999>`__
 -  azure: Warn about extra and missing gating tests compared to PR-CI
-   `commit <https://pagure.io/freeipa/c/0dd0631b21ce768d5624128983e7eb1c953297a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dd0631b21ce768d5624128983e7eb1c953297a3>`__
 -  ipatests: dnssec: Add alternative approach for checking chain of
    trust
-   `commit <https://pagure.io/freeipa/c/3ada2d983fa136016c94cf827f3c3ef1d65a8323>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ada2d983fa136016c94cf827f3c3ef1d65a8323>`__
    `#8793 <https://pagure.io/freeipa/issue/8793>`__
 -  azure: Collect installed packages
-   `commit <https://pagure.io/freeipa/c/3049b9587f0ded768ba3a61ec0e98368a6316a0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3049b9587f0ded768ba3a61ec0e98368a6316a0a>`__
 -  ipatests: Suppress list trust or certificates
-   `commit <https://pagure.io/freeipa/c/c92f10029b08b31969d1e1da9dfe6f4b6c1b7dff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c92f10029b08b31969d1e1da9dfe6f4b6c1b7dff>`__
 -  ipatests: Ignore warnings on failed to read files on tarring
-   `commit <https://pagure.io/freeipa/c/535131d633f80f3dd07206df9082b200b1d257c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/535131d633f80f3dd07206df9082b200b1d257c5>`__
 -  pytest: Show extra summary information for all except passed tests
-   `commit <https://pagure.io/freeipa/c/645f90a835d8ba8080ffdd9a7a3f98f40a3ac550>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/645f90a835d8ba8080ffdd9a7a3f98f40a3ac550>`__
 -  dns: get_reverse_zone: Ignore resolver's timeout
-   `commit <https://pagure.io/freeipa/c/9e1531180336083fe1b873045a06647ae9074633>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e1531180336083fe1b873045a06647ae9074633>`__
    `#7397 <https://pagure.io/freeipa/issue/7397>`__
 -  dnsutil: Improvements for IPA DNS Resolver
-   `commit <https://pagure.io/freeipa/c/b487629262671714b5e36c74c8dbc193b008ce7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b487629262671714b5e36c74c8dbc193b008ce7d>`__
 -  ipatests: Handle network-isolated mode
-   `commit <https://pagure.io/freeipa/c/a192c21b2ce7e6167aba4132ed9504a46aeebf4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a192c21b2ce7e6167aba4132ed9504a46aeebf4e>`__
 -  azure: Run Base and XMLRPC tests is isolated network
-   `commit <https://pagure.io/freeipa/c/5501fda5617739d1514e09eb0edebbda1fcf77b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5501fda5617739d1514e09eb0edebbda1fcf77b1>`__
 -  ipatests: Setup and collect BIND logs
-   `commit <https://pagure.io/freeipa/c/64c0f900306295d1e9832ed58844bb9b2338a339>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64c0f900306295d1e9832ed58844bb9b2338a339>`__
 -  BIND: Setup logging
-   `commit <https://pagure.io/freeipa/c/0932c9217ff343d788b13ee1845fecb9666cbea8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0932c9217ff343d788b13ee1845fecb9666cbea8>`__
    `#8856 <https://pagure.io/freeipa/issue/8856>`__
 -  azure: Warn about memory issues
-   `commit <https://pagure.io/freeipa/c/6164bfb56ad6d3acce9ea778cebf6694a15dd3d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6164bfb56ad6d3acce9ea778cebf6694a15dd3d8>`__
 -  azure: Add workaround for PhantomJS against OpenSSL 1.1.1
-   `commit <https://pagure.io/freeipa/c/aa0c8c832350cad0de1bfa99e7b23f8c6cadb4de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa0c8c832350cad0de1bfa99e7b23f8c6cadb4de>`__
 -  ipatests: Update expectations for test_detect_container
-   `commit <https://pagure.io/freeipa/c/c90a3636a4bb1b424f916a4498dd8aeef5d37dde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c90a3636a4bb1b424f916a4498dd8aeef5d37dde>`__
 -  azure: Mask systemd-resolved
-   `commit <https://pagure.io/freeipa/c/4d53d9fdf2339307033a14e2214bfb98923f4e9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d53d9fdf2339307033a14e2214bfb98923f4e9d>`__
 -  azure: Remove no longer needed repo
-   `commit <https://pagure.io/freeipa/c/e243b956f4fb04adbbee80a8ffdaca92f9eabf7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e243b956f4fb04adbbee80a8ffdaca92f9eabf7c>`__
 -  azure: Wait for systemd booted
-   `commit <https://pagure.io/freeipa/c/eb0a5db3043ead31194143926a56923dec593349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb0a5db3043ead31194143926a56923dec593349>`__
 -  azure: Enforce multi-user.target as default systemd's target
-   `commit <https://pagure.io/freeipa/c/c26907bc020afc4d54826606f2c00889a15bf06f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c26907bc020afc4d54826606f2c00889a15bf06f>`__
 -  azure: Collect systemd boot log
-   `commit <https://pagure.io/freeipa/c/c711292bcf5a0cb2ce02cd470be6a37b67200b25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c711292bcf5a0cb2ce02cd470be6a37b67200b25>`__
 -  azure: bump F32->F34
-   `commit <https://pagure.io/freeipa/c/b9fd47a7ae58085be49bcf6772d688779b492748>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9fd47a7ae58085be49bcf6772d688779b492748>`__
    `#8848 <https://pagure.io/freeipa/issue/8848>`__
 -  pkispawn: Make timeout consistent with IPA's startup_timeout
-   `commit <https://pagure.io/freeipa/c/5afe830e541296aad3d43598898bf335be8f6dd9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5afe830e541296aad3d43598898bf335be8f6dd9>`__
    `#8830 <https://pagure.io/freeipa/issue/8830>`__
 -  pylint: Adapt to new Pylint 2.8
-   `commit <https://pagure.io/freeipa/c/eefbe8558b25ca9e9da10b391ec41e2987b8bd2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eefbe8558b25ca9e9da10b391ec41e2987b8bd2d>`__
    `#8818 <https://pagure.io/freeipa/issue/8818>`__
 
 
@@ -560,7 +560,7 @@ Sergey Orlov (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: increase timeout for test_commands up to 1.5 hours
-   `commit <https://pagure.io/freeipa/c/a1ed05d7f91cf78e6d704dbf6051c72314973140>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1ed05d7f91cf78e6d704dbf6051c72314973140>`__
 
 
 
@@ -569,11 +569,11 @@ Serhii Tsymbaliuk (2)
 
 -  WebUI tests: Add test for 'ipaautoprivategroups' field on 'ID Ranges'
    page
-   `commit <https://pagure.io/freeipa/c/dfbafafc3e38fd5b07fc3843c28fa019900a0ee7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfbafafc3e38fd5b07fc3843c28fa019900a0ee7>`__
    `#8837 <https://pagure.io/freeipa/issue/8837>`__
 -  WebUI: Add support of 'ipaautoprivategroups' LDAP attribute on 'ID
    Ranges' page
-   `commit <https://pagure.io/freeipa/c/15b47c8b0c7bb484240726f29a126411a2483393>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15b47c8b0c7bb484240726f29a126411a2483393>`__
    `#8837 <https://pagure.io/freeipa/issue/8837>`__
 
 
@@ -583,4 +583,4 @@ Sudhir Menon (1)
 
 -  ipatests: Test to check ipa-healthcheck tool displays warning when
    run on ipa-client
-   `commit <https://pagure.io/freeipa/c/8c5eb88f7e5c3275fa94260b52c417e197a906e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c5eb88f7e5c3275fa94260b52c417e197a906e7>`__

--- a/src/page/Releases/4.9.5.rst
+++ b/src/page/Releases/4.9.5.rst
@@ -67,7 +67,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Bump PR-CI boxes
-   `commit <https://pagure.io/freeipa/c/79e0919132adf0df764400f9c27268cbadd2578b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79e0919132adf0df764400f9c27268cbadd2578b>`__
 
 
 
@@ -75,12 +75,12 @@ Alexander Bokovoy (3)
 ----------------------------------------------------------------------------------------------
 
 -  Become FreeIPA 4.9.5
-   `commit <https://pagure.io/freeipa/c/e045f118c87346bfab5b5634fd23f3054f082f7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e045f118c87346bfab5b5634fd23f3054f082f7f>`__
 -  get_credentials: return ValueError for missing creds
-   `commit <https://pagure.io/freeipa/c/5238651da06547bb004de2434ae7d357422ba735>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5238651da06547bb004de2434ae7d357422ba735>`__
    `#8873 <https://pagure.io/freeipa/issue/8873>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/b25f5bd9109b87916e097dd8353ea5f0dc49e398>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b25f5bd9109b87916e097dd8353ea5f0dc49e398>`__
 
 
 
@@ -88,17 +88,17 @@ Florence Blanc-Renaud (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-cert-fix man page: add note about certmonger renewal
-   `commit <https://pagure.io/freeipa/c/06a445aff10c1ab84e8784ab41b0a838e500e617>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a445aff10c1ab84e8784ab41b0a838e500e617>`__
    `#8702 <https://pagure.io/freeipa/issue/8702>`__
 -  freeipa.spec: bump 389-ds version
-   `commit <https://pagure.io/freeipa/c/6eb535334d33f8f375b856e3a2d0b8853b318b4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6eb535334d33f8f375b856e3a2d0b8853b318b4d>`__
    `#8691 <https://pagure.io/freeipa/issue/8691>`__,
    `#8756 <https://pagure.io/freeipa/issue/8756>`__
 -  ipatests: delete the replica before uninstallation
-   `commit <https://pagure.io/freeipa/c/2b22450dfdc1657b463683b09b9c69816f9152d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b22450dfdc1657b463683b09b9c69816f9152d9>`__
    `#8876 <https://pagure.io/freeipa/issue/8876>`__
 -  ipatests: set selinux context for fips mode
-   `commit <https://pagure.io/freeipa/c/13b257d7a05fd255df472144712edb34604dbe06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13b257d7a05fd255df472144712edb34604dbe06>`__
    `#8868 <https://pagure.io/freeipa/issue/8868>`__
 
 
@@ -107,9 +107,9 @@ Stanislav Levin (2)
 ----------------------------------------------------------------------------------------------
 
 -  gssproxy: Don't refresh expired delegated credentials
-   `commit <https://pagure.io/freeipa/c/0fd06f33b83aec19a88c594d3750bc476157ab83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fd06f33b83aec19a88c594d3750bc476157ab83>`__
 -  krb_utils: Simplify get_credentials
-   `commit <https://pagure.io/freeipa/c/700be74975cad998e7dbcc4fb437e6b0bbd77305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/700be74975cad998e7dbcc4fb437e6b0bbd77305>`__
    `#8873 <https://pagure.io/freeipa/issue/8873>`__
 
 
@@ -118,9 +118,9 @@ Sergey Orlov (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: disable test_nfs.py::TestNFS in nightly runs on Fedora 33
-   `commit <https://pagure.io/freeipa/c/c9f5acc0d281f1a27471091648c36f94528c5a29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9f5acc0d281f1a27471091648c36f94528c5a29>`__
    `#8877 <https://pagure.io/freeipa/issue/8877>`__
 -  ipatests: temporary disable execution of test_nfs.py::TestNFS in
    nightly runs
-   `commit <https://pagure.io/freeipa/c/6ee14f513711ae9be799cfa2bd009f13c5248932>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ee14f513711ae9be799cfa2bd009f13c5248932>`__
    `#8877 <https://pagure.io/freeipa/issue/8877>`__

--- a/src/page/Releases/4.9.6.rst
+++ b/src/page/Releases/4.9.6.rst
@@ -109,9 +109,9 @@ Alexander Bokovoy (2)
 ----------------------------------------------------------------------------------------------
 
 -  Become IPA v.4.9.6
-   `commit <https://pagure.io/freeipa/c/6b3496a7b3f6aaf23b8364e41c10a2689dc6e513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b3496a7b3f6aaf23b8364e41c10a2689dc6e513>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/9f16174c5f929a0884fcafb3da357a27e963b9bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f16174c5f929a0884fcafb3da357a27e963b9bc>`__
 
 
 
@@ -119,16 +119,16 @@ Antonio Torres (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test host update using shortname
-   `commit <https://pagure.io/freeipa/c/27a65a1a352b50304fa6765a535443993b445044>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27a65a1a352b50304fa6765a535443993b445044>`__
    `#8726 <https://pagure.io/freeipa/issue/8726>`__,
    `#8884 <https://pagure.io/freeipa/issue/8884>`__
 -  host: try to resolve FQDN before command execution
-   `commit <https://pagure.io/freeipa/c/48370cb3e8fa928dcc51406a4a5e7dbe5bf8243f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48370cb3e8fa928dcc51406a4a5e7dbe5bf8243f>`__
    `#8726 <https://pagure.io/freeipa/issue/8726>`__,
    `#8884 <https://pagure.io/freeipa/issue/8884>`__
 -  Allow PKINIT to be enabled when updating from a pre-PKINIT IPA CA
    server
-   `commit <https://pagure.io/freeipa/c/7bed7e4b06e70b04e16410878ad269564291eec4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7bed7e4b06e70b04e16410878ad269564291eec4>`__
    `#8532 <https://pagure.io/freeipa/issue/8532>`__
 
 
@@ -137,24 +137,24 @@ Christian Heimes (7)
 ----------------------------------------------------------------------------------------------
 
 -  Also drop Custodia client and forwarder
-   `commit <https://pagure.io/freeipa/c/62647ff3217331339e66170a0665b529e204be2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62647ff3217331339e66170a0665b529e204be2e>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 -  Add Custodia tests
-   `commit <https://pagure.io/freeipa/c/cde5e2d4d7c36fadad492a7a753547297ffbaf60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cde5e2d4d7c36fadad492a7a753547297ffbaf60>`__
 -  Remove more unused Custodia code
-   `commit <https://pagure.io/freeipa/c/7cb2c89d5900dc02df1e587dd87d7f820404cd92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7cb2c89d5900dc02df1e587dd87d7f820404cd92>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 -  Fix Custodia pylint issues
-   `commit <https://pagure.io/freeipa/c/0ec775fcfa15f1da20841111484e1e25d9f13d38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ec775fcfa15f1da20841111484e1e25d9f13d38>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 -  Fix Custodia imports
-   `commit <https://pagure.io/freeipa/c/02ece292ada0da25864bc71ed4f2f16d01933df5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02ece292ada0da25864bc71ed4f2f16d01933df5>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 -  Remove unused Custodia modules
-   `commit <https://pagure.io/freeipa/c/d804f1feeddd31957bc3d88dfb79e9bd119813cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d804f1feeddd31957bc3d88dfb79e9bd119813cb>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 -  Add Custodia 0.6.0 to ipaserver package
-   `commit <https://pagure.io/freeipa/c/1be15d2024f327bc846e5fe324dc24fb2a96a828>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1be15d2024f327bc846e5fe324dc24fb2a96a828>`__
    `#8882 <https://pagure.io/freeipa/issue/8882>`__
 
 
@@ -163,13 +163,13 @@ François Cami (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-client-install: update sssd.conf if nsupdate requires -g
-   `commit <https://pagure.io/freeipa/c/3cbd24dd04ece7ab24c5cbd3448a46aeb02363f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cbd24dd04ece7ab24c5cbd3448a46aeb02363f8>`__
    `#8402 <https://pagure.io/freeipa/issue/8402>`__
 -  ipa-client-install: invoke nsupdate twice (GSS-TSIG, plain)
-   `commit <https://pagure.io/freeipa/c/a8588c5006a61855cb178643916a02513df3fa31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8588c5006a61855cb178643916a02513df3fa31>`__
    `#8402 <https://pagure.io/freeipa/issue/8402>`__
 -  ipa-client-install: remove fsync in do_nsupdate()
-   `commit <https://pagure.io/freeipa/c/e82f2538326af62802a587dbd66ff1a06514af60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e82f2538326af62802a587dbd66ff1a06514af60>`__
    `#8402 <https://pagure.io/freeipa/issue/8402>`__
 
 
@@ -178,10 +178,10 @@ Florence Blanc-Renaud (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: use non-ascii chars in CA-less install
-   `commit <https://pagure.io/freeipa/c/4b040e10d3fac2cfb5ce057718e537ecbe8e2ac1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b040e10d3fac2cfb5ce057718e537ecbe8e2ac1>`__
    `#8880 <https://pagure.io/freeipa/issue/8880>`__
 -  CA-less install: non-ASCII chars in CA cert subject
-   `commit <https://pagure.io/freeipa/c/7b278b63b417edea74ca9344688e02b70e64b8bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b278b63b417edea74ca9344688e02b70e64b8bf>`__
    `#8880 <https://pagure.io/freeipa/issue/8880>`__
 
 
@@ -190,13 +190,13 @@ Rob Crittenden (3)
 ----------------------------------------------------------------------------------------------
 
 -  Return a copy of cached entries, only with requested attributes
-   `commit <https://pagure.io/freeipa/c/ae4478de1f0e9e35098d1bbbfae1b3506bcf3672>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae4478de1f0e9e35098d1bbbfae1b3506bcf3672>`__
    `#8897 <https://pagure.io/freeipa/issue/8897>`__
 -  Use get_replication_plugin_name in LDAP updater
-   `commit <https://pagure.io/freeipa/c/45d8118e6c94f25c0971fe2fe07d8f6eb7eb6f7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/45d8118e6c94f25c0971fe2fe07d8f6eb7eb6f7c>`__
    `#8885 <https://pagure.io/freeipa/issue/8885>`__
 -  When loading certificates verify that it is X.509 v3
-   `commit <https://pagure.io/freeipa/c/22f0d8c50ab4618b05d0263380f594b23153724b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22f0d8c50ab4618b05d0263380f594b23153724b>`__
    `#8817 <https://pagure.io/freeipa/issue/8817>`__
 
 
@@ -205,15 +205,15 @@ Stanislav Levin (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Add tests for \`env\` plugin
-   `commit <https://pagure.io/freeipa/c/0abae79183207a4bdc7a6147eb143319806ad567>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0abae79183207a4bdc7a6147eb143319806ad567>`__
 -  ipatests: Add tests for \`plugins\` plugin
-   `commit <https://pagure.io/freeipa/c/15d710247d389e992844637fdb8a35610b595ba2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15d710247d389e992844637fdb8a35610b595ba2>`__
    `#8898 <https://pagure.io/freeipa/issue/8898>`__
 -  plugins: Don't treat keys of api as bytes
-   `commit <https://pagure.io/freeipa/c/32eb409cf6c4bf03d4ae3451001c81d175310a7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/32eb409cf6c4bf03d4ae3451001c81d175310a7c>`__
    `#8898 <https://pagure.io/freeipa/issue/8898>`__
 -  ipatests: healthcheck: Update IPAHostKeytab assumptions
-   `commit <https://pagure.io/freeipa/c/d744ff3caef509af8d3c25393aac6c2d83fdb78c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d744ff3caef509af8d3c25393aac6c2d83fdb78c>`__
    `#8889 <https://pagure.io/freeipa/issue/8889>`__
 
 
@@ -222,7 +222,7 @@ Serhii Tsymbaliuk (1)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Fix certificate serial number representation
-   `commit <https://pagure.io/freeipa/c/52e60889ff85b0129503d086214419fc2f9700d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52e60889ff85b0129503d086214419fc2f9700d8>`__
    `#8754 <https://pagure.io/freeipa/issue/8754>`__
 
 
@@ -231,8 +231,8 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  Increase timeout for test_commands.py
-   `commit <https://pagure.io/freeipa/c/5d995b8c2ae7fd6902107f1566d59e00a16adcd9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d995b8c2ae7fd6902107f1566d59e00a16adcd9>`__
 -  ipatests: Test to check that ResponseNotReady error is not displayed
    when user session cache is deleted
-   `commit <https://pagure.io/freeipa/c/2aa77992090499b2706ca077cc8ca980f47abbc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2aa77992090499b2706ca077cc8ca980f47abbc0>`__
    `#7752 <https://pagure.io/freeipa/issue/7752>`__

--- a/src/page/Releases/4.9.7.rst
+++ b/src/page/Releases/4.9.7.rst
@@ -196,7 +196,7 @@ Armando Neto (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: bump prci boxes + move gating to f34
-   `commit <https://pagure.io/freeipa/c/02447762a3f62383313f0b8cd7c5d129dc2c6213>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02447762a3f62383313f0b8cd7c5d129dc2c6213>`__
    `#8935 <https://pagure.io/freeipa/issue/8935>`__
 
 
@@ -205,10 +205,10 @@ Alexander Bokovoy (2)
 ----------------------------------------------------------------------------------------------
 
 -  rhel platform: add a named crypto-policy support
-   `commit <https://pagure.io/freeipa/c/1a5159b216455070eb51b6a11ceaf0033fc8ce4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a5159b216455070eb51b6a11ceaf0033fc8ce4c>`__
    `#8925 <https://pagure.io/freeipa/issue/8925>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/2b7e8841824b44fc41581717c51ccd4b0fc553ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b7e8841824b44fc41581717c51ccd4b0fc553ff>`__
 
 
 
@@ -216,17 +216,17 @@ Anuja More (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test unsecure nsupdate.
-   `commit <https://pagure.io/freeipa/c/4fdab0c94c4e17e42e5f38a0e671bea39bcc9b74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fdab0c94c4e17e42e5f38a0e671bea39bcc9b74>`__
    `#8402 <https://pagure.io/freeipa/issue/8402>`__
 -  ipatests: Refactor test_check_otpd_after_idle_timeout
-   `commit <https://pagure.io/freeipa/c/eac03d6828d0bac1925c897090fc77e250eaee04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eac03d6828d0bac1925c897090fc77e250eaee04>`__
    `#6587 <https://pagure.io/freeipa/issue/6587>`__
 -  ipatests: skip test_basesearch_compat_tree on fedora.
-   `commit <https://pagure.io/freeipa/c/d4062e407d242a72b9d4e32f4fdd6aed086ce005>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4062e407d242a72b9d4e32f4fdd6aed086ce005>`__
 -  ipatests: Test ldapsearch with base scope works with compat tree.
-   `commit <https://pagure.io/freeipa/c/a3d71eb72a6125a80a9d7b698f34dcb95dc25184>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a3d71eb72a6125a80a9d7b698f34dcb95dc25184>`__
 -  ipatests: Test for OTP when the LDAP connection timed out.
-   `commit <https://pagure.io/freeipa/c/25a4acf3ad5964eacddbcb83ddf9f84432968918>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25a4acf3ad5964eacddbcb83ddf9f84432968918>`__
    `#6587 <https://pagure.io/freeipa/issue/6587>`__
 
 
@@ -235,23 +235,23 @@ Antonio Torres (6)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: expect SOA serial option deprecation warning
-   `commit <https://pagure.io/freeipa/c/1d7512495d3e7f933d95707f74a6b6f0aeecd00f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d7512495d3e7f933d95707f74a6b6f0aeecd00f>`__
    `#8227 <https://pagure.io/freeipa/issue/8227>`__
 -  dnszone: deprecate option for setting SOA serial
-   `commit <https://pagure.io/freeipa/c/4c0dcabd6e2163dfa80a4d2a18064824934274fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c0dcabd6e2163dfa80a4d2a18064824934274fa>`__
    `#8227 <https://pagure.io/freeipa/issue/8227>`__
 -  ipatests: test if KRA install fails when ca_host is overriden
-   `commit <https://pagure.io/freeipa/c/a4e13a33247fb14145c632fb53b4480fc5fb10ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4e13a33247fb14145c632fb53b4480fc5fb10ea>`__
    `#8245 <https://pagure.io/freeipa/issue/8245>`__
 -  ipa-kra-install: exit if ca_host is overriden
-   `commit <https://pagure.io/freeipa/c/ab4720d9c2bae059e8f622cd4a331510fefe27ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab4720d9c2bae059e8f622cd4a331510fefe27ae>`__
    `#8245 <https://pagure.io/freeipa/issue/8245>`__
 -  ipatests: ensure auth indicators can't be added to internal IPA
    services
-   `commit <https://pagure.io/freeipa/c/28484c3dee225662e41acc691bfe6b1c1cee99c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28484c3dee225662e41acc691bfe6b1c1cee99c8>`__
    `#8206 <https://pagure.io/freeipa/issue/8206>`__
 -  Add checks to prevent adding auth indicators to internal IPA services
-   `commit <https://pagure.io/freeipa/c/a5d2857297cfcf87ed8973df96e89ebcef22850d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5d2857297cfcf87ed8973df96e89ebcef22850d>`__
    `#8206 <https://pagure.io/freeipa/issue/8206>`__
 
 
@@ -260,23 +260,23 @@ Christian Heimes (8)
 ----------------------------------------------------------------------------------------------
 
 -  Fix string check in uninstall helper
-   `commit <https://pagure.io/freeipa/c/c5b5bc9099fc26b863d7c964e47dbdcd0ff008c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5b5bc9099fc26b863d7c964e47dbdcd0ff008c8>`__
    `#8937 <https://pagure.io/freeipa/issue/8937>`__
 -  Fix ldapupdate.get_sub_dict() for missing named user
-   `commit <https://pagure.io/freeipa/c/a1eb13cdbc109da8c028bb886a1207ea2cc23cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a1eb13cdbc109da8c028bb886a1207ea2cc23cee>`__
    `#8936 <https://pagure.io/freeipa/issue/8936>`__
 -  Test DNA plugin configuration
-   `commit <https://pagure.io/freeipa/c/b53a52a1fafa94e0129e6e3e55fddd59909f0f0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b53a52a1fafa94e0129e6e3e55fddd59909f0f0a>`__
 -  Fix oid of ipaUserDefaultSubordinateId
-   `commit <https://pagure.io/freeipa/c/44ccc0f64bac9fc2e7e3264984af26635bb34742>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44ccc0f64bac9fc2e7e3264984af26635bb34742>`__
 -  Fix ipa-server-upgrade
-   `commit <https://pagure.io/freeipa/c/e6e3fb606d08b0dc57bfa360a0f0082052441db6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6e3fb606d08b0dc57bfa360a0f0082052441db6>`__
 -  Use 389-DS' dnaInterval setting to assign intervals
-   `commit <https://pagure.io/freeipa/c/ef115b04182d572bf61e32e2405bbb68ff65e928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef115b04182d572bf61e32e2405bbb68ff65e928>`__
 -  Redesign subid feature
-   `commit <https://pagure.io/freeipa/c/5d4fe06663c3e66b1da73c01ce022790634a3e3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d4fe06663c3e66b1da73c01ce022790634a3e3b>`__
 -  Add basic support for subordinate user/group ids
-   `commit <https://pagure.io/freeipa/c/3540986a11d4f3401ba4918f25229a79283d9dbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3540986a11d4f3401ba4918f25229a79283d9dbd>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__
 
 
@@ -285,9 +285,9 @@ Chris Kelley (2)
 ----------------------------------------------------------------------------------------------
 
 -  Parse cert chain as JSON not XML
-   `commit <https://pagure.io/freeipa/c/40f76a53f78267b4d2b890defa3e4f7d27fdfb7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40f76a53f78267b4d2b890defa3e4f7d27fdfb7a>`__
 -  Parse getStatus as JSON not XML
-   `commit <https://pagure.io/freeipa/c/7fb95cc638b1c9b7f2e9a67dba859ef8126f2c5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fb95cc638b1c9b7f2e9a67dba859ef8126f2c5f>`__
 
 
 
@@ -295,40 +295,40 @@ François Cami (13)
 ----------------------------------------------------------------------------------------------
 
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/3cb6b5c801b04922c3a23070e79aab20399d033b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cb6b5c801b04922c3a23070e79aab20399d033b>`__
 -  ipatests: use krb5_trace in TestIpaAdTrustInstall
-   `commit <https://pagure.io/freeipa/c/9ae23e1257478bfee04b08b54f36dda7f5850348>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ae23e1257478bfee04b08b54f36dda7f5850348>`__
    `#8944 <https://pagure.io/freeipa/issue/8944>`__
 -  freeipa.spec.in: remove python3-pexpect from Requires
-   `commit <https://pagure.io/freeipa/c/e0e1d6f94dd16c8066be8ce3c75ef306890a3e2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0e1d6f94dd16c8066be8ce3c75ef306890a3e2b>`__
    `#8938 <https://pagure.io/freeipa/issue/8938>`__
 -  gating.yaml: Fix TestInstallMaster timeout
-   `commit <https://pagure.io/freeipa/c/33c561dcd30dc346ccbaa00933bcd1cac5e994b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33c561dcd30dc346ccbaa00933bcd1cac5e994b6>`__
 -  Azure: temporarily disable problematic tests, #2
-   `commit <https://pagure.io/freeipa/c/18ccaea7cb36b3d1069f0d12a15b06357b3f94f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18ccaea7cb36b3d1069f0d12a15b06357b3f94f0>`__
    `#8864 <https://pagure.io/freeipa/issue/8864>`__
 -  Azure: temporarily disable problematic tests, #1
-   `commit <https://pagure.io/freeipa/c/eb1d509fd5271d39cc899838b57e5398683401f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb1d509fd5271d39cc899838b57e5398683401f7>`__
    `#8864 <https://pagure.io/freeipa/issue/8864>`__
 -  tasks.py: fix flake8-reported issues
-   `commit <https://pagure.io/freeipa/c/5b826ab3582566b15a618f57cb2e002a9c16ef64>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b826ab3582566b15a618f57cb2e002a9c16ef64>`__
    `#8931 <https://pagure.io/freeipa/issue/8931>`__
 -  test_acme: make password renewal more robust
-   `commit <https://pagure.io/freeipa/c/701adb9185c77194ba1ad0c5fd2f13484417ef6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/701adb9185c77194ba1ad0c5fd2f13484417ef6f>`__
    `#8929 <https://pagure.io/freeipa/issue/8929>`__
 -  test_acme: refactor with tasks
-   `commit <https://pagure.io/freeipa/c/86869364a30f071ee79974b301ff68e80c0950ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86869364a30f071ee79974b301ff68e80c0950ba>`__
 -  ipatests: smbclient "-k" => "--use-kerberos=desired"
-   `commit <https://pagure.io/freeipa/c/161d5844eb1214e60c636bdb73713c6a43f1e75c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/161d5844eb1214e60c636bdb73713c6a43f1e75c>`__
    `#8926 <https://pagure.io/freeipa/issue/8926>`__
 -  rpcserver.py: perf_counter_ns is Python 3.7+
-   `commit <https://pagure.io/freeipa/c/1539c7383116647ad9c5b125b343f972e9c9653b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1539c7383116647ad9c5b125b343f972e9c9653b>`__
    `#8891 <https://pagure.io/freeipa/issue/8891>`__
 -  ipatests: smoke test for server debug mode.
-   `commit <https://pagure.io/freeipa/c/ee4be290e1583834a573c3896ee1d97b3fbb6c24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee4be290e1583834a573c3896ee1d97b3fbb6c24>`__
    `#8891 <https://pagure.io/freeipa/issue/8891>`__
 -  paths: add IPA_SERVER_CONF
-   `commit <https://pagure.io/freeipa/c/e713c227bb420a841ce3ae146bca55a84a1b0dbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e713c227bb420a841ce3ae146bca55a84a1b0dbf>`__
    `#8891 <https://pagure.io/freeipa/issue/8891>`__
 
 
@@ -337,41 +337,41 @@ Florence Blanc-Renaud (12)
 ----------------------------------------------------------------------------------------------
 
 -  webui tests: fix algo for finding available idrange
-   `commit <https://pagure.io/freeipa/c/f7997ed0b7d5b915c0184bf8e8864ff935cd6232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7997ed0b7d5b915c0184bf8e8864ff935cd6232>`__
    `#8919 <https://pagure.io/freeipa/issue/8919>`__
 -  Index: Fix definition for memberOf
-   `commit <https://pagure.io/freeipa/c/b132956e42a88ab39bb8d6a854e7c5d28d544a11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b132956e42a88ab39bb8d6a854e7c5d28d544a11>`__
    `#8920 <https://pagure.io/freeipa/issue/8920>`__
 -  spec file: Trust controller role should pull sssd-winbind-idmap
    package
-   `commit <https://pagure.io/freeipa/c/1a4f459b81bc77cdf233b65f41d0f76dbb5f2fce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a4f459b81bc77cdf233b65f41d0f76dbb5f2fce>`__
    `#8923 <https://pagure.io/freeipa/issue/8923>`__
 -  webui tests: close notification when revoking cert
-   `commit <https://pagure.io/freeipa/c/40e4ccf1ea943aba4d10e8126ffa49feddd2e683>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40e4ccf1ea943aba4d10e8126ffa49feddd2e683>`__
    `#8911 <https://pagure.io/freeipa/issue/8911>`__
 -  pr-ci definitions: add subid-related jobs
-   `commit <https://pagure.io/freeipa/c/d456649feb40d462f73321a4a220b4aff7adb443>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d456649feb40d462f73321a4a220b4aff7adb443>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__
 -  ipatests: use whole date when calling journalctl --since
-   `commit <https://pagure.io/freeipa/c/b2e6292337c6f7f68ac383db8aa54a1abfa3f6b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2e6292337c6f7f68ac383db8aa54a1abfa3f6b4>`__
    `#8918 <https://pagure.io/freeipa/issue/8918>`__
 -  Server install: do not use unchecked ip addr for ipa-ca record
-   `commit <https://pagure.io/freeipa/c/2c0a123e99d943f115cc726e391f5d79b5bfb70e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c0a123e99d943f115cc726e391f5d79b5bfb70e>`__
    `#8810 <https://pagure.io/freeipa/issue/8810>`__
 -  man page: update ipa-server-upgrade.1
-   `commit <https://pagure.io/freeipa/c/195035cef51a132b2b80df57ed50f2fe620244e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/195035cef51a132b2b80df57ed50f2fe620244e6>`__
    `#8913 <https://pagure.io/freeipa/issue/8913>`__
 -  augeas: bump version for rhel9
-   `commit <https://pagure.io/freeipa/c/076e499f6f1223458cb896f1e90296e511c922d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/076e499f6f1223458cb896f1e90296e511c922d7>`__
    `#8676 <https://pagure.io/freeipa/issue/8676>`__
 -  XMLRPC test: add a test for stageuser-add --user-auth-type
-   `commit <https://pagure.io/freeipa/c/4a5a0fe7d25209a41a2eadd159f7f4c771e5d7fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a5a0fe7d25209a41a2eadd159f7f4c771e5d7fc>`__
    `#8909 <https://pagure.io/freeipa/issue/8909>`__
 -  stageuser: add ipauserauthtypeclass when required
-   `commit <https://pagure.io/freeipa/c/06468b2f604c56b02231904072cb57412966a701>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06468b2f604c56b02231904072cb57412966a701>`__
    `#8909 <https://pagure.io/freeipa/issue/8909>`__
 -  Remove unneeded dependency on python-coverage
-   `commit <https://pagure.io/freeipa/c/9cfae2623420356fd99e09bf8559b11da66e2ccd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cfae2623420356fd99e09bf8559b11da66e2ccd>`__
    `#8905 <https://pagure.io/freeipa/issue/8905>`__
 
 
@@ -380,15 +380,15 @@ Michal Polovka (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: test_ipahealthcheck: Verify permissions for /var/log/ files
-   `commit <https://pagure.io/freeipa/c/488ac7e3ba9f36d6b187687d120920d2d80d8b7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/488ac7e3ba9f36d6b187687d120920d2d80d8b7f>`__
    `#8949 <https://pagure.io/freeipa/issue/8949>`__
 -  ipatests: test_installation: move tracking_reqs dependency to ipalib
    constants ipaserver: krainstance: utilize moved tracking_reqs
    dependency
-   `commit <https://pagure.io/freeipa/c/e5df4dc4884f1a66ccbca79b9a0d83874c996d1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5df4dc4884f1a66ccbca79b9a0d83874c996d1d>`__
    `#8795 <https://pagure.io/freeipa/issue/8795>`__
 -  ipatests: test_ipahealthcheck: print a message if a system is healthy
-   `commit <https://pagure.io/freeipa/c/7f910eb2dda8595da435b4aed6e759a2916df813>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f910eb2dda8595da435b4aed6e759a2916df813>`__
    `#8892 <https://pagure.io/freeipa/issue/8892>`__
 
 
@@ -397,11 +397,11 @@ Mohammad Rizwan (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Look for warning into stderr instead of stdout
-   `commit <https://pagure.io/freeipa/c/96dd8ac1cd2e7fb8177d83e7ba5c6d79f4216ea3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96dd8ac1cd2e7fb8177d83e7ba5c6d79f4216ea3>`__
    `#8890 <https://pagure.io/freeipa/issue/8890>`__
 -  ipatests: Test ipa-cert-fix warns when startup directive is missing
    from CS.cfg
-   `commit <https://pagure.io/freeipa/c/02c0da3ef74948579106aab4b669f6e64dd60b24>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/02c0da3ef74948579106aab4b669f6e64dd60b24>`__
    `#8890 <https://pagure.io/freeipa/issue/8890>`__
 
 
@@ -410,66 +410,66 @@ Rob Crittenden (21)
 ----------------------------------------------------------------------------------------------
 
 -  Only call add_agent_to_security_domain_admins() when CA is installed
-   `commit <https://pagure.io/freeipa/c/da1d543c2bfa9e4acb6fde170e66c88e521ac232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da1d543c2bfa9e4acb6fde170e66c88e521ac232>`__
    `#8956 <https://pagure.io/freeipa/issue/8956>`__
 -  ipatests: Verify that securitydomain is updated on server-del
-   `commit <https://pagure.io/freeipa/c/a417810df5500b5780396ab88d53eaea74f74ccc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a417810df5500b5780396ab88d53eaea74f74ccc>`__
    `#8930 <https://pagure.io/freeipa/issue/8930>`__
 -  Clean up the PKI securitydomain when removing a server
-   `commit <https://pagure.io/freeipa/c/be3a0f3201bbb060a9d53fb65cbbccf6c7bf9bb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be3a0f3201bbb060a9d53fb65cbbccf6c7bf9bb4>`__
    `#8930 <https://pagure.io/freeipa/issue/8930>`__
 -  pr-ci definitions: add custom plugin-related jobs
-   `commit <https://pagure.io/freeipa/c/78c48199782743e619463cefa7411817f4fe4a14>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78c48199782743e619463cefa7411817f4fe4a14>`__
    `#8415 <https://pagure.io/freeipa/issue/8415>`__
 -  ipatests: add suite for testing custom plugins
-   `commit <https://pagure.io/freeipa/c/e28e45402c7edb007e356a59cf09ed8e10cd14d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e28e45402c7edb007e356a59cf09ed8e10cd14d9>`__
    `#8415 <https://pagure.io/freeipa/issue/8415>`__
 -  Don't assume that plugin attributes and objectclasses are lowercase
-   `commit <https://pagure.io/freeipa/c/97a2a925348d3bd732e582108feb02d644ba011a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97a2a925348d3bd732e582108feb02d644ba011a>`__
    `#8415 <https://pagure.io/freeipa/issue/8415>`__
 -  Add index for sudoorder
-   `commit <https://pagure.io/freeipa/c/0526174971017aebfb9d9fcb29c6dde6e67438fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0526174971017aebfb9d9fcb29c6dde6e67438fe>`__
    `#8939 <https://pagure.io/freeipa/issue/8939>`__
 -  ipatests: verify that getcert output includes the issued date
-   `commit <https://pagure.io/freeipa/c/826b5825bd644fc69a9bee17626d71fe03cc0190>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/826b5825bd644fc69a9bee17626d71fe03cc0190>`__
 -  ipa-advise: Define the domain used when looking up ipa-ca
-   `commit <https://pagure.io/freeipa/c/9a4a6cdd27781573351595e38d38eeadc8ab090d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9a4a6cdd27781573351595e38d38eeadc8ab090d>`__
    `#8934 <https://pagure.io/freeipa/issue/8934>`__
 -  ipa-advise: if p11-kit provides opensc, don't add to NSS db
-   `commit <https://pagure.io/freeipa/c/018ee09ccbe7fc0a5b0909592eadd168224b2409>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/018ee09ccbe7fc0a5b0909592eadd168224b2409>`__
    `#8934 <https://pagure.io/freeipa/issue/8934>`__
 -  ipatests: test ipa-getkeytab server option
-   `commit <https://pagure.io/freeipa/c/7a13200fd8b92dd90ebc4b6416ef25659df8aa71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a13200fd8b92dd90ebc4b6416ef25659df8aa71>`__
    `#8478 <https://pagure.io/freeipa/issue/8478>`__
 -  ipa-getkeytab: fix compiler warnings
-   `commit <https://pagure.io/freeipa/c/0114d24ea160676b784ef7010c19bbacc67ceea0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0114d24ea160676b784ef7010c19bbacc67ceea0>`__
    `#8478 <https://pagure.io/freeipa/issue/8478>`__
 -  ipa-getkeytab: add option to discover servers using DNS SRV
-   `commit <https://pagure.io/freeipa/c/42206df69adc9c1eefa3ee576891b2ae3ac269e0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42206df69adc9c1eefa3ee576891b2ae3ac269e0>`__
    `#8478 <https://pagure.io/freeipa/issue/8478>`__
 -  Provide more information in ipa-certupdate on ccache failure
-   `commit <https://pagure.io/freeipa/c/fbbff3edc0fcc8bf2624283ccd88848eedaac8d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fbbff3edc0fcc8bf2624283ccd88848eedaac8d7>`__
    `#8257 <https://pagure.io/freeipa/issue/8257>`__
 -  Fix automountlocation-tofiles expected output in xmlrpc test
-   `commit <https://pagure.io/freeipa/c/ded3cd3fc8490561e44310e8f89efc3e13e82884>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ded3cd3fc8490561e44310e8f89efc3e13e82884>`__
    `#7814 <https://pagure.io/freeipa/issue/7814>`__
 -  ipatests: Add test for ipa automountlocation-tofiles
-   `commit <https://pagure.io/freeipa/c/dbe4159e27d44550085cb3ce0629d1e525c9b30e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbe4159e27d44550085cb3ce0629d1e525c9b30e>`__
    `#7814 <https://pagure.io/freeipa/issue/7814>`__
 -  Display all orphaned keys in automountlocation-tofiles
-   `commit <https://pagure.io/freeipa/c/89ca5c8836333aece9caf2ac433ccab1140f909a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89ca5c8836333aece9caf2ac433ccab1140f909a>`__
    `#7814 <https://pagure.io/freeipa/issue/7814>`__
 -  ipatests: test removing last KRA when it is not running
-   `commit <https://pagure.io/freeipa/c/8ea8f8b68b5a7217518f68065a5fc1df16126314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ea8f8b68b5a7217518f68065a5fc1df16126314>`__
    `#8397 <https://pagure.io/freeipa/issue/8397>`__
 -  Use new method in check to prevent removal of last KRA
-   `commit <https://pagure.io/freeipa/c/0b9adf1d8d5efb48e734650e4101e8816b01e1d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b9adf1d8d5efb48e734650e4101e8816b01e1d3>`__
    `#8397 <https://pagure.io/freeipa/issue/8397>`__
 -  Fall back to krbprincipalname when validating host auth indicators
-   `commit <https://pagure.io/freeipa/c/8ad535b618d60fa016061212ff85d0ad28ccae59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ad535b618d60fa016061212ff85d0ad28ccae59>`__
    `#8206 <https://pagure.io/freeipa/issue/8206>`__
 -  Add SHA384withRSA as a certificate signing algorithm
-   `commit <https://pagure.io/freeipa/c/ca8c7010e8aa0f87bde11c36947fefd549bae8fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca8c7010e8aa0f87bde11c36947fefd549bae8fd>`__
    `#8906 <https://pagure.io/freeipa/issue/8906>`__
 
 
@@ -478,7 +478,7 @@ Stanislav Levin (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fix TestAJPSecretUpgrade tests on systems without pkiuser
-   `commit <https://pagure.io/freeipa/c/c9bc471e063f2865d6423e4f1c9b81e73a45e43f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9bc471e063f2865d6423e4f1c9b81e73a45e43f>`__
    `#8942 <https://pagure.io/freeipa/issue/8942>`__
 
 
@@ -487,7 +487,7 @@ Serhii Tsymbaliuk (1)
 ----------------------------------------------------------------------------------------------
 
 -  WebUI: Improve subordinate ids user workflow
-   `commit <https://pagure.io/freeipa/c/9f4b8982cd06011df8daac480a726637fc52649e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f4b8982cd06011df8daac480a726637fc52649e>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__
 
 
@@ -497,5 +497,5 @@ Sudhir Menon (1)
 
 -  ipatests: Fix for
    test_source_ipahealthcheck_ipa_host_check_ipahostkeytab
-   `commit <https://pagure.io/freeipa/c/26be7ffdba87e0e6294ea035ab3dc9bd933fba43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26be7ffdba87e0e6294ea035ab3dc9bd933fba43>`__
    `#8889 <https://pagure.io/freeipa/issue/8889>`__

--- a/src/page/Releases/4.9.8.rst
+++ b/src/page/Releases/4.9.8.rst
@@ -322,10 +322,10 @@ Armando Neto (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Fix UI_driver method after Selenium upgrade
-   `commit <https://pagure.io/freeipa/c/bb5ef716070cb564b3455ddf7a6656de5e228d0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb5ef716070cb564b3455ddf7a6656de5e228d0e>`__
    `#9029 <https://pagure.io/freeipa/issue/9029>`__
 -  ipatests: Bump PR-CI latest templates to Fedora 35
-   `commit <https://pagure.io/freeipa/c/d97250fac563c4a41dc0c4dddc84502c0af16ff6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d97250fac563c4a41dc0c4dddc84502c0af16ff6>`__
 
 
 
@@ -333,41 +333,41 @@ Alexander Bokovoy (12)
 ----------------------------------------------------------------------------------------------
 
 -  freeipa.spec.in: -server subpackage should require samba-client-libs
-   `commit <https://pagure.io/freeipa/c/c850cd52dcee8d2e5107af5ddf33e79b4e33527f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c850cd52dcee8d2e5107af5ddf33e79b4e33527f>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: validate domain SID in incoming PAC for trusted domains for
    S4U
-   `commit <https://pagure.io/freeipa/c/5213c1e42cdedf4a862bf7173d7c632d0c1460b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5213c1e42cdedf4a862bf7173d7c632d0c1460b5>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: honor SID from the host or service entry
-   `commit <https://pagure.io/freeipa/c/a95ccd908f9e04375380f5dba1110f6c55a93638>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a95ccd908f9e04375380f5dba1110f6c55a93638>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  SMB: switch IPA domain controller role
-   `commit <https://pagure.io/freeipa/c/693c165ce83df9e21a4928cde64bdea9f997d1a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/693c165ce83df9e21a4928cde64bdea9f997d1a6>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: Use proper account flags for Kerberos principal in PAC
-   `commit <https://pagure.io/freeipa/c/adf5ab7344b810106cb4b493c798af597d14a080>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adf5ab7344b810106cb4b493c798af597d14a080>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: add PAC_ATTRIBUTES_INFO PAC buffer support
-   `commit <https://pagure.io/freeipa/c/b71467e2fe5942688d2d988999340ef398b97a29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b71467e2fe5942688d2d988999340ef398b97a29>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: add support for PAC_REQUESTER_SID buffer
-   `commit <https://pagure.io/freeipa/c/879ef1b1a69ed187fcfa8fff007ab95ec72a1a65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/879ef1b1a69ed187fcfa8fff007ab95ec72a1a65>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: add support for PAC_UPN_DNS_INFO_EX
-   `commit <https://pagure.io/freeipa/c/4cafdac1dfbd95087c3d0510cbf2638fc31c4d94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cafdac1dfbd95087c3d0510cbf2638fc31c4d94>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: S4U2Proxy target should use a service name without realm
-   `commit <https://pagure.io/freeipa/c/8b5e496101963c7059fac2a4a5c8b5e15ad9f726>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b5e496101963c7059fac2a4a5c8b5e15ad9f726>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: use entry DN to compare aliased entries in S4U operations
-   `commit <https://pagure.io/freeipa/c/eb5a93ddbe0ab17c36d5c78e5c0fcf020745484a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eb5a93ddbe0ab17c36d5c78e5c0fcf020745484a>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: enforce SID checks when generating PAC
-   `commit <https://pagure.io/freeipa/c/9ecbdd8e5968b1b4033bedb90fccdd0f05720b40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ecbdd8e5968b1b4033bedb90fccdd0f05720b40>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: store SID in the principal entry
-   `commit <https://pagure.io/freeipa/c/9ded98b66ed62a2edc7b27c02e0b94a6e6fa8ae9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ded98b66ed62a2edc7b27c02e0b94a6e6fa8ae9>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 
 
@@ -376,13 +376,13 @@ Antonio Torres (4)
 ----------------------------------------------------------------------------------------------
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/8042bdc90c0ca8080f94c9baf54b713e08873232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8042bdc90c0ca8080f94c9baf54b713e08873232>`__
 -  Become IPA 4.9.8
-   `commit <https://pagure.io/freeipa/c/a9620a5d7171de49f176a9504d1bb32db2d9650e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9620a5d7171de49f176a9504d1bb32db2d9650e>`__
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/b4f9026e80cd936f2e21420a9b6d233f53cb894a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4f9026e80cd936f2e21420a9b6d233f53cb894a>`__
 -  Update translations to FreeIPA ipa-4-9 state
-   `commit <https://pagure.io/freeipa/c/c587db883df9ae28a6d2500dbe32de14c6c4c119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c587db883df9ae28a6d2500dbe32de14c6c4c119>`__
 
 
 
@@ -390,7 +390,7 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Add URI system records for KDC
-   `commit <https://pagure.io/freeipa/c/2cf0ad5cfd2d558c844bc9640c121fa35ebb1c30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2cf0ad5cfd2d558c844bc9640c121fa35ebb1c30>`__
    `#8968 <https://pagure.io/freeipa/issue/8968>`__
 
 
@@ -399,7 +399,7 @@ Chris Kelley (1)
 ----------------------------------------------------------------------------------------------
 
 -  Make Dogtag return XML for ipa cert-find
-   `commit <https://pagure.io/freeipa/c/bbda3590bb20a2915261f2fd9b8a8e0b169f93f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbda3590bb20a2915261f2fd9b8a8e0b169f93f4>`__
    `#8980 <https://pagure.io/freeipa/issue/8980>`__
 
 
@@ -408,7 +408,7 @@ Endi Sukma Dewata (1)
 ----------------------------------------------------------------------------------------------
 
 -  Specify PKI installation log paths
-   `commit <https://pagure.io/freeipa/c/5abf1bc79f8b32c6638ff98fbe2e4a8dec9a5010>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5abf1bc79f8b32c6638ff98fbe2e4a8dec9a5010>`__
    `#8966 <https://pagure.io/freeipa/issue/8966>`__
 
 
@@ -417,20 +417,20 @@ François Cami (6)
 ----------------------------------------------------------------------------------------------
 
 -  freeipa.spec: depend on bind-dnssec-utils
-   `commit <https://pagure.io/freeipa/c/f89d59b6e18b54967682f6a37ce92ae67ab3fcda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f89d59b6e18b54967682f6a37ce92ae67ab3fcda>`__
    `#9026 <https://pagure.io/freeipa/issue/9026>`__
 -  pwpolicy: change lifetime error message
-   `commit <https://pagure.io/freeipa/c/76afa643f4afd0167fd670142aa70369d91d7af2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76afa643f4afd0167fd670142aa70369d91d7af2>`__
    `#9038 <https://pagure.io/freeipa/issue/9038>`__
 -  subid: subid-match: display the owner's ID not DN
-   `commit <https://pagure.io/freeipa/c/4785a90946ec694ccc082f062b2181b23c7099e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4785a90946ec694ccc082f062b2181b23c7099e3>`__
 -  ipatests: refactor test_ipa_cert_fix with tasks
-   `commit <https://pagure.io/freeipa/c/4a3a15f45aad016730252c09e3e173a18184603e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a3a15f45aad016730252c09e3e173a18184603e>`__
    `#8932 <https://pagure.io/freeipa/issue/8932>`__
 -  freeipa.spec.in: update 389-DS version
-   `commit <https://pagure.io/freeipa/c/210c53dd41a85b7619eb7a2ad427055c994ee1e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/210c53dd41a85b7619eb7a2ad427055c994ee1e5>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/60745116a2bc71bef508be5a7a2e1f6082f24bca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60745116a2bc71bef508be5a7a2e1f6082f24bca>`__
 
 
 
@@ -438,85 +438,85 @@ Florence Blanc-Renaud (27)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: remove xfail on f35+ for test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/a9c080734cb533d7a494b7259ac8d1ef89394d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9c080734cb533d7a494b7259ac8d1ef89394d2c>`__
    `#8700 <https://pagure.io/freeipa/issue/8700>`__
 -  ipatests: mark test_installation_TestInstallWithCA_DNS3 as xfail
-   `commit <https://pagure.io/freeipa/c/8ca5b094f829f47b0629301c23818096a5834609>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ca5b094f829f47b0629301c23818096a5834609>`__
    `#8700 <https://pagure.io/freeipa/issue/8700>`__
 -  ipatests: fix get_user_result method
-   `commit <https://pagure.io/freeipa/c/421e12468d3ebaf8e259789bdba173a785c9e5d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/421e12468d3ebaf8e259789bdba173a785c9e5d4>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipatests: update the expected output of user-add cmd
-   `commit <https://pagure.io/freeipa/c/009a8cdfcba78ab6153e132ef653792018e1662b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/009a8cdfcba78ab6153e132ef653792018e1662b>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  User plugin: do not return the SID on user creation
-   `commit <https://pagure.io/freeipa/c/61f42aefe35d60432d5542ed5fa3f546e6d71f0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61f42aefe35d60432d5542ed5fa3f546e6d71f0b>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  Webui tests: new idrange now requires base RID
-   `commit <https://pagure.io/freeipa/c/9c7e8c669740528812a06f9af73fe927313270c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c7e8c669740528812a06f9af73fe927313270c9>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipatests: backup-reinstall-restore needs to clear sssd cache
-   `commit <https://pagure.io/freeipa/c/c6fd0d00bacf56f1c3bffb2674042058a4608f10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6fd0d00bacf56f1c3bffb2674042058a4608f10>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  User lifecycle: ignore SID when moving from preserved to staged
-   `commit <https://pagure.io/freeipa/c/86d1683e0966a5d33e570b9cc2bb032e9af98bf0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86d1683e0966a5d33e570b9cc2bb032e9af98bf0>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipatests: adapt expected output with SID
-   `commit <https://pagure.io/freeipa/c/efc9df086725a151e15fc93b7550bc01df8d1151>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efc9df086725a151e15fc93b7550bc01df8d1151>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipatests: interactive install prompts for netbios name
-   `commit <https://pagure.io/freeipa/c/31d095eac1aa7158761de29aa4f3c42604e83f17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31d095eac1aa7158761de29aa4f3c42604e83f17>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipatests: add test ensuring SIDs are generated for new installs
-   `commit <https://pagure.io/freeipa/c/5bb56f910c39b3db762b6802a6dfaa25a0e77c76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5bb56f910c39b3db762b6802a6dfaa25a0e77c76>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipa config: add --enable-sid option
-   `commit <https://pagure.io/freeipa/c/b98ecabba196107c692825e081fd1c7a6123c2aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b98ecabba196107c692825e081fd1c7a6123c2aa>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  adtrust install: define constants for rid bases
-   `commit <https://pagure.io/freeipa/c/a91e6712e80a19070cb9f201b2d2f15ac8b28ff4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a91e6712e80a19070cb9f201b2d2f15ac8b28ff4>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  Installers: configure sid generation in server/replica installer
-   `commit <https://pagure.io/freeipa/c/e527857d000e558b3288a7a210400abaf2171237>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e527857d000e558b3288a7a210400abaf2171237>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  SID generation: define SIDInstallInterface
-   `commit <https://pagure.io/freeipa/c/dd07db29eec92b421569a194a1d2294852cd6a5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd07db29eec92b421569a194a1d2294852cd6a5c>`__
    `#8995 <https://pagure.io/freeipa/issue/8995>`__
 -  ipa-server-install uninstall: remove tdb files
-   `commit <https://pagure.io/freeipa/c/6302769b83af75f267c76fe6f854d5b42b6b80f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6302769b83af75f267c76fe6f854d5b42b6b80f5>`__
    `#8687 <https://pagure.io/freeipa/issue/8687>`__
 -  ipa-client-samba uninstall: remove tdb files
-   `commit <https://pagure.io/freeipa/c/82eaa2eac454aed75a498d2c6ccd9e921f9c8a89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82eaa2eac454aed75a498d2c6ccd9e921f9c8a89>`__
    `#8687 <https://pagure.io/freeipa/issue/8687>`__
 -  ipatests: Update the subca used in TestIPACommand::test_cacert_manage
-   `commit <https://pagure.io/freeipa/c/34d6f51fb8ddc97d21470db9a638386127c4c581>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34d6f51fb8ddc97d21470db9a638386127c4c581>`__
    `#9006 <https://pagure.io/freeipa/issue/9006>`__
 -  webui test: close notification after selinux user map update
-   `commit <https://pagure.io/freeipa/c/b706483c827a971aeae855199b9d4ce6005e53b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b706483c827a971aeae855199b9d4ce6005e53b1>`__
    `#8846 <https://pagure.io/freeipa/issue/8846>`__
 -  ipatests: increase sosreport verbosity
-   `commit <https://pagure.io/freeipa/c/fc384b0773c92e1743152b6c04af12b0f17e842b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc384b0773c92e1743152b6c04af12b0f17e842b>`__
    `#9000 <https://pagure.io/freeipa/issue/9000>`__
 -  ipatests: update expected error message for openssl verify
-   `commit <https://pagure.io/freeipa/c/01dfce68d97f373c92dd82e355392e5123df8f07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01dfce68d97f373c92dd82e355392e5123df8f07>`__
    `#8999 <https://pagure.io/freeipa/issue/8999>`__
 -  ipatests: fix expected msg in tasks.run_ssh_cmd
-   `commit <https://pagure.io/freeipa/c/ef58efe7e4c3f8ed3e31623035eba2a3bdba6e46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef58efe7e4c3f8ed3e31623035eba2a3bdba6e46>`__
    `#8989 <https://pagure.io/freeipa/issue/8989>`__
 -  ipatests: fix logic waiting for repl in TestIPACommand
-   `commit <https://pagure.io/freeipa/c/4f569c68cde408865389c61f9befb2ea23bd6d30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f569c68cde408865389c61f9befb2ea23bd6d30>`__
    `#8975 <https://pagure.io/freeipa/issue/8975>`__
 -  migrate-ds: workaround to detect compat tree
-   `commit <https://pagure.io/freeipa/c/3c4f9e7347965ff9a887147df34e720224ffa7cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c4f9e7347965ff9a887147df34e720224ffa7cc>`__
    `#8984 <https://pagure.io/freeipa/issue/8984>`__
 -  ipatests: rpcclient now uses --use-kerberos=desired
-   `commit <https://pagure.io/freeipa/c/395b0d26d0b042d5384bc8e7272f0121db0989ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/395b0d26d0b042d5384bc8e7272f0121db0989ed>`__
    `#8979 <https://pagure.io/freeipa/issue/8979>`__
 -  selinux policy: allow custodia to access /proc/cpuinfo
-   `commit <https://pagure.io/freeipa/c/07e2bf732f54f936cccc4e0c7b468d77f97e911a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07e2bf732f54f936cccc4e0c7b468d77f97e911a>`__
    `#8972 <https://pagure.io/freeipa/issue/8972>`__
 -  ipatests: use whole date for journalctl --since
-   `commit <https://pagure.io/freeipa/c/b5036b5ce9ae4fab011e57fe2b37a35fdd098a70>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5036b5ce9ae4fab011e57fe2b37a35fdd098a70>`__
    `#8953 <https://pagure.io/freeipa/issue/8953>`__
 
 
@@ -525,7 +525,7 @@ Jochen Kellner (1)
 ----------------------------------------------------------------------------------------------
 
 -  Remove duplicate \_() in the error path
-   `commit <https://pagure.io/freeipa/c/1660cfa3d2ec4a27c0456b3545a40eadbae45cfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1660cfa3d2ec4a27c0456b3545a40eadbae45cfb>`__
    `#9046 <https://pagure.io/freeipa/issue/9046>`__
 
 
@@ -534,7 +534,7 @@ Michal Polovka (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: webui: Specify configuration loader
-   `commit <https://pagure.io/freeipa/c/17ba2732f90a69b860f70662133e6904d7373b04>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17ba2732f90a69b860f70662133e6904d7373b04>`__
    `#9009 <https://pagure.io/freeipa/issue/9009>`__
 
 
@@ -543,14 +543,14 @@ Mohammad Rizwan (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: remove redundant kinit from test
-   `commit <https://pagure.io/freeipa/c/d3edc039419e9a944ee37dd9e02edfd6a627db5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3edc039419e9a944ee37dd9e02edfd6a627db5a>`__
 -  ipatests: update the timemout for test_ipa_cert_fix.py in nightlies
-   `commit <https://pagure.io/freeipa/c/1b38afc0487efde57f04cf4a8c15f03be46971f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b38afc0487efde57f04cf4a8c15f03be46971f3>`__
 -  ipatests: wait while http/ldap/pkinit cert get renew on replica
-   `commit <https://pagure.io/freeipa/c/a620e5e9e152defe144705913521c3cf556faa0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a620e5e9e152defe144705913521c3cf556faa0e>`__
    `#8815 <https://pagure.io/freeipa/issue/8815>`__
 -  ipatests: test to renew certs on replica using ipa-cert-fix
-   `commit <https://pagure.io/freeipa/c/e0aef5296b66c0b460f7e10993610fe68b312241>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0aef5296b66c0b460f7e10993610fe68b312241>`__
    `#7885 <https://pagure.io/freeipa/issue/7885>`__
 
 
@@ -559,7 +559,7 @@ Pavel Březina (1)
 ----------------------------------------------------------------------------------------------
 
 -  kdb: fix typo in ipa_kdcpolicy_check_as
-   `commit <https://pagure.io/freeipa/c/bdf479e8cdab14a3985d8acc9fe234e13820108a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdf479e8cdab14a3985d8acc9fe234e13820108a>`__
 
 
 
@@ -567,10 +567,10 @@ Petr Voborník (2)
 ----------------------------------------------------------------------------------------------
 
 -  webui tests: remove unnecessary code in add_record
-   `commit <https://pagure.io/freeipa/c/a286cd31ec031e07b4d196715ae501f873a4bde2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a286cd31ec031e07b4d196715ae501f873a4bde2>`__
    `#9036 <https://pagure.io/freeipa/issue/9036>`__
 -  fix(webui): create correct PTR record when navigated from host page
-   `commit <https://pagure.io/freeipa/c/4f5ed837b43d378ed9e003c279e311656b1773ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f5ed837b43d378ed9e003c279e311656b1773ab>`__
    `#9036 <https://pagure.io/freeipa/issue/9036>`__
 
 
@@ -579,25 +579,25 @@ Rob Crittenden (7)
 ----------------------------------------------------------------------------------------------
 
 -  Don't limit role-find by hostname when searching for last KRA
-   `commit <https://pagure.io/freeipa/c/1c66226e83bb8797122d3925b555516201edb8bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c66226e83bb8797122d3925b555516201edb8bd>`__
    `#8397 <https://pagure.io/freeipa/issue/8397>`__
 -  Make the schema cache TTL user-configurable
-   `commit <https://pagure.io/freeipa/c/331cadd8f25ab627fc419c48f2db6cc9cafafe40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/331cadd8f25ab627fc419c48f2db6cc9cafafe40>`__
    `#8492 <https://pagure.io/freeipa/issue/8492>`__
 -  On redhat-based platforms rely on authselect to enable sudo
-   `commit <https://pagure.io/freeipa/c/c1baae842529d89b7fda78ace5ffcff165a995ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c1baae842529d89b7fda78ace5ffcff165a995ce>`__
    `#8755 <https://pagure.io/freeipa/issue/8755>`__
 -  ipatests: Test that a user can be issued multiple certificates
-   `commit <https://pagure.io/freeipa/c/86588640137562b2016fdb0f91142d00bc38e54a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86588640137562b2016fdb0f91142d00bc38e54a>`__
    `#8986 <https://pagure.io/freeipa/issue/8986>`__
 -  Don't store entries with a usercertificate in the LDAP cache
-   `commit <https://pagure.io/freeipa/c/be1e3bbfc13aff9a583108376f245b81cc3666fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be1e3bbfc13aff9a583108376f245b81cc3666fb>`__
    `#8986 <https://pagure.io/freeipa/issue/8986>`__
 -  Increase default limit on LDAP searches to 100k
-   `commit <https://pagure.io/freeipa/c/3fb0f5333613beabeead3feb73dc0fea9694bcdc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fb0f5333613beabeead3feb73dc0fea9694bcdc>`__
    `#8962 <https://pagure.io/freeipa/issue/8962>`__
 -  Catch and log errors when adding CA profiles
-   `commit <https://pagure.io/freeipa/c/a6e708ab4006d6623c37de1692de5362fcdb5dd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6e708ab4006d6623c37de1692de5362fcdb5dd6>`__
    `#8974 <https://pagure.io/freeipa/issue/8974>`__
 
 
@@ -606,7 +606,7 @@ Sumit Bose (1)
 ----------------------------------------------------------------------------------------------
 
 -  extdom: return LDAP_NO_SUCH_OBJECT if domains differ
-   `commit <https://pagure.io/freeipa/c/4fca95751ca32a1ed16a6d8a4e557c5799ec5c78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fca95751ca32a1ed16a6d8a4e557c5799ec5c78>`__
    `#8965 <https://pagure.io/freeipa/issue/8965>`__
 
 
@@ -615,50 +615,50 @@ Stanislav Levin (15)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: TestMultipleExternalCA: Create tempfiles on remote host
-   `commit <https://pagure.io/freeipa/c/7480844765e029ccb5e7149059efd4c56e400982>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7480844765e029ccb5e7149059efd4c56e400982>`__
    `#9013 <https://pagure.io/freeipa/issue/9013>`__
 -  azure: Don't customize pip's builddir
-   `commit <https://pagure.io/freeipa/c/8dd788daf9fbf694754771082db9ee1d7f64fef0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8dd788daf9fbf694754771082db9ee1d7f64fef0>`__
    `#9011 <https://pagure.io/freeipa/issue/9011>`__
 -  seccomp profile: Default to ENOSYS instead of EPERM
-   `commit <https://pagure.io/freeipa/c/488fb1049397c3adc10a2b80737374cff5a87af4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/488fb1049397c3adc10a2b80737374cff5a87af4>`__
    `#9008 <https://pagure.io/freeipa/issue/9008>`__
 -  test_schema_plugin: Add missing tests for command, class and topic
    commands
-   `commit <https://pagure.io/freeipa/c/973334c9fc247ce6334bcd67f5cd9c3c6b35c660>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/973334c9fc247ce6334bcd67f5cd9c3c6b35c660>`__
    `#8954 <https://pagure.io/freeipa/issue/8954>`__
 -  test_schema_plugin: Drop dependency on Tracker
-   `commit <https://pagure.io/freeipa/c/83405a75c2496c8728f9560823738f8ad51cdc33>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83405a75c2496c8728f9560823738f8ad51cdc33>`__
    `#8954 <https://pagure.io/freeipa/issue/8954>`__
 -  command_defaults: Don't crash on nonexistent command
-   `commit <https://pagure.io/freeipa/c/e4839b048040877cc7d780d2d98b25233db62537>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4839b048040877cc7d780d2d98b25233db62537>`__
    `#8954 <https://pagure.io/freeipa/issue/8954>`__
 -  schema plugin: Fix commands without metaobject arg
-   `commit <https://pagure.io/freeipa/c/a9f7300732f1be90bfb736a8ec3e5fb58c8ce288>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f7300732f1be90bfb736a8ec3e5fb58c8ce288>`__
    `#8954 <https://pagure.io/freeipa/issue/8954>`__
 -  ipatests: Log debug messages for locator plugin
-   `commit <https://pagure.io/freeipa/c/12ebc658a8bcde3cf5a9665e10981f822fa00dad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12ebc658a8bcde3cf5a9665e10981f822fa00dad>`__
    `#8353 <https://pagure.io/freeipa/issue/8353>`__
 -  krb5: Pin kpasswd server to a primary one
-   `commit <https://pagure.io/freeipa/c/8fcc0f077bc24e0c7d0c7434fbd4e91372021217>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fcc0f077bc24e0c7d0c7434fbd4e91372021217>`__
    `#8353 <https://pagure.io/freeipa/issue/8353>`__
 -  azure: Ignore tar errors
-   `commit <https://pagure.io/freeipa/c/dfe94640ed8befbf29e3c35f0cb57e702211ef44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfe94640ed8befbf29e3c35f0cb57e702211ef44>`__
    `#8983 <https://pagure.io/freeipa/issue/8983>`__
 -  docs: Make use of \`text\` highlighting
-   `commit <https://pagure.io/freeipa/c/d1343e8f539679227c8dbfb58ba634810d3857da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1343e8f539679227c8dbfb58ba634810d3857da>`__
    `#8985 <https://pagure.io/freeipa/issue/8985>`__
 -  ipatests: Add tests for \`schema\` Command
-   `commit <https://pagure.io/freeipa/c/14ad52238543ab845a8d6dadd65ff2fb6e67d8df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14ad52238543ab845a8d6dadd65ff2fb6e67d8df>`__
    `#8955 <https://pagure.io/freeipa/issue/8955>`__
 -  schema plugin: Generate stable fingerprint
-   `commit <https://pagure.io/freeipa/c/939d0f5df67aa39cd31f68a6da4153460066ca66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/939d0f5df67aa39cd31f68a6da4153460066ca66>`__
    `#8955 <https://pagure.io/freeipa/issue/8955>`__
 -  pycodestyle: Check \*.in Python files
-   `commit <https://pagure.io/freeipa/c/31afc004bc034f3170247d4c7ccd3a7cc0d32551>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31afc004bc034f3170247d4c7ccd3a7cc0d32551>`__
    `#8961 <https://pagure.io/freeipa/issue/8961>`__
 -  Azure: Run pycodestyle check in Lint job
-   `commit <https://pagure.io/freeipa/c/0b359fbdef8174b9f53d4af0770a6a2e72198e3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b359fbdef8174b9f53d4af0770a6a2e72198e3b>`__
    `#8961 <https://pagure.io/freeipa/issue/8961>`__
 
 
@@ -667,10 +667,10 @@ Sergey Orlov (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: use AD domain name from config instead of hardcoded value
-   `commit <https://pagure.io/freeipa/c/b3bee9b52a037b8ae44ceb6c7d40608a352325a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b3bee9b52a037b8ae44ceb6c7d40608a352325a7>`__
 -  ipatests: check for message in sssd log only during actual test
    action
-   `commit <https://pagure.io/freeipa/c/e60076690cc02105d4a6abd9afb6aba5dd70b6bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e60076690cc02105d4a6abd9afb6aba5dd70b6bd>`__
    `#8987 <https://pagure.io/freeipa/issue/8987>`__
 
 
@@ -680,7 +680,7 @@ Sumedh Sidhaye (1)
 
 -  Test to verify if the case of a request for
    /ca/rest/authority/{id}/cert (or .../chain)
-   `commit <https://pagure.io/freeipa/c/4c14b8cfddf78d4e792eb944ef1a765a115e3f10>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c14b8cfddf78d4e792eb944ef1a765a115e3f10>`__
 
 
 
@@ -688,4 +688,4 @@ Vit Mojzis (1)
 ----------------------------------------------------------------------------------------------
 
 -  selinux: Fix file context definition for /var/run
-   `commit <https://pagure.io/freeipa/c/186497cb790a81d43c35659f81fab2eb47ea65cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/186497cb790a81d43c35659f81fab2eb47ea65cd>`__

--- a/src/page/Releases/4.9.9.rst
+++ b/src/page/Releases/4.9.9.rst
@@ -227,67 +227,67 @@ Alexander Bokovoy (20)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: collect samba logs when setting up trust to AD
-   `commit <https://pagure.io/freeipa/c/ee6472cee20ff99d16cde1a97c3dd5167b7cd893>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee6472cee20ff99d16cde1a97c3dd5167b7cd893>`__
 -  ipa-sam: retrieve trusted domain account credential from the TDO
    itself
-   `commit <https://pagure.io/freeipa/c/91d083c36e1daf88686bf8096691b3913d2ad23c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91d083c36e1daf88686bf8096691b3913d2ad23c>`__
    `#9134 <https://pagure.io/freeipa/issue/9134>`__
 -  ipa-pwd-extop: allow ipasam to request RC4-HMAC in Kerberos keys for
    trusted domain objects
-   `commit <https://pagure.io/freeipa/c/710314a794eb3446f0467d33133d70d2425fbf65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/710314a794eb3446f0467d33133d70d2425fbf65>`__
    `#9134 <https://pagure.io/freeipa/issue/9134>`__
 -  ipatests: fix check for AD topology being present
-   `commit <https://pagure.io/freeipa/c/b6b5f6073bf4e12b8357a6ec9f5a4f6bb683437f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6b5f6073bf4e12b8357a6ec9f5a4f6bb683437f>`__
    `#9133 <https://pagure.io/freeipa/issue/9133>`__
 -  tests: ensure AD-SUPPORT subpolicy is active in more cases
-   `commit <https://pagure.io/freeipa/c/09481117b58f1a237bb1048d3fe8d44caf9e167f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09481117b58f1a237bb1048d3fe8d44caf9e167f>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  ipalib/util.py: switch to ssl.PROTOCOL_TLS_CLIENT by default
-   `commit <https://pagure.io/freeipa/c/3e8a355dd49a6c080103a030ced03597ee4baece>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e8a355dd49a6c080103a030ced03597ee4baece>`__
    `#9129 <https://pagure.io/freeipa/issue/9129>`__
 -  test_krbtpolicy: skip SPAKE-related tests in FIPS mode
-   `commit <https://pagure.io/freeipa/c/2e70535f74e7d9dd76e728eca1119ce522fd138a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e70535f74e7d9dd76e728eca1119ce522fd138a>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  test_otp: do not use paramiko unless it is really needed
-   `commit <https://pagure.io/freeipa/c/3baae8d1bd0a0c4c707314524289e86e6ecbc0df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3baae8d1bd0a0c4c707314524289e86e6ecbc0df>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  Kerberos instance: default to AES256-SHA2 for master key encryption
-   `commit <https://pagure.io/freeipa/c/3e54c4362490b4da1b6cb3e141bb6e08fecc58c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e54c4362490b4da1b6cb3e141bb6e08fecc58c0>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  freeipa.spec: bump crypto-policies dependency for CentOS 9 Stream
-   `commit <https://pagure.io/freeipa/c/ee39de46a1c1ea96bbe524f159ae435319b2d072>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee39de46a1c1ea96bbe524f159ae435319b2d072>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  ipatests: extend AES keyset to SHA2-based ones
-   `commit <https://pagure.io/freeipa/c/49d9147e38c5b50c52a1ebc7283753c779c2f81f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49d9147e38c5b50c52a1ebc7283753c779c2f81f>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  tests: ensure AD-SUPPORT subpolicy is active
-   `commit <https://pagure.io/freeipa/c/b016683552a58f9cc2a05cf628cc467234eaf599>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b016683552a58f9cc2a05cf628cc467234eaf599>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  KRB instance: make provision to work with crypto policy without SHA-1
    HMAC types
-   `commit <https://pagure.io/freeipa/c/a51900819bd5332bc05ec9d513f062844b3a7763>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a51900819bd5332bc05ec9d513f062844b3a7763>`__
    `#9119 <https://pagure.io/freeipa/issue/9119>`__
 -  translations: regenerate translations after changes in help message
    in sudorule
-   `commit <https://pagure.io/freeipa/c/0d034d7fd409a8dbbc48a7307ad6d042a4098a74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d034d7fd409a8dbbc48a7307ad6d042a4098a74>`__
    `#9106 <https://pagure.io/freeipa/issue/9106>`__
 -  pylint: workaround incorrect pylint detection of a local function
-   `commit <https://pagure.io/freeipa/c/10d32d43e4640f61aa3d021b3e8136ca6132e493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10d32d43e4640f61aa3d021b3e8136ca6132e493>`__
 -  OpenLDAP 2.6+: use only -H option to specify LDAP url
-   `commit <https://pagure.io/freeipa/c/85ce7acb733e09ea7916a8a26d42fb3d4b5fe3bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85ce7acb733e09ea7916a8a26d42fb3d4b5fe3bd>`__
    `#9106 <https://pagure.io/freeipa/issue/9106>`__
 -  ipa-kdb: refactor KDB driver to prepare for KDB version 9
-   `commit <https://pagure.io/freeipa/c/ace0bbfdc8eb02a4ba47f8293809ff4734856ab8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ace0bbfdc8eb02a4ba47f8293809ff4734856ab8>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  Support building against OpenLDAP 2.6+
-   `commit <https://pagure.io/freeipa/c/ce112e68bd711199baee1f7103d31a4bb0c5ad97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce112e68bd711199baee1f7103d31a4bb0c5ad97>`__
    `#9080 <https://pagure.io/freeipa/issue/9080>`__
 -  ipa-kdb: fix requester SID check according to MS-KILE and MS-SFU
    updates
-   `commit <https://pagure.io/freeipa/c/7d93bda31ce0b4e0e22c6e464c9138800dcf8b1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d93bda31ce0b4e0e22c6e464c9138800dcf8b1c>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 -  ipa-kdb: issue PAC_REQUESTER_SID only for TGTs
-   `commit <https://pagure.io/freeipa/c/669f3d71161741c676ddd6a08bd08d4a4ccd495b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/669f3d71161741c676ddd6a08bd08d4a4ccd495b>`__
    `#9031 <https://pagure.io/freeipa/issue/9031>`__
 
 
@@ -297,20 +297,20 @@ Anuja More (6)
 
 -  Mark xfail
    test_gidnumber_not_corresponding_existing_group[true,hybrid]
-   `commit <https://pagure.io/freeipa/c/7ad500e5d3f7d9af81e8a3137158672c6fafb0b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ad500e5d3f7d9af81e8a3137158672c6fafb0b4>`__
 -  mark xfail for test_idoverride_with_auto_private_group[hybrid]
-   `commit <https://pagure.io/freeipa/c/84381001d2e114b1f29fe89e16155c040b56b80f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84381001d2e114b1f29fe89e16155c040b56b80f>`__
 -  ipatests: Tests for Autoprivate group.
-   `commit <https://pagure.io/freeipa/c/6b70e3c49acc55b5553101cf850fc40978861979>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b70e3c49acc55b5553101cf850fc40978861979>`__
    `#8807 <https://pagure.io/freeipa/issue/8807>`__
 -  ipatests: remove additional check for failed units.
-   `commit <https://pagure.io/freeipa/c/b36bcf4ea5ed93baa4dc63f8e2be542d678211fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36bcf4ea5ed93baa4dc63f8e2be542d678211fb>`__
    `#9108 <https://pagure.io/freeipa/issue/9108>`__
 -  ipatests: webui: Tests for subordinate ids.
-   `commit <https://pagure.io/freeipa/c/edbd8f692a28fc999b92e9032614d366511db323>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edbd8f692a28fc999b92e9032614d366511db323>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__
 -  ipatests: Test default value of nsslapd-sizelimit.
-   `commit <https://pagure.io/freeipa/c/465f1669a6c5abc72da1ecaf9aefa8488f80806c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/465f1669a6c5abc72da1ecaf9aefa8488f80806c>`__
    `#8962 <https://pagure.io/freeipa/issue/8962>`__
 
 
@@ -319,7 +319,7 @@ Antonio Torres (1)
 ----------------------------------------------------------------------------------------------
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/8042bdc90c0ca8080f94c9baf54b713e08873232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8042bdc90c0ca8080f94c9baf54b713e08873232>`__
 
 
 
@@ -327,7 +327,7 @@ Brian Turek (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipalib: Handle percent signs in saved values
-   `commit <https://pagure.io/freeipa/c/837702199c0bc8df1b2a29defaebed083c51d7b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/837702199c0bc8df1b2a29defaebed083c51d7b2>`__
    `#9085 <https://pagure.io/freeipa/issue/9085>`__
 
 
@@ -336,7 +336,7 @@ Christian Heimes (1)
 ----------------------------------------------------------------------------------------------
 
 -  Support AES for KRA archival wrapping
-   `commit <https://pagure.io/freeipa/c/895e99b6843c2fa2274acab824607c33c1a560a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/895e99b6843c2fa2274acab824607c33c1a560a4>`__
    `#6524 <https://pagure.io/freeipa/issue/6524>`__
 
 
@@ -345,47 +345,47 @@ Florence Blanc-Renaud (14)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: fix wrong condition in xfail_context for auto private grp
-   `commit <https://pagure.io/freeipa/c/5ba5143f9ed55e94668501123969e64a9ec180d2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5ba5143f9ed55e94668501123969e64a9ec180d2>`__
    `#9141 <https://pagure.io/freeipa/issue/9141>`__
 -  ipatests: Fix a call to run_command with wildcard
-   `commit <https://pagure.io/freeipa/c/85b2c8191b8622a5cfe3c8c6e3811ef5e1eee0eb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85b2c8191b8622a5cfe3c8c6e3811ef5e1eee0eb>`__
    `#8506 <https://pagure.io/freeipa/issue/8506>`__
 -  ipatests: remove certmonger tracking before uninstall
-   `commit <https://pagure.io/freeipa/c/12785a3657996def6c7c142898c6a61b2edc16fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12785a3657996def6c7c142898c6a61b2edc16fe>`__
    `#9123 <https://pagure.io/freeipa/issue/9123>`__
 -  ipatests: add missing test in the nightly defs
-   `commit <https://pagure.io/freeipa/c/42f41ff637452e5025b205396638b26dfaae77e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42f41ff637452e5025b205396638b26dfaae77e1>`__
 -  Commit template: use either Fixes or Related
-   `commit <https://pagure.io/freeipa/c/f2731107db5703efbba12cd608b738347a987649>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2731107db5703efbba12cd608b738347a987649>`__
 -  ipatests: update images for f34 and f35
-   `commit <https://pagure.io/freeipa/c/896d0f351646e6a7c96037cb13957b7be0408776>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/896d0f351646e6a7c96037cb13957b7be0408776>`__
    `#9051 <https://pagure.io/freeipa/issue/9051>`__,
    `#9069 <https://pagure.io/freeipa/issue/9069>`__
 -  ipa-pki-proxy.conf: provide access to /kra/admin/kra/getStatus
-   `commit <https://pagure.io/freeipa/c/9bae5492270d8b695999cd82831cbee62b04626b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9bae5492270d8b695999cd82831cbee62b04626b>`__
    `#8582 <https://pagure.io/freeipa/issue/8582>`__,
    `#9099 <https://pagure.io/freeipa/issue/9099>`__
 -  ipatests: fix expected automount config in nsswitch.conf
-   `commit <https://pagure.io/freeipa/c/cd8e9ce173303e192e848e4973aaf2c7bd31ee0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd8e9ce173303e192e848e4973aaf2c7bd31ee0a>`__
    `#9067 <https://pagure.io/freeipa/issue/9067>`__
 -  ipatests: update images for f34 and f35
-   `commit <https://pagure.io/freeipa/c/d8a7f15e32e9fb62125aa910e18c32117285d672>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8a7f15e32e9fb62125aa910e18c32117285d672>`__
    `#9087 <https://pagure.io/freeipa/issue/9087>`__
 -  config plugin: add a test ensuring EmptyModlist is returned
-   `commit <https://pagure.io/freeipa/c/cd735099e86304294217147ed578ac902fcf3dd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd735099e86304294217147ed578ac902fcf3dd3>`__
    `#9063 <https://pagure.io/freeipa/issue/9063>`__
 -  Config plugin: return EmptyModlist when no change is applied
-   `commit <https://pagure.io/freeipa/c/b9c42fed9b6f60801f908c368d0d97a2a69f7bb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9c42fed9b6f60801f908c368d0d97a2a69f7bb2>`__
    `#9063 <https://pagure.io/freeipa/issue/9063>`__
 -  automember default group: remove --desc parameter
-   `commit <https://pagure.io/freeipa/c/6ff7491172961fe210a6ec51b556231af9e123ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ff7491172961fe210a6ec51b556231af9e123ba>`__
    `#9068 <https://pagure.io/freeipa/issue/9068>`__
 -  ipatests: update images for f34 and f35
-   `commit <https://pagure.io/freeipa/c/1efdda078e502e1d67a047ccd06e8b7f555f8802>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1efdda078e502e1d67a047ccd06e8b7f555f8802>`__
    `#8865 <https://pagure.io/freeipa/issue/8865>`__,
    `#9024 <https://pagure.io/freeipa/issue/9024>`__
 -  ipatests: fix TestOTPToken::test_check_otpd_after_idle_timeout
-   `commit <https://pagure.io/freeipa/c/4c54e9d6ddb72eab6f654bf3dc2d29f27498ac96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4c54e9d6ddb72eab6f654bf3dc2d29f27498ac96>`__
    `#9044 <https://pagure.io/freeipa/issue/9044>`__
 
 
@@ -394,13 +394,13 @@ Francisco Trivino (3)
 ----------------------------------------------------------------------------------------------
 
 -  Set AES as default for KRA archival wrapping
-   `commit <https://pagure.io/freeipa/c/984190eea01ac42cd1f97567a67dd9446e5b0bf9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/984190eea01ac42cd1f97567a67dd9446e5b0bf9>`__
    `#6524 <https://pagure.io/freeipa/issue/6524>`__
 -  ipa_cldap: fix memory leak
-   `commit <https://pagure.io/freeipa/c/186ebe311bc9545d7a9860cd5e8c748131bbe41e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/186ebe311bc9545d7a9860cd5e8c748131bbe41e>`__
    `#9110 <https://pagure.io/freeipa/issue/9110>`__
 -  Custodia: use a stronger encryption algo when exporting keys
-   `commit <https://pagure.io/freeipa/c/653a7fe02880c168755984133ee143567cc7bb4e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/653a7fe02880c168755984133ee143567cc7bb4e>`__
    `#9101 <https://pagure.io/freeipa/issue/9101>`__
 
 
@@ -409,7 +409,7 @@ Fraser Tweedale (1)
 ----------------------------------------------------------------------------------------------
 
 -  allow overriding systemd-tmpfiles program
-   `commit <https://pagure.io/freeipa/c/b413a327f33c5d97a1f830fe7a9a8aef39c847c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b413a327f33c5d97a1f830fe7a9a8aef39c847c1>`__
    `#9126 <https://pagure.io/freeipa/issue/9126>`__
 
 
@@ -418,7 +418,7 @@ jh23453 (1)
 ----------------------------------------------------------------------------------------------
 
 -  Remove deprecation warning when installing a CA replica
-   `commit <https://pagure.io/freeipa/c/e11cf7f489d34adeca990a5f58d9c6d247b33ec1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e11cf7f489d34adeca990a5f58d9c6d247b33ec1>`__
 
 
 
@@ -426,9 +426,9 @@ Julien Rische (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add case for hardened-only ticket policy
-   `commit <https://pagure.io/freeipa/c/294ae35a61e6ca8816b261c57508e4be21221864>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/294ae35a61e6ca8816b261c57508e4be21221864>`__
 -  ipa-kdb: do not remove keys for hardened auth-enabled users
-   `commit <https://pagure.io/freeipa/c/6d70421f57d0eca066a922e09416ef7195ee96d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d70421f57d0eca066a922e09416ef7195ee96d4>`__
    `#8001 <https://pagure.io/freeipa/issue/8001>`__,
    `#9065 <https://pagure.io/freeipa/issue/9065>`__
 
@@ -438,10 +438,10 @@ Michal Polovka (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: webui: Use safe-loader for loading YAML configuration file
-   `commit <https://pagure.io/freeipa/c/419d7fd6e5a9ed2d356ad05eef1043309f5646ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/419d7fd6e5a9ed2d356ad05eef1043309f5646ef>`__
    `#9009 <https://pagure.io/freeipa/issue/9009>`__
 -  pr-ci definitions: add web-ui subid-related jobs
-   `commit <https://pagure.io/freeipa/c/878859f4a27aa03c905b82f68327815825ceb1fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/878859f4a27aa03c905b82f68327815825ceb1fa>`__
    `#8361 <https://pagure.io/freeipa/issue/8361>`__
 
 
@@ -450,27 +450,27 @@ Mohammad Rizwan (8)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: extend find_segment with suffix param
-   `commit <https://pagure.io/freeipa/c/de1f4467fb1bd9be857b8c95b2b7398962656342>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de1f4467fb1bd9be857b8c95b2b7398962656342>`__
 -  ipatests: fix the topologysegment-reinitialize command
-   `commit <https://pagure.io/freeipa/c/c3bd6908fa29b479fbd5e8e785c7237c477e29a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3bd6908fa29b479fbd5e8e785c7237c477e29a2>`__
    `#9137 <https://pagure.io/freeipa/issue/9137>`__
 -  ipatests: Check maxlife error message where minlife > maxlife
    specified
-   `commit <https://pagure.io/freeipa/c/83551693b36c852ba455185469e4e459de435f0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83551693b36c852ba455185469e4e459de435f0e>`__
    `#9038 <https://pagure.io/freeipa/issue/9038>`__
 -  Test ipa-ccache-sweep.timer enabled by default during installation
-   `commit <https://pagure.io/freeipa/c/0d9eb3d515385412abefe9c33e0099ea14f33cbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d9eb3d515385412abefe9c33e0099ea14f33cbc>`__
    `#9107 <https://pagure.io/freeipa/issue/9107>`__
 -  PEP8 Fixes
-   `commit <https://pagure.io/freeipa/c/5444da016edc416c0c9481c660c013053dbb93b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5444da016edc416c0c9481c660c013053dbb93b5>`__
 -  Test cases for ipa-replica-conncheck command
-   `commit <https://pagure.io/freeipa/c/1d19b860d4cd3bd65a4b143b588425d9a64237fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d19b860d4cd3bd65a4b143b588425d9a64237fd>`__
    `#9047 <https://pagure.io/freeipa/issue/9047>`__
 -  ipatests: Test empty cert request doesn't force certmonger to
    segfault
-   `commit <https://pagure.io/freeipa/c/cbd9ac6ab07dfb60f67da762fdd70856ad35c230>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbd9ac6ab07dfb60f67da762fdd70856ad35c230>`__
 -  ipatests: Fix test_ipa_cert_fix.py::TestCertFixReplica teardown
-   `commit <https://pagure.io/freeipa/c/ba7ec71ba96280da3841ebe47df2a6dc1cd6341e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba7ec71ba96280da3841ebe47df2a6dc1cd6341e>`__
    `#9052 <https://pagure.io/freeipa/issue/9052>`__
 
 
@@ -479,38 +479,38 @@ Rob Crittenden (11)
 ----------------------------------------------------------------------------------------------
 
 -  Remove the --no-sssd option from ipa-client-automount
-   `commit <https://pagure.io/freeipa/c/c46ea21ed33f606a6ca5c3c6aad9f8cd1ae1f796>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c46ea21ed33f606a6ca5c3c6aad9f8cd1ae1f796>`__
    `#7671 <https://pagure.io/freeipa/issue/7671>`__,
    `#9084 <https://pagure.io/freeipa/issue/9084>`__
 -  Convert values using \_SYNTAX_MAPPING with --delattr
-   `commit <https://pagure.io/freeipa/c/bd8748f6b7bf5edc3f5a2023393e503ee4399f8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd8748f6b7bf5edc3f5a2023393e503ee4399f8c>`__
    `#9004 <https://pagure.io/freeipa/issue/9004>`__
 -  ipatests: Give the subCA more time to be loaded by the CA
-   `commit <https://pagure.io/freeipa/c/3a4238ba96e7f4ad5790d65ec4123983062b28a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a4238ba96e7f4ad5790d65ec4123983062b28a1>`__
    `#9096 <https://pagure.io/freeipa/issue/9096>`__
 -  Strip off trailing period of a user-provided FQDN in installer
-   `commit <https://pagure.io/freeipa/c/57de18e914e5b448402c18ffe938538cbac5e0a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/57de18e914e5b448402c18ffe938538cbac5e0a3>`__
    `#9111 <https://pagure.io/freeipa/issue/9111>`__
 -  Verify the user-provided hostname in the server installer
-   `commit <https://pagure.io/freeipa/c/7ac8e9696ea1eae9f20640102c0d83fee89db9fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ac8e9696ea1eae9f20640102c0d83fee89db9fa>`__
    `#9111 <https://pagure.io/freeipa/issue/9111>`__
 -  ipa-restore: Mark a restored server as enabled
-   `commit <https://pagure.io/freeipa/c/ab9e7dac4138ba222c86d0594937ff4d663ba060>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab9e7dac4138ba222c86d0594937ff4d663ba060>`__
    `#9095 <https://pagure.io/freeipa/issue/9095>`__
 -  Set the mode on ipaupgrade.log during RPM %post snipppet
-   `commit <https://pagure.io/freeipa/c/d8174b0ca60ef123f268f34f47b8be123b8d1c89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8174b0ca60ef123f268f34f47b8be123b8d1c89>`__
    `#8899 <https://pagure.io/freeipa/issue/8899>`__
 -  ipatests: Remove certmonger tracking before uninstall in cert tests
-   `commit <https://pagure.io/freeipa/c/cc2348aedbee3e59b31df75a23aa14d1c6bbe10c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc2348aedbee3e59b31df75a23aa14d1c6bbe10c>`__
    `#8506 <https://pagure.io/freeipa/issue/8506>`__
 -  Enable the ccache sweep timer during installation
-   `commit <https://pagure.io/freeipa/c/9b6d0bb1245c4891ccc270f360d0f72a4b1444c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b6d0bb1245c4891ccc270f360d0f72a4b1444c1>`__
    `#9107 <https://pagure.io/freeipa/issue/9107>`__
 -  Remove ipa-join errors from behind the debug option
-   `commit <https://pagure.io/freeipa/c/7c5540bb47799b4db95673d22f61995ad5c56440>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7c5540bb47799b4db95673d22f61995ad5c56440>`__
    `#9103 <https://pagure.io/freeipa/issue/9103>`__
 -  Don't always override the port in import_included_profiles
-   `commit <https://pagure.io/freeipa/c/edb216849e4f47d6cae95981edf0c3fe2653fd7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edb216849e4f47d6cae95981edf0c3fe2653fd7a>`__
    `#9100 <https://pagure.io/freeipa/issue/9100>`__
 
 
@@ -519,10 +519,10 @@ Sumit Bose (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipa-kdb: fix make check
-   `commit <https://pagure.io/freeipa/c/9cd48d1854b19a40a2026891f9e28c1b79af2637>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9cd48d1854b19a40a2026891f9e28c1b79af2637>`__
    `#9083 <https://pagure.io/freeipa/issue/9083>`__
 -  extdom: user getorigby{user|group}name if available
-   `commit <https://pagure.io/freeipa/c/cedca75f4fbae3293b2f2443fa6ee479d59a8ef1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cedca75f4fbae3293b2f2443fa6ee479d59a8ef1>`__
    `#9127 <https://pagure.io/freeipa/issue/9127>`__
 
 
@@ -531,107 +531,107 @@ Stanislav Levin (34)
 ----------------------------------------------------------------------------------------------
 
 -  azure: Bump supported Pylint
-   `commit <https://pagure.io/freeipa/c/1e2cf55150e9e4a44c29193e764a709cfec0fa08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e2cf55150e9e4a44c29193e764a709cfec0fa08>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip false-positive invalid-sequence-index
-   `commit <https://pagure.io/freeipa/c/b58ec49da983bcd25473ef6ae246eaadf32cd174>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b58ec49da983bcd25473ef6ae246eaadf32cd174>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix useless-suppression
-   `commit <https://pagure.io/freeipa/c/6202a7d85bea2b8717e19fc2f09cca66276dcd9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6202a7d85bea2b8717e19fc2f09cca66276dcd9d>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix format-string-without-interpolation
-   `commit <https://pagure.io/freeipa/c/c5b4657869738d6173eaff310bc243df0fff289e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5b4657869738d6173eaff310bc243df0fff289e>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip unsupported-assignment-operation
-   `commit <https://pagure.io/freeipa/c/bfb233185a7bb863dd94a65674489890c79f6f2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfb233185a7bb863dd94a65674489890c79f6f2f>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix deprecated-method for threading
-   `commit <https://pagure.io/freeipa/c/fd99e4d47a4bb1518686b55e4cf04636d76128ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd99e4d47a4bb1518686b55e4cf04636d76128ca>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip deprecated-method for match_hostname
-   `commit <https://pagure.io/freeipa/c/1f17ade67f21bfde9eda4d810394577f5a28906d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f17ade67f21bfde9eda4d810394577f5a28906d>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix consider-using-in
-   `commit <https://pagure.io/freeipa/c/3ea0e1bd8d25c2f553852c1a0882618d2da86dd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ea0e1bd8d25c2f553852c1a0882618d2da86dd3>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix arguments-renamed
-   `commit <https://pagure.io/freeipa/c/a960adc6c26fb4fc9d8f5f4f10029419d8fc3b69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a960adc6c26fb4fc9d8f5f4f10029419d8fc3b69>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip use-implicit-booleaness-not-comparison
-   `commit <https://pagure.io/freeipa/c/03cd914381de3fbcd9dbfe228a569fab6a6d62a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03cd914381de3fbcd9dbfe228a569fab6a6d62a9>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Enable useless-suppression
-   `commit <https://pagure.io/freeipa/c/2db2c6cb323014580baa5cb2aa4fdbe179327bc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2db2c6cb323014580baa5cb2aa4fdbe179327bc8>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip raising-bad-type
-   `commit <https://pagure.io/freeipa/c/bb515f41b384b3947451bef454acd7c355d67084>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb515f41b384b3947451bef454acd7c355d67084>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix consider-using-dict-items
-   `commit <https://pagure.io/freeipa/c/322d08921a126183358b8d68d350c33e37453871>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/322d08921a126183358b8d68d350c33e37453871>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip not-callable
-   `commit <https://pagure.io/freeipa/c/13e5720d184b1f6e31e65be5435cdcca8229b319>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13e5720d184b1f6e31e65be5435cdcca8229b319>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix unused-variable
-   `commit <https://pagure.io/freeipa/c/76c2c08fdb47b5692d3023ebf0a1b9b35a528518>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76c2c08fdb47b5692d3023ebf0a1b9b35a528518>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix no-member
-   `commit <https://pagure.io/freeipa/c/08f2db78555ff1da56122c58275680fd98916c4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08f2db78555ff1da56122c58275680fd98916c4d>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip isinstance-second-argument-not-valid-type
-   `commit <https://pagure.io/freeipa/c/afba414770ad01a6fe4aec6015e2722860764c2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/afba414770ad01a6fe4aec6015e2722860764c2f>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix deprecated-decorator
-   `commit <https://pagure.io/freeipa/c/054376c1a0aa0f600458ad6415e72f2198c7339e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/054376c1a0aa0f600458ad6415e72f2198c7339e>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix unnecessary-dict-index-lookup
-   `commit <https://pagure.io/freeipa/c/d3b384b5ca18a555b54ce4385bcca603ad7251b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3b384b5ca18a555b54ce4385bcca603ad7251b9>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix deprecated-class
-   `commit <https://pagure.io/freeipa/c/ccf9334da9c51aa9a379141fd2fead0a5b5bf55d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ccf9334da9c51aa9a379141fd2fead0a5b5bf55d>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Remove unused \__convert_iter
-   `commit <https://pagure.io/freeipa/c/0ebf09e061b79e12f3b80fbc224e3aac49608c21>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ebf09e061b79e12f3b80fbc224e3aac49608c21>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Drop no longer used \__home
-   `commit <https://pagure.io/freeipa/c/91ff7b87d9b3231ec1145ffec0f8bb072130b701>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91ff7b87d9b3231ec1145ffec0f8bb072130b701>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix unused-private-member
-   `commit <https://pagure.io/freeipa/c/4da897c3dc71f99911878e0f05ed8ed386867dec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4da897c3dc71f99911878e0f05ed8ed386867dec>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip unused-private-member for unsupported cases
-   `commit <https://pagure.io/freeipa/c/bffde84c813ddd45ec7971c96c74c2e5b54e3d72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bffde84c813ddd45ec7971c96c74c2e5b54e3d72>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip unused-private-member for property case
-   `commit <https://pagure.io/freeipa/c/9ca818b1797e03dd41f05eb14d9181546995c246>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ca818b1797e03dd41f05eb14d9181546995c246>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Drop no longer used \__finalized
-   `commit <https://pagure.io/freeipa/c/dfa1ceac6f70e32184d2ef19706cd2c582df1cc7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfa1ceac6f70e32184d2ef19706cd2c582df1cc7>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Drop never used
    \__remove_lightweight_ca_key_retrieval_custodia
-   `commit <https://pagure.io/freeipa/c/3c77949ab458d6e5f8250fe7c2a8757091f8da76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c77949ab458d6e5f8250fe7c2a8757091f8da76>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Clean up \__convert_to_gssapi_replication
-   `commit <https://pagure.io/freeipa/c/04c4032370dddafe5c8c5bd6e26882a24c597628>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04c4032370dddafe5c8c5bd6e26882a24c597628>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Fix use-maxsplit-arg
-   `commit <https://pagure.io/freeipa/c/6fd75de5a72e5f5889c33cdcc802d93dc6f067f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fd75de5a72e5f5889c33cdcc802d93dc6f067f3>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip unspecified-encoding
-   `commit <https://pagure.io/freeipa/c/106d011e5f39eea73b4d5db62c82398144a61ec8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/106d011e5f39eea73b4d5db62c82398144a61ec8>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip use-dict-literal/use-list-literal
-   `commit <https://pagure.io/freeipa/c/40ee6a47ac62419caf302882914f2df885abd589>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40ee6a47ac62419caf302882914f2df885abd589>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip consider-using-f-string
-   `commit <https://pagure.io/freeipa/c/b5fc2eeff9779cb868ff56edefd7e3355fcd5bca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5fc2eeff9779cb868ff56edefd7e3355fcd5bca>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  pylint: Skip redundant-u-string-prefix
-   `commit <https://pagure.io/freeipa/c/7f8b4f036859db570b2874b6c87ba3ba4de70eb1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f8b4f036859db570b2874b6c87ba3ba4de70eb1>`__
    `#9117 <https://pagure.io/freeipa/issue/9117>`__
 -  ipatests: healthcheck: Sync the expected system RRs
-   `commit <https://pagure.io/freeipa/c/86b98b86f62fae195c0f84fa9a5891166f69c786>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86b98b86f62fae195c0f84fa9a5891166f69c786>`__
    `#9054 <https://pagure.io/freeipa/issue/9054>`__
 
 
@@ -640,13 +640,13 @@ Sumedh Sidhaye (3)
 ----------------------------------------------------------------------------------------------
 
 -  Added nightly job definitions
-   `commit <https://pagure.io/freeipa/c/ef43ea03ef90cd34f2ce55a946df9a1d8e17badf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef43ea03ef90cd34f2ce55a946df9a1d8e17badf>`__
 -  Added test automation for SHA384withRSA CSR support
-   `commit <https://pagure.io/freeipa/c/0edf915efbb39fac45c784171dd715ec6b28861a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0edf915efbb39fac45c784171dd715ec6b28861a>`__
    `#8906 <https://pagure.io/freeipa/issue/8906>`__
 -  Extend test to see if replica is not shown when running
    \`ipa-replica-manage list -v \`
-   `commit <https://pagure.io/freeipa/c/8b22ee018c3bb7f58a1b6694a7fd611688f8e74f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b22ee018c3bb7f58a1b6694a7fd611688f8e74f>`__
    `#8605 <https://pagure.io/freeipa/issue/8605>`__
 
 
@@ -656,7 +656,7 @@ Sudhir Menon (1)
 
 -  ipatests: Test for
    pki.server.healthcheck.clones.connectivity_and_data
-   `commit <https://pagure.io/freeipa/c/98eb661fd8eed87119e7b299379cba48bde0f387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/98eb661fd8eed87119e7b299379cba48bde0f387>`__
 
 
 
@@ -664,18 +664,18 @@ Timo Aaltonen (7)
 ----------------------------------------------------------------------------------------------
 
 -  configure: Use HTTPD_GROUP in init/tmpfiles/ipa.conf.in
-   `commit <https://pagure.io/freeipa/c/69f5f319d1b8bf1b18a8798149d2fcffa43642ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69f5f319d1b8bf1b18a8798149d2fcffa43642ec>`__
    `#9014 <https://pagure.io/freeipa/issue/9014>`__
 -  ipaplatform: Modify paths to fips-mode-setup and systemd-tmpfiles
-   `commit <https://pagure.io/freeipa/c/739d3566951e50b6467c80835945b2697fab8576>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/739d3566951e50b6467c80835945b2697fab8576>`__
 -  ipatests/test_ipaplatform: Skip test_ipa_version on Debian
-   `commit <https://pagure.io/freeipa/c/e99870f7d0b58d88e9c18ad8ecc7edc1adb16051>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e99870f7d0b58d88e9c18ad8ecc7edc1adb16051>`__
 -  ipaplatform/debian: Fix ntpd service name
-   `commit <https://pagure.io/freeipa/c/dcdc31b6f9f750b617b23717f7c39ec560133c2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dcdc31b6f9f750b617b23717f7c39ec560133c2d>`__
 -  ipaplatform/debian: Fix named keytab name
-   `commit <https://pagure.io/freeipa/c/da9be70f7030dfa8c99efd6952dfa0f24b590fc5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da9be70f7030dfa8c99efd6952dfa0f24b590fc5>`__
 -  ipaplatform: Add support for recognizing systemd-timesyncd
-   `commit <https://pagure.io/freeipa/c/cf9c4cc7dabace4f7971a810bbdde4c258d7a4be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf9c4cc7dabace4f7971a810bbdde4c258d7a4be>`__
 -  ipaplatform/debian: Fix HTTPD_ALIAS_DIR, and drop some obsolete
    paths.
-   `commit <https://pagure.io/freeipa/c/a0eb02cfb6635eff82482b297965ff5348c660cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0eb02cfb6635eff82482b297965ff5348c660cd>`__

--- a/src/page/Roadmap.rst
+++ b/src/page/Roadmap.rst
@@ -16,10 +16,7 @@ Requests for upstream
 ---------------------
 
 A primary and authoritative source of enhancement/bug tickets is our
-upstream `Pagure page <https://pagure.io/freeipa/>`__. It contains the
-planned fixes for both current development and maintenance branch (see
-`FreeIPA roadmap <https://pagure.io/freeipa/roadmap>`__ for more
-details).
+upstream `Codeberg page <https://codeberg.org/freeipa/freeipa>`__.
 
 
 

--- a/src/page/Troubleshooting.rst
+++ b/src/page/Troubleshooting.rst
@@ -12,8 +12,8 @@ Feedback is expected to be sent either to:
 
 -  `freeipa-users mailing
    list <https://lists.fedorahosted.org/archives/list/freeipa-users@lists.fedorahosted.org/>`__
--  or by filing an issue to `FreeIPA Pagure ticketing
-   system <https://pagure.io/freeipa/new_issue>`__ or `Red Hat
+-  or by filing an issue to `FreeIPA Codeberg ticketing
+   system <https://codeberg.org/freeipa/freeipa>`__ or `Red Hat
    Bugzilla <https://bugzilla.redhat.com/enter_bug.cgi?bug_status=NEW&component=freeipa&form_name=enter_bug&product=Fedora>`__.
 
 Before we dive into particular scenarios we offer you presentation about

--- a/src/release-notes/4-10-2.rst
+++ b/src/release-notes/4-10-2.rst
@@ -62,11 +62,11 @@ Highlights in 4.10.2
       1.21 or later. On older MIT Kerberos versions, the lack of the new
       ticket signature will be tolerated to allow gradual upgrades. More
       details are available at
-      https://pagure.io/freeipa/c/3f1b373cb2028416e40a26e3dd99b0f4c82525c7.
+      https://codeberg.org/freeipa/freeipa/commit/3f1b373cb2028416e40a26e3dd99b0f4c82525c7.
       In addition, a 'full PAC' signature type was added to MIT Kerberos
       1.21. FreeIPA will support the new signature when running against
       newer MIT Kerberos version. For older versions, please see
-      https://pagure.io/freeipa/c/9cd5f49c74f28dbe070b072b394747a039cef463.
+      https://codeberg.org/freeipa/freeipa/commit/9cd5f49c74f28dbe070b072b394747a039cef463.
       This new PAC signature will be required by default by Active
       Directory in July 2023 for S4U requests, and opt-out will no
       longer be possible after October 2023. We recommend upgrading to
@@ -304,73 +304,73 @@ Alexander Bokovoy (23)
 
 -  ipa-kdb: be compatible with krb5 1.19 when checking for server
    referral
-   `commit <https://pagure.io/freeipa/c/f2b821abca72e0d444c96598799c4947e2173d3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b821abca72e0d444c96598799c4947e2173d3f>`__
    `#9164 <https://pagure.io/freeipa/issue/9164>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
-   `commit <https://pagure.io/freeipa/c/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
 -  ipa-kdb: skip verification of PAC full checksum
-   `commit <https://pagure.io/freeipa/c/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
    `#9371 <https://pagure.io/freeipa/issue/9371>`__
 -  ipa-kdb: process out of realm server lookup during S4U
-   `commit <https://pagure.io/freeipa/c/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
    `#9164 <https://pagure.io/freeipa/issue/9164>`__
 -  ipa-kdb: postpone ticket checksum configuration
-   `commit <https://pagure.io/freeipa/c/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
 -  ipa-kdb: protect against context corruption
-   `commit <https://pagure.io/freeipa/c/803a44777f901217d634f8fd7feed8b66ece352a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/803a44777f901217d634f8fd7feed8b66ece352a>`__
 -  ipa-kdb: hint KDC to use aes256-sha1 for forest trust TGT
-   `commit <https://pagure.io/freeipa/c/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  Change doc theme to 'book'
-   `commit <https://pagure.io/freeipa/c/1c43d914d9a365097a80c5c2278017b91c619266>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c43d914d9a365097a80c5c2278017b91c619266>`__
 -  doc/designs/rbcd.md: document use of S-1-18-\* SIDs
-   `commit <https://pagure.io/freeipa/c/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  doc/designs/rbcd.md: add usage examples
-   `commit <https://pagure.io/freeipa/c/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  RBCD: add basic test for RBCD handling
-   `commit <https://pagure.io/freeipa/c/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  kdb: implement RBCD handling in KDB driver
-   `commit <https://pagure.io/freeipa/c/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  IPA API changes to support RBCD
-   `commit <https://pagure.io/freeipa/c/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  doc: add design document for Kerberos constrained delegation
-   `commit <https://pagure.io/freeipa/c/18cd909b4ad854147008a1010c97c75640a54177>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18cd909b4ad854147008a1010c97c75640a54177>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  ipa-kdb: search S4U2Proxy ACLs in cn=s4u2proxy,cn=etc,$BASEDN subtree
    only
-   `commit <https://pagure.io/freeipa/c/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
    `#5444 <https://pagure.io/freeipa/issue/5444>`__
 -  test_xmlrpc: adopt to automember plugin message changes in 389-ds
-   `commit <https://pagure.io/freeipa/c/52e6da9056697e2210736d5528826ae424fec9b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52e6da9056697e2210736d5528826ae424fec9b1>`__
 -  Ignore empty modification error in case cifs/.. principal already
    added
-   `commit <https://pagure.io/freeipa/c/e7506403a988b98cc3381d2d986b53aee48448cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7506403a988b98cc3381d2d986b53aee48448cb>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
-   `commit <https://pagure.io/freeipa/c/e07ead943abf070107a9669fc4564c9dc7518832>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e07ead943abf070107a9669fc4564c9dc7518832>`__
    `#9355 <https://pagure.io/freeipa/issue/9355>`__
 -  Fix tox in Azure CI
-   `commit <https://pagure.io/freeipa/c/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Use system-wide chromium for webui tests
-   `commit <https://pagure.io/freeipa/c/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Don't fail if optional RPM macros file is missing
-   `commit <https://pagure.io/freeipa/c/b93f6b52a29659663fae65be51dafe350606eb6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b93f6b52a29659663fae65be51dafe350606eb6d>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
-   `commit <https://pagure.io/freeipa/c/0206369eec8530e96c66986c4ca501d8962193ce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0206369eec8530e96c66986c4ca501d8962193ce>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
-   `commit <https://pagure.io/freeipa/c/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -379,16 +379,16 @@ Anuja More (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test that non admin user can search hbac rule.
-   `commit <https://pagure.io/freeipa/c/051bbe36dce57837bd1769aa4a88569e39565774>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/051bbe36dce57837bd1769aa4a88569e39565774>`__
    `#5130 <https://pagure.io/freeipa/issue/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
-   `commit <https://pagure.io/freeipa/c/983a6516f147ae95a512435cd05d237233d0b5fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/983a6516f147ae95a512435cd05d237233d0b5fc>`__
    `#6044 <https://pagure.io/freeipa/issue/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
-   `commit <https://pagure.io/freeipa/c/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  Add test for SSH with GSSAPI auth.
-   `commit <https://pagure.io/freeipa/c/a6cb905de74da38d62f9c3bd7957018924282521>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6cb905de74da38d62f9c3bd7957018924282521>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 
 
@@ -397,27 +397,27 @@ Antonio Torres (10)
 ----------------------------------------------------------------------------------------------
 
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/03b92fb42f173e9ba26d6d19f0d6f35f6c5f38b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03b92fb42f173e9ba26d6d19f0d6f35f6c5f38b2>`__
 -  Update translations to FreeIPA ipa-4-10 state
-   `commit <https://pagure.io/freeipa/c/e3797ca2e03097a36bd3795fc1687a2ed4922e59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3797ca2e03097a36bd3795fc1687a2ed4922e59>`__
 -  Extend API documentation
-   `commit <https://pagure.io/freeipa/c/9c6b4f4445dbd1eefffbfff191063980a2f3a342>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c6b4f4445dbd1eefffbfff191063980a2f3a342>`__
 -  doc: allow notes on Param API Reference pages
-   `commit <https://pagure.io/freeipa/c/3eed25e92f951689658f6bbd178a5baca37442c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3eed25e92f951689658f6bbd178a5baca37442c6>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
-   `commit <https://pagure.io/freeipa/c/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
-   `commit <https://pagure.io/freeipa/c/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
 -  API doc: add note about ipa show-mappings to usage guide
-   `commit <https://pagure.io/freeipa/c/a20acb6f833a22baad214a466848cb5833954532>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a20acb6f833a22baad214a466848cb5833954532>`__
 -  API doc: validate generated reference
-   `commit <https://pagure.io/freeipa/c/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
    `#9287 <https://pagure.io/freeipa/issue/9287>`__
 -  API doc: add basic user management guide
-   `commit <https://pagure.io/freeipa/c/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/657a7b2556e22b70802809dd784fe576d3edea95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/657a7b2556e22b70802809dd784fe576d3edea95>`__
 
 
 
@@ -425,7 +425,7 @@ Carla Martinez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update 'Auth indicators' doc string
-   `commit <https://pagure.io/freeipa/c/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
    `#9338 <https://pagure.io/freeipa/issue/9338>`__
 
 
@@ -434,13 +434,13 @@ Christian Heimes (3)
 ----------------------------------------------------------------------------------------------
 
 -  Speed up installer by restarting DS after DNA plugin
-   `commit <https://pagure.io/freeipa/c/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
    `#9358 <https://pagure.io/freeipa/issue/9358>`__
 -  Don't block when kinit_pkinit() fails
-   `commit <https://pagure.io/freeipa/c/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
    `#9333 <https://pagure.io/freeipa/issue/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
-   `commit <https://pagure.io/freeipa/c/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
    `#9285 <https://pagure.io/freeipa/issue/9285>`__
 
 
@@ -449,7 +449,7 @@ Chris Kelley (1)
 ----------------------------------------------------------------------------------------------
 
 -  Check that CADogtagCertsConfigCheck can handle cert renewal
-   `commit <https://pagure.io/freeipa/c/a786d3d584c8696df3b18858df1c429cba03721f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a786d3d584c8696df3b18858df1c429cba03721f>`__
 
 
 
@@ -457,9 +457,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  doc: Use case examples for PR-CI checker tool
-   `commit <https://pagure.io/freeipa/c/41c32174b2b3cf71474ea74df32f1f763f4a2c5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41c32174b2b3cf71474ea74df32f1f763f4a2c5b>`__
 -  ipatests: fix (prci_checker) duplicated check & error return code
-   `commit <https://pagure.io/freeipa/c/1a965a3a6304607eb5acbdfee45843ebe8746c67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a965a3a6304607eb5acbdfee45843ebe8746c67>`__
 
 
 
@@ -468,7 +468,7 @@ Erik Belko (1)
 
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
-   `commit <https://pagure.io/freeipa/c/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -478,7 +478,7 @@ Filip Dvorak (1)
 
 -  ipa tests: Add LANG before kinit command to fix issue with locale
    settings
-   `commit <https://pagure.io/freeipa/c/2520a7adff7a49ddcddaaf19f0e586425dc0d878>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2520a7adff7a49ddcddaaf19f0e586425dc0d878>`__
 
 
 
@@ -486,159 +486,159 @@ Florence Blanc-Renaud (55)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: remove xfail from test_smb
-   `commit <https://pagure.io/freeipa/c/283f5463f091ac9fcc733092fc6becff586ae97f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/283f5463f091ac9fcc733092fc6becff586ae97f>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
-   `commit <https://pagure.io/freeipa/c/a6f485fcade619980f6538edadf115dca69e1314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6f485fcade619980f6538edadf115dca69e1314>`__
    `#9383 <https://pagure.io/freeipa/issue/9383>`__
 -  user or group name: explain the supported format
-   `commit <https://pagure.io/freeipa/c/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
 -  azure tests: move to fedora 38
-   `commit <https://pagure.io/freeipa/c/627c1101a08a281d07cd930193232e434a0cd9a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/627c1101a08a281d07cd930193232e434a0cd9a0>`__
 -  Tests: test on f37 and f38
-   `commit <https://pagure.io/freeipa/c/12d1aafe60de457815adb822bbef466926626d6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/12d1aafe60de457815adb822bbef466926626d6f>`__
 -  idview: improve performance of idview-show
-   `commit <https://pagure.io/freeipa/c/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
    `#9372 <https://pagure.io/freeipa/issue/9372>`__
 -  spec file: force nodejs < 20 on fedora < 39
-   `commit <https://pagure.io/freeipa/c/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
    `#9374 <https://pagure.io/freeipa/issue/9374>`__
 -  Nightly test: add +15min for test_ipahealthcheck
-   `commit <https://pagure.io/freeipa/c/717228c908816c72b98cee86abfe7c22cb07c44e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/717228c908816c72b98cee86abfe7c22cb07c44e>`__
    `#9362 <https://pagure.io/freeipa/issue/9362>`__
 -  cert_find: fix call with --all
-   `commit <https://pagure.io/freeipa/c/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  ipatests: mark known failures for autoprivategroup
-   `commit <https://pagure.io/freeipa/c/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
    `#9295 <https://pagure.io/freeipa/issue/9295>`__
 -  ipatests: fix test definition for test_trust
-   `commit <https://pagure.io/freeipa/c/def07260da883b1d27330b308bd0337205bf53a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/def07260da883b1d27330b308bd0337205bf53a8>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: increase timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/ae014c6a3e17da7b0775be79a425d769a2717243>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae014c6a3e17da7b0775be79a425d769a2717243>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: adapt for new automembership fixup behavior
-   `commit <https://pagure.io/freeipa/c/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
    `#9313 <https://pagure.io/freeipa/issue/9313>`__
 -  ipatests: increase timeout for test_acme
-   `commit <https://pagure.io/freeipa/c/0a8a3922487b8029c509635c85b533474008bb9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0a8a3922487b8029c509635c85b533474008bb9d>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
-   `commit <https://pagure.io/freeipa/c/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
-   `commit <https://pagure.io/freeipa/c/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
    `#9310 <https://pagure.io/freeipa/issue/9310>`__
 -  Spec file: use %autosetup instead of %setup
-   `commit <https://pagure.io/freeipa/c/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
 -  Spec file: unify with RHEL9 spec
-   `commit <https://pagure.io/freeipa/c/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
 -  Installer: create RID base before domain object
-   `commit <https://pagure.io/freeipa/c/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
    `#9309 <https://pagure.io/freeipa/issue/9309>`__
 -  Tests: force key type in ACME tests
-   `commit <https://pagure.io/freeipa/c/0fa95852c935c7b079f8ed966d4f194099217038>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0fa95852c935c7b079f8ed966d4f194099217038>`__
    `#9298 <https://pagure.io/freeipa/issue/9298>`__
 -  server install: remove error log about missing bkup file
-   `commit <https://pagure.io/freeipa/c/894dca12c120f0bfa705307a0609da47326b8fb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/894dca12c120f0bfa705307a0609da47326b8fb2>`__
    `#9306 <https://pagure.io/freeipa/issue/9306>`__
 -  ipatests: mark test_smb as xfail
-   `commit <https://pagure.io/freeipa/c/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  pylint: disable deprecated-module message
-   `commit <https://pagure.io/freeipa/c/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix comparison-of-constants
-   `commit <https://pagure.io/freeipa/c/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable comparison-of-constants
-   `commit <https://pagure.io/freeipa/c/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix consider-iterating-dictionary
-   `commit <https://pagure.io/freeipa/c/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: globally disable useless-object-inheritance
-   `commit <https://pagure.io/freeipa/c/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable unhashable-member
-   `commit <https://pagure.io/freeipa/c/07111438389fde4a74845f9f797656712335795f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07111438389fde4a74845f9f797656712335795f>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable invalid-sequence-index
-   `commit <https://pagure.io/freeipa/c/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix deprecated-class SafeConfigParser
-   `commit <https://pagure.io/freeipa/c/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix duplicate-value
-   `commit <https://pagure.io/freeipa/c/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: fix implicit-str-concat
-   `commit <https://pagure.io/freeipa/c/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable missing-timeout message
-   `commit <https://pagure.io/freeipa/c/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: globally disable unnecessary-lambda-assignment message
-   `commit <https://pagure.io/freeipa/c/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable unnecessary-dunder-call message
-   `commit <https://pagure.io/freeipa/c/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable using-constant-test
-   `commit <https://pagure.io/freeipa/c/5434c12b6012f035528f0b137c1af5c1be113542>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5434c12b6012f035528f0b137c1af5c1be113542>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove arguments-renamed warnings
-   `commit <https://pagure.io/freeipa/c/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable modified-iterating-list
-   `commit <https://pagure.io/freeipa/c/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: replace deprecated distutils module
-   `commit <https://pagure.io/freeipa/c/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable used-before-assignment
-   `commit <https://pagure.io/freeipa/c/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: disable redefined-slots-in-subclass
-   `commit <https://pagure.io/freeipa/c/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove useless suppression
-   `commit <https://pagure.io/freeipa/c/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: remove unneeded disable=unused-private-member
-   `commit <https://pagure.io/freeipa/c/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  azure tests: move to fedora 37
-   `commit <https://pagure.io/freeipa/c/782873a2277ca7defa5554d2b7859f1c14767d68>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/782873a2277ca7defa5554d2b7859f1c14767d68>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/304978924a09677805fd3b73614aad6a2de232a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/304978924a09677805fd3b73614aad6a2de232a2>`__
    `#9135 <https://pagure.io/freeipa/issue/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
-   `commit <https://pagure.io/freeipa/c/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
 -  FIPS setup: fix typo filtering camellia encryption
-   `commit <https://pagure.io/freeipa/c/dfba6ebf9ab7b7d17e65f928c90ae63b31d9cae7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfba6ebf9ab7b7d17e65f928c90ae63b31d9cae7>`__
 -  cert utilities: MAC verification is incompatible with FIPS mode
-   `commit <https://pagure.io/freeipa/c/c853cfde56fb56798424bd402012d78ed47647c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c853cfde56fb56798424bd402012d78ed47647c0>`__
 -  ipatests: update the fake fips mode expected message
-   `commit <https://pagure.io/freeipa/c/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
    `#9002 <https://pagure.io/freeipa/issue/9002>`__
 -  ipatests: xfail on all fedora for test_ipa_login_with_sso_user
-   `commit <https://pagure.io/freeipa/c/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
    `#9264 <https://pagure.io/freeipa/issue/9264>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
-   `commit <https://pagure.io/freeipa/c/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
    `#9290 <https://pagure.io/freeipa/issue/9290>`__
 -  webui tests: fix assertion in test_subid.py
-   `commit <https://pagure.io/freeipa/c/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
    `#9282 <https://pagure.io/freeipa/issue/9282>`__
 -  PRCI: update memory reqs for each topology
-   `commit <https://pagure.io/freeipa/c/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
 -  API reference: update dnszone_add generated doc
-   `commit <https://pagure.io/freeipa/c/660da9ab1d93fd8e561643728ae3821193953433>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/660da9ab1d93fd8e561643728ae3821193953433>`__
    `#9249 <https://pagure.io/freeipa/issue/9249>`__
 -  API reference: update vault doc
-   `commit <https://pagure.io/freeipa/c/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
    `#9259 <https://pagure.io/freeipa/issue/9259>`__
 
 
@@ -647,7 +647,7 @@ s1341 (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipaplatform: add initial nixos support
-   `commit <https://pagure.io/freeipa/c/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
    `#9299 <https://pagure.io/freeipa/issue/9299>`__
 
 
@@ -656,10 +656,10 @@ Jarl Gullberg (2)
 ----------------------------------------------------------------------------------------------
 
 -  install: Fix missing dyndb keytab directive
-   `commit <https://pagure.io/freeipa/c/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
    `#9344 <https://pagure.io/freeipa/issue/9344>`__
 -  ipaplatform/debian: fix path to ldap.so
-   `commit <https://pagure.io/freeipa/c/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
 
 
 
@@ -667,13 +667,13 @@ Julien Rische (3)
 ----------------------------------------------------------------------------------------------
 
 -  Filter out constrained delegation ACL from KDB entry
-   `commit <https://pagure.io/freeipa/c/7ea3b86696f5451f1d227d365018ab7dc53024af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ea3b86696f5451f1d227d365018ab7dc53024af>`__
 -  Tolerate absence of PAC ticket signature depending of server
    capabilities
-   `commit <https://pagure.io/freeipa/c/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
    `#9371 <https://pagure.io/freeipa/issue/9371>`__
 -  kdb: Use krb5_pac_full_sign_compat() when available
-   `commit <https://pagure.io/freeipa/c/630cda5c06428825dd5604493621b9cbdab70073>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/630cda5c06428825dd5604493621b9cbdab70073>`__
    `#9373 <https://pagure.io/freeipa/issue/9373>`__
 
 
@@ -682,7 +682,7 @@ Jerry James (1)
 ----------------------------------------------------------------------------------------------
 
 -  Change fontawesome-fonts requires to match fontawesome 4.x
-   `commit <https://pagure.io/freeipa/c/58173c021388dd31b4501d1c7bc1e6747cea8bb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58173c021388dd31b4501d1c7bc1e6747cea8bb8>`__
 
 
 
@@ -690,19 +690,19 @@ mbhalodi (5)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: add remove automember condition tests
-   `commit <https://pagure.io/freeipa/c/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: Test for sequence processing failures with server context
-   `commit <https://pagure.io/freeipa/c/304fd550613e83d120c72f0dad89f6a89d31231c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/304fd550613e83d120c72f0dad89f6a89d31231c>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  ipatests: add missing automember-cli tests
-   `commit <https://pagure.io/freeipa/c/6db9bbd85a837950d9244502507535c1f79ab64a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6db9bbd85a837950d9244502507535c1f79ab64a>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/cd07413cba37150b12d6b279510941aad49b5afb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd07413cba37150b12d6b279510941aad49b5afb>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/88b9be29036a3580a8bccd31986fc30faa9852df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88b9be29036a3580a8bccd31986fc30faa9852df>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 
 
@@ -711,10 +711,10 @@ Michal Polovka (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: commands: Wait for the SSSD to become available
-   `commit <https://pagure.io/freeipa/c/bc39443211e998d7088571f0ef70233b6e456e1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc39443211e998d7088571f0ef70233b6e456e1d>`__
    `#9377 <https://pagure.io/freeipa/issue/9377>`__
 -  ipatest: loginscreen: do not use hardcoded password
-   `commit <https://pagure.io/freeipa/c/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 
 
@@ -723,12 +723,12 @@ Mohammad Rizwan (3)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: wait for sssd-kcm to settle after date change
-   `commit <https://pagure.io/freeipa/c/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
 -  ipatests: fix tests in TestACMEPrune
-   `commit <https://pagure.io/freeipa/c/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  ipatests: tests for certificate pruning
-   `commit <https://pagure.io/freeipa/c/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 
 
@@ -737,49 +737,49 @@ Rob Crittenden (15)
 ----------------------------------------------------------------------------------------------
 
 -  Don't allow a group to be converted to POSIX and external
-   `commit <https://pagure.io/freeipa/c/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
    `#8990 <https://pagure.io/freeipa/issue/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
-   `commit <https://pagure.io/freeipa/c/325a13196b32c627854c8d7594e23b58167499f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/325a13196b32c627854c8d7594e23b58167499f0>`__
    `#8941 <https://pagure.io/freeipa/issue/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
-   `commit <https://pagure.io/freeipa/c/abe71fe145a3d16257043ccfbb43002607458cee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abe71fe145a3d16257043ccfbb43002607458cee>`__
    `#9086 <https://pagure.io/freeipa/issue/9086>`__
 -  Return the value cert-find failures from the CA
-   `commit <https://pagure.io/freeipa/c/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
    `#9369 <https://pagure.io/freeipa/issue/9369>`__
 -  Use the OpenSSL certificate parser in cert-find
-   `commit <https://pagure.io/freeipa/c/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Enforce sizelimit in cert-find
-   `commit <https://pagure.io/freeipa/c/e2576670e692117c11987118abd5e9381bb90b1f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2576670e692117c11987118abd5e9381bb90b1f>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  doc: Update pruning design with implement enable/disable options
-   `commit <https://pagure.io/freeipa/c/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
    `#9323 <https://pagure.io/freeipa/issue/9323>`__
 -  Wipe the ipa-ca DNS record when updating system records
-   `commit <https://pagure.io/freeipa/c/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
    `#9195 <https://pagure.io/freeipa/issue/9195>`__
 -  Fix setting values of 0 in ACME pruning
-   `commit <https://pagure.io/freeipa/c/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
    `#9325 <https://pagure.io/freeipa/issue/9325>`__
 -  tests: add wrapper around ACME RSNv3 test
-   `commit <https://pagure.io/freeipa/c/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
    `#9322 <https://pagure.io/freeipa/issue/9322>`__
 -  doc: add the --run command for manual job execution
-   `commit <https://pagure.io/freeipa/c/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  ipa-acme-manage: add certificate/request pruning management
-   `commit <https://pagure.io/freeipa/c/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
-   `commit <https://pagure.io/freeipa/c/6ca119686aadfa72c0474f72758b63cd671952d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ca119686aadfa72c0474f72758b63cd671952d4>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
-   `commit <https://pagure.io/freeipa/c/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  doc: Design for certificate pruning
-   `commit <https://pagure.io/freeipa/c/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
    `#9294 <https://pagure.io/freeipa/issue/9294>`__
 
 
@@ -788,10 +788,10 @@ Rafael Guterres Jeffman (2)
 ----------------------------------------------------------------------------------------------
 
 -  Fix "no entry" condition when searching PAC info
-   `commit <https://pagure.io/freeipa/c/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
    `#9368 <https://pagure.io/freeipa/issue/9368>`__
 -  Migrated to SPDX license.
-   `commit <https://pagure.io/freeipa/c/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
    `#9342 <https://pagure.io/freeipa/issue/9342>`__
 
 
@@ -800,68 +800,68 @@ Stanislav Levin (21)
 ----------------------------------------------------------------------------------------------
 
 -  ipasphinx: Correct import of progress_message for Sphinx 6.1.0+
-   `commit <https://pagure.io/freeipa/c/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
    `#9361 <https://pagure.io/freeipa/issue/9361>`__
 -  fastlint: Correct concatenation of file lists
-   `commit <https://pagure.io/freeipa/c/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
    `#9318 <https://pagure.io/freeipa/issue/9318>`__
 -  dns: Fix support for dnspython 1.1x
-   `commit <https://pagure.io/freeipa/c/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
    `#9339 <https://pagure.io/freeipa/issue/9339>`__
 -  tests: webui: Update vendored qunit
-   `commit <https://pagure.io/freeipa/c/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  AP: webui: List installed nodejs packages
-   `commit <https://pagure.io/freeipa/c/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Load qunit only once
-   `commit <https://pagure.io/freeipa/c/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Allow file access from files in tests
-   `commit <https://pagure.io/freeipa/c/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
-   `commit <https://pagure.io/freeipa/c/d662b125985369181a3ebcbad82a4a43215282f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d662b125985369181a3ebcbad82a4a43215282f6>`__
    `#9319 <https://pagure.io/freeipa/issue/9319>`__
 -  spec: Drop no longer used build dependency on paste
-   `commit <https://pagure.io/freeipa/c/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
    `#9314 <https://pagure.io/freeipa/issue/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
-   `commit <https://pagure.io/freeipa/c/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
    `#9315 <https://pagure.io/freeipa/issue/9315>`__
 -  pylint: Replace deprecated cgi module
-   `commit <https://pagure.io/freeipa/c/2009889d763ccc26479c966931ca1b60378496fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2009889d763ccc26479c966931ca1b60378496fd>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix useless-object-inheritance
-   `commit <https://pagure.io/freeipa/c/bccd3c942084c753543d63b4d409ac46f819d314>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bccd3c942084c753543d63b4d409ac46f819d314>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix unhashable-member
-   `commit <https://pagure.io/freeipa/c/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix unnecessary-lambda-assignment
-   `commit <https://pagure.io/freeipa/c/dc8c8a7824565178333ef7ae8ac7934467424691>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc8c8a7824565178333ef7ae8ac7934467424691>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix modified-iterating-list
-   `commit <https://pagure.io/freeipa/c/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix used-before-assignment
-   `commit <https://pagure.io/freeipa/c/b12376560da944b0845b9ac0d424adaf5435670f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b12376560da944b0845b9ac0d424adaf5435670f>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Replace deprecated pipes
-   `commit <https://pagure.io/freeipa/c/1261bbf0016d4824f908a589d4943513e98f8b01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1261bbf0016d4824f908a589d4943513e98f8b01>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Fix cyclic-import
-   `commit <https://pagure.io/freeipa/c/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
    `#9232 <https://pagure.io/freeipa/issue/9232>`__,
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Replace deprecated extension-pkg-whitelist
-   `commit <https://pagure.io/freeipa/c/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: More allowed C extensions
-   `commit <https://pagure.io/freeipa/c/f9822697659f134146e1dcfce0c48e2279a8becb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9822697659f134146e1dcfce0c48e2279a8becb>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 -  pylint: Lint in single process mode
-   `commit <https://pagure.io/freeipa/c/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
    `#9278 <https://pagure.io/freeipa/issue/9278>`__
 
 
@@ -870,9 +870,9 @@ Sudhir Menon (2)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: ipa-adtrust-install command test scenarios
-   `commit <https://pagure.io/freeipa/c/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
-   `commit <https://pagure.io/freeipa/c/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
    `#9279 <https://pagure.io/freeipa/issue/9279>`__
 
 
@@ -881,7 +881,7 @@ Timo Aaltonen (1)
 ----------------------------------------------------------------------------------------------
 
 -  Drop duplicate includedir from krb5.conf
-   `commit <https://pagure.io/freeipa/c/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
    `#9267 <https://pagure.io/freeipa/issue/9267>`__
 
 
@@ -890,9 +890,9 @@ Todd Zullinger (2)
 ----------------------------------------------------------------------------------------------
 
 -  spec: silence krb5 pkgconf errors in %krb5_base_version
-   `commit <https://pagure.io/freeipa/c/90d0f04987b5477efa64d64416d89890e6bcda75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90d0f04987b5477efa64d64416d89890e6bcda75>`__
 -  spec: verify upstream source signature
-   `commit <https://pagure.io/freeipa/c/3b64eaa153d89920cbb0be87e5c2b512c4bf2008>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b64eaa153d89920cbb0be87e5c2b512c4bf2008>`__
 
 
 
@@ -900,4 +900,4 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  external-idp: change idp server name to reference name
-   `commit <https://pagure.io/freeipa/c/9323bafb645a377192efe17b489124a440c055c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9323bafb645a377192efe17b489124a440c055c3>`__

--- a/src/release-notes/4-10-3.rst
+++ b/src/release-notes/4-10-3.rst
@@ -66,7 +66,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.10.3
-   `commit <https://pagure.io/freeipa/c/74710a8ed24b4b8a14a07ca0642507d260039b30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/74710a8ed24b4b8a14a07ca0642507d260039b30>`__
 
 .. _rob_crittenden_2:
 
@@ -74,6 +74,6 @@ Rob Crittenden (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Integration tests for verifying Referer header in the UI
-   `commit <https://pagure.io/freeipa/c/48ec350051ead9c17e58a91405b3ab6935347f1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48ec350051ead9c17e58a91405b3ab6935347f1b>`__
 -  Check the HTTP Referer header on all requests
-   `commit <https://pagure.io/freeipa/c/363fd5de98e883800ac08b2760e8c3150783e7e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/363fd5de98e883800ac08b2760e8c3150783e7e2>`__

--- a/src/release-notes/4-11-0-beta.rst
+++ b/src/release-notes/4-11-0-beta.rst
@@ -207,7 +207,7 @@ Armando Neto (1)
 ~~~~~~~~~~~~~~~~
 
 -  ipatests: update rawhide template
-   `commit <https://pagure.io/freeipa/c/52782b55f5cb0020be446f75e734cbebc8a4d3cb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52782b55f5cb0020be446f75e734cbebc8a4d3cb>`__
 
 .. _alexander_bokovoy_36:
 
@@ -215,29 +215,29 @@ Alexander Bokovoy (10)
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipalib/x509.py: Add signature_algorithm_parameters
-   `commit <https://pagure.io/freeipa/c/18bf495ce88fbb032f23f7db7f941458ecf55c7a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18bf495ce88fbb032f23f7db7f941458ecf55c7a>`__
 -  ipa-kdb: postpone ticket checksum configuration
-   `commit <https://pagure.io/freeipa/c/03897d8a6899691b7218428b296f6d22ccadcfb2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03897d8a6899691b7218428b296f6d22ccadcfb2>`__
 -  ipa-kdb: protect against context corruption
-   `commit <https://pagure.io/freeipa/c/4ef8258d58046ee905c929c0e889653a8b86d383>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ef8258d58046ee905c929c0e889653a8b86d383>`__
 -  doc/designs: update link to SSSD passkey design page
-   `commit <https://pagure.io/freeipa/c/e5c292cdada69a93a03de0fa6e48aa713b432ba1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5c292cdada69a93a03de0fa6e48aa713b432ba1>`__
 -  ipa-kdb: initial support for passkeys
-   `commit <https://pagure.io/freeipa/c/56e179748ba4844ce0c5e505803170b901e2a3c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56e179748ba4844ce0c5e505803170b901e2a3c4>`__
    `#9263 <https://pagure.io/freeipa/issue/9263>`__
 -  Change doc theme to 'book'
-   `commit <https://pagure.io/freeipa/c/e0c4f83abdbbaaa77707e5d15f91ce2bb0bf9329>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0c4f83abdbbaaa77707e5d15f91ce2bb0bf9329>`__
 -  idp: when adding an IdP allow to override IdP options
-   `commit <https://pagure.io/freeipa/c/69e4397421d16fad7d16b2f5d53d2bd9316407a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69e4397421d16fad7d16b2f5d53d2bd9316407a1>`__
    `#9421 <https://pagure.io/freeipa/issue/9421>`__
 -  ipa-epn: don't use too general exception
-   `commit <https://pagure.io/freeipa/c/8173e5df2d0e8dac48f26882ff16979d0da325b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8173e5df2d0e8dac48f26882ff16979d0da325b5>`__
    `#9425 <https://pagure.io/freeipa/issue/9425>`__
 -  python 3.12: utcnow function is deprecated
-   `commit <https://pagure.io/freeipa/c/09497d2df0fbd4bb5ad798e5c0798a0faa632f11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09497d2df0fbd4bb5ad798e5c0798a0faa632f11>`__
    `#9425 <https://pagure.io/freeipa/issue/9425>`__
 -  support more DateTime attributes in LDAP searches in IPA API
-   `commit <https://pagure.io/freeipa/c/ef955c90150d7d1df145b16b1f17940769d42f56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef955c90150d7d1df145b16b1f17940769d42f56>`__
    `#9395 <https://pagure.io/freeipa/issue/9395>`__
 
 
@@ -247,7 +247,7 @@ Andika Triwidada (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/c7ba8f5f28e20566f2dbfcccbe81a1330ddf6ee4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7ba8f5f28e20566f2dbfcccbe81a1330ddf6ee4>`__
 
 .. _antonio_torres_14:
 
@@ -255,11 +255,11 @@ Antonio Torres (3)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Update contributors list
-   `commit <https://pagure.io/freeipa/c/479a24f28593da1de9b39f938e60be6bb89b8995>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/479a24f28593da1de9b39f938e60be6bb89b8995>`__
 -  Update translations to FreeIPA master state
-   `commit <https://pagure.io/freeipa/c/eec46800d5d288cc4e9481fd0d9025cfdd5ba2f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eec46800d5d288cc4e9481fd0d9025cfdd5ba2f7>`__
 -  Bump to IPA 4.11
-   `commit <https://pagure.io/freeipa/c/9819058d730be6ab3b09a1505061d0bc6c3f9210>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9819058d730be6ab3b09a1505061d0bc6c3f9210>`__
 
 .. _alexey_tikhonov_3:
 
@@ -268,9 +268,9 @@ Alexey Tikhonov (2)
 
 -  extdom: avoid sss_nss_getorigby*() calls when get*_r_wrapper()
    returns object from a wrong domain (performance optimization)
-   `commit <https://pagure.io/freeipa/c/147123e6b9fcbb570608651d248945c93f81fc01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/147123e6b9fcbb570608651d248945c93f81fc01>`__
 -  extdom: internal functions should be static
-   `commit <https://pagure.io/freeipa/c/f0c26fe0946a6ff4382235c9caf723777d3b9699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f0c26fe0946a6ff4382235c9caf723777d3b9699>`__
 
 .. _chris_kelley_1:
 
@@ -278,7 +278,7 @@ Chris Kelley (1)
 ~~~~~~~~~~~~~~~~
 
 -  Check that CADogtagCertsConfigCheck can handle cert renewal
-   `commit <https://pagure.io/freeipa/c/614d3bd9c009204920406b791057fe3646d640bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/614d3bd9c009204920406b791057fe3646d640bc>`__
 
 .. _jan_kuparinen_14:
 
@@ -286,33 +286,33 @@ Jan Kuparinen (14)
 ~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e20e1a446c36c875537398c7f28212b8320d667a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e20e1a446c36c875537398c7f28212b8320d667a>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/ea95f0dda07021e655c1d58c6078f5b1a8b6bc5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea95f0dda07021e655c1d58c6078f5b1a8b6bc5c>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e92b847850b3fc9a8027a1d2aca3073dddb1d652>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e92b847850b3fc9a8027a1d2aca3073dddb1d652>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/cd702b542179322d8a3d9797d283c4a76c6ad3b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd702b542179322d8a3d9797d283c4a76c6ad3b6>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/f680614b5c6842f9466e4f317b0564adad015a78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f680614b5c6842f9466e4f317b0564adad015a78>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/581dfddcf7c8304fc72fa9f5d7c5acf7fbab9411>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/581dfddcf7c8304fc72fa9f5d7c5acf7fbab9411>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/7fc89bc0bac8239b214d3a157cf11c284c7d3a40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7fc89bc0bac8239b214d3a157cf11c284c7d3a40>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/386e51168a1f78db93f9f00e2daa25567bdcfffe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/386e51168a1f78db93f9f00e2daa25567bdcfffe>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/feb94b3aa55f7e71cbcfd8c17662732d33806438>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/feb94b3aa55f7e71cbcfd8c17662732d33806438>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e39ccf59889f13499fe47ffb9a9ae6e01e0430b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e39ccf59889f13499fe47ffb9a9ae6e01e0430b1>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/706faddf242105d95f7901d040736c13feb3c213>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/706faddf242105d95f7901d040736c13feb3c213>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/dd345aaca840ed86f77aedae682860ffc721ff3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd345aaca840ed86f77aedae682860ffc721ff3f>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/31ba6aa500f1ddb8af43aeebb9f12854431f1a66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31ba6aa500f1ddb8af43aeebb9f12854431f1a66>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/41855787056b0836e1d64c02fa2125f195acda0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41855787056b0836e1d64c02fa2125f195acda0b>`__
 
 .. _david_pascual_4:
 
@@ -320,13 +320,13 @@ David Pascual (4)
 ~~~~~~~~~~~~~~~~~
 
 -  doc: Use case examples for PR-CI checker tool
-   `commit <https://pagure.io/freeipa/c/b0636c540883c948349b2f374a9da9ee8a731e94>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0636c540883c948349b2f374a9da9ee8a731e94>`__
 -  ipatests: fix (prci_checker) duplicated check & error return code
-   `commit <https://pagure.io/freeipa/c/07927b21ba64c5a7dd75bd6357c914494397af78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07927b21ba64c5a7dd75bd6357c914494397af78>`__
 -  ipatest: fix prci checker target masked return code & add pylint
-   `commit <https://pagure.io/freeipa/c/8297b749749e22fbc2a7c36d5cffb9c2e12c31dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8297b749749e22fbc2a7c36d5cffb9c2e12c31dc>`__
 -  ipatests: Checker script for prci definitions
-   `commit <https://pagure.io/freeipa/c/3237ade3d2df20c3aeba4405f46a45a2130fbc7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3237ade3d2df20c3aeba4405f46a45a2130fbc7e>`__
 
 .. _erik_belko_5:
 
@@ -334,7 +334,7 @@ Erik Belko (1)
 ~~~~~~~~~~~~~~
 
 -  test: add tests for descriptive error message in ipa user-add
-   `commit <https://pagure.io/freeipa/c/4a3e3efb84cee9e3784246f3bc47f1f56b266bc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a3e3efb84cee9e3784246f3bc47f1f56b266bc0>`__
    `#9378 <https://pagure.io/freeipa/issue/9378>`__
 
 .. _endi_sukma_dewata_2:
@@ -343,17 +343,17 @@ Endi Sukma Dewata (6)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Explicitly use legacy ID generators by default
-   `commit <https://pagure.io/freeipa/c/38728dd518fbdfef692aa94230298901f42e6071>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38728dd518fbdfef692aa94230298901f42e6071>`__
 -  Remove pki_restart_configured_instance
-   `commit <https://pagure.io/freeipa/c/06183a061a00b9f9b36107d3e3d1e6c81cdf5146>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06183a061a00b9f9b36107d3e3d1e6c81cdf5146>`__
 -  Remove default values for pki_ca_signing_*_path
-   `commit <https://pagure.io/freeipa/c/33c2740d82634654da6a1e047fd638512083c3f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33c2740d82634654da6a1e047fd638512083c3f0>`__
 -  Remove non-existent default pki_cert_chain_path
-   `commit <https://pagure.io/freeipa/c/a9ee2adec38b23d7d957d503d79e20b2174cc512>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9ee2adec38b23d7d957d503d79e20b2174cc512>`__
 -  Add pki_share_dbuser_dn for CA
-   `commit <https://pagure.io/freeipa/c/7233944e741b2659889429c2a768ef227f4a3a2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7233944e741b2659889429c2a768ef227f4a3a2d>`__
 -  Remove unused subsystem.count
-   `commit <https://pagure.io/freeipa/c/cfc4f47a10c13a50fcd04115db65936568ea4409>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cfc4f47a10c13a50fcd04115db65936568ea4409>`__
 
 .. _filip_dvorak_1:
 
@@ -362,7 +362,7 @@ Filip Dvorak (1)
 
 -  ipa tests: Add LANG before kinit command to fix issue with locale
    settings
-   `commit <https://pagure.io/freeipa/c/1611d545492ecfcd1f4d312d62402fe7d1fb3b07>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1611d545492ecfcd1f4d312d62402fe7d1fb3b07>`__
 
 .. _florence_blanc_renaud_109:
 
@@ -370,151 +370,151 @@ Florence Blanc-Renaud (56)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  xmlrpc tests: add a test for user plugin with non-existing idp
-   `commit <https://pagure.io/freeipa/c/7517e2ce217c20651b720b8a5e5a4a134e7cdfbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7517e2ce217c20651b720b8a5e5a4a134e7cdfbf>`__
    `#9416 <https://pagure.io/freeipa/issue/9416>`__
 -  User plugin: improve error related to non existing idp
-   `commit <https://pagure.io/freeipa/c/f57a7dbf508b9214dc8222ea0ba0acf162025d2e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f57a7dbf508b9214dc8222ea0ba0acf162025d2e>`__
    `#9416 <https://pagure.io/freeipa/issue/9416>`__
 -  OTP: fix data type to avoid endianness issue
-   `commit <https://pagure.io/freeipa/c/7060e3a031fb4e4cdf85f616f1e1a3435d61e696>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7060e3a031fb4e4cdf85f616f1e1a3435d61e696>`__
    `#9402 <https://pagure.io/freeipa/issue/9402>`__
 -  ipatests: use dnf download to download pkgs
-   `commit <https://pagure.io/freeipa/c/ce9346e74e98a73c927bda5d294e9bab2785c713>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce9346e74e98a73c927bda5d294e9bab2785c713>`__
    `#9399 <https://pagure.io/freeipa/issue/9399>`__
 -  tests: fix backup-restore scenario with replica
-   `commit <https://pagure.io/freeipa/c/8de6405b1130a9b21bae87689a18439059515399>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8de6405b1130a9b21bae87689a18439059515399>`__
    `#9404 <https://pagure.io/freeipa/issue/9404>`__
 -  Detection of PKI subsystem
-   `commit <https://pagure.io/freeipa/c/6c84ae5c3035ecd917404cc41c32a4b25c607b46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c84ae5c3035ecd917404cc41c32a4b25c607b46>`__
    `#9330 <https://pagure.io/freeipa/issue/9330>`__
 -  Uninstaller: uninstall PKI before shutting down services
-   `commit <https://pagure.io/freeipa/c/67a33e5a305c7510fb182f84e46f304043f6ab37>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67a33e5a305c7510fb182f84e46f304043f6ab37>`__
    `#9330 <https://pagure.io/freeipa/issue/9330>`__
 -  Integration tests: add a test to ipa-server-upgrade
-   `commit <https://pagure.io/freeipa/c/ac78a84fbe90f361a4a58fb2748d539647ffea52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac78a84fbe90f361a4a58fb2748d539647ffea52>`__
    `#9385 <https://pagure.io/freeipa/issue/9385>`__
 -  Upgrade: fix replica agreement
-   `commit <https://pagure.io/freeipa/c/143c3eb1612f9bb7f015dcf2dcb496e8ef324a38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/143c3eb1612f9bb7f015dcf2dcb496e8ef324a38>`__
    `#9385 <https://pagure.io/freeipa/issue/9385>`__
 -  Integration test: add a test for upgrade and PKI drop-in file
-   `commit <https://pagure.io/freeipa/c/d76f8fcedab7cb6e1089eb32bbc7f7856a4e4b0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d76f8fcedab7cb6e1089eb32bbc7f7856a4e4b0d>`__
    `#9381 <https://pagure.io/freeipa/issue/9381>`__
 -  Upgrade: add PKI drop-in file if missing
-   `commit <https://pagure.io/freeipa/c/0472067ca63e4c4a9a3f060de7802b39af6d671d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0472067ca63e4c4a9a3f060de7802b39af6d671d>`__
    `#9381 <https://pagure.io/freeipa/issue/9381>`__
 -  xmlrpc tests: add test renaming user or group with setattr
-   `commit <https://pagure.io/freeipa/c/ae6549ffae1ffe2bb6a1ba7dce0620ec0c20cabf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae6549ffae1ffe2bb6a1ba7dce0620ec0c20cabf>`__
    `#9396 <https://pagure.io/freeipa/issue/9396>`__
 -  User and groups: rename with --setattr must check format
-   `commit <https://pagure.io/freeipa/c/794b2c32f67aa8e69616171f3e8de99654698b7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/794b2c32f67aa8e69616171f3e8de99654698b7e>`__
    `#9396 <https://pagure.io/freeipa/issue/9396>`__
 -  webuitests: close notification which hides Add button
-   `commit <https://pagure.io/freeipa/c/1aea1cc29e3235313a97dfbd979437a396411a7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1aea1cc29e3235313a97dfbd979437a396411a7c>`__
    `#9389 <https://pagure.io/freeipa/issue/9389>`__
 -  Spec file: bump SSSD version for passkey support
-   `commit <https://pagure.io/freeipa/c/665227e43755c0869f25e986265c0533af1cc7f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/665227e43755c0869f25e986265c0533af1cc7f7>`__
 -  Passkey: add a weak dependency on sssd-passkey
-   `commit <https://pagure.io/freeipa/c/31b70ee32470b6999306bdc38035266d6a496c9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31b70ee32470b6999306bdc38035266d6a496c9e>`__
 -  Webui tests: fix test failure
-   `commit <https://pagure.io/freeipa/c/14526c50bbabb8df43fa6420b678fcfc3ecd6436>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14526c50bbabb8df43fa6420b678fcfc3ecd6436>`__
 -  passkey: adjust selinux security context for passkey_child
-   `commit <https://pagure.io/freeipa/c/c0f71b052560e5ac9782c582f151ca0bc7312d62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0f71b052560e5ac9782c582f151ca0bc7312d62>`__
 -  passkeyconfig: require-user-verification is a boolean
-   `commit <https://pagure.io/freeipa/c/0075c8b8f66a28f80029fb3184e1eeb6b0f99f79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0075c8b8f66a28f80029fb3184e1eeb6b0f99f79>`__
 -  Passkey: update the API doc
-   `commit <https://pagure.io/freeipa/c/9963dcdd5b261011793072d92168c5961ece35ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9963dcdd5b261011793072d92168c5961ece35ad>`__
 -  Passkey: extract the passkey from stdout
-   `commit <https://pagure.io/freeipa/c/b650783a180e6c81a6ccec3fd18ee9ed13edaf12>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b650783a180e6c81a6ccec3fd18ee9ed13edaf12>`__
 -  Passkey: add "passkey configuration" to webui
-   `commit <https://pagure.io/freeipa/c/c016e271b2bddde5c26822fee78e7f07b95dddc3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c016e271b2bddde5c26822fee78e7f07b95dddc3>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  WebUI: improve passkey display
-   `commit <https://pagure.io/freeipa/c/510f806a9f4f82d39772f22e3262ca6c17c918be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/510f806a9f4f82d39772f22e3262ca6c17c918be>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  Passkey support: show the passkey in webui
-   `commit <https://pagure.io/freeipa/c/c58e483095d21aaa98f546425a99dc22d31dfb4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c58e483095d21aaa98f546425a99dc22d31dfb4a>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  Passkey: add support for discoverable credentials
-   `commit <https://pagure.io/freeipa/c/6f0da62f5afa65941c280e16bd12215a57e4d6b0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f0da62f5afa65941c280e16bd12215a57e4d6b0>`__
 -  WebUI tests: add test for krbtpolicy passkey maxlife/maxrenew
-   `commit <https://pagure.io/freeipa/c/d207f6bf328a9f2a3e07094aeab111aebca932de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d207f6bf328a9f2a3e07094aeab111aebca932de>`__
    `#9262 <https://pagure.io/freeipa/issue/9262>`__
 -  WebUI: add support for passkey auth type and auth indicator
-   `commit <https://pagure.io/freeipa/c/f8580cae4b01568a6ab98b405435e83231994896>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8580cae4b01568a6ab98b405435e83231994896>`__
    `#9262 <https://pagure.io/freeipa/issue/9262>`__
 -  XMLRPC tests: add new tests for passkey auth type
-   `commit <https://pagure.io/freeipa/c/a7d90c1ef5e70a532f4515c18bf3e073c11ab87c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7d90c1ef5e70a532f4515c18bf3e073c11ab87c>`__
 -  CLI: add support for passkey authentication type
-   `commit <https://pagure.io/freeipa/c/7911b2466d892386721952991d5150412530fb6e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7911b2466d892386721952991d5150412530fb6e>`__
    `#9262 <https://pagure.io/freeipa/issue/9262>`__
 -  XMLRPC tests: test new passkey commands
-   `commit <https://pagure.io/freeipa/c/ae3c281a64c994cae10709a2e284f3830de64781>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae3c281a64c994cae10709a2e284f3830de64781>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  API: add new commands for passkey mappings
-   `commit <https://pagure.io/freeipa/c/a21214cb9e96ff7fdb4f55b5a4817b1ce60632c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a21214cb9e96ff7fdb4f55b5a4817b1ce60632c0>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  API: add new commands for ipa passkeyconfig-show \| mod
-   `commit <https://pagure.io/freeipa/c/4bd1be9e90ea7369edb4ae15ff8c51232d5ab850>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4bd1be9e90ea7369edb4ae15ff8c51232d5ab850>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  New schema for Passkey mappings
-   `commit <https://pagure.io/freeipa/c/af569508c1cefbbbfde2fe52b02fe4545818b04a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af569508c1cefbbbfde2fe52b02fe4545818b04a>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  Design for passkey support
-   `commit <https://pagure.io/freeipa/c/574517cb165eb3d89dc3492895cf830a9bde67b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/574517cb165eb3d89dc3492895cf830a9bde67b2>`__
    `#9261 <https://pagure.io/freeipa/issue/9261>`__
 -  PRCI: update rawhide box
-   `commit <https://pagure.io/freeipa/c/2be07242b70b5c80ecf606d76378f0c299fdb829>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2be07242b70b5c80ecf606d76378f0c299fdb829>`__
 -  user or group name: explain the supported format
-   `commit <https://pagure.io/freeipa/c/7b0ad59feaf7ad017799c89010a95c2f6f55699d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b0ad59feaf7ad017799c89010a95c2f6f55699d>`__
 -  azure tests: move to fedora 38
-   `commit <https://pagure.io/freeipa/c/72dccd82448d588c4d61d8f5ffe51d559853a520>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72dccd82448d588c4d61d8f5ffe51d559853a520>`__
 -  Tests: test on f37 and f38
-   `commit <https://pagure.io/freeipa/c/72cc53a22e585b68bf3a111b17aceae1a1e93919>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/72cc53a22e585b68bf3a111b17aceae1a1e93919>`__
 -  cert_find: fix call with --all
-   `commit <https://pagure.io/freeipa/c/1f30cc65276a532e7288217f216b72a2b0628c8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f30cc65276a532e7288217f216b72a2b0628c8f>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Spec file: use %autosetup instead of %setup
-   `commit <https://pagure.io/freeipa/c/295b4e23b44c74817fd83428f9ffe4cdb1e7bb8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/295b4e23b44c74817fd83428f9ffe4cdb1e7bb8a>`__
 -  Spec file: unify with RHEL9 spec
-   `commit <https://pagure.io/freeipa/c/6ab93f8be3c853944d2f4a7bd8061cafc8db8f58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ab93f8be3c853944d2f4a7bd8061cafc8db8f58>`__
 -  azure tests: move to fedora 37
-   `commit <https://pagure.io/freeipa/c/232b5a9ddeb222035a9393bfc495b2ffba557801>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/232b5a9ddeb222035a9393bfc495b2ffba557801>`__
 -  Spec file: bump krb5_kdb_version on rawhide
-   `commit <https://pagure.io/freeipa/c/be21cabad48395f48f123c5041c858608de52d38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/be21cabad48395f48f123c5041c858608de52d38>`__
 -  FIPS setup: fix typo filtering camellia encryption
-   `commit <https://pagure.io/freeipa/c/17a5d5bff1df5e12899e9316f4a4364d2512a64f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/17a5d5bff1df5e12899e9316f4a4364d2512a64f>`__
 -  cert utilities: MAC verification is incompatible with FIPS mode
-   `commit <https://pagure.io/freeipa/c/6bd9d156e05c6dd0d4f9ece2aa3df34e77c58749>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bd9d156e05c6dd0d4f9ece2aa3df34e77c58749>`__
 -  PRCI: update memory reqs for each topology
-   `commit <https://pagure.io/freeipa/c/ab8b1fa6f542cf3f435a170cec248795bfcf544e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab8b1fa6f542cf3f435a170cec248795bfcf544e>`__
 -  ipatests: update vagrant boxes
-   `commit <https://pagure.io/freeipa/c/3d6d7e9fdf452d04f6600ae70d36d9057e5f87c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3d6d7e9fdf452d04f6600ae70d36d9057e5f87c4>`__
 -  Tests: test on f37 and f36
-   `commit <https://pagure.io/freeipa/c/43fcfe45f16d579ca1913c46437c73de9450fe92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43fcfe45f16d579ca1913c46437c73de9450fe92>`__
 -  gitignore: add install/oddjob/org.freeipa.server.config-enable-sid
-   `commit <https://pagure.io/freeipa/c/21091c2bc779d65d9049e01cd6ac6a7f2d2ef60d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21091c2bc779d65d9049e01cd6ac6a7f2d2ef60d>`__
 -  ipatests: update expected cksum for epn.conf
-   `commit <https://pagure.io/freeipa/c/bb9b44f5700564e936a928b4063d241b8996e172>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb9b44f5700564e936a928b4063d241b8996e172>`__
    `#9419 <https://pagure.io/freeipa/issue/9419>`__
 -  ipatests: update expected webui msg for admin deletion
-   `commit <https://pagure.io/freeipa/c/e49ec1048db85f514e2db5960f773e5d56fa0cec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e49ec1048db85f514e2db5960f773e5d56fa0cec>`__
    `#8878 <https://pagure.io/freeipa/issue/8878>`__
 -  ipatests: fixture can produce IndexError
-   `commit <https://pagure.io/freeipa/c/a6f01115cf2abbf6be5570d96fa607e716ba7ba9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6f01115cf2abbf6be5570d96fa607e716ba7ba9>`__
    `#9348 <https://pagure.io/freeipa/issue/9348>`__
 -  ipatests: fix test_topology
-   `commit <https://pagure.io/freeipa/c/6f5fe80de0ee9a5474fdfa5ae7880910b7384a62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f5fe80de0ee9a5474fdfa5ae7880910b7384a62>`__
 -  Installer: activate nss and pam services in sssd.conf
-   `commit <https://pagure.io/freeipa/c/7796b7b9585e9459bb44b8ea92c50eb2592319cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7796b7b9585e9459bb44b8ea92c50eb2592319cf>`__
    `#9427 <https://pagure.io/freeipa/issue/9427>`__
 -  ipa-server-guard: make the lock timezone aware
-   `commit <https://pagure.io/freeipa/c/33549183effa3a880f2d79955939b25142e72ff9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33549183effa3a880f2d79955939b25142e72ff9>`__
    `#9425 <https://pagure.io/freeipa/issue/9425>`__
 -  ipa-cert-fix: use timezone-aware datetime
-   `commit <https://pagure.io/freeipa/c/0f16b72bcb86764aaffa69a9ccad4011e811f856>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f16b72bcb86764aaffa69a9ccad4011e811f856>`__
    `#9425 <https://pagure.io/freeipa/issue/9425>`__
 -  ipa-epn: include timezone info
-   `commit <https://pagure.io/freeipa/c/59e68f79e48e5eaa18c60f3dc418d0bf516684ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/59e68f79e48e5eaa18c60f3dc418d0bf516684ab>`__
    `#9425 <https://pagure.io/freeipa/issue/9425>`__
 
 .. _fraser_tweedale_3:
@@ -523,7 +523,7 @@ Fraser Tweedale (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  BUILD.txt: remove redundant dnf-builddep option
-   `commit <https://pagure.io/freeipa/c/7a40948d6e05d75e536f257b6771cc6040ac85e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a40948d6e05d75e536f257b6771cc6040ac85e6>`__
 
 .. _iker_pedrosa_4:
 
@@ -531,13 +531,13 @@ Iker Pedrosa (4)
 ~~~~~~~~~~~~~~~~
 
 -  Passkey design: add second sssd design page
-   `commit <https://pagure.io/freeipa/c/105b03370cd5725a9ae57701da09efd0cdeed1f6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/105b03370cd5725a9ae57701da09efd0cdeed1f6>`__
 -  Passkey design: user verification clarification
-   `commit <https://pagure.io/freeipa/c/957d67aca50958ad03a7e4d9831ef722b592fa69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/957d67aca50958ad03a7e4d9831ef722b592fa69>`__
 -  Passkey design: fix user verification
-   `commit <https://pagure.io/freeipa/c/e0acc51ff579251aeadf2a624ffd2bb91c2a4ef0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0acc51ff579251aeadf2a624ffd2bb91c2a4ef0>`__
 -  ipatests: definitions for SSSD COPR nightly
-   `commit <https://pagure.io/freeipa/c/03e9139504261f043c215879a54c18a89f81c534>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03e9139504261f043c215879a54c18a89f81c534>`__
 
 .. _jarl_gullberg_2:
 
@@ -545,7 +545,7 @@ Jarl Gullberg (1)
 ~~~~~~~~~~~~~~~~~
 
 -  ipaplatform/debian: fix path to ldap.so
-   `commit <https://pagure.io/freeipa/c/5a0eed0b1addc777a0506485f40ee611763a15af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a0eed0b1addc777a0506485f40ee611763a15af>`__
 
 .. _julien_rische_4:
 
@@ -553,9 +553,9 @@ Julien Rische (2)
 ~~~~~~~~~~~~~~~~~
 
 -  Filter out constrained delegation ACL from KDB entry
-   `commit <https://pagure.io/freeipa/c/545a363dd2f7f551fa3ec3fed66c80b30ae3c1e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/545a363dd2f7f551fa3ec3fed66c80b30ae3c1e1>`__
 -  ipa-kdb: fix error handling of is_master_host()
-   `commit <https://pagure.io/freeipa/c/c84c59c66f1b22ebc671960cae90088a024d2d62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c84c59c66f1b22ebc671960cae90088a024d2d62>`__
    `#9422 <https://pagure.io/freeipa/issue/9422>`__
 
 .. _lenz_grimmer_1:
@@ -564,7 +564,7 @@ Lenz Grimmer (1)
 ~~~~~~~~~~~~~~~~
 
 -  doc: Fix incorrect URL format
-   `commit <https://pagure.io/freeipa/c/4eba0481eca5b00b926a01c13b0b089061ec81b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4eba0481eca5b00b926a01c13b0b089061ec81b2>`__
 
 .. _jerry_james_1:
 
@@ -572,7 +572,7 @@ Jerry James (1)
 ~~~~~~~~~~~~~~~
 
 -  Change fontawesome-fonts requires to match fontawesome 4.x
-   `commit <https://pagure.io/freeipa/c/da65cc35bdac530eec6c62307a48d76d582c177c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da65cc35bdac530eec6c62307a48d76d582c177c>`__
 
 
 .. _miro_hrončok_1:
@@ -582,7 +582,7 @@ Miro Hrončok (1)
 
 -  Use ssl.match_hostname from urllib3 as it was removed from Python
    3.12
-   `commit <https://pagure.io/freeipa/c/d2ed490ff446d96520b89ea47387ce8ee33c1c7d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2ed490ff446d96520b89ea47387ce8ee33c1c7d>`__
    `#9409 <https://pagure.io/freeipa/issue/9409>`__
 
 .. _mohammad_rizwan_5:
@@ -591,13 +591,13 @@ Mohammad Rizwan (4)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: enable firewall rule for http service on acme client
-   `commit <https://pagure.io/freeipa/c/00c0a62a6a0400a2353de6cf39c7d47e783f586e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00c0a62a6a0400a2353de6cf39c7d47e783f586e>`__
 -  ipatests: wait for sssd-kcm to settle after date change
-   `commit <https://pagure.io/freeipa/c/2eb4cdb64141c9c4001693f672e108beff8d621f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2eb4cdb64141c9c4001693f672e108beff8d621f>`__
 -  ipatests: Test newly added certificate lable
-   `commit <https://pagure.io/freeipa/c/746a036c7eab177fd87a37f0515a46419f22c12b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/746a036c7eab177fd87a37f0515a46419f22c12b>`__
 -  ipatests: remove fixture call and wait to get things settle
-   `commit <https://pagure.io/freeipa/c/bbb53a12711f864601a9d7c024145603c9c596a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbb53a12711f864601a9d7c024145603c9c596a1>`__
    `#9348 <https://pagure.io/freeipa/issue/9348>`__
 
 .. _weblate_5:
@@ -606,15 +606,15 @@ Weblate (5)
 ~~~~~~~~~~~
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/1d1b31a2f451cf90f083033ee256901bb3439f17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d1b31a2f451cf90f083033ee256901bb3439f17>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/6f3c9a2533631dff2a3521c140b73cb63478a240>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f3c9a2533631dff2a3521c140b73cb63478a240>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/8b1eb488bd2c523e5288063626bc67510af38958>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b1eb488bd2c523e5288063626bc67510af38958>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/3c7fe6c49df7c68054e1d8a778276d7db522fd17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c7fe6c49df7c68054e1d8a778276d7db522fd17>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/ac2c3de8891142a3c90086203e7c3ed98280f4dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac2c3de8891142a3c90086203e7c3ed98280f4dc>`__
 
 .. _piotr_drąg_2:
 
@@ -622,9 +622,9 @@ Piotr Drąg (2)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/35f58c9af45cd1eba333054d6e73ba25e53f17a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35f58c9af45cd1eba333054d6e73ba25e53f17a4>`__
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/fd985ae43a7e685959adf2098ab46bfd09cfdd1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd985ae43a7e685959adf2098ab46bfd09cfdd1a>`__
 
 .. _rob_crittenden_33:
 
@@ -632,34 +632,34 @@ Rob Crittenden (10)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Differentiate location meaning between host and server
-   `commit <https://pagure.io/freeipa/c/f1ed46eb93bcb5bc87783dc3daad72faffc7c6af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1ed46eb93bcb5bc87783dc3daad72faffc7c6af>`__
    `#9317 <https://pagure.io/freeipa/issue/9317>`__
 -  Use the python-cryptography parser directly in cert-find
-   `commit <https://pagure.io/freeipa/c/fa3a69f91fcb4e15714f78a6eee4944bb8ca5e1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa3a69f91fcb4e15714f78a6eee4944bb8ca5e1b>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Revert "cert_find: fix call with --all"
-   `commit <https://pagure.io/freeipa/c/8a250201494fa0864c81ba0bb2d16a485cdd2533>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a250201494fa0864c81ba0bb2d16a485cdd2533>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Revert "Use the OpenSSL certificate parser in cert-find"
-   `commit <https://pagure.io/freeipa/c/2a605c5d07906e157e79458724be098aab28cc7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a605c5d07906e157e79458724be098aab28cc7c>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Don't allow the FQDN to match the domain on server installs
-   `commit <https://pagure.io/freeipa/c/c2bce952d8f4358a028eb067154011cc1f6d8a44>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2bce952d8f4358a028eb067154011cc1f6d8a44>`__
    `#9003 <https://pagure.io/freeipa/issue/9003>`__
 -  Use the OpenSSL certificate parser in cert-find
-   `commit <https://pagure.io/freeipa/c/191880bc9f77c3e8a3cecc82e6eea33ab5ad03e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/191880bc9f77c3e8a3cecc82e6eea33ab5ad03e4>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Enforce sizelimit in cert-find
-   `commit <https://pagure.io/freeipa/c/2b2f10c2eb7f3b796c68771bc8cbf5dbaa646481>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b2f10c2eb7f3b796c68771bc8cbf5dbaa646481>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Fix memory leak in the OTP last token plugin
-   `commit <https://pagure.io/freeipa/c/089907b4853207ea70c7ca02896b84718251cf6f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/089907b4853207ea70c7ca02896b84718251cf6f>`__
    `#9403 <https://pagure.io/freeipa/issue/9403>`__
 -  Prevent the admin user from being deleted
-   `commit <https://pagure.io/freeipa/c/dea35922cd086883c0699646ec39fdef8f0ba579>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dea35922cd086883c0699646ec39fdef8f0ba579>`__
    `#8878 <https://pagure.io/freeipa/issue/8878>`__
 -  Remove all references to deleted indirect map from parent map
-   `commit <https://pagure.io/freeipa/c/d98d5e475133ad5fae0af3d08beca8b01950427f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d98d5e475133ad5fae0af3d08beca8b01950427f>`__
    `#9397 <https://pagure.io/freeipa/issue/9397>`__
 
 .. _ricky_tigg_3:
@@ -668,11 +668,11 @@ Ricky Tigg (3)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/ab652aa11ae47e105f6af4d18b4c2a52a78da119>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab652aa11ae47e105f6af4d18b4c2a52a78da119>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/e7623b4f5a36146170dd2e7619ff89cd91950ec8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7623b4f5a36146170dd2e7619ff89cd91950ec8>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/0ab38702291df131851a9a343d52c0ab1ab31463>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ab38702291df131851a9a343d52c0ab1ab31463>`__
 
 .. _rafael_guterres_jeffman_3:
 
@@ -680,10 +680,10 @@ Rafael Guterres Jeffman (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  selinux: Update SELinux policy
-   `commit <https://pagure.io/freeipa/c/a78c47b2d331d22c0a21d449a4f13370913f58ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a78c47b2d331d22c0a21d449a4f13370913f58ed>`__
    `#9386 <https://pagure.io/freeipa/issue/9386>`__
 -  Fix typo in "Subordinate ID Selfservice User" role
-   `commit <https://pagure.io/freeipa/c/82b129fe765ad32328df540be2ec4d27fc33df0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82b129fe765ad32328df540be2ec4d27fc33df0a>`__
    `#9418 <https://pagure.io/freeipa/issue/9418>`__
 
 .. _sumit_bose_7:
@@ -692,20 +692,20 @@ Sumit Bose (7)
 ~~~~~~~~~~~~~~
 
 -  ipa-otpd: add passkey_child_debug_level option
-   `commit <https://pagure.io/freeipa/c/8d12d497f68961a5c2b614572f016980a9acca55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d12d497f68961a5c2b614572f016980a9acca55>`__
 -  ipa-otpd: add support for passkey authentication
-   `commit <https://pagure.io/freeipa/c/b252988da63c1b14da241438c744b882f416f189>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b252988da63c1b14da241438c744b882f416f189>`__
 -  ipa-otpd: make get_krad_attr_from_packet() public
-   `commit <https://pagure.io/freeipa/c/a02fd5305ee42307a159db7ece40ffc305bc7e59>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a02fd5305ee42307a159db7ece40ffc305bc7e59>`__
 -  ipa-otpd: make auth_type_is(), get_string() and get_string_array()
    public
-   `commit <https://pagure.io/freeipa/c/62e28e424769b35a19d424de45eade38c26082f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62e28e424769b35a19d424de45eade38c26082f3>`__
 -  ipa-otpd: make add_krad_attr_to_set() public
-   `commit <https://pagure.io/freeipa/c/e7a69b3d9f6768afd524bf36dc9b208d9f7730f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7a69b3d9f6768afd524bf36dc9b208d9f7730f1>`__
 -  ipa-otpd: suppress "function declaration isn't a prototype" warning
-   `commit <https://pagure.io/freeipa/c/9caea3205cbd99649bd9b9eca4e9322f058d4a98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9caea3205cbd99649bd9b9eca4e9322f058d4a98>`__
 -  ipa-kdb: do not fail if certmap rule cannot be added
-   `commit <https://pagure.io/freeipa/c/0ce3ab36b486297cd89064095a11803d611660ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ce3ab36b486297cd89064095a11803d611660ac>`__
 
 .. _김인수_4:
 
@@ -713,13 +713,13 @@ Sumit Bose (7)
 ~~~~~~~~~~
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/6e6a07188ba69e80aaf67c56e6c4d4efc8213cae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e6a07188ba69e80aaf67c56e6c4d4efc8213cae>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/a2a70ab7acfd51b67ffc4337d0ba596d714f5c55>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2a70ab7acfd51b67ffc4337d0ba596d714f5c55>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/526b5165fed95be8143771e9b0cf2e4d7fcd8ae9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/526b5165fed95be8143771e9b0cf2e4d7fcd8ae9>`__
 -  Added translation using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/e9d590885100ec6fb11695cd80dc3acfe33a0307>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9d590885100ec6fb11695cd80dc3acfe33a0307>`__
 
 .. _simon_nussbaum_1:
 
@@ -727,7 +727,7 @@ Simon Nussbaum (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  component: mail_from_realname config setting added to IPA-EPN
-   `commit <https://pagure.io/freeipa/c/fcad9c9aa76b5e027ca247941620c4e6a4be991e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fcad9c9aa76b5e027ca247941620c4e6a4be991e>`__
    `#9336 <https://pagure.io/freeipa/issue/9336>`__
 
 
@@ -737,7 +737,7 @@ Scott Poore (1)
 ~~~~~~~~~~~~~~~
 
 -  ipatests: add prci definitions for test_sso jobs
-   `commit <https://pagure.io/freeipa/c/04c2b0698426d4e9eb8aa3510d2a26677e5c75ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04c2b0698426d4e9eb8aa3510d2a26677e5c75ac>`__
 
 .. _sudhir_menon_4:
 
@@ -745,9 +745,9 @@ Sudhir Menon (2)
 ~~~~~~~~~~~~~~~~
 
 -  ipatests: ipa-adtrust-install command test scenarios
-   `commit <https://pagure.io/freeipa/c/dd22bd2528d376d347c7a672b613c865d91e890a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd22bd2528d376d347c7a672b613c865d91e890a>`__
 -  ipatests: idm api related tests.
-   `commit <https://pagure.io/freeipa/c/8e142bc1d48183674859d3e63144d71a89ce1836>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8e142bc1d48183674859d3e63144d71a89ce1836>`__
 
 .. _temuri_doghonadze_4:
 
@@ -755,13 +755,13 @@ Temuri Doghonadze (4)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/2ee7fcdfbaacf5033422251d7ac28e0e102d1c98>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ee7fcdfbaacf5033422251d7ac28e0e102d1c98>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/d12908ffce43a65bdc441727ef082bf80d2462a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d12908ffce43a65bdc441727ef082bf80d2462a1>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/097615c34c0c3a94b5dce9bcac86fb0c452a5c74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/097615c34c0c3a94b5dce9bcac86fb0c452a5c74>`__
 -  Added translation using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/b2cdddeaea5936dad622fd97de4e92b545d6c0d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2cdddeaea5936dad622fd97de4e92b545d6c0d9>`__
 
 .. _todd_zullinger_2:
 
@@ -769,9 +769,9 @@ Todd Zullinger (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  spec: silence krb5 pkgconf errors in %krb5_base_version
-   `commit <https://pagure.io/freeipa/c/4f9e6b1bedd2d223bef7113d5f7e68cea48537de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f9e6b1bedd2d223bef7113d5f7e68cea48537de>`__
 -  spec: verify upstream source signature
-   `commit <https://pagure.io/freeipa/c/0d72a6cf5c22d452d04faadfd930b9fc24a2a879>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d72a6cf5c22d452d04faadfd930b9fc24a2a879>`__
 
 .. _thorsten_scherf_1:
 
@@ -779,7 +779,7 @@ Thorsten Scherf (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  external-idp: change idp server name to reference name
-   `commit <https://pagure.io/freeipa/c/2aeb963fc9f3261e5f9539450cef96b8dbf84135>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2aeb963fc9f3261e5f9539450cef96b8dbf84135>`__
 
 .. _viacheslav_sychov_1:
 
@@ -787,7 +787,7 @@ Viacheslav Sychov (1)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  fix: Handle /proc/1/sched missing error
-   `commit <https://pagure.io/freeipa/c/d33a2523eeebcc26149535c38d8607a39a4c51df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d33a2523eeebcc26149535c38d8607a39a4c51df>`__
 
 .. _yuri_chornoivan_6:
 
@@ -795,14 +795,14 @@ Yuri Chornoivan (6)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/7a82bc090eae37b2bcb4100e27494492c6363bb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a82bc090eae37b2bcb4100e27494492c6363bb0>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/0f2d2d36ee6420fcbca90a6dab9fe224d634e24a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0f2d2d36ee6420fcbca90a6dab9fe224d634e24a>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/cf338b5b35f429dcb1cef5f2c6de60bff6be522c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf338b5b35f429dcb1cef5f2c6de60bff6be522c>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/b9f94620556384eca769d59d621d10ab7ccc3e1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9f94620556384eca769d59d621d10ab7ccc3e1a>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/5cc8e5b869d213a39a29c8bb30f757be1e29c61a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cc8e5b869d213a39a29c8bb30f757be1e29c61a>`__
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/a0e0d57a429afa097fb2a322152aa1edc1b1ed85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0e0d57a429afa097fb2a322152aa1edc1b1ed85>`__

--- a/src/release-notes/4-11-0.rst
+++ b/src/release-notes/4-11-0.rst
@@ -189,16 +189,16 @@ Alexander Bokovoy (4)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Allow ipa-otpd to access USB devices for passkeys
-   `commit <https://pagure.io/freeipa/c/637ccae0b4b0ecd36756b4540c666724a73f4633>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/637ccae0b4b0ecd36756b4540c666724a73f4633>`__
    `#9434 <https://pagure.io/freeipa/issue/9434>`__
 -  Restore selinux states if they exist at uninstall time
-   `commit <https://pagure.io/freeipa/c/2220f72321dc6af8a7a94e1fad1c6980ee4cf522>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2220f72321dc6af8a7a94e1fad1c6980ee4cf522>`__
    `#9434 <https://pagure.io/freeipa/issue/9434>`__
 -  ipa-client-install: enable SELinux for SSSD
-   `commit <https://pagure.io/freeipa/c/d62be1da4542e91521b44595f2d41b557ba7a49e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d62be1da4542e91521b44595f2d41b557ba7a49e>`__
    `#9434 <https://pagure.io/freeipa/issue/9434>`__
 -  updates: add ACIs for RBCD self-management
-   `commit <https://pagure.io/freeipa/c/fc9b527dee2652c8056eb99080d9a050a7e648ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc9b527dee2652c8056eb99080d9a050a7e648ff>`__
    `#9354 <https://pagure.io/freeipa/issue/9354>`__
 
 .. _alexandra_nikandrova_1:
@@ -207,7 +207,7 @@ Alexandra Nikandrova (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  doc: typo in basic_usage.md
-   `commit <https://pagure.io/freeipa/c/f7422b7812e6c2bed0a7ff7c4d93f64cd863810f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7422b7812e6c2bed0a7ff7c4d93f64cd863810f>`__
 
 .. _antonio_torres_2:
 
@@ -215,10 +215,10 @@ Antonio Torres (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipatests: rename 'ipatuura' directory to 'scim' in bridge tests
-   `commit <https://pagure.io/freeipa/c/47463294097e01e08b0df3a51f3e2ccc9df9e309>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47463294097e01e08b0df3a51f3e2ccc9df9e309>`__
    `#9447 <https://pagure.io/freeipa/issue/9447>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/4b1c5a5a83e4e5d667218e1b1b32322e7a0e29de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b1c5a5a83e4e5d667218e1b1b32322e7a0e29de>`__
 
 .. _christian_heimes_1:
 
@@ -226,10 +226,10 @@ Christian Heimes (2)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  Use find_spec() in meta importer
-   `commit <https://pagure.io/freeipa/c/bc9385d15cf7a975063754572eb65556a1df9c8a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc9385d15cf7a975063754572eb65556a1df9c8a>`__
    `#9437 <https://pagure.io/freeipa/issue/9437>`__
 -  Add context manager to ipalib.API
-   `commit <https://pagure.io/freeipa/c/ed094e11ec59409c6cb361fa871e9b5e3da02172>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed094e11ec59409c6cb361fa871e9b5e3da02172>`__
    `#9443 <https://pagure.io/freeipa/issue/9443>`__
 
 .. _florence_blanc_renaud_1:
@@ -238,7 +238,7 @@ Florence Blanc-Renaud (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  idp: add the ipaidpuser objectclass when needed
-   `commit <https://pagure.io/freeipa/c/f16b6e3e0a1f3dc507c3150c347276255f3b3e72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f16b6e3e0a1f3dc507c3150c347276255f3b3e72>`__
    `#9433 <https://pagure.io/freeipa/issue/9433>`__
 
 .. _francisco_trivino_1:
@@ -247,7 +247,7 @@ Francisco Trivino (1)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Workshop: fix broken Sphinx cross-references.
-   `commit <https://pagure.io/freeipa/c/fd01b234e3c2e011a441750e8a44c9b293f8086a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd01b234e3c2e011a441750e8a44c9b293f8086a>`__
 
 .. _mohammad_rizwan_2:
 
@@ -255,10 +255,10 @@ Mohammad Rizwan (2)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: restart ipa services after moving date
-   `commit <https://pagure.io/freeipa/c/9c10d7ee2c7a7f1f2c2643e19e3a3b8cf8a211be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c10d7ee2c7a7f1f2c2643e19e3a3b8cf8a211be>`__
    `#9379 <https://pagure.io/freeipa/issue/9379>`__
 -  ipatests: accommodate DST in ACME cert expiry
-   `commit <https://pagure.io/freeipa/c/b13b8fbb472ec24dfe35a690147e43aea363f3e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b13b8fbb472ec24dfe35a690147e43aea363f3e4>`__
    `#9428 <https://pagure.io/freeipa/issue/9428>`__
 
 .. _rob_crittenden_4:
@@ -267,19 +267,19 @@ Rob Crittenden (5)
 ~~~~~~~~~~~~~~~~~~
 
 -  Don't assume KRB5CCNAME is in the environment in replica install
-   `commit <https://pagure.io/freeipa/c/169f9abb6b9fdc11dc5d3e4ec8e6e9c3ef4dfd4f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/169f9abb6b9fdc11dc5d3e4ec8e6e9c3ef4dfd4f>`__
    `#9446 <https://pagure.io/freeipa/issue/9446>`__
 -  Configure affinity during server installation
-   `commit <https://pagure.io/freeipa/c/54a251bceaabfaf82d0a18b2614c261e2bded0c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54a251bceaabfaf82d0a18b2614c261e2bded0c0>`__
    `#9289 <https://pagure.io/freeipa/issue/9289>`__
 -  Adjust test to handle revocation reason REMOVE_FROM_CRL
-   `commit <https://pagure.io/freeipa/c/37b433d4a79ae3f9160a27b6a03a58f371d2bd34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/37b433d4a79ae3f9160a27b6a03a58f371d2bd34>`__
    `#9345 <https://pagure.io/freeipa/issue/9345>`__
 -  Use the PKI REST API wherever possible instead of XML
-   `commit <https://pagure.io/freeipa/c/0b870694f62701534a32fdb4cbdd5c06a3ea4559>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b870694f62701534a32fdb4cbdd5c06a3ea4559>`__
    `#9345 <https://pagure.io/freeipa/issue/9345>`__
 -  Covscan issues: deadcode and Use after free
-   `commit <https://pagure.io/freeipa/c/cb14a30a1523305606d3bfbf7211cda1e197c9e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb14a30a1523305606d3bfbf7211cda1e197c9e9>`__
    `#9345 <https://pagure.io/freeipa/issue/9431>`__
 
 .. _viktor_ashirov_1:
@@ -288,5 +288,5 @@ Viktor Ashirov (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  BDB tuning should be applied only when BDB backend is used
-   `commit <https://pagure.io/freeipa/c/3f874eece90741cd3951578b15fd78fae9d50750>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f874eece90741cd3951578b15fd78fae9d50750>`__
    `#9435 <https://pagure.io/freeipa/issue/9435>`__

--- a/src/release-notes/4-11-1.rst
+++ b/src/release-notes/4-11-1.rst
@@ -66,7 +66,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.11.1
-   `commit <https://pagure.io/freeipa/c/e18ac3538e2f06f82a1f4eda7980e56e91017d47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e18ac3538e2f06f82a1f4eda7980e56e91017d47>`__
 
 .. _rob_crittenden_2:
 
@@ -74,6 +74,6 @@ Rob Crittenden (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Integration tests for verifying Referer header in the UI
-   `commit <https://pagure.io/freeipa/c/e4ae6881da3cdfb2be35300ab1326313bac256d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4ae6881da3cdfb2be35300ab1326313bac256d5>`__
 -  Check the HTTP Referer header on all requests
-   `commit <https://pagure.io/freeipa/c/08e6fb3a2c1d28dc7efcd3395aaf4b705fec4305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08e6fb3a2c1d28dc7efcd3395aaf4b705fec4305>`__

--- a/src/release-notes/4-11-2.rst
+++ b/src/release-notes/4-11-2.rst
@@ -106,7 +106,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.11.2
-   `commit <https://pagure.io/freeipa/c/66fd76a9f36213cb4e2bb41bf44653f15af26d6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66fd76a9f36213cb4e2bb41bf44653f15af26d6c>`__
 
 .. _julien_rische_2:
 
@@ -114,6 +114,6 @@ Julien Rische (2)
 ~~~~~~~~~~~~~~~~~
 
 -  kdb: apply combinatorial logic for ticket flags
-   `commit <https://pagure.io/freeipa/c/3793bc6d9b167da65e4718a2681794aba0257fe5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3793bc6d9b167da65e4718a2681794aba0257fe5>`__
 -  kdb: fix vulnerability in GCD rules handling
-   `commit <https://pagure.io/freeipa/c/8dac50c0b624b4284ed67d58addcbbb98692675d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8dac50c0b624b4284ed67d58addcbbb98692675d>`__

--- a/src/release-notes/4-12-0.rst
+++ b/src/release-notes/4-12-0.rst
@@ -371,7 +371,7 @@ Detailed changelog since 4.11.1
 ~~~~~~~~~~~~~~~
 
 -  webui: Unify user group members columns with users columns
-   `commit <https://pagure.io/freeipa/c/49c090b97655cf1b845a270503bd6cbe75a48278>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49c090b97655cf1b845a270503bd6cbe75a48278>`__
    `#9390 <https://pagure.io/freeipa/issue/9390>`__
 
 .. _alexander_bokovoy_31:
@@ -380,123 +380,123 @@ Alexander Bokovoy (43)
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  console: for public errors only print a final one
-   `commit <https://pagure.io/freeipa/c/1223016ef29aef4009a0d976af0d0b2bca871013>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1223016ef29aef4009a0d976af0d0b2bca871013>`__
    `#9590 <https://pagure.io/freeipa/issue/9590>`__
 -  custodia: do not use deprecated jwcrypto wrappers
-   `commit <https://pagure.io/freeipa/c/536812080502baa51818d9a33ea6533675800b30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/536812080502baa51818d9a33ea6533675800b30>`__
    `#9597 <https://pagure.io/freeipa/issue/9597>`__
 -  frontend: add systemd journal audit of executed API commands
-   `commit <https://pagure.io/freeipa/c/84eed2a67fb515f4d5d0af3479c077bf5b788d56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84eed2a67fb515f4d5d0af3479c077bf5b788d56>`__
    `#9589 <https://pagure.io/freeipa/issue/9589>`__
 -  ipalib/rpc: Reformat after moving json code around
-   `commit <https://pagure.io/freeipa/c/145e33174d99e4826d388b4796ecadb73698cf47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/145e33174d99e4826d388b4796ecadb73698cf47>`__
 -  ipalib: move json formatter to a separate file
-   `commit <https://pagure.io/freeipa/c/fd0f432fec692a2db25c270b2e69b3f423ba7f4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd0f432fec692a2db25c270b2e69b3f423ba7f4a>`__
 -  batch: add keeponly option
-   `commit <https://pagure.io/freeipa/c/9e861693fcb79d256af6d0cfe26f27c7f7ff8e13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e861693fcb79d256af6d0cfe26f27c7f7ff8e13>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  pylint: use yield_from for trivial cases
-   `commit <https://pagure.io/freeipa/c/6cc0a0b9a8439f97cfc688e5610c25b5e494ba0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cc0a0b9a8439f97cfc688e5610c25b5e494ba0b>`__
 -  user: handle LDAP auto-bind for whoami case
-   `commit <https://pagure.io/freeipa/c/c325f9c045787a4c4e18096e23cb2f84f514b28e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c325f9c045787a4c4e18096e23cb2f84f514b28e>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  passwd: handle LDAP auto-bind use case as well
-   `commit <https://pagure.io/freeipa/c/902c8b0bae90b04d3f1d91f0703c2a0eca4e39f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/902c8b0bae90b04d3f1d91f0703c2a0eca4e39f1>`__
 -  cert: use context.principal only when it is defined
-   `commit <https://pagure.io/freeipa/c/e386e22046fec4de062116245a3cd9e79c457499>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e386e22046fec4de062116245a3cd9e79c457499>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  trust: handle stray pylint warning
-   `commit <https://pagure.io/freeipa/c/b6131b57371f6eade697125a4500c140997478c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6131b57371f6eade697125a4500c140997478c0>`__
 -  trust: use context.principal only when it is defined
-   `commit <https://pagure.io/freeipa/c/08f1e6f2fdb19db681c0560db53a7a5fa1ce3784>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08f1e6f2fdb19db681c0560db53a7a5fa1ce3784>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  server: use context.principal only when it is defined
-   `commit <https://pagure.io/freeipa/c/ab5465639d5c083d6396551f06c450fe4d349d1b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab5465639d5c083d6396551f06c450fe4d349d1b>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  config: use context.principal only when it is defined
-   `commit <https://pagure.io/freeipa/c/71d886f0713b2c58d8eb57f2267d59cc0be39345>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/71d886f0713b2c58d8eb57f2267d59cc0be39345>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  batch: account for auto-binding in server context
-   `commit <https://pagure.io/freeipa/c/3608b2b63de736186176f8da0fad36ce3b0d57a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3608b2b63de736186176f8da0fad36ce3b0d57a3>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  privilege: use context.principal only when it is defined
-   `commit <https://pagure.io/freeipa/c/295ac6385c33d28502396ffeb9e7a5297b63a005>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/295ac6385c33d28502396ffeb9e7a5297b63a005>`__
    `#9583 <https://pagure.io/freeipa/issue/9583>`__
 -  internal: fix 'tokensfor' typo and regenerate pot file
-   `commit <https://pagure.io/freeipa/c/d16c34997f2223bd3f3d00a734c3372552bd8863>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d16c34997f2223bd3f3d00a734c3372552bd8863>`__
 -  Use raw strings for Python 3 compatibility in old API client code
-   `commit <https://pagure.io/freeipa/c/ca6604b58be0448e45b2a68d03d4f8dacbceab7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca6604b58be0448e45b2a68d03d4f8dacbceab7b>`__
    `#9565 <https://pagure.io/freeipa/issue/9565>`__
 -  idrange: only issue warning to restart services for a local range
-   `commit <https://pagure.io/freeipa/c/a57b665be027bd67b582cba784aca5f2f8399459>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a57b665be027bd67b582cba784aca5f2f8399459>`__
    `#9558 <https://pagure.io/freeipa/issue/9558>`__
 -  dcerpc: invalidate forest trust info cache when filtering out realm
    domains
-   `commit <https://pagure.io/freeipa/c/f9a1d74f5ea63a63880abf8d4b5568664c372417>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9a1d74f5ea63a63880abf8d4b5568664c372417>`__
    `#9551 <https://pagure.io/freeipa/issue/9551>`__
 -  ipa-pwd-extop: declare operation notes support from 389-ds locally
-   `commit <https://pagure.io/freeipa/c/e431ce0ce7699a3857ee4ef1e6b4e27d57874370>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e431ce0ce7699a3857ee4ef1e6b4e27d57874370>`__
    `#9554 <https://pagure.io/freeipa/issue/9554>`__
 -  ipa-pwd-extop: add MFA note in case of a successful LDAP bind with
    OTP
-   `commit <https://pagure.io/freeipa/c/23b224d7ad2e90d03543a0001f9a83731a8a14a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23b224d7ad2e90d03543a0001f9a83731a8a14a5>`__
    `#5169 <https://pagure.io/freeipa/issue/5169>`__
 -  ipa-pwd-extop: allow enforcing 2FA-only over LDAP bind
-   `commit <https://pagure.io/freeipa/c/1d2897e3d7cc88c2c5698126ecb1e59fff396bbc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d2897e3d7cc88c2c5698126ecb1e59fff396bbc>`__
    `#5169 <https://pagure.io/freeipa/issue/5169>`__
 -  rpcserver: validate Kerberos principal name before running kinit
-   `commit <https://pagure.io/freeipa/c/404fe1018e08e546fd14c83741e00b900c1cd208>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/404fe1018e08e546fd14c83741e00b900c1cd208>`__
    `#9541 <https://pagure.io/freeipa/issue/9541>`__
 -  ipa-kdb: support Samba 4.20 private libraries
-   `commit <https://pagure.io/freeipa/c/bd04dc28c829649e27ee0ceb207f24a56edd35c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd04dc28c829649e27ee0ceb207f24a56edd35c4>`__
 -  kdb: PAC generator: do not fail if canonical principal is missing
-   `commit <https://pagure.io/freeipa/c/ed977a6e8206366a33fe90ba97844834068f56c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed977a6e8206366a33fe90ba97844834068f56c8>`__
    `#9465 <https://pagure.io/freeipa/issue/9465>`__
 -  sidgen: fix missing prototypes
-   `commit <https://pagure.io/freeipa/c/89d945fe6f9265c5667e825554b2663cc63db3e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89d945fe6f9265c5667e825554b2663cc63db3e3>`__
 -  sidgen: ignore staged users when generating SIDs
-   `commit <https://pagure.io/freeipa/c/f8dcd78873cc098d5a60e2c56ea4102009631fd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8dcd78873cc098d5a60e2c56ea4102009631fd6>`__
    `#9517 <https://pagure.io/freeipa/issue/9517>`__
 -  doc/designs/id-mapping.md: expand on ID range allocation details
-   `commit <https://pagure.io/freeipa/c/d4ffc53b2a3534d4f6c12e150fdfb3cfcb11cbae>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4ffc53b2a3534d4f6c12e150fdfb3cfcb11cbae>`__
    `#9477 <https://pagure.io/freeipa/issue/9477>`__
 -  doc/Makefile: run sphinx in serial mode
-   `commit <https://pagure.io/freeipa/c/5adc07ae55ff83332f7eeddc4a0eb2a9e4c07c29>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5adc07ae55ff83332f7eeddc4a0eb2a9e4c07c29>`__
 -  ipasam: make krbtgt TDO principal canonical
-   `commit <https://pagure.io/freeipa/c/e399232a78a60cd4ab895c9c2cb363fafbb84198>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e399232a78a60cd4ab895c9c2cb363fafbb84198>`__
    `#9471 <https://pagure.io/freeipa/issue/9471>`__
 -  adtrustinstance: make sure NetBIOS name defaults are set properly
-   `commit <https://pagure.io/freeipa/c/9b456101a3072cdf7f48dfdcfea1002d10d35597>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b456101a3072cdf7f48dfdcfea1002d10d35597>`__
    `#9514 <https://pagure.io/freeipa/issue/9514>`__
 -  host: update System: Manage Host Keytab permission
-   `commit <https://pagure.io/freeipa/c/a5d38ca17100fc2d0550e8ebda9347acafd1398b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5d38ca17100fc2d0550e8ebda9347acafd1398b>`__
    `#9496 <https://pagure.io/freeipa/issue/9496>`__
 -  ipatests: make sure PKINIT enrollment works with a strict policy
-   `commit <https://pagure.io/freeipa/c/c3bc938650b19a51706d8ccd98cdf8deaa26dc28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3bc938650b19a51706d8ccd98cdf8deaa26dc28>`__
    `#9485 <https://pagure.io/freeipa/issue/9485>`__
 -  ipa-kdb: clarify user auth table mapping use of \_AUTH_PASSWORD
-   `commit <https://pagure.io/freeipa/c/62c44c9e69aa2721990ca3628434713e1af6f59b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62c44c9e69aa2721990ca3628434713e1af6f59b>`__
    `#9485 <https://pagure.io/freeipa/issue/9485>`__
 -  ipa-kdb: when applying ticket policy, do not deny PKINIT
-   `commit <https://pagure.io/freeipa/c/69ae9febfb4462766b3bfe3e07e76550ece97b42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ae9febfb4462766b3bfe3e07e76550ece97b42>`__
    `#9485 <https://pagure.io/freeipa/issue/9485>`__
 -  ipa-kdb: add better detection of allowed user auth type
-   `commit <https://pagure.io/freeipa/c/00f8ddbfd2795228b343e1c39c1944b44d482c18>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00f8ddbfd2795228b343e1c39c1944b44d482c18>`__
    `#9485 <https://pagure.io/freeipa/issue/9485>`__
 -  doc/designs: add description of identity mapping in IPA
-   `commit <https://pagure.io/freeipa/c/7ee2d7d359a80876ae536f3427caaae20d03af17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ee2d7d359a80876ae536f3427caaae20d03af17>`__
    `#9477 <https://pagure.io/freeipa/issue/9477>`__
 -  Remove upgrade test from Azure CI
-   `commit <https://pagure.io/freeipa/c/6bc9e9d06ec33a1fbeb8d06a2ce30d0ca2e555d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6bc9e9d06ec33a1fbeb8d06a2ce30d0ca2e555d3>`__
 -  Remove ipaserver.custodia.\__init\_\_.py
-   `commit <https://pagure.io/freeipa/c/5e17c134aa67abbcee788f4ab4ea0b7f694aed5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5e17c134aa67abbcee788f4ab4ea0b7f694aed5a>`__
    `#9467 <https://pagure.io/freeipa/issue/9467>`__
 -  Azure CI: increase memory for forced reenrollment test
-   `commit <https://pagure.io/freeipa/c/b22605ee54ec82b9a4b6a435be06fe8b39f2fe23>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b22605ee54ec82b9a4b6a435be06fe8b39f2fe23>`__
 -  Increase memory usage for Azure CI upgrade test
-   `commit <https://pagure.io/freeipa/c/48cfe6848ccfd55d945531fbd2b34221e153adee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48cfe6848ccfd55d945531fbd2b34221e153adee>`__
 -  Use datetime.timezone.utc instead of newer datetime.UTC alias
-   `commit <https://pagure.io/freeipa/c/1a2cd7f408a274759584ddadd358360d39b3c4fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a2cd7f408a274759584ddadd358360d39b3c4fa>`__
    `#9454 <https://pagure.io/freeipa/issue/9454>`__
 
 .. _alexandra_nikandrova_1:
@@ -505,7 +505,7 @@ Alexandra Nikandrova (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  doc: typo in basic_usage.md
-   `commit <https://pagure.io/freeipa/c/dade02d5bb575764e700b78686fa8a03cc0fe3c4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dade02d5bb575764e700b78686fa8a03cc0fe3c4>`__
 
 .. _andika_triwidada_1:
 
@@ -513,7 +513,7 @@ Andika Triwidada (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/b9552bcb71085cb963553a56eba2938e6ec2dc85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9552bcb71085cb963553a56eba2938e6ec2dc85>`__
 
 .. _antonio_torres_5:
 
@@ -521,13 +521,13 @@ Antonio Torres (4)
 ~~~~~~~~~~~~~~~~~~
 
 -  Update translations to FreeIPA master state
-   `commit <https://pagure.io/freeipa/c/519685823bd4173e9fc5d9307602c0917e7ecdfb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/519685823bd4173e9fc5d9307602c0917e7ecdfb>`__
 -  Update list of contributors
-   `commit <https://pagure.io/freeipa/c/fe223cde95a2a4230782ee342a313faea561ce53>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe223cde95a2a4230782ee342a313faea561ce53>`__
 -  Update translations to FreeIPA master state
-   `commit <https://pagure.io/freeipa/c/843f4a74580178da08e0f5621a0ae34faf632564>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/843f4a74580178da08e0f5621a0ae34faf632564>`__
 -  Bump to IPA 4.12
-   `commit <https://pagure.io/freeipa/c/1251c15faef9800f3ef48105afe8df4f5c361dd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1251c15faef9800f3ef48105afe8df4f5c361dd0>`__
 
 .. _carla_martinez_1:
 
@@ -535,7 +535,7 @@ Carla Martinez (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipatests: test new columns in group details
-   `commit <https://pagure.io/freeipa/c/2874823c12fc05692352129c406e2a1b592a28ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2874823c12fc05692352129c406e2a1b592a28ea>`__
 
 .. _christian_heimes_8:
 
@@ -543,20 +543,20 @@ Christian Heimes (6)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  Move ipalib.install.kinit to ipalib
-   `commit <https://pagure.io/freeipa/c/38d0e74b6da63deedf3380a04dda2f6fe7c75d82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38d0e74b6da63deedf3380a04dda2f6fe7c75d82>`__
 -  test_acme: Use ipalib.x509
-   `commit <https://pagure.io/freeipa/c/22875ea2c61039163766332dd9eb4a524d9d3c75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22875ea2c61039163766332dd9eb4a524d9d3c75>`__
    `#9518 <https://pagure.io/freeipa/issue/9518>`__
 -  Compatibility fix for PyCA cryptography 42.0.0
-   `commit <https://pagure.io/freeipa/c/a45a7a20d96af51d463a285cb9318582720be708>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a45a7a20d96af51d463a285cb9318582720be708>`__
    `#9518 <https://pagure.io/freeipa/issue/9518>`__
 -  Add 'cache_dir' option to api.env
-   `commit <https://pagure.io/freeipa/c/5deeee31c0ebbbf15642a928d9c30e42150bbfc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5deeee31c0ebbbf15642a928d9c30e42150bbfc2>`__
    `#9438 <https://pagure.io/freeipa/issue/9438>`__
 -  docs: Mention that Keycloak requires openid scope
-   `commit <https://pagure.io/freeipa/c/d97d62dead0a7b75929dec89ab072b87a0d889dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d97d62dead0a7b75929dec89ab072b87a0d889dd>`__
 -  Refactor CA file handling in replica installer
-   `commit <https://pagure.io/freeipa/c/8f25b2a74a587548976f3d29f0b69d566d70125d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8f25b2a74a587548976f3d29f0b69d566d70125d>`__
    `#9272 <https://pagure.io/freeipa/issue/9272>`__
 
 .. _jan_kuparinen_1:
@@ -565,7 +565,7 @@ Jan Kuparinen (1)
 ~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/c3cb63e5823b59213f9968449319807bd667dfda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3cb63e5823b59213f9968449319807bd667dfda>`__
 
 .. _erik_belko_1:
 
@@ -573,10 +573,10 @@ Erik Belko (2)
 ~~~~~~~~~~~~~~
 
 -  ipatests: Update ipa-adtrust-install test
-   `commit <https://pagure.io/freeipa/c/47920e78c81380c0a40986e55f05246aac132fbb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47920e78c81380c0a40986e55f05246aac132fbb>`__
    `#9575 <https://pagure.io/freeipa/issue/9575>`__
 -  xmlrpc tests: Create user with manager option set using user-add
-   `commit <https://pagure.io/freeipa/c/fc7c2cb6243468d150e6be7c78a0e3f906a7e291>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc7c2cb6243468d150e6be7c78a0e3f906a7e291>`__
    `#9515 <https://pagure.io/freeipa/issue/9515>`__
 
 .. _endi_sukma_dewata_4:
@@ -585,13 +585,13 @@ Endi Sukma Dewata (4)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Remove unused pki_theme\_\* params
-   `commit <https://pagure.io/freeipa/c/dc2ab91681f890b876191fcfe139c33c4f0dee61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc2ab91681f890b876191fcfe139c33c4f0dee61>`__
 -  Replace subsystem.select with CAInstance.is_crlgen_enabled()
-   `commit <https://pagure.io/freeipa/c/1202d0149bbf82c2183896c86764d818e8b2f02c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1202d0149bbf82c2183896c86764d818e8b2f02c>`__
 -  Remove unused hierarchy.select
-   `commit <https://pagure.io/freeipa/c/44349cfa76a860314292120b00fe3814a6fed892>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/44349cfa76a860314292120b00fe3814a6fed892>`__
 -  Enable LWCA monitor explicitly
-   `commit <https://pagure.io/freeipa/c/5270d58a049560458be62e1c6a17bbc8163926d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5270d58a049560458be62e1c6a17bbc8163926d5>`__
 
 .. _emilio_herrera_1:
 
@@ -599,7 +599,7 @@ Emilio Herrera (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/f3a3d29117bfefb6d01db68d648ab1c3b88079ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3a3d29117bfefb6d01db68d648ab1c3b88079ff>`__
 
 .. _florence_blanc_renaud_31:
 
@@ -607,87 +607,87 @@ Florence Blanc-Renaud (30)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa-replica-manage list-ruvs: display FQDN in the output
-   `commit <https://pagure.io/freeipa/c/69c6a817ce84a9c2bd111158bec4b10850dba544>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69c6a817ce84a9c2bd111158bec4b10850dba544>`__
    `#9598 <https://pagure.io/freeipa/issue/9598>`__
 -  Spec file: depend on nfs-utils or nfsv4-client-utils
-   `commit <https://pagure.io/freeipa/c/bb8dd0bfcd42f9221e12f4a675b54432848db441>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb8dd0bfcd42f9221e12f4a675b54432848db441>`__
    `#9586 <https://pagure.io/freeipa/issue/9586>`__
 -  webui test: Update message for admin disable
-   `commit <https://pagure.io/freeipa/c/dda223668acf76f19efc6b85829139beba424cd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dda223668acf76f19efc6b85829139beba424cd6>`__
    `#9489 <https://pagure.io/freeipa/issue/9489>`__,
    `#9574 <https://pagure.io/freeipa/issue/9574>`__
 -  xmlrpc: adapt range plugin test
-   `commit <https://pagure.io/freeipa/c/6cc668ffeb7ddd4ebd75304f14adaa3aaf3b4cb0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cc668ffeb7ddd4ebd75304f14adaa3aaf3b4cb0>`__
    `#9558 <https://pagure.io/freeipa/issue/9558>`__
 -  idrange-add: add a warning because 389ds restart is required
-   `commit <https://pagure.io/freeipa/c/64861a0cf9a8ac18d83a206c11fd3b42be3c578c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64861a0cf9a8ac18d83a206c11fd3b42be3c578c>`__
    `#9558 <https://pagure.io/freeipa/issue/9558>`__
 -  ipatests: some tests are date-sensitive and fail Feb 29
-   `commit <https://pagure.io/freeipa/c/558a7de8b7fa920c2c597e0a10d8480f3e66e1c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/558a7de8b7fa920c2c597e0a10d8480f3e66e1c6>`__
    `#9548 <https://pagure.io/freeipa/issue/9548>`__
 -  ipatests: fix tasks.wait_for_replication method
-   `commit <https://pagure.io/freeipa/c/e5bb0f392a5f0a6e49c92b2da953b12c5cd66ffc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5bb0f392a5f0a6e49c92b2da953b12c5cd66ffc>`__
    `#9530 <https://pagure.io/freeipa/issue/9530>`__
 -  ipatests: add xfail for autoprivate group test with override
-   `commit <https://pagure.io/freeipa/c/908ef6a17946b75c69bf48486f43fddb9158b993>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/908ef6a17946b75c69bf48486f43fddb9158b993>`__
 -  ipatests: remove xfail thanks to sssd 2.9.4
-   `commit <https://pagure.io/freeipa/c/dfb5099e7f5abfbacf8ac1abc57630da845e433f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfb5099e7f5abfbacf8ac1abc57630da845e433f>`__
    `#9295 <https://pagure.io/freeipa/issue/9295>`__
 -  ipatests: test_idp fails calling yum list wget
-   `commit <https://pagure.io/freeipa/c/9c470d10a59f18c2861f39c74c3ae928e7909b26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c470d10a59f18c2861f39c74c3ae928e7909b26>`__
    `#9522 <https://pagure.io/freeipa/issue/9522>`__
 -  ipa-backup: adapt for 389ds switch to LMDB
-   `commit <https://pagure.io/freeipa/c/677d30806662856595289525ef529a77adbf2272>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/677d30806662856595289525ef529a77adbf2272>`__
    `#9516 <https://pagure.io/freeipa/issue/9516>`__
 -  Nightly tests: test on f38 and f39
-   `commit <https://pagure.io/freeipa/c/717ae87a756f9a4859804bbe09057c90381db668>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/717ae87a756f9a4859804bbe09057c90381db668>`__
 -  Tox: use sitepackages
-   `commit <https://pagure.io/freeipa/c/bf1110bda1e8b47869c210b596c12369f2242e49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf1110bda1e8b47869c210b596c12369f2242e49>`__
 -  pylint: fix errors
-   `commit <https://pagure.io/freeipa/c/8d7bd6c6ab68a4ef3fed2620ef8e07a03aa92d34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d7bd6c6ab68a4ef3fed2620ef8e07a03aa92d34>`__
 -  pylint: disable new checks
-   `commit <https://pagure.io/freeipa/c/7f485ba7dcd627ba8ae62ead1f13fb26bd90088c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f485ba7dcd627ba8ae62ead1f13fb26bd90088c>`__
 -  pylint: updates related to deprecations
-   `commit <https://pagure.io/freeipa/c/020af153db23b37da6370a5cc70ba967245f42c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/020af153db23b37da6370a5cc70ba967245f42c0>`__
 -  azure tests: move to fedora 39
-   `commit <https://pagure.io/freeipa/c/8981ede1a2d62e61d24b0c500016212e20c31a13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8981ede1a2d62e61d24b0c500016212e20c31a13>`__
 -  ipatests: disable dnssec validation in tests using dnf
-   `commit <https://pagure.io/freeipa/c/a177121af66516deed7c6794b92f15a74cc30bd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a177121af66516deed7c6794b92f15a74cc30bd3>`__
    `#9498 <https://pagure.io/freeipa/issue/9498>`__
 -  Webui: use service options to init Firefox driver
-   `commit <https://pagure.io/freeipa/c/25b58e6dea2b3ff7237eea5600891f8e72054531>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/25b58e6dea2b3ff7237eea5600891f8e72054531>`__
    `#9492 <https://pagure.io/freeipa/issue/9492>`__
 -  test_install: restart services after date change
-   `commit <https://pagure.io/freeipa/c/9abb50eb1e9a186161e1f3a9d2f1d07763f5e279>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9abb50eb1e9a186161e1f3a9d2f1d07763f5e279>`__
    `#9405 <https://pagure.io/freeipa/issue/9405>`__
 -  test_external_idp: update code for selenium 4.10
-   `commit <https://pagure.io/freeipa/c/53951ca860db1564666b2eb6886389ff0f85e46c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53951ca860db1564666b2eb6886389ff0f85e46c>`__
    `#9493 <https://pagure.io/freeipa/issue/9493>`__
 -  Make test_external_ca.py compatible with crypto 41.0.0
-   `commit <https://pagure.io/freeipa/c/d61d1b059c8d760b37c7aae9ea47cb06674c76cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d61d1b059c8d760b37c7aae9ea47cb06674c76cd>`__
    `#9490 <https://pagure.io/freeipa/issue/9490>`__
 -  Integration tests: disable test_sso
-   `commit <https://pagure.io/freeipa/c/5028b391f16a9dcb275037a430a6e3c6f3eed872>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5028b391f16a9dcb275037a430a6e3c6f3eed872>`__
    `#9476 <https://pagure.io/freeipa/issue/9476>`__
 -  ipatests: fix expected output for ipahealthcheck.meta.services
-   `commit <https://pagure.io/freeipa/c/07e5637269e470f5c2fd24ec62949af81c66bee5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07e5637269e470f5c2fd24ec62949af81c66bee5>`__
    `#9460 <https://pagure.io/freeipa/issue/9460>`__
 -  Handle samba changes in samba.security.dom_sid()
-   `commit <https://pagure.io/freeipa/c/ed6fa6029d863aed1522b449d3360e6c4028e066>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed6fa6029d863aed1522b449d3360e6c4028e066>`__
    `#9466 <https://pagure.io/freeipa/issue/9466>`__
 -  group-add-member fails with an external member
-   `commit <https://pagure.io/freeipa/c/d50624dce932d02ea03a00d3ac2ec1be69e8d3b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d50624dce932d02ea03a00d3ac2ec1be69e8d3b6>`__
    `#9466 <https://pagure.io/freeipa/issue/9466>`__
 -  ipalib: fix the IPACertificate validity dates
-   `commit <https://pagure.io/freeipa/c/b6af3a43c7bf7ef632c60cfd633b9cb98b31dcd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b6af3a43c7bf7ef632c60cfd633b9cb98b31dcd8>`__
    `#9462 <https://pagure.io/freeipa/issue/9462>`__
 -  ipatests: fix test_ipactl_scenario_check
-   `commit <https://pagure.io/freeipa/c/430054db4102c6bde873414fc2f25e650baaebb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/430054db4102c6bde873414fc2f25e650baaebb6>`__
    `#9415 <https://pagure.io/freeipa/issue/9415>`__
 -  ipatests: fix healthcheck test for --indent option
-   `commit <https://pagure.io/freeipa/c/e459e5b8bc81c4bb3b39dc51a50f388a8c8dd34d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e459e5b8bc81c4bb3b39dc51a50f388a8c8dd34d>`__
 -  ipatests: fix healthcheck test without DNS
-   `commit <https://pagure.io/freeipa/c/f9075f9f77ec2c8b595210a5de478f8650943733>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9075f9f77ec2c8b595210a5de478f8650943733>`__
    `#9459 <https://pagure.io/freeipa/issue/9459>`__
 
 
@@ -697,22 +697,22 @@ Francisco Trivino (6)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Spec file: add support for sss_ssh_knownhosts
-   `commit <https://pagure.io/freeipa/c/b34525c76e9f8182950bbbdd6fa3ae62f5301064>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b34525c76e9f8182950bbbdd6fa3ae62f5301064>`__
    `#9536 <https://pagure.io/freeipa/issue/9536>`__
 -  ipa-client-install: add support for sss_ssh_knownhosts
-   `commit <https://pagure.io/freeipa/c/7d54a6daaf0ef91d608d67b3c70e2d566868be05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d54a6daaf0ef91d608d67b3c70e2d566868be05>`__
    `#9536 <https://pagure.io/freeipa/issue/9536>`__
 -  kra: set RSA-OAEP as default wrapping algo when FIPS is enabled
-   `commit <https://pagure.io/freeipa/c/305fcc25b4dd0aea4f87a0508c5f47c7634cfb82>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/305fcc25b4dd0aea4f87a0508c5f47c7634cfb82>`__
    `#9191 <https://pagure.io/freeipa/issue/9191>`__
 -  Vault: improve vault server archival/retrieval calls error handling
-   `commit <https://pagure.io/freeipa/c/4cc6b9cd1791e1a5fdbcd8e28904a5856e1f0b41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4cc6b9cd1791e1a5fdbcd8e28904a5856e1f0b41>`__
    `#9191 <https://pagure.io/freeipa/issue/9191>`__
 -  Vault: add support for RSA-OAEP wrapping algo
-   `commit <https://pagure.io/freeipa/c/2d0a088f93ec27ddb55c82e43c33bcc425a759ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a088f93ec27ddb55c82e43c33bcc425a759ef>`__
    `#9191 <https://pagure.io/freeipa/issue/9191>`__
 -  Workshop: fix broken Sphinx cross-references.
-   `commit <https://pagure.io/freeipa/c/4af05dde4819c6dd9926baacb4f642e7d1c5bde9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4af05dde4819c6dd9926baacb4f642e7d1c5bde9>`__
 
 .. _jeremy_frasier_1:
 
@@ -720,7 +720,7 @@ Jeremy Frasier (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Fixes: Python SyntaxWarnings about invalid escape sequences
-   `commit <https://pagure.io/freeipa/c/c63fe925fb3173f5845664627499f3f0f0cadcec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c63fe925fb3173f5845664627499f3f0f0cadcec>`__
    `#9483 <https://pagure.io/freeipa/issue/9483>`__
 
 .. _julien_rische_3:
@@ -729,13 +729,13 @@ Julien Rische (3)
 ~~~~~~~~~~~~~~~~~
 
 -  ipa-kdb: Fix double free in ipadb_reinit_mspac()
-   `commit <https://pagure.io/freeipa/c/dc3e902b0bf9f817f7aafb606f1d5d3287873ab2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dc3e902b0bf9f817f7aafb606f1d5d3287873ab2>`__
    `#9535 <https://pagure.io/freeipa/issue/9535>`__
 -  ipa-kdb: Rework ipadb_reinit_mspac()
-   `commit <https://pagure.io/freeipa/c/835929353d935613ae3dd6fc6f70b21d3252fbc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/835929353d935613ae3dd6fc6f70b21d3252fbc8>`__
    `#9535 <https://pagure.io/freeipa/issue/9535>`__
 -  ipa-kdb: Fix memory leak during PAC verification
-   `commit <https://pagure.io/freeipa/c/75afdfea5d0aa7540fa20f6e8ad15625d56513b6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/75afdfea5d0aa7540fa20f6e8ad15625d56513b6>`__
    `#9520 <https://pagure.io/freeipa/issue/9520>`__
 
 .. _masahiro_matsuya_1:
@@ -744,7 +744,7 @@ Masahiro Matsuya (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: wait for replica update in test_dns_locations
-   `commit <https://pagure.io/freeipa/c/c740cb84ba1e5cab871ae4f197a04d87f40c5b9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c740cb84ba1e5cab871ae4f197a04d87f40c5b9e>`__
    `#9504 <https://pagure.io/freeipa/issue/9504>`__
 
 .. _mark_reynolds_16:
@@ -753,52 +753,52 @@ Mark Reynolds (16)
 ~~~~~~~~~~~~~~~~~~
 
 -  Issue 9591 - Allow get_ruv() to handle incomplete RUV elements
-   `commit <https://pagure.io/freeipa/c/544652aae43506ef974fc7331ce8612884a7d01e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/544652aae43506ef974fc7331ce8612884a7d01e>`__
    `#9591 <https://pagure.io/freeipa/issue/9591>`__
 -  Issue 9579 - Remove bash_completions_dir for RHEL
-   `commit <https://pagure.io/freeipa/c/cce8dc4da87a934644712158b97242960a8d138e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cce8dc4da87a934644712158b97242960a8d138e>`__
    `#9579 <https://pagure.io/freeipa/issue/9579>`__
 -  Issue 9570 - migrate nsaccountlock
-   `commit <https://pagure.io/freeipa/c/f9f96ac4a802e9b38d156fddbc98592ac0981726>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9f96ac4a802e9b38d156fddbc98592ac0981726>`__
    `#9570 <https://pagure.io/freeipa/issue/9570>`__
 -  Issue 9568 - Update IPA to IPA migration design doc
-   `commit <https://pagure.io/freeipa/c/8084b94c17d2d2e83288cae5aa9ab96dc7c32ce4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8084b94c17d2d2e83288cae5aa9ab96dc7c32ce4>`__
    `#9568 <https://pagure.io/freeipa/issue/9568>`__
 -  IPA-to-IPA migration tool (beta)
-   `commit <https://pagure.io/freeipa/c/cbe18735913aa1d033937088c1f2628a962a9254>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbe18735913aa1d033937088c1f2628a962a9254>`__
    `#3656 <https://pagure.io/freeipa/issue/3656>`__
 -  Issue 9547 - Update IPA to IPA migration design doc
-   `commit <https://pagure.io/freeipa/c/557f0a5639e65b952ed0ce82e4ef42683bf75178>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/557f0a5639e65b952ed0ce82e4ef42683bf75178>`__
    `#9547 <https://pagure.io/freeipa/issue/9547>`__
 -  Issue 9497 - update debug logging in ipa_uuid
-   `commit <https://pagure.io/freeipa/c/6d3d191825f4da5b2f4e98845b0be9770172f71c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d3d191825f4da5b2f4e98845b0be9770172f71c>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa-pwd-extop
-   `commit <https://pagure.io/freeipa/c/0007876f4205c289018fd6828f87529890c9ba2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0007876f4205c289018fd6828f87529890c9ba2f>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa_otp_lasttoken
-   `commit <https://pagure.io/freeipa/c/6cd5a0847a49083da7d76525142880628931078d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cd5a0847a49083da7d76525142880628931078d>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa_otp_counter
-   `commit <https://pagure.io/freeipa/c/2a1d454c748792434d6d27306c1330e6d518a6c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2a1d454c748792434d6d27306c1330e6d518a6c3>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa_modrdn
-   `commit <https://pagure.io/freeipa/c/79b08556a4b4a5750bc53eb29be67c7e018213b4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79b08556a4b4a5750bc53eb29be67c7e018213b4>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa_lockout
-   `commit <https://pagure.io/freeipa/c/23ead1dc2388947a254cecf4cf90147a317bcefc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23ead1dc2388947a254cecf4cf90147a317bcefc>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - update debug logging in ipa_graceperiod
-   `commit <https://pagure.io/freeipa/c/8a6361dc755b97b19380a96050c474e4d7eb4c15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a6361dc755b97b19380a96050c474e4d7eb4c15>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - Update logging in ipa_enrollment
-   `commit <https://pagure.io/freeipa/c/1a16130a9a98f4d735fc76129f4cb434eafc3e67>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a16130a9a98f4d735fc76129f4cb434eafc3e67>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 9497 - Add new password policy logging function
-   `commit <https://pagure.io/freeipa/c/3fd5d57ed670232fc03aef1feed4fe04f3d996d9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3fd5d57ed670232fc03aef1feed4fe04f3d996d9>`__
    `#9497 <https://pagure.io/freeipa/issue/9497>`__
 -  Issue 3656 - Extend schema function to return MAY or MUST attrs
-   `commit <https://pagure.io/freeipa/c/5c8614157d5546033528f92700f5abfebd4e5838>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c8614157d5546033528f92700f5abfebd4e5838>`__
    `#3656 <https://pagure.io/freeipa/issue/3656>`__
 
 .. _mohammad_rizwan_4:
@@ -807,10 +807,10 @@ Mohammad Rizwan (2)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: test software HSM installation with server & replica
-   `commit <https://pagure.io/freeipa/c/1ec875c6fe677357d4dfb50090dc18ae902328a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ec875c6fe677357d4dfb50090dc18ae902328a1>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  ipatests: test software HSM installation with server & replica
-   `commit <https://pagure.io/freeipa/c/36dbc6b0258f3e21a3fe6c72cd55bf0c141c0946>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/36dbc6b0258f3e21a3fe6c72cd55bf0c141c0946>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 
 .. _weblate_translation_memory_19:
@@ -819,43 +819,43 @@ Weblate Translation Memory (19)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/ca776b6a9ca9f6b9884491909eb7e01522aef58b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca776b6a9ca9f6b9884491909eb7e01522aef58b>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/05f1bf9e2c0acafb60499ff999b814fb19e0037c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05f1bf9e2c0acafb60499ff999b814fb19e0037c>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/d8a4bde2c65791a97b70160193f39ef1040748c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8a4bde2c65791a97b70160193f39ef1040748c8>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/ee6ff01b46e5bc3f33c8a400943b0fed1d4ff8a9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee6ff01b46e5bc3f33c8a400943b0fed1d4ff8a9>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f4a1696a3b9cdf9526b77ec156e377add8209ab8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4a1696a3b9cdf9526b77ec156e377add8209ab8>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/7b2ac6a293bac4064a7780edb18702a4749d3f88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b2ac6a293bac4064a7780edb18702a4749d3f88>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/78d86ba060f314ffdd0979f06226307f4a0ead66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78d86ba060f314ffdd0979f06226307f4a0ead66>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/c6aae2042d593120dd4f0c49dd3014339cfa985b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6aae2042d593120dd4f0c49dd3014339cfa985b>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f4504e1e918ff80d8dda0d1e2ef3e2aadc6994fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f4504e1e918ff80d8dda0d1e2ef3e2aadc6994fa>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/049a56d603ff4f629da19b9932c2936d32f42a4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/049a56d603ff4f629da19b9932c2936d32f42a4b>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/23d64942e1a2f9926a053bedb6983e8d8ec034b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23d64942e1a2f9926a053bedb6983e8d8ec034b9>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/20b01b09f2a784d34d663b37f134611cf12e99c3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20b01b09f2a784d34d663b37f134611cf12e99c3>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f18db3abd7981a0487e7ebe3b0525de191bf5324>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f18db3abd7981a0487e7ebe3b0525de191bf5324>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/2959bec776cbcf18cf68a55291ae26d4ae004cd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2959bec776cbcf18cf68a55291ae26d4ae004cd3>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/cb073530fa0c378b56357e5972f647d9ba805e34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb073530fa0c378b56357e5972f647d9ba805e34>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/da8ab4b54fd902f9ebfee2c18df84a948f17a662>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da8ab4b54fd902f9ebfee2c18df84a948f17a662>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/5c91cb2f47ecbdfeb3009b48f7c899763b99ee08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5c91cb2f47ecbdfeb3009b48f7c899763b99ee08>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/5b182399514380035c6f6bfca8d7d518e79d0149>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b182399514380035c6f6bfca8d7d518e79d0149>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/2750637544a3fc8d936d173d0c1aa27f1fb8af25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2750637544a3fc8d936d173d0c1aa27f1fb8af25>`__
 
 .. _weblate_1:
 
@@ -863,7 +863,7 @@ Weblate (1)
 ~~~~~~~~~~~
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/6a59110947cb682d56f73f54ec71f76c72952799>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a59110947cb682d56f73f54ec71f76c72952799>`__
 
 .. _pavel_březina_1:
 
@@ -871,7 +871,7 @@ Pavel Březina (1)
 ~~~~~~~~~~~~~~~~~
 
 -  ipaserver: fix incorrect double negative in exception message
-   `commit <https://pagure.io/freeipa/c/9e1e22d46b19a4728bf8e67633613fa71bd8acaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e1e22d46b19a4728bf8e67633613fa71bd8acaa>`__
 
 .. _piotr_drąg_1:
 
@@ -879,7 +879,7 @@ Piotr Drąg (1)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/9e31e7043499cfb6f3f3fc0a12bb17df0c2c1dc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e31e7043499cfb6f3f3fc0a12bb17df0c2c1dc2>`__
 
 .. _rafael_fontenelle_2:
 
@@ -887,9 +887,9 @@ Rafael Fontenelle (2)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/8b48c5f9067718128755268b0d283b5e0ab26c72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b48c5f9067718128755268b0d283b5e0ab26c72>`__
 -  Translated using Weblate (Portuguese (Brazil))
-   `commit <https://pagure.io/freeipa/c/d6aaa626a6fb88b1658fa6c934a8adb5ffb95a0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6aaa626a6fb88b1658fa6c934a8adb5ffb95a0d>`__
 
 .. _rob_crittenden_62:
 
@@ -897,162 +897,162 @@ Rob Crittenden (55)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Add permissions for topologysegment
-   `commit <https://pagure.io/freeipa/c/6fc35156d91ce2265f02ed12224bce08c21b99e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fc35156d91ce2265f02ed12224bce08c21b99e6>`__
    `#9594 <https://pagure.io/freeipa/issue/9594>`__
 -  Don't try to validate the HSM arguments on a non-HSM installation
-   `commit <https://pagure.io/freeipa/c/f225b3df17a4c01e62f659fe70fc5427bab1f387>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f225b3df17a4c01e62f659fe70fc5427bab1f387>`__
    `#9593 <https://pagure.io/freeipa/issue/9593>`__
 -  docs: Add a section on SELinux modules to the HSM design
-   `commit <https://pagure.io/freeipa/c/6af8577d58c4b2bed04ec0bd02042ba7122ab518>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6af8577d58c4b2bed04ec0bd02042ba7122ab518>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add SELinux module checking to hsm_validator
-   `commit <https://pagure.io/freeipa/c/c861ce5a1634b43b04c3d38d49d5b3e4e599b7d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c861ce5a1634b43b04c3d38d49d5b3e4e599b7d7>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Call hsm_validator on KRA installs and validate the HSM password
-   `commit <https://pagure.io/freeipa/c/6b6c1879c5174869128ae28048673995242b18c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b6c1879c5174869128ae28048673995242b18c1>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Include the HSM tests in the nightlies
-   `commit <https://pagure.io/freeipa/c/879a937dddf17478378d9e855317ee199ac645c9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/879a937dddf17478378d9e855317ee199ac645c9>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Require certmonger 0.79.17+ for required HSM changes
-   `commit <https://pagure.io/freeipa/c/bcd8d2d90a41eb94422ad5fad730bd0570108f91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcd8d2d90a41eb94422ad5fad730bd0570108f91>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  After an HSM replica install ensure all certs are visible
-   `commit <https://pagure.io/freeipa/c/ea0bf4020ce0b1e32572e128e9323c5af60ec93d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea0bf4020ce0b1e32572e128e9323c5af60ec93d>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  KRA: force OAEP for some HSM-based installations
-   `commit <https://pagure.io/freeipa/c/b9ec2fb0a91034934b48d419c2d0eaa2c36faef1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9ec2fb0a91034934b48d419c2d0eaa2c36faef1>`__
    `#9191 <https://pagure.io/freeipa/issue/9191>`__
 -  Prompt for token password if not provided in replica/ipa-ca-install
-   `commit <https://pagure.io/freeipa/c/31fda79a0e3f34dcf71a9e2687faa958ecb91ab8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31fda79a0e3f34dcf71a9e2687faa958ecb91ab8>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  dogtag-ipa-ca-renew-agent-submit: expect certs to be on HSMs
-   `commit <https://pagure.io/freeipa/c/c6f2d0212bf9aa2ed816779540d69233fe7110a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6f2d0212bf9aa2ed816779540d69233fe7110a5>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  tests: Fix failing test test_testconfig.py with missing token
    variables
-   `commit <https://pagure.io/freeipa/c/b63103c88a57b1320ce2e38f7483ef37692feebd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b63103c88a57b1320ce2e38f7483ef37692feebd>`__
 -  Add SELinux subpackage for Thales Luna HSM support
-   `commit <https://pagure.io/freeipa/c/f8798b3e16d9f51a3ae355a2270f7346754301dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f8798b3e16d9f51a3ae355a2270f7346754301dc>`__
 -  Add SELinux subpackage for nCipher nfast HSM support
-   `commit <https://pagure.io/freeipa/c/87ecca0f180fb0cd7ffefb1d9c1b200683a2e38a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/87ecca0f180fb0cd7ffefb1d9c1b200683a2e38a>`__
 -  Remove caSigningCert from list of certs to renew
-   `commit <https://pagure.io/freeipa/c/c6dd21f04e9f14b0c1e5c064e87b3266ff02f60f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c6dd21f04e9f14b0c1e5c064e87b3266ff02f60f>`__
 -  Validate the HSM token library path and name during installation
-   `commit <https://pagure.io/freeipa/c/31d66bac64501efd54afe2041b9d00da66ac0ae3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31d66bac64501efd54afe2041b9d00da66ac0ae3>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  After installing a KRA, copy the updated token to other machines
-   `commit <https://pagure.io/freeipa/c/6b894f28b5ac07fff3863cc4fec6b9a2383b615e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b894f28b5ac07fff3863cc4fec6b9a2383b615e>`__
 -  tests: helper to copy files from one host to another
-   `commit <https://pagure.io/freeipa/c/06a8791b9beec5a95a5072e9a02a4379ac46770d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06a8791b9beec5a95a5072e9a02a4379ac46770d>`__
 -  renew_ca_cert: set peer trust on the KRA audit certificate
-   `commit <https://pagure.io/freeipa/c/b89aa919778a048fbb54f0a3426423d23f6c38df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b89aa919778a048fbb54f0a3426423d23f6c38df>`__
    `#9353 <https://pagure.io/freeipa/issue/9353>`__
 -  renew_ca_cert: skip removing non-CA certs, fix nickname
-   `commit <https://pagure.io/freeipa/c/0708f603e2d632db77a95d135e28242c6d1a7ee7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0708f603e2d632db77a95d135e28242c6d1a7ee7>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  If HSM is configured add the token name to config-show output
-   `commit <https://pagure.io/freeipa/c/d0c489e28228f4ce5f92c2dfc2c7b9e86c7fcb36>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0c489e28228f4ce5f92c2dfc2c7b9e86c7fcb36>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add token support to the renew_ca_cert certmonger helper
-   `commit <https://pagure.io/freeipa/c/93622005ba0f14e68010a84b07cc050cfdc4bedc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93622005ba0f14e68010a84b07cc050cfdc4bedc>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Update SELinux policy to allow certmonger to PKI config files
-   `commit <https://pagure.io/freeipa/c/7ad3b489f6272e5b041d410f8098f454b584209e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ad3b489f6272e5b041d410f8098f454b584209e>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add attribute ipacahsmconfiguration to the "Read CAs" ACI
-   `commit <https://pagure.io/freeipa/c/a99091adc0bf8dd745ef3f5980a5bc66294e8c06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a99091adc0bf8dd745ef3f5980a5bc66294e8c06>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add HSM configuration options to installer scripts
-   `commit <https://pagure.io/freeipa/c/82c0b19acce147b3f82183b561883c7ca9137403>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82c0b19acce147b3f82183b561883c7ca9137403>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add LDAP attribute ipaCaHSMConfiguration to store HSM state
-   `commit <https://pagure.io/freeipa/c/d9efa728c5c93e232eaf03b432b0699804189012>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9efa728c5c93e232eaf03b432b0699804189012>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  doc: Add token-password-file to HSM design, set new OID
-   `commit <https://pagure.io/freeipa/c/f658a264f9cbdb190aa4ff6ab21903da0a7e84c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f658a264f9cbdb190aa4ff6ab21903da0a7e84c8>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Don't move KRA keys when key backup is disabled
-   `commit <https://pagure.io/freeipa/c/e3234708ac356065641ce1ea4d6460c7fd50c815>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3234708ac356065641ce1ea4d6460c7fd50c815>`__
    `#7677 <https://pagure.io/freeipa/issue/7677>`__,
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Only generate kracert.p12 when not installing with HSM
-   `commit <https://pagure.io/freeipa/c/73d52a613518ca1e2d2303b660f9dc439987f90f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/73d52a613518ca1e2d2303b660f9dc439987f90f>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Add token support to installer certificate handling
-   `commit <https://pagure.io/freeipa/c/34f28f06db291c7408fbeb7276dcdaae5f0ef18a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34f28f06db291c7408fbeb7276dcdaae5f0ef18a>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Don't generate a cafile on HSM instalations
-   `commit <https://pagure.io/freeipa/c/e6078c639c332e0079fa0cbff3fa54882d79b3bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6078c639c332e0079fa0cbff3fa54882d79b3bd>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  Support the certmonger nss-user option
-   `commit <https://pagure.io/freeipa/c/cba3094c9af5ceac66dd2c11839acbab80c6e9d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cba3094c9af5ceac66dd2c11839acbab80c6e9d3>`__
    `#9273 <https://pagure.io/freeipa/issue/9273>`__
 -  ipa-crlgen-manage: manage the cert status task execution time
-   `commit <https://pagure.io/freeipa/c/f78d25fc972813f500c4ccfcf0faa2c6aa0d48b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f78d25fc972813f500c4ccfcf0faa2c6aa0d48b2>`__
    `#9569 <https://pagure.io/freeipa/issue/9569>`__
 -  Allow the admin user to be disabled
-   `commit <https://pagure.io/freeipa/c/6b0f6ff19e4b56b775cca91435be0a612600f837>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b0f6ff19e4b56b775cca91435be0a612600f837>`__
    `#9489 <https://pagure.io/freeipa/issue/9489>`__
 -  ipatests: Ignore spacing in OpenSSL validation error message
-   `commit <https://pagure.io/freeipa/c/6294b93e14e3b538061a2892bc48edcb31866928>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6294b93e14e3b538061a2892bc48edcb31866928>`__
    `#9567 <https://pagure.io/freeipa/issue/9567>`__
 -  Return 2 when certificates are not found during requests
-   `commit <https://pagure.io/freeipa/c/5d3c6b761b9d59ce6640d1141848eb66585795f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d3c6b761b9d59ce6640d1141848eb66585795f7>`__
    `#9562 <https://pagure.io/freeipa/issue/9562>`__
 -  Check for file permissions after the ca/cert-show is complete
-   `commit <https://pagure.io/freeipa/c/a9bb811296b99d21a150adf0c7a0282df3337c7c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9bb811296b99d21a150adf0c7a0282df3337c7c>`__
    `#9562 <https://pagure.io/freeipa/issue/9562>`__
 -  Vault: add additional fallback to RSA-OAEP wrapping algo
-   `commit <https://pagure.io/freeipa/c/c3d228d4a3c99f8eaf3d9f1d5825fed5cdff5810>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c3d228d4a3c99f8eaf3d9f1d5825fed5cdff5810>`__
    `#9191 <https://pagure.io/freeipa/issue/9191>`__
 -  ipa-restore: adapt for 389-ds switch to LMDB
-   `commit <https://pagure.io/freeipa/c/3766fb98637254110db04b086299e2eefd59cca6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3766fb98637254110db04b086299e2eefd59cca6>`__
    `#9526 <https://pagure.io/freeipa/issue/9526>`__
 -  validate_principal: Don't try to verify that the realm is known
-   `commit <https://pagure.io/freeipa/c/33af154b7f2c92e199d10a36a48310da9b7e77a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/33af154b7f2c92e199d10a36a48310da9b7e77a8>`__
    `#9541 <https://pagure.io/freeipa/issue/9541>`__
 -  Server affinity: call ca.install() if there is a CA in the topology
-   `commit <https://pagure.io/freeipa/c/e6014a5c1996528b255480b67fe2937203bff81b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6014a5c1996528b255480b67fe2937203bff81b>`__
    `#9510 <https://pagure.io/freeipa/issue/9510>`__
 -  Server affinity: Don't rely just on [ca|kra]_enabled for installs
-   `commit <https://pagure.io/freeipa/c/3645543670562f9c7c0b9ac04721f146844e07de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3645543670562f9c7c0b9ac04721f146844e07de>`__
    `#9510 <https://pagure.io/freeipa/issue/9510>`__
 -  get_directive: don't error out on substring mismatch
-   `commit <https://pagure.io/freeipa/c/e5a9e46138041876c650bc2c3eab4b5dde28b2ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e5a9e46138041876c650bc2c3eab4b5dde28b2ea>`__
    `#9506 <https://pagure.io/freeipa/issue/9506>`__
 -  ipa-client-automount: Don't use deprecated ipadiscovery.IPADiscovery
-   `commit <https://pagure.io/freeipa/c/54fb1173f9ab1025c12a77b3a5bf205afa8f63e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54fb1173f9ab1025c12a77b3a5bf205afa8f63e2>`__
    `#9487 <https://pagure.io/freeipa/issue/9487>`__
 -  ipatests: Test client install/uninstall with automount enabled
-   `commit <https://pagure.io/freeipa/c/ce811db6be532a9f258d7429234028975eb99f50>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce811db6be532a9f258d7429234028975eb99f50>`__
    `#9487 <https://pagure.io/freeipa/issue/9487>`__
 -  Fix ipa-client-automount install/uninstall with new install states
-   `commit <https://pagure.io/freeipa/c/e4420624ffed47c42b3bd0dfd580cd98f667e843>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4420624ffed47c42b3bd0dfd580cd98f667e843>`__
    `#9487 <https://pagure.io/freeipa/issue/9487>`__
 -  ACME: Don't treat pki-server ca-config-show failures as fatal
-   `commit <https://pagure.io/freeipa/c/a44cb097137453aa13bbc1b9e206a7e70628ef88>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a44cb097137453aa13bbc1b9e206a7e70628ef88>`__
    `#9503 <https://pagure.io/freeipa/issue/9503>`__
 -  Include supported migration scenarios in the ipa-to-ipa docs
-   `commit <https://pagure.io/freeipa/c/11877d59030ef3cd158aefb298c3a6a334047412>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11877d59030ef3cd158aefb298c3a6a334047412>`__
 -  ipatests: Verify that hbactest will return messages
-   `commit <https://pagure.io/freeipa/c/d1e09c68af8ac77f656dd639af5d9a7f07c41f9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1e09c68af8ac77f656dd639af5d9a7f07c41f9d>`__
    `#9486 <https://pagure.io/freeipa/issue/9486>`__
 -  hbactest was not collecting or returning messages
-   `commit <https://pagure.io/freeipa/c/48846e98e5e988d600ddf81c937f353fcecdea1a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48846e98e5e988d600ddf81c937f353fcecdea1a>`__
    `#9486 <https://pagure.io/freeipa/issue/9486>`__
 -  ipatests: fix expected output for ipahealthcheck.ipa.host
-   `commit <https://pagure.io/freeipa/c/f00b52ce6dbc1a4008974e118f252d90e26301a1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f00b52ce6dbc1a4008974e118f252d90e26301a1>`__
    `#9482 <https://pagure.io/freeipa/issue/9482>`__
 -  ipatests: ignore nsslapd-accesslog-logbuffering WARN in healthcheck
-   `commit <https://pagure.io/freeipa/c/d659d21b432cde9fb3a6e1fe4ba65014587a127f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d659d21b432cde9fb3a6e1fe4ba65014587a127f>`__
    `#9400 <https://pagure.io/freeipa/issue/9400>`__
 -  WIP: Get the PKI version from the remote to determine the argument
-   `commit <https://pagure.io/freeipa/c/caccd6c693fe86e09a84f7fe7263a08d34a22d7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/caccd6c693fe86e09a84f7fe7263a08d34a22d7e>`__
 -  ipa-client: correct directory location by using constants instead
-   `commit <https://pagure.io/freeipa/c/a8a923033bf764b744496199d8f86ff7a7fe183e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8a923033bf764b744496199d8f86ff7a7fe183e>`__
 -  Allow password policy minlength to be removed like other values
-   `commit <https://pagure.io/freeipa/c/62454574a1504354935e69e3769fb1b2451d72b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62454574a1504354935e69e3769fb1b2451d72b9>`__
    `#9297 <https://pagure.io/freeipa/issue/9297>`__
 
 
@@ -1062,10 +1062,10 @@ Rafael Guterres Jeffman (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Replace netifaces with ifaddr
-   `commit <https://pagure.io/freeipa/c/6c6b9354b5f970983655ca5423c726763d9015fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c6b9354b5f970983655ca5423c726763d9015fa>`__
    `#9555 <https://pagure.io/freeipa/issue/9555>`__
 -  ipaserver/dcerpc: avoid logging stack trace in retrieve_anonymously
-   `commit <https://pagure.io/freeipa/c/60fe752da468e84a642af51090b27468446606f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60fe752da468e84a642af51090b27468446606f7>`__
    `#9484 <https://pagure.io/freeipa/issue/9484>`__
 
 .. _김인수_19:
@@ -1074,43 +1074,43 @@ Rafael Guterres Jeffman (2)
 ~~~~~~~~~~~
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/bf5c9892e9bcf6eca500bf8537a7ee0becbe461f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf5c9892e9bcf6eca500bf8537a7ee0becbe461f>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/04ac64a4eda9fbb531814a03909eed839e62b702>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/04ac64a4eda9fbb531814a03909eed839e62b702>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/e60072fe8996daad9528f41389b8d64a11eff8af>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e60072fe8996daad9528f41389b8d64a11eff8af>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/9ad27c954e35be2767f1215efab6aded06f4907a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ad27c954e35be2767f1215efab6aded06f4907a>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f2befb494410a3fd68a310b721e38ad0b99a72a3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2befb494410a3fd68a310b721e38ad0b99a72a3>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/99922e99635645d1d6f184f86acbc39f371156ff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99922e99635645d1d6f184f86acbc39f371156ff>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/86aae371fa0cda75dfc4ef27d23cc103d332f219>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86aae371fa0cda75dfc4ef27d23cc103d332f219>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/d9afa62814e29a385557cc98a21a5cacd811461e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9afa62814e29a385557cc98a21a5cacd811461e>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/1ce532d5a892e691b7bb0231c9d5d419afc33b6a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ce532d5a892e691b7bb0231c9d5d419afc33b6a>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/2877cae09ff74672a1ba28b5e9b2dea4215c2def>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2877cae09ff74672a1ba28b5e9b2dea4215c2def>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/da9f2294e60c64bfb8ac990b7e586fd38d840327>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/da9f2294e60c64bfb8ac990b7e586fd38d840327>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/bc3085cd015d9c38c59e6fa8246c84263fff8d2c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc3085cd015d9c38c59e6fa8246c84263fff8d2c>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/f7a56eb35c24298306ad3c6858d997fd8bedadb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f7a56eb35c24298306ad3c6858d997fd8bedadb4>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/cd1a36f23332515e63747085e83d30d97302724f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd1a36f23332515e63747085e83d30d97302724f>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/655b13193a37b79beb3a2c72d1e0ac365e1f9ea7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/655b13193a37b79beb3a2c72d1e0ac365e1f9ea7>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/b4da6896d6f8d76423f96bc036079d4cb12ef76c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b4da6896d6f8d76423f96bc036079d4cb12ef76c>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/633ea8ba62d10fd30e96ba4d6a33adab26aa07c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/633ea8ba62d10fd30e96ba4d6a33adab26aa07c8>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/bea9614b126fd69a7851d7fcdc8b758e6f4a1df8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bea9614b126fd69a7851d7fcdc8b758e6f4a1df8>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/abc48e285e1a12efc953d51533b1aed3a212fe36>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/abc48e285e1a12efc953d51533b1aed3a212fe36>`__
 
 .. _stanislav_levin_4:
 
@@ -1118,16 +1118,16 @@ Stanislav Levin (4)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ap: Migrate to docker compose V2
-   `commit <https://pagure.io/freeipa/c/1df2abbd5f3d758d494a196567cc2323bf2ab91c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1df2abbd5f3d758d494a196567cc2323bf2ab91c>`__
    `#9566 <https://pagure.io/freeipa/issue/9566>`__
 -  ipapython: Propagate KRB5Error exceptions on iterating ccache
-   `commit <https://pagure.io/freeipa/c/9802e852cb29fdbc43b056816ade27f453001706>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9802e852cb29fdbc43b056816ade27f453001706>`__
    `#9519 <https://pagure.io/freeipa/issue/9519>`__
 -  ipapython: Correct return type of krb5_free_cred_contents
-   `commit <https://pagure.io/freeipa/c/6cd04875dea09c83e01261a805aa27360768d46f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cd04875dea09c83e01261a805aa27360768d46f>`__
    `#9519 <https://pagure.io/freeipa/issue/9519>`__
 -  ipapython: Clean up krb5_error
-   `commit <https://pagure.io/freeipa/c/d002a4d7c991966ccb73e4ab34d0288b90f033ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d002a4d7c991966ccb73e4ab34d0288b90f033ab>`__
    `#9519 <https://pagure.io/freeipa/issue/9519>`__
 
 .. _sudhir_menon_4:
@@ -1137,13 +1137,13 @@ Sudhir Menon (4)
 
 -  ipatests: Fixes for test_ipahealthcheck_ipansschainvalidation
    testcases.
-   `commit <https://pagure.io/freeipa/c/adf95dcf86239f7d4145509303a01f0518134b0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/adf95dcf86239f7d4145509303a01f0518134b0f>`__
 -  ipatests: Skip tests for ipahealtcheck tests for specific pki version
-   `commit <https://pagure.io/freeipa/c/7f849956df3301a10b5b5bafba17fb5869ab4858>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f849956df3301a10b5b5bafba17fb5869ab4858>`__
 -  ipatests: Skip ds_encryption tests on RHEL9 SUT.
-   `commit <https://pagure.io/freeipa/c/8ef3d6ce5c6538756f8eef3e6d89b36baebc88e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8ef3d6ce5c6538756f8eef3e6d89b36baebc88e7>`__
 -  ipatests: Skip the test failing due to FIPS policy
-   `commit <https://pagure.io/freeipa/c/9d49f403c2f23e13991d1cd5f109f4f0e056d96f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d49f403c2f23e13991d1cd5f109f4f0e056d96f>`__
 
 .. _temuri_doghonadze_7:
 
@@ -1151,19 +1151,19 @@ Temuri Doghonadze (7)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/282b55153327b354623532312d84a82db48cc9f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/282b55153327b354623532312d84a82db48cc9f0>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/150050eda3f6b73509b4bf09cef64088d46baba0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/150050eda3f6b73509b4bf09cef64088d46baba0>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/4ab602a61fde9fb746d0212336455274ab5b6a34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ab602a61fde9fb746d0212336455274ab5b6a34>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/e2cab8e90026945f221cb8226ca494f144bbaf57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e2cab8e90026945f221cb8226ca494f144bbaf57>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/b29f2e23073da62a60b33645651d9dbafd048203>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b29f2e23073da62a60b33645651d9dbafd048203>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/05f8eaea6317725d6a13dd5fd0d714995ad8147d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05f8eaea6317725d6a13dd5fd0d714995ad8147d>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/41bc6fc3825644cf3d7fc29dd4c5575a94c6caa7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/41bc6fc3825644cf3d7fc29dd4c5575a94c6caa7>`__
 
 .. _thorsten_scherf_1:
 
@@ -1171,7 +1171,7 @@ Thorsten Scherf (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipa-client: Check if IPA CA cert is empty
-   `commit <https://pagure.io/freeipa/c/821259f069941ec1bf38a417bd029c13932314b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/821259f069941ec1bf38a417bd029c13932314b1>`__
    `#9499 <https://pagure.io/freeipa/issue/9499>`__
 
 .. _thomas_woerner_1:
@@ -1180,10 +1180,10 @@ Thomas Woerner (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  idviews: Use ipaAnchorUUID without DCERPC bindings for SID anchors
-   `commit <https://pagure.io/freeipa/c/9dc57ef77e276773b91c567f83498a69d382ba13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9dc57ef77e276773b91c567f83498a69d382ba13>`__
    `#9544 <https://pagure.io/freeipa/issue/9544>`__
 -  principal_has_privilege: Check also idoverriseuser (ipaOriginalUid)
-   `commit <https://pagure.io/freeipa/c/182dca38c2bb84acce8ab5dcfab6fb5e4abf31da>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/182dca38c2bb84acce8ab5dcfab6fb5e4abf31da>`__
    `#9542 <https://pagure.io/freeipa/issue/9542>`__
 
 .. _viktor_ashirov_2:
@@ -1192,7 +1192,7 @@ Viktor Ashirov (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  WebUI: update favicon.ico
-   `commit <https://pagure.io/freeipa/c/fe005dd3880baff72bda2c2857f9445d3b129b87>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fe005dd3880baff72bda2c2857f9445d3b129b87>`__
    `#9449 <https://pagure.io/freeipa/issue/9449>`__
 
 .. _yuri_chornoivan_1:
@@ -1201,7 +1201,7 @@ Yuri Chornoivan (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/591bbee847f03450540e54101bbf07475c61f303>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/591bbee847f03450540e54101bbf07475c61f303>`__
 
 .. _zoedong_1:
 
@@ -1209,5 +1209,5 @@ zoedong (1)
 ~~~~~~~~~~~
 
 -  ipaplatform: add opencloudos/tencentos support
-   `commit <https://pagure.io/freeipa/c/2c0fe1dd924b428eef1fcc4ebf209a1f0dfe3de1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c0fe1dd924b428eef1fcc4ebf209a1f0dfe3de1>`__
    `#9501 <https://pagure.io/freeipa/issue/9501>`__

--- a/src/release-notes/4-12-1.rst
+++ b/src/release-notes/4-12-1.rst
@@ -106,7 +106,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.12.1
-   `commit <https://pagure.io/freeipa/c/1664042ffa0d299c123cdb4572a16ea907c5e7f9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1664042ffa0d299c123cdb4572a16ea907c5e7f9>`__
 
 .. _julien_rische_2:
 
@@ -114,6 +114,6 @@ Julien Rische (2)
 ~~~~~~~~~~~~~~~~~
 
 -  kdb: apply combinatorial logic for ticket flags
-   `commit <https://pagure.io/freeipa/c/fdc42f70ada4c29e6e9fbbc6e821c1849ed24eee>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdc42f70ada4c29e6e9fbbc6e821c1849ed24eee>`__
 -  kdb: fix vulnerability in GCD rules handling
-   `commit <https://pagure.io/freeipa/c/2e1132a90a1d753db95ba2c699e0b18c2fc6f256>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2e1132a90a1d753db95ba2c699e0b18c2fc6f256>`__

--- a/src/release-notes/4-12-2.rst
+++ b/src/release-notes/4-12-2.rst
@@ -186,19 +186,19 @@ Alexander Bokovoy (5)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Get rid of unicode and long helpers in ipa-otptoken-import
-   `commit <https://pagure.io/freeipa/c/7b5f3d79712a84f88ced6e9055bc96c9980b0b20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7b5f3d79712a84f88ced6e9055bc96c9980b0b20>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  ipalib/constants.py: factor out TripleDES use
-   `commit <https://pagure.io/freeipa/c/fc029043401bb852d2bfe8e8eccb926f50627b3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc029043401bb852d2bfe8e8eccb926f50627b3b>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  ipalib/x509.py: get rid of unicode helper
-   `commit <https://pagure.io/freeipa/c/7f9c890c049f1151d3225e154fcde9bfed8cebb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f9c890c049f1151d3225e154fcde9bfed8cebb3>`__
    `#9644 <https://pagure.io/freeipa/issue/9644>`__
 -  ipalib/x509.py: support Cryptography 43
-   `commit <https://pagure.io/freeipa/c/531bd05de9b3764b90804fcdad3b0b49ceb06110>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/531bd05de9b3764b90804fcdad3b0b49ceb06110>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  ipa-pwd-extop: differentiate OTP requirements in LDAP binds
-   `commit <https://pagure.io/freeipa/c/051d61fdc301f2768ac78c45e93a5f9eeff8aa28>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/051d61fdc301f2768ac78c45e93a5f9eeff8aa28>`__
    `#5169 <https://pagure.io/freeipa/issue/5169>`__
 
 .. _anuja_more_1:
@@ -207,7 +207,7 @@ Anuja More (1)
 ~~~~~~~~~~~~~~
 
 -  ipatests: Test replica installation using AD admin.
-   `commit <https://pagure.io/freeipa/c/8b703150a47bf509f37856bdc27cfa99e85e5e6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8b703150a47bf509f37856bdc27cfa99e85e5e6b>`__
    `#9542 <https://pagure.io/freeipa/issue/9542>`__
 
 .. _antonio_torres_2:
@@ -216,9 +216,9 @@ Antonio Torres (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Bump minor version number
-   `commit <https://pagure.io/freeipa/c/5b3735b09df0bc44ebaa59c5d8d1f3893b8dc33f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5b3735b09df0bc44ebaa59c5d8d1f3893b8dc33f>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/ea375937861375f9052c17fe1ded2cdd2caad288>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea375937861375f9052c17fe1ded2cdd2caad288>`__
 
 .. _florence_blanc_renaud_20:
 
@@ -226,62 +226,62 @@ Florence Blanc-Renaud (20)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  trust-add: handle unavailable domain
-   `commit <https://pagure.io/freeipa/c/f37c2eb8782ec06e538d8964bf904f1b7e79c15e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f37c2eb8782ec06e538d8964bf904f1b7e79c15e>`__
    `#9488 <https://pagure.io/freeipa/issue/9488>`__
 -  HSM: fix the module name
-   `commit <https://pagure.io/freeipa/c/1fc63e2b5150548edb3e910aa270e49c8b35223b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fc63e2b5150548edb3e910aa270e49c8b35223b>`__
    `#9636 <https://pagure.io/freeipa/issue/9636>`__
 -  ipatests: skip HSM test if pki < 11.5.9
-   `commit <https://pagure.io/freeipa/c/84751a26a95ee7bda541122c921a9c7fe4eb13d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84751a26a95ee7bda541122c921a9c7fe4eb13d7>`__
    `#9648 <https://pagure.io/freeipa/issue/9648>`__
 -  ipatests: increase the timeout for test_hsm.py::TestHSMInstall
-   `commit <https://pagure.io/freeipa/c/81401e6c010a05b52bcc10306400dee9075b0e91>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81401e6c010a05b52bcc10306400dee9075b0e91>`__
 -  Replica CA installation: ignore time skew during initial replication
-   `commit <https://pagure.io/freeipa/c/aadb8051d4a3172aac3790f47ff4d241a245bab4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aadb8051d4a3172aac3790f47ff4d241a245bab4>`__
    `#9635 <https://pagure.io/freeipa/issue/9635>`__
 -  spec file: do not use nodejs-22 on f39 and f40
-   `commit <https://pagure.io/freeipa/c/2ddca5d5d57a877fbd598d8bdc29d0fe032621e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ddca5d5d57a877fbd598d8bdc29d0fe032621e8>`__
    `#9643 <https://pagure.io/freeipa/issue/9643>`__
 -  ipatests: remove xfail for test_ipa_migrate_stage_mode
-   `commit <https://pagure.io/freeipa/c/6eb6a929308c2916df9aed2da9ee6ef9d98e2438>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6eb6a929308c2916df9aed2da9ee6ef9d98e2438>`__
    `#9621 <https://pagure.io/freeipa/issue/9621>`__
 -  ipatests: remove xfail for test_ipa_migrate_version_option
-   `commit <https://pagure.io/freeipa/c/de940802bb6631fbbc97afd11869d87cba18f47f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/de940802bb6631fbbc97afd11869d87cba18f47f>`__
    `#9620 <https://pagure.io/freeipa/issue/9620>`__
 -  test_replica_install_after_restore: kinit after restore
-   `commit <https://pagure.io/freeipa/c/d635d701100c9d3bdc179bae1f0d715fce30b461>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d635d701100c9d3bdc179bae1f0d715fce30b461>`__
    `#9613 <https://pagure.io/freeipa/issue/9613>`__
 -  Uninstall: stop sssd-kcm before removing KCM ccaches database
-   `commit <https://pagure.io/freeipa/c/6fe268af5bc6c5296f7a380917e3134f8fa46fda>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6fe268af5bc6c5296f7a380917e3134f8fa46fda>`__
    `#9616 <https://pagure.io/freeipa/issue/9616>`__
 -  ipa-ods-enforcer: stop must also stop the socket
-   `commit <https://pagure.io/freeipa/c/2f902efd0e47eb2461429ce658f89d2a11f0891e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f902efd0e47eb2461429ce658f89d2a11f0891e>`__
    `#9613 <https://pagure.io/freeipa/issue/9613>`__
 -  ipatests: fix / permissions for test_nested_group_members
-   `commit <https://pagure.io/freeipa/c/48ff7da5cb7ca8c3a5c21ce57f7c51e3e19958c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48ff7da5cb7ca8c3a5c21ce57f7c51e3e19958c8>`__
    `#9615 <https://pagure.io/freeipa/issue/9615>`__
 -  ipatests: fix / permissions to allow ssh with private key
-   `commit <https://pagure.io/freeipa/c/60c127d197f79fa4ed612f7173e752d156885415>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60c127d197f79fa4ed612f7173e752d156885415>`__
    `#9607 <https://pagure.io/freeipa/issue/9607>`__
 -  ipatests: mark test_ca_show_error_handling as xfail
-   `commit <https://pagure.io/freeipa/c/4521fe5f9125c74b4ad6e4e51f8c66c009079281>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4521fe5f9125c74b4ad6e4e51f8c66c009079281>`__
    `#9606 <https://pagure.io/freeipa/issue/9606>`__
 -  ipatests: configure gating and nightly tests on ipa-4-12 branch
-   `commit <https://pagure.io/freeipa/c/58154be74fa950b3356712e60687930abb6480f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58154be74fa950b3356712e60687930abb6480f1>`__
 -  ipatests: add test for PKINIT renewal on hidden replica
-   `commit <https://pagure.io/freeipa/c/467ec04f93a29fd31ba037cef348c09547541fe7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/467ec04f93a29fd31ba037cef348c09547541fe7>`__
    `#9611 <https://pagure.io/freeipa/issue/9611>`__
 -  PKINIT certificate: fix renewal on hidden replica
-   `commit <https://pagure.io/freeipa/c/c8e3fdeb0015f9c52c64816d6cd39279c5d3ad5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8e3fdeb0015f9c52c64816d6cd39279c5d3ad5a>`__
    `#9611 <https://pagure.io/freeipa/issue/9611>`__
 -  ipatests: add test for ticket 9610
-   `commit <https://pagure.io/freeipa/c/4d51446bd3cd9ab222f9978f8f5def1f3a37fa0e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d51446bd3cd9ab222f9978f8f5def1f3a37fa0e>`__
    `#9610 <https://pagure.io/freeipa/issue/9610>`__
 -  spec file: do not create /etc/ssh/ssh_config.orig if unchanged
-   `commit <https://pagure.io/freeipa/c/09e66dc936cf2d99bcc44d60d6851aafa9ede46a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09e66dc936cf2d99bcc44d60d6851aafa9ede46a>`__
    `#9610 <https://pagure.io/freeipa/issue/9610>`__
 -  ipa-otptoken-import: open the key file in binary mode
-   `commit <https://pagure.io/freeipa/c/9de053ef02db8cb63e14edc64ac22ec2d3d7bbc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9de053ef02db8cb63e14edc64ac22ec2d3d7bbc9>`__
    `#9609 <https://pagure.io/freeipa/issue/9609>`__
 
 .. _julien_rische_4:
@@ -290,15 +290,15 @@ Julien Rische (4)
 ~~~~~~~~~~~~~~~~~
 
 -  Remove RC4 and 3DES default encryption types on update
-   `commit <https://pagure.io/freeipa/c/9f88188204e443dd5d1d22ebe65b947452558f66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f88188204e443dd5d1d22ebe65b947452558f66>`__
    `#9633 <https://pagure.io/freeipa/issue/9633>`__
 -  Unconditionally add MS-PAC to global config on update
-   `commit <https://pagure.io/freeipa/c/d1a485a435ea9dba7587d1998451a09d3aa4077b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1a485a435ea9dba7587d1998451a09d3aa4077b>`__
    `#9632 <https://pagure.io/freeipa/issue/9632>`__
 -  kdb: apply combinatorial logic for ticket flags
-   `commit <https://pagure.io/freeipa/c/4a61184da640759e9cd8907eaf975a8bfe9a1263>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a61184da640759e9cd8907eaf975a8bfe9a1263>`__
 -  kdb: fix vulnerability in GCD rules handling
-   `commit <https://pagure.io/freeipa/c/f77c0a573c613fe541a040b938ae00524724584c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f77c0a573c613fe541a040b938ae00524724584c>`__
 
 .. _takahashi_masatsuna_1:
 
@@ -306,7 +306,7 @@ TAKAHASHI Masatsuna (1)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa-advise ipa-backup ipa-restore: Fix --v option of the manual.
-   `commit <https://pagure.io/freeipa/c/52ea4ad46e5579bd41939680d75bf02c76ab119d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52ea4ad46e5579bd41939680d75bf02c76ab119d>`__
    `#9617 <https://pagure.io/freeipa/issue/9617>`__
 
 .. _shunsuke_matsumoto_1:
@@ -315,7 +315,7 @@ Shunsuke matsumoto (1)
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  The -d option of the ipa-advise command was able to used.
-   `commit <https://pagure.io/freeipa/c/06c02f5f2c524928b23ae3deeb42c6c57d3e47aa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/06c02f5f2c524928b23ae3deeb42c6c57d3e47aa>`__
    `#9625 <https://pagure.io/freeipa/issue/9625>`__
 
 .. _mark_reynolds_4:
@@ -324,17 +324,17 @@ Mark Reynolds (4)
 ~~~~~~~~~~~~~~~~~
 
 -  ipa-migrate - properly handle invalid certificates
-   `commit <https://pagure.io/freeipa/c/0e4fbc3b0d15fd219d831b0b49f5312894448206>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e4fbc3b0d15fd219d831b0b49f5312894448206>`__
    `#9642 <https://pagure.io/freeipa/issue/9642>`__
 -  Issue 9621 - ipa-migrate - should not update mapped attributes in
    managed entries
-   `commit <https://pagure.io/freeipa/c/85a853ba93c1d23d5bad13a1ae2bee802dc90131>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/85a853ba93c1d23d5bad13a1ae2bee802dc90131>`__
    `#9621 <https://pagure.io/freeipa/issue/9621>`__
 -  ipa-migrate - starttls does not work
-   `commit <https://pagure.io/freeipa/c/eeade50933cb2251b43ee34c642bcae69a216655>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eeade50933cb2251b43ee34c642bcae69a216655>`__
    `#9619 <https://pagure.io/freeipa/issue/9619>`__
 -  ipa-migrate - remove -V option
-   `commit <https://pagure.io/freeipa/c/efa57193630f244185b3f295ed0de17c6d08f75a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efa57193630f244185b3f295ed0de17c6d08f75a>`__
    `#9620 <https://pagure.io/freeipa/issue/9620>`__
 
 .. _mohammad_rizwan_2:
@@ -344,10 +344,10 @@ Mohammad Rizwan (2)
 
 -  ipatests: Verify that SIDgen task continue even if it fails to assign
    sid
-   `commit <https://pagure.io/freeipa/c/ee96c129a6034d02245a41c58fa3398c12c9ee75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ee96c129a6034d02245a41c58fa3398c12c9ee75>`__
    `#9618 <https://pagure.io/freeipa/issue/9618>`__
 -  ipatests: tests related to --token-password-file
-   `commit <https://pagure.io/freeipa/c/4ea1ad6acae910574a524403bc82c80d24b525d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ea1ad6acae910574a524403bc82c80d24b525d6>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 
 .. _rob_crittenden_14:
@@ -356,46 +356,46 @@ Rob Crittenden (14)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Fix some resource leaks identified by a static analyzer
-   `commit <https://pagure.io/freeipa/c/21c6ccc982b54e13b8058f9af130ce64426bd4bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21c6ccc982b54e13b8058f9af130ce64426bd4bb>`__
    `#9367 <https://pagure.io/freeipa/issue/9367>`__
 -  Ignore TripleDES python-cryptography import warnings
-   `commit <https://pagure.io/freeipa/c/d0684a7ecf474fcaf468816f4d9892ea5f2dc897>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0684a7ecf474fcaf468816f4d9892ea5f2dc897>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  Correct usage of public_key_algorithm_oid in ipalib/x509
-   `commit <https://pagure.io/freeipa/c/5cc7941f30f14964abe14f7907e480e91a612ba2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7941f30f14964abe14f7907e480e91a612ba2>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  Log errors reported by adtrustinstance.check_inst() using logger
-   `commit <https://pagure.io/freeipa/c/e83d949c7f1734dff70379e360e9bbf626149c61>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e83d949c7f1734dff70379e360e9bbf626149c61>`__
    `#9637 <https://pagure.io/freeipa/issue/9637>`__
 -  Force a logout in KerberosSession if a login is needed
-   `commit <https://pagure.io/freeipa/c/ffba69648aa6b20cdc3d8950a982b49fd8004aa2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffba69648aa6b20cdc3d8950a982b49fd8004aa2>`__
    `#9624 <https://pagure.io/freeipa/issue/9624>`__
 -  Run HSM validation as pkiuser to verify token permissions
-   `commit <https://pagure.io/freeipa/c/38b83c2b9329b8b16096d63e83f186c91d578ce8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/38b83c2b9329b8b16096d63e83f186c91d578ce8>`__
    `#9626 <https://pagure.io/freeipa/issue/9626>`__
 -  ipatests: Fix usage of token_password_file
-   `commit <https://pagure.io/freeipa/c/f03a96a7b914eb5130552cea626fd28e26b2108d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f03a96a7b914eb5130552cea626fd28e26b2108d>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Fix a copy/paste issue when detecting the HSM SELinux subpackage
-   `commit <https://pagure.io/freeipa/c/fdd471d55c73503456683b1dea55769700730b16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdd471d55c73503456683b1dea55769700730b16>`__
    `#9636 <https://pagure.io/freeipa/issue/9636>`__
 -  Include token password options in ipa-kra-install man page
-   `commit <https://pagure.io/freeipa/c/6c53a22a2cacf7807df11e51492d1a2c42aeeda1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6c53a22a2cacf7807df11e51492d1a2c42aeeda1>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Re-organize HSM validation to be more consistent/less duplication
-   `commit <https://pagure.io/freeipa/c/7ab1bcb2d364c26024db4ec99c707ebefffcd3e7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ab1bcb2d364c26024db4ec99c707ebefffcd3e7>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Fix syntax error in the selinux-luna %postun script
-   `commit <https://pagure.io/freeipa/c/1b278de4ab9c5e00fb48dc2de1ea31d9bdfc94bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b278de4ab9c5e00fb48dc2de1ea31d9bdfc94bc>`__
    `#9629 <https://pagure.io/freeipa/issue/9629>`__
 -  Clean up more files and directories created by the installer(s)
-   `commit <https://pagure.io/freeipa/c/9e364910f537413cfce2b6ee2434579a5acf5c16>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9e364910f537413cfce2b6ee2434579a5acf5c16>`__
    `#8080 <https://pagure.io/freeipa/issue/8080>`__
 -  Add iparepltopoconf objectclass to topology permissions
-   `commit <https://pagure.io/freeipa/c/ebccaac3cf8a5688739d76426924469d5b4df6b1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebccaac3cf8a5688739d76426924469d5b4df6b1>`__
    `#9594 <https://pagure.io/freeipa/issue/9594>`__
 -  Use a unique task name for each backend in ipa-backup
-   `commit <https://pagure.io/freeipa/c/584d0cecbcb99a09b09d5698fc906b4849a7234c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/584d0cecbcb99a09b09d5698fc906b4849a7234c>`__
    `#9584 <https://pagure.io/freeipa/issue/9584>`__
 
 .. _sudhir_menon_4:
@@ -405,14 +405,14 @@ Sudhir Menon (4)
 
 -  ipatests: Replace 'usermod -r' command with 'gpasswd -d' in
    test_hsm.py
-   `commit <https://pagure.io/freeipa/c/ed813fe6f0716906c8b9cd09c27e3acfb8b21e43>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed813fe6f0716906c8b9cd09c27e3acfb8b21e43>`__
    `#9626 <https://pagure.io/freeipa/issue/9626>`__
 -  ipatests: ipa-migrate tool with -Z option (CACERTFILE)
-   `commit <https://pagure.io/freeipa/c/8046023fc46c628c099d84b026ab866f7c6e16d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8046023fc46c628c099d84b026ab866f7c6e16d6>`__
 -  Added new testsuite(ipa_ipa_migration) in prci definitions
-   `commit <https://pagure.io/freeipa/c/ab47696fa69499bedc393f61909fd5675815123e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab47696fa69499bedc393f61909fd5675815123e>`__
 -  ipatests: Tests for ipa-ipa migration tool
-   `commit <https://pagure.io/freeipa/c/90b22ff888cc55132c78024d08ffcf0ce8021cea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90b22ff888cc55132c78024d08ffcf0ce8021cea>`__
 
 .. _thomas_woerner_1:
 
@@ -420,5 +420,5 @@ Thomas Woerner (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipa_sidgen: Allow sidgen_task to continue after finding issues
-   `commit <https://pagure.io/freeipa/c/a8e75bbb77e15e3a42adb2d30933cf9e1edd2f0b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a8e75bbb77e15e3a42adb2d30933cf9e1edd2f0b>`__
    `#9618 <https://pagure.io/freeipa/issue/9618>`__

--- a/src/release-notes/4-12-3.rst
+++ b/src/release-notes/4-12-3.rst
@@ -84,9 +84,9 @@ Alexander Bokovoy (2)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa tools: remove sensitive material from the commandline
-   `commit <https://pagure.io/freeipa/c/3b38efe75865d0696829b4f26572575a8e74ddce>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b38efe75865d0696829b4f26572575a8e74ddce>`__
 -  Unify use of option parsers
-   `commit <https://pagure.io/freeipa/c/cf84a22228460957f578ac102f02516febe13f92>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf84a22228460957f578ac102f02516febe13f92>`__
 
 .. _sumit_bose_1:
 
@@ -94,4 +94,4 @@ Sumit Bose (1)
 ~~~~~~~~~~~~~~
 
 -  ipa-otpd: use oidc_child's --client-secret-stdin option
-   `commit <https://pagure.io/freeipa/c/7a5a10b6bf2e3eafd4b69362ffaece39791be2a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a5a10b6bf2e3eafd4b69362ffaece39791be2a8>`__

--- a/src/release-notes/4-12-4.rst
+++ b/src/release-notes/4-12-4.rst
@@ -106,7 +106,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.12.4
-   `commit <https://pagure.io/freeipa/c/f2fc367fb00193a8ca8a1f22786fccd6b0024dac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2fc367fb00193a8ca8a1f22786fccd6b0024dac>`__
 
 .. _julien_rische_1:
 
@@ -115,7 +115,7 @@ Julien Rische (1)
 
 -  kdb: keep ipadb_get_connection() from succeeding with null LDAP
    context
-   `commit <https://pagure.io/freeipa/c/6ae52a2fb451bbe57a4f0c584e14bca0274b85e8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ae52a2fb451bbe57a4f0c584e14bca0274b85e8>`__
    `#9777 <https://pagure.io/freeipa/issue/9777>`__
 
 .. _rob_crittenden_1:
@@ -124,4 +124,4 @@ Rob Crittenden (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Set krbCanonicalName=admin@REALM on the admin user
-   `commit <https://pagure.io/freeipa/c/e8c410ae5f7cdd36fecba66713ca94bd47465122>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8c410ae5f7cdd36fecba66713ca94bd47465122>`__

--- a/src/release-notes/4-12-5.rst
+++ b/src/release-notes/4-12-5.rst
@@ -115,7 +115,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.12.5
-   `commit <https://pagure.io/freeipa/c/96ea6f94c898f4458edcbb18de21338095dd5664>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96ea6f94c898f4458edcbb18de21338095dd5664>`__
 
 .. _florence_blanc_renaud_1:
 
@@ -123,7 +123,7 @@ Florence Blanc-Renaud (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: extend test for unique krbcanonicalname 
-   `commit <https://pagure.io/freeipa/c/20c03a3e89c920ae8c4f9b1f18fd515f661fc622>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20c03a3e89c920ae8c4f9b1f18fd515f661fc622>`__
 
 .. _julien_rische_1:
 
@@ -131,7 +131,7 @@ Julien Rische (1)
 ~~~~~~~~~~~~~~~~~
 
 -  ipa-kdb: enforce PAC presence on TGT for TGS-REQ context
-   `commit <https://pagure.io/freeipa/c/bb24703a18f9f74d4ae258abf05f32a90f25e70e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bb24703a18f9f74d4ae258abf05f32a90f25e70e>`__
 
 .. _rob_crittenden_1:
 
@@ -139,4 +139,4 @@ Rob Crittenden (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Enforce uniqueness across krbprincipalname and krbcanonicalname
-   `commit <https://pagure.io/freeipa/c/67a9d537e3c981e88fbddb49007e86b534b36b56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67a9d537e3c981e88fbddb49007e86b534b36b56>`__

--- a/src/release-notes/4-13-0.rst
+++ b/src/release-notes/4-13-0.rst
@@ -577,160 +577,160 @@ Alexander Bokovoy (60)
 
 -  sysaccounts: extend permissions to include description and account
    lock
-   `commit <https://pagure.io/freeipa/c/ec22295fede3f1c71b6111e4d36a7386080cf39e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec22295fede3f1c71b6111e4d36a7386080cf39e>`__
    `#9875 <https://pagure.io/freeipa/issue/9875>`__
 -  sysaccount: make sure nsaccountlock is always present
-   `commit <https://pagure.io/freeipa/c/f2fc104f067221f7621537a2daa40c13239522e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2fc104f067221f7621537a2daa40c13239522e3>`__
    `#9842 <https://pagure.io/freeipa/issue/9842>`__
 -  freeipa.spec: use proper package name when installing Web UI license
-   `commit <https://pagure.io/freeipa/c/d4c3b150fb4494313ef4b0e3324cc9e48efa87a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4c3b150fb4494313ef4b0e3324cc9e48efa87a2>`__
 -  sysaccounts: add integration test
-   `commit <https://pagure.io/freeipa/c/8c7427a2bae5f88e1ef3aa1fd267b7dddbe09605>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8c7427a2bae5f88e1ef3aa1fd267b7dddbe09605>`__
    `#9842 <https://pagure.io/freeipa/issue/9842>`__
 -  Add system accounts (sysaccounts)
-   `commit <https://pagure.io/freeipa/c/24e4fd5c0c346b316845e3eea2ff437222fe0823>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/24e4fd5c0c346b316845e3eea2ff437222fe0823>`__
    `#9842 <https://pagure.io/freeipa/issue/9842>`__
 -  ipa-pwd-extop: add SysAcctManagersDNs support
-   `commit <https://pagure.io/freeipa/c/f17fba0adc91f9ecacfdb4cd975dc20ce051b80f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f17fba0adc91f9ecacfdb4cd975dc20ce051b80f>`__
    `#9842 <https://pagure.io/freeipa/issue/9842>`__
 -  Require krb5.conf.d because we install snippets there
-   `commit <https://pagure.io/freeipa/c/7a6391f245257e53ec1d648e2186c9ece069e901>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a6391f245257e53ec1d648e2186c9ece069e901>`__
 -  krb5.conf templates: move IPA domain configuration into a separate
    snippet
-   `commit <https://pagure.io/freeipa/c/890474ae3c48eec1aca180fc1db0613e67572a85>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/890474ae3c48eec1aca180fc1db0613e67572a85>`__
 -  krb5.conf templates: remove Kerberos 4 support
-   `commit <https://pagure.io/freeipa/c/166dbfb630440819eb17c6d7a268a5b5e736908b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/166dbfb630440819eb17c6d7a268a5b5e736908b>`__
 -  API: correct ordering for password policy credits
-   `commit <https://pagure.io/freeipa/c/0e272e33ac2d76dad18b23b4059c649b3dad825e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e272e33ac2d76dad18b23b4059c649b3dad825e>`__
 -  makeapi: enforce en_US.UTF-8 locale when sorting API files
-   `commit <https://pagure.io/freeipa/c/205563ccb120b32093c0fa38de163f23a28ccfc2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/205563ccb120b32093c0fa38de163f23a28ccfc2>`__
 -  doc/api: regenerate notes
-   `commit <https://pagure.io/freeipa/c/3bb87c2684484e5e793502dff7f140f5a8ed2d38>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3bb87c2684484e5e793502dff7f140f5a8ed2d38>`__
 -  ipasam: remove definitions which included from ndr_drsblobs.h
-   `commit <https://pagure.io/freeipa/c/2b2cd1eade1d03296727cb88a08cc919003f5e0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2b2cd1eade1d03296727cb88a08cc919003f5e0f>`__
 -  GetEntryFromLDIF: handle DNs case-insensitive
-   `commit <https://pagure.io/freeipa/c/2f3c035e2b8a8ac70b98264d17e84201578f2871>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f3c035e2b8a8ac70b98264d17e84201578f2871>`__
    `#9854 <https://pagure.io/freeipa/issue/9854>`__
 -  ipasam: define prototypes
-   `commit <https://pagure.io/freeipa/c/516ad5a82147ccd1cbec1fdddfb36b2d0a90fb40>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/516ad5a82147ccd1cbec1fdddfb36b2d0a90fb40>`__
 -  ipasam: address signedness warnings
-   `commit <https://pagure.io/freeipa/c/3c3a094500f2e89fe759e5580d2d96b08857cf1c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c3a094500f2e89fe759e5580d2d96b08857cf1c>`__
 -  ipasam: simplify error handling in fill_pdb_trusted_domain
-   `commit <https://pagure.io/freeipa/c/6594c9d5e3fa89cde013c55d94d64caff70c1731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6594c9d5e3fa89cde013c55d94d64caff70c1731>`__
    `#9852 <https://pagure.io/freeipa/issue/9852>`__
 -  dcerpc: Support Samba 4.23
-   `commit <https://pagure.io/freeipa/c/ae8e850708b118b3da9c9ebc2d5cf8b085d845df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ae8e850708b118b3da9c9ebc2d5cf8b085d845df>`__
    `#9852 <https://pagure.io/freeipa/issue/9852>`__
 -  dcerpc: make sure forest trust info structure version is 1
-   `commit <https://pagure.io/freeipa/c/96c3d2d1ad6c947678a15928de258f462c3ea4ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96c3d2d1ad6c947678a15928de258f462c3ea4ed>`__
    `#9852 <https://pagure.io/freeipa/issue/9852>`__
 -  kdb: prevent double crash in RBCD ACL free
-   `commit <https://pagure.io/freeipa/c/a53b2a374da3683ae303896996737b98d0f57b1d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a53b2a374da3683ae303896996737b98d0f57b1d>`__
    `#9367 <https://pagure.io/freeipa/issue/9367>`__
 -  freeipa.spec.in: protect scriptlets in environment where dbus or
    systemd do not run
-   `commit <https://pagure.io/freeipa/c/eada98e48d4307b2b85d33c14c59b4be73127e0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/eada98e48d4307b2b85d33c14c59b4be73127e0c>`__
    `#9826 <https://pagure.io/freeipa/issue/9826>`__
 -  test_schema: do not fool pytest with a non-test class name
-   `commit <https://pagure.io/freeipa/c/e7095dce69d6f811b7420148f3c017869d10d70c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e7095dce69d6f811b7420148f3c017869d10d70c>`__
 -  Azure CI: do not run test_ipaserver/test_migratepw
-   `commit <https://pagure.io/freeipa/c/df319b973847b82d4d3447f4b8233a24eda0608d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df319b973847b82d4d3447f4b8233a24eda0608d>`__
 -  Make IPAAbstractVersion available to all platforms
-   `commit <https://pagure.io/freeipa/c/8934728d460bf822556d86e190c240ba489d8e25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8934728d460bf822556d86e190c240ba489d8e25>`__
 -  test_console: rework matching to adjust to Python 3.13
-   `commit <https://pagure.io/freeipa/c/1493aec49ffbc0c7a82ec349f33b472f8cc14442>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1493aec49ffbc0c7a82ec349f33b472f8cc14442>`__
 -  pylint: do not use return at the end of flow
-   `commit <https://pagure.io/freeipa/c/94a0552cc603c2cf7b551ae07b999707ed870523>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/94a0552cc603c2cf7b551ae07b999707ed870523>`__
 -  fix used-before-assignment errors where pylint cannot infer logic
-   `commit <https://pagure.io/freeipa/c/ef6ead4c5d29b0a437a6677069a06748d1dd9bd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ef6ead4c5d29b0a437a6677069a06748d1dd9bd0>`__
 -  Move wheel constraints to F41+
-   `commit <https://pagure.io/freeipa/c/ec990a5e8b1d802d2de60df3a68fb0086440c911>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec990a5e8b1d802d2de60df3a68fb0086440c911>`__
 -  freeipa.spec.in: do not recommend encrypted DNS on pre-F42 systems
-   `commit <https://pagure.io/freeipa/c/d7b454e1593ad65d8addc8389325bfa095f9138d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7b454e1593ad65d8addc8389325bfa095f9138d>`__
 -  freeipa.spec.in: update BIND-related dependencies
-   `commit <https://pagure.io/freeipa/c/c9f7cf11241ed83409439c737442ac22fc355eed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c9f7cf11241ed83409439c737442ac22fc355eed>`__
    `#9696 <https://pagure.io/freeipa/issue/9696>`__
 -  ipa-dnskeysyncd: use systemd-tmpfiles to handle tokens
-   `commit <https://pagure.io/freeipa/c/b9579fe08c83593b01b8f1781250617a5aef5975>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9579fe08c83593b01b8f1781250617a5aef5975>`__
    `#9696 <https://pagure.io/freeipa/issue/9696>`__
 -  DNS: detect when OpenSSL engine should be removed on upgrade
-   `commit <https://pagure.io/freeipa/c/d1e22146d2a4463ed09e63d2f78d618c1b9e7137>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1e22146d2a4463ed09e63d2f78d618c1b9e7137>`__
    `#9696 <https://pagure.io/freeipa/issue/9696>`__
 -  Use OpenSSL provider with BIND for Fedora 42+ and RHEL10+
-   `commit <https://pagure.io/freeipa/c/1311df2e0e7343632e25f2d0adfbbbd79adfda51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1311df2e0e7343632e25f2d0adfbbbd79adfda51>`__
    `#9696 <https://pagure.io/freeipa/issue/9696>`__
 -  Revert "add sourcery.ai github action"
-   `commit <https://pagure.io/freeipa/c/f9eb1154d089383bb2c6beb4dcb60908d7b81680>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f9eb1154d089383bb2c6beb4dcb60908d7b81680>`__
 -  add sourcery.ai github action
-   `commit <https://pagure.io/freeipa/c/e3f991948a439bd6d84f22263c98a13f9b47d2a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3f991948a439bd6d84f22263c98a13f9b47d2a0>`__
 -  ipatests: add a test to use full 32-bit ID range space
-   `commit <https://pagure.io/freeipa/c/5a398d270f5987a9c1ac54d8d7107bae724f6757>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a398d270f5987a9c1ac54d8d7107bae724f6757>`__
    `#9757 <https://pagure.io/freeipa/issue/9757>`__
 -  baseuser: allow uidNumber and gidNumber of 32-bit range
-   `commit <https://pagure.io/freeipa/c/99decb113145c39206a71676f8f589ce675af79d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99decb113145c39206a71676f8f589ce675af79d>`__
    `#9757 <https://pagure.io/freeipa/issue/9757>`__
 -  update_dna_shared_config: do not fail when config is not found
-   `commit <https://pagure.io/freeipa/c/cdafe1d3e4bc297f93d94fdcf3a3b3bd4ef4d2c8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdafe1d3e4bc297f93d94fdcf3a3b3bd4ef4d2c8>`__
    `#9757 <https://pagure.io/freeipa/issue/9757>`__
 -  config-mod: allow disabling subordinate ID integration
-   `commit <https://pagure.io/freeipa/c/cc763d78cc9d4f3fb858b9c5771cf9f6b5317990>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc763d78cc9d4f3fb858b9c5771cf9f6b5317990>`__
    `#9757 <https://pagure.io/freeipa/issue/9757>`__
 -  Reintroduce test_idp to gating tests
-   `commit <https://pagure.io/freeipa/c/92ca7c63322f2a8f496cd6b2faf322e7cbc9b4cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92ca7c63322f2a8f496cd6b2faf322e7cbc9b4cf>`__
    `#9734 <https://pagure.io/freeipa/issue/9734>`__
 -  Migrate Keycloak tests to JDK 21 and Keycloak 26
-   `commit <https://pagure.io/freeipa/c/4e43dd7cd30042588a2264fca98b6e6b9d4d25bb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e43dd7cd30042588a2264fca98b6e6b9d4d25bb>`__
 -  ipa-otpd: do not pass OIDC client secret if there is none to pass
-   `commit <https://pagure.io/freeipa/c/f12c4ed600e9b35c930d386b37e36064fbf83968>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f12c4ed600e9b35c930d386b37e36064fbf83968>`__
    `#9734 <https://pagure.io/freeipa/issue/9734>`__
 -  ipa tools: remove sensitive material from the commandline
-   `commit <https://pagure.io/freeipa/c/0591de367f6999df955f30a4b42ff98df45f9487>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0591de367f6999df955f30a4b42ff98df45f9487>`__
 -  Unify use of option parsers
-   `commit <https://pagure.io/freeipa/c/ba720b921d9813e0ed1f9a6010ee195bd77e59f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba720b921d9813e0ed1f9a6010ee195bd77e59f1>`__
 -  ipa-pwd-extop: clarify OTP use over LDAP binds
-   `commit <https://pagure.io/freeipa/c/60f9bd043075ad9efce4cd908b23781b81065ca4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/60f9bd043075ad9efce4cd908b23781b81065ca4>`__
    `#9699 <https://pagure.io/freeipa/issue/9699>`__,
    `#9711 <https://pagure.io/freeipa/issue/9711>`__
 -  ipalib/x509: support PyCA 44.0
-   `commit <https://pagure.io/freeipa/c/a47475f3794533b207cd763b407a0f414c33b459>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a47475f3794533b207cd763b407a0f414c33b459>`__
    `#9708 <https://pagure.io/freeipa/issue/9708>`__
 -  Revert "readthedocs: install crypto 43.0.0"
-   `commit <https://pagure.io/freeipa/c/8a8b8a76acb1290bc62cceec9d153e28e88f73b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8a8b8a76acb1290bc62cceec9d153e28e88f73b3>`__
 -  ipaserver/dcerpc: support Samba 4.21
-   `commit <https://pagure.io/freeipa/c/aa81bd25f1442b408f4788d7082b42c3536b39bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/aa81bd25f1442b408f4788d7082b42c3536b39bd>`__
    `#9702 <https://pagure.io/freeipa/issue/9702>`__
 -  vault: handle pyca InternalError exception for PKCS#1 v1.5 padding
-   `commit <https://pagure.io/freeipa/c/c100b1a294f399e23ee6b0c9a68d4d26d50f2d5f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c100b1a294f399e23ee6b0c9a68d4d26d50f2d5f>`__
    `#9689 <https://pagure.io/freeipa/issue/9689>`__
 -  web ui: Add explicit white border for QR code widget
-   `commit <https://pagure.io/freeipa/c/67441226125da127c01a12397a1940cc635d911f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67441226125da127c01a12397a1940cc635d911f>`__
    `#9202 <https://pagure.io/freeipa/issue/9202>`__
 -  Extend nightly tests with Cockpit test
-   `commit <https://pagure.io/freeipa/c/c4f3d9034ddfcddcb13e75d1c149d38da34dea08>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c4f3d9034ddfcddcb13e75d1c149d38da34dea08>`__
    `#9675 <https://pagure.io/freeipa/issue/9675>`__
 -  Minimal test for Cockpit integration on IPA master
-   `commit <https://pagure.io/freeipa/c/4519c2fde183d8b8c4f49da37fed68a41a220d72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4519c2fde183d8b8c4f49da37fed68a41a220d72>`__
    `#9675 <https://pagure.io/freeipa/issue/9675>`__
 -  selinux: allow Cockpit to use HTTP keytab on IPA servers
-   `commit <https://pagure.io/freeipa/c/c775de3c2bf05b447bfd17646306f62406ffc6dc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c775de3c2bf05b447bfd17646306f62406ffc6dc>`__
    `#9675 <https://pagure.io/freeipa/issue/9675>`__
 -  selinux: add all IPA log files to ipa_log_t file context
-   `commit <https://pagure.io/freeipa/c/2959c989942a96ef93bffd5b308c36d3fec5542f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2959c989942a96ef93bffd5b308c36d3fec5542f>`__
    `#9654 <https://pagure.io/freeipa/issue/9654>`__
 -  Remove NIS server support
-   `commit <https://pagure.io/freeipa/c/e98a80827bcc42dc16b516355077fed844220107>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e98a80827bcc42dc16b516355077fed844220107>`__
    `#9363 <https://pagure.io/freeipa/issue/9363>`__
 -  Get rid of unicode and long helpers in ipa-otptoken-import
-   `commit <https://pagure.io/freeipa/c/af316dd6f99c4ffad82e0c8002356c77197bdeff>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af316dd6f99c4ffad82e0c8002356c77197bdeff>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  ipalib/constants.py: factor out TripleDES use
-   `commit <https://pagure.io/freeipa/c/cb008bc9dc3bfff966f480a329b17544c4614f49>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cb008bc9dc3bfff966f480a329b17544c4614f49>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  ipalib/x509.py: get rid of unicode helper
-   `commit <https://pagure.io/freeipa/c/fc5728804b720207a60d68f4b92ccced8de00325>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc5728804b720207a60d68f4b92ccced8de00325>`__
    `#9644 <https://pagure.io/freeipa/issue/9644>`__
 -  ipalib/x509.py: support Cryptography 43
-   `commit <https://pagure.io/freeipa/c/3b9ac93f5bc0481998468992adc39a7edc60692e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b9ac93f5bc0481998468992adc39a7edc60692e>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 
 .. _anuja_more_5:
@@ -739,25 +739,25 @@ Anuja More (7)
 ~~~~~~~~~~~~~~
 
 -  ipatests: Refactor and port trust functional SUDO tests.
-   `commit <https://pagure.io/freeipa/c/f395e162e1da4d58482b0520fcfc4068f5792f17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f395e162e1da4d58482b0520fcfc4068f5792f17>`__
    `#9845 <https://pagure.io/freeipa/issue/9845>`__
 -  Revert "Temp commit"
-   `commit <https://pagure.io/freeipa/c/b38b681480f6e9f19ec2d7be0e86a97d4f772c19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b38b681480f6e9f19ec2d7be0e86a97d4f772c19>`__
 -  ipatests: Refactor and port trust functional HBAC tests.
-   `commit <https://pagure.io/freeipa/c/14d7a5b3b6a4eae8df838e737ed23515b017dec3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14d7a5b3b6a4eae8df838e737ed23515b017dec3>`__
    `#9845 <https://pagure.io/freeipa/issue/9845>`__
 -  ipatests: Add comprehensive tests for ipa-client-automount --domain
    option
-   `commit <https://pagure.io/freeipa/c/76727f970c1c810b5cfd182734a4db260bb192bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76727f970c1c810b5cfd182734a4db260bb192bd>`__
    `#9780 <https://pagure.io/freeipa/issue/9780>`__
 -  ipatests: Remove xfail from test_installation::test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/d8017371d3752a42c53577264aab0184756c804a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8017371d3752a42c53577264aab0184756c804a>`__
    `#9135 <https://pagure.io/freeipa/issue/9135>`__
 -  ipatests: Update ipatests to test topology with multiple domain.
-   `commit <https://pagure.io/freeipa/c/817d8849b4c9ad14dc068882244bc5046c0afed5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/817d8849b4c9ad14dc068882244bc5046c0afed5>`__
    `#9657 <https://pagure.io/freeipa/issue/9657>`__
 -  Added template for ad_master_1replica_1client
-   `commit <https://pagure.io/freeipa/c/b5f40a304c6d1732dc980ac1f4eae1bdc98ca709>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5f40a304c6d1732dc980ac1f4eae1bdc98ca709>`__
 
 .. _andi_chandler_2:
 
@@ -765,11 +765,11 @@ Andi Chandler (3)
 ~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (English (United Kingdom))
-   `commit <https://pagure.io/freeipa/c/cc986fd89df5f567c354ce71e0b1d7500baf1f47>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc986fd89df5f567c354ce71e0b1d7500baf1f47>`__
 -  Translated using Weblate (English (United Kingdom))
-   `commit <https://pagure.io/freeipa/c/538e5c12158712d3288251c80e5f171394018409>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/538e5c12158712d3288251c80e5f171394018409>`__
 -  Translated using Weblate (English (United Kingdom))
-   `commit <https://pagure.io/freeipa/c/6ce87f096f2991844808608b5f844aae5d85557f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ce87f096f2991844808608b5f844aae5d85557f>`__
 
 .. _antonio_torres_10:
 
@@ -777,32 +777,32 @@ Antonio Torres (11)
 ~~~~~~~~~~~~~~~~~~~
 
 -  eDNS: disable dnsconfd before configuring Unbound
-   `commit <https://pagure.io/freeipa/c/68cc47a3e430fd4717aa60934677898afb95a961>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68cc47a3e430fd4717aa60934677898afb95a961>`__
    `#9859 <https://pagure.io/freeipa/issue/9859>`__
 -  dns: disable all previous Unbound configuration before deploying ours
-   `commit <https://pagure.io/freeipa/c/e6445b88ab56c664376c3cafce9b69a602be6624>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6445b88ab56c664376c3cafce9b69a602be6624>`__
    `#9814 <https://pagure.io/freeipa/issue/9814>`__
 -  dns: only overwrite resolv.conf during eDNS setup when needed
-   `commit <https://pagure.io/freeipa/c/76b3a342d523be8574d6b8a6c0c75849418a9ea6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76b3a342d523be8574d6b8a6c0c75849418a9ea6>`__
    `#9813 <https://pagure.io/freeipa/issue/9813>`__
 -  Fix inconsistency in manpage for DoT forwarder option
-   `commit <https://pagure.io/freeipa/c/34ed47f820b2c44ee9981367d5ea5c9e3427460c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34ed47f820b2c44ee9981367d5ea5c9e3427460c>`__
    `#9804 <https://pagure.io/freeipa/issue/9804>`__
 -  dns: don't populate forwarders with DoT forwarders
-   `commit <https://pagure.io/freeipa/c/f1c30c5f6b587cb6ad31c0c5563ead05e8d55c51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f1c30c5f6b587cb6ad31c0c5563ead05e8d55c51>`__
    `#9748 <https://pagure.io/freeipa/issue/9748>`__
 -  dns: only disable unbound when DoT is enabled
-   `commit <https://pagure.io/freeipa/c/91353b10748f1153540c6f5447a80864dee59d7f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/91353b10748f1153540c6f5447a80864dee59d7f>`__
 -  spec: add unbound requirement and template file
-   `commit <https://pagure.io/freeipa/c/432390086309b831f969c9f5892cb0a3ff2cad7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/432390086309b831f969c9f5892cb0a3ff2cad7e>`__
 -  PRCI: add definitions for DNS over TLS tests
-   `commit <https://pagure.io/freeipa/c/4d0aacaa05eacff9cb95c830a256de9381f7c56b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d0aacaa05eacff9cb95c830a256de9381f7c56b>`__
 -  ipatests: add tests for DNS over TLS
-   `commit <https://pagure.io/freeipa/c/62c6c09689ad4e6f793a278c1a5637b1e7e60c3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62c6c09689ad4e6f793a278c1a5637b1e7e60c3b>`__
 -  Add DNS over TLS support
-   `commit <https://pagure.io/freeipa/c/3de127433c5552c1f9f82c6bb73f2a32caa03e9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3de127433c5552c1f9f82c6bb73f2a32caa03e9b>`__
 -  Bump to IPA 4.13
-   `commit <https://pagure.io/freeipa/c/3f3ac4f148650ad27d65e2648e3b89eb756e6b6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3f3ac4f148650ad27d65e2648e3b89eb756e6b6c>`__
 
 .. _arif_budiman_2:
 
@@ -810,9 +810,9 @@ Arif Budiman (2)
 ~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/136ab8ca308c6675f10c1ba24eaa2121ea99eb4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/136ab8ca308c6675f10c1ba24eaa2121ea99eb4a>`__
 -  Translated using Weblate (Indonesian)
-   `commit <https://pagure.io/freeipa/c/872189e235cf2e04e84acd81597ed33e96baf180>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/872189e235cf2e04e84acd81597ed33e96baf180>`__
 
 .. _aleksandr_sharov_4:
 
@@ -821,23 +821,23 @@ Aleksandr Sharov (6)
 
 -  Correctly recognize OID 2.5.4.97, organizationIdentifier as a
    subject/issuer DN of the CA certificate
-   `commit <https://pagure.io/freeipa/c/e0b9ad0ae00ea478b6603fb56c9b369afd957d34>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e0b9ad0ae00ea478b6603fb56c9b369afd957d34>`__
    `#9866 <https://pagure.io/freeipa/issue/9866>`__
 -  Allow ipa tool to force specific server
-   `commit <https://pagure.io/freeipa/c/d9a2a6abcdaa66f4e2053c6cbf303c959d8be4f4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9a2a6abcdaa66f4e2053c6cbf303c959d8be4f4>`__
    `#9744 <https://pagure.io/freeipa/issue/9744>`__
 -  Test fix for the update
-   `commit <https://pagure.io/freeipa/c/23bfcdd4e22013552e8d95ed5d150c580201bdc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23bfcdd4e22013552e8d95ed5d150c580201bdc9>`__
    `#9760 <https://pagure.io/freeipa/issue/9760>`__
 -  Add a check into ipa-cert-fix tool to avoid updating certs if CA is
    close to being expired.
-   `commit <https://pagure.io/freeipa/c/ac6eee670d8a753e66ba69a65eff55447fff2822>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac6eee670d8a753e66ba69a65eff55447fff2822>`__
    `#9760 <https://pagure.io/freeipa/issue/9760>`__
 -  Add PR-CI definitions
-   `commit <https://pagure.io/freeipa/c/90297c4c1a2b9b8e09275550f055bdf9d02942a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90297c4c1a2b9b8e09275550f055bdf9d02942a6>`__
    `#9612 <https://pagure.io/freeipa/issue/9612>`__
 -  Add ipa-idrange-fix
-   `commit <https://pagure.io/freeipa/c/01d90b4a53c6810499bfdb6495559e52b9f9001f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/01d90b4a53c6810499bfdb6495559e52b9f9001f>`__
    `#9612 <https://pagure.io/freeipa/issue/9612>`__
 
 .. _carla_martinez_1:
@@ -846,9 +846,9 @@ Carla Martinez (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Modern WebUI version v0.1.7
-   `commit <https://pagure.io/freeipa/c/c03fe90186c47645093f65854c0a922af7fba5d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c03fe90186c47645093f65854c0a922af7fba5d5>`__
 -  Fix: 'Organization' field in Okta not required
-   `commit <https://pagure.io/freeipa/c/13281e785a74b01fda5368a645477f3a7ed3675f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/13281e785a74b01fda5368a645477f3a7ed3675f>`__
    `#9687 <https://pagure.io/freeipa/issue/9687>`__
 
 .. _david_hanina_8:
@@ -857,34 +857,34 @@ David Hanina (11)
 ~~~~~~~~~~~~~~~~
 
 -  Fix webui submodule copr build
-   `commit <https://pagure.io/freeipa/c/a66df6d7b4cf0c8b466d18f44ab613379e222b99>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a66df6d7b4cf0c8b466d18f44ab613379e222b99>`__
 -  Add info about modern webui
-   `commit <https://pagure.io/freeipa/c/563f20e2a4dd63e6abdec1da65a2c0f95a49d33e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/563f20e2a4dd63e6abdec1da65a2c0f95a49d33e>`__
 -  Add modern webui build
-   `commit <https://pagure.io/freeipa/c/9b7fc311d3fa83ff146d83f665ab6aee846e0a4a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b7fc311d3fa83ff146d83f665ab6aee846e0a4a>`__
 -  Fix terminal height for Rawhide
-   `commit <https://pagure.io/freeipa/c/4484ad72905d12741b2dd0f29484480fa0566587>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4484ad72905d12741b2dd0f29484480fa0566587>`__
    `#9824 <https://pagure.io/freeipa/issue/9824>`__
 -  Warn when UID is out of local ID ranges
-   `commit <https://pagure.io/freeipa/c/b36c163fe8c225e12737d0e25092bb1a7fc9fd5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b36c163fe8c225e12737d0e25092bb1a7fc9fd5c>`__
    `#9781 <https://pagure.io/freeipa/issue/9781>`__
 -  Require baserid and secondarybaserid
-   `commit <https://pagure.io/freeipa/c/247adf43133222745c78d53624ca921e43e42f7b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/247adf43133222745c78d53624ca921e43e42f7b>`__
    `#9779 <https://pagure.io/freeipa/issue/9779>`__
 -  Correct dnsrecord\_\* tests for --raw --structured
-   `commit <https://pagure.io/freeipa/c/ea374e83460a35cfca1caed7357fe1b70ffd7fab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ea374e83460a35cfca1caed7357fe1b70ffd7fab>`__
    `#9768 <https://pagure.io/freeipa/issue/9768>`__
 -  Disallow removal of dogtag and ipa-dnskeysyncd services on IPA
    servers
-   `commit <https://pagure.io/freeipa/c/14196891138e2f88b57d23120a4471496a3cccb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/14196891138e2f88b57d23120a4471496a3cccb6>`__
    `#9764 <https://pagure.io/freeipa/issue/9764>`__
 -  Disable --raw and --structured together
-   `commit <https://pagure.io/freeipa/c/b917b320a856bcedd313721e85c962a885095dfd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b917b320a856bcedd313721e85c962a885095dfd>`__
    `#9756 <https://pagure.io/freeipa/issue/9756>`__
 -  Skip for unpatched freeipa-healthcheck
-   `commit <https://pagure.io/freeipa/c/90d70b5dd019f4f0d81b4c3a2096c4b64a736849>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/90d70b5dd019f4f0d81b4c3a2096c4b64a736849>`__
 -  Replace fips-mode-setup
-   `commit <https://pagure.io/freeipa/c/3c50bc23897abb74a414ed1d6986023674dd8ac2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c50bc23897abb74a414ed1d6986023674dd8ac2>`__
    `#9750 <https://pagure.io/freeipa/issue/9750>`__
 
 .. _erik_belko_2:
@@ -893,9 +893,9 @@ Erik Belko (2)
 ~~~~~~~~~~~~~~
 
 -  man: fix formatting and syntax issues
-   `commit <https://pagure.io/freeipa/c/a542a9185a127ac0202ac0c0b0bc255d11aaf355>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a542a9185a127ac0202ac0c0b0bc255d11aaf355>`__
 -  ipatests: Update ipa-adtrust-install test
-   `commit <https://pagure.io/freeipa/c/d87dc8296039ef093198e0cb4d648d52ba953ed2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d87dc8296039ef093198e0cb4d648d52ba953ed2>`__
    `#9655 <https://pagure.io/freeipa/issue/9655>`__
 
 .. _emilio_herrera_1:
@@ -904,7 +904,7 @@ Emilio Herrera (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/d018361c6feb4e7b5376b3b6bb964864cb52e477>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d018361c6feb4e7b5376b3b6bb964864cb52e477>`__
 
 .. _finn_krein_schuch_1:
 
@@ -912,7 +912,7 @@ Finn Krein-Schuch (1)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Use mod_auth_gssapi option GssapiNegotiateOnce
-   `commit <https://pagure.io/freeipa/c/2dcc943e6bb9915494dcca3fecb35956943e1709>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2dcc943e6bb9915494dcca3fecb35956943e1709>`__
    `#5614 <https://pagure.io/freeipa/issue/5614>`__
 
 .. _florence_blanc_renaud_84:
@@ -921,301 +921,301 @@ Florence Blanc-Renaud (112)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: fix teardown of TestIpaCertFix
-   `commit <https://pagure.io/freeipa/c/443aff6a0ae4bc35ceb7a4adc06c9b7bb2704743>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/443aff6a0ae4bc35ceb7a4adc06c9b7bb2704743>`__
    `#9888 <https://pagure.io/freeipa/issue/9888>`__
 -  test_ipahealthcheck_dogtag_ca_connectivity_check: update expected msg
-   `commit <https://pagure.io/freeipa/c/9b9c71475b6a8d009335738108050c86213b0251>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b9c71475b6a8d009335738108050c86213b0251>`__
    `#9881 <https://pagure.io/freeipa/issue/9881>`__
 -  temp_commit: revert to the version pre 0b521f7
-   `commit <https://pagure.io/freeipa/c/bcbc88dc4a77d159ffcfa8ca4d2d98ef90f089d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bcbc88dc4a77d159ffcfa8ca4d2d98ef90f089d6>`__
 -  ipatests: mark test_dnssec as xfail in fips mode
-   `commit <https://pagure.io/freeipa/c/ca5510a08dd5e8bdad617589a3acf1aee427373a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca5510a08dd5e8bdad617589a3acf1aee427373a>`__
    `#9785 <https://pagure.io/freeipa/issue/9785>`__
 -  FIPS mode: openssl pkcs12 command needs -nomacver option
-   `commit <https://pagure.io/freeipa/c/3e6b5b954b355df3f4f0859961f1a5ae151d72f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e6b5b954b355df3f4f0859961f1a5ae151d72f5>`__
    `#9878 <https://pagure.io/freeipa/issue/9878>`__
 -  test_sudo: do not clean the cache for offline cache tests
-   `commit <https://pagure.io/freeipa/c/d3909d8601e0bdb6c78dcdf2507e7bf71f656e8f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d3909d8601e0bdb6c78dcdf2507e7bf71f656e8f>`__
    `#9874 <https://pagure.io/freeipa/issue/9874>`__
 -  test_idp: use more recent keycloak server
-   `commit <https://pagure.io/freeipa/c/54f9e0f3e69dde43082889afe101d01edfe93fdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/54f9e0f3e69dde43082889afe101d01edfe93fdd>`__
    `#9833 <https://pagure.io/freeipa/issue/9833>`__
 -  PRCI: switch testing from f41 and f42 to f42 and f43
-   `commit <https://pagure.io/freeipa/c/ec308a0358f109bd9acb1cdb189a4019fb7c53f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ec308a0358f109bd9acb1cdb189a4019fb7c53f1>`__
 -  Backup-restore: backup krb5.conf.d snippet files
-   `commit <https://pagure.io/freeipa/c/bd8288476fa0be98458cb18a92e1ffb9811e568e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd8288476fa0be98458cb18a92e1ffb9811e568e>`__
    `#9870 <https://pagure.io/freeipa/issue/9870>`__
 -  TestHttpKdcProxy: use the snippet file for krb5 config
-   `commit <https://pagure.io/freeipa/c/0ff5d6a388912bc0a3645de4a57b5ab228652ff4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0ff5d6a388912bc0a3645de4a57b5ab228652ff4>`__
    `#9871 <https://pagure.io/freeipa/issue/9871>`__
 -  Localization: remove zh_Hant file
-   `commit <https://pagure.io/freeipa/c/1550fedee1131c5432f4b1bba5625f472d8a7599>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1550fedee1131c5432f4b1bba5625f472d8a7599>`__
 -  Modern webui: refresh to the tip of main branch
-   `commit <https://pagure.io/freeipa/c/ce1e44b8dc6f9b84619fe1ec375c8f4f023704b3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce1e44b8dc6f9b84619fe1ec375c8f4f023704b3>`__
 -  Azure: fix WebUI tests
-   `commit <https://pagure.io/freeipa/c/1652e70f2cabce4a582edf5a9ea2646737994393>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1652e70f2cabce4a582edf5a9ea2646737994393>`__
 -  Azure: fix the configuration issue
-   `commit <https://pagure.io/freeipa/c/3c5160bba46041ee4cbf984be11dacf08592d5d1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3c5160bba46041ee4cbf984be11dacf08592d5d1>`__
 -  Azure CI: Use F43
-   `commit <https://pagure.io/freeipa/c/a4ff2fcc183752593e82c3e608de14a84cbbf3e9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4ff2fcc183752593e82c3e608de14a84cbbf3e9>`__
 -  ipatests: mark test_scale_add_subca as xfail
-   `commit <https://pagure.io/freeipa/c/a0a8cbf7fa457daefdf51c720e05be5a0dda2211>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a0a8cbf7fa457daefdf51c720e05be5a0dda2211>`__
 -  Integration test: fix teardown of test_expiration_date_post_2038
-   `commit <https://pagure.io/freeipa/c/c7f07d451c8fdbf1da98bb6f36296608c975c98a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7f07d451c8fdbf1da98bb6f36296608c975c98a>`__
 -  test_cert: adapt the expect error message to PKI 11.7.0-5
-   `commit <https://pagure.io/freeipa/c/78b432567744e147dae22a05fff7b90188ad4b31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78b432567744e147dae22a05fff7b90188ad4b31>`__
 -  Revert "Tests xmlrpc: mark xfail tests requesting cert with subca"
-   `commit <https://pagure.io/freeipa/c/7f8841cd8bf4002fe25b2a1f76fcd348b5752649>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f8841cd8bf4002fe25b2a1f76fcd348b5752649>`__
 -  PRCI tests: update vagrant image with latest PKI / certmonger package
-   `commit <https://pagure.io/freeipa/c/dd8b7214b49001cf2814b4f0e13ca46bf9bbe402>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd8b7214b49001cf2814b4f0e13ca46bf9bbe402>`__
 -  ipatests: fix TestIpaClientAutomountDiscovery
-   `commit <https://pagure.io/freeipa/c/db4ff377924381a19ae39582fdd734d2af7431c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db4ff377924381a19ae39582fdd734d2af7431c6>`__
 -  Spec file: bump version for 389-ds
-   `commit <https://pagure.io/freeipa/c/1c8003ca5e3bbcd375dae77105c691f0c315ef2f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c8003ca5e3bbcd375dae77105c691f0c315ef2f>`__
 -  Tests xmlrpc: mark xfail tests requesting cert with subca
-   `commit <https://pagure.io/freeipa/c/db188b9ad8dd361ccf3046cf4492499d1bdf9c74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/db188b9ad8dd361ccf3046cf4492499d1bdf9c74>`__
 -  ipatests: extend test for unique krbcanonicalname
-   `commit <https://pagure.io/freeipa/c/96a5e706d16724b805d31478eb3f6e9ed2882309>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/96a5e706d16724b805d31478eb3f6e9ed2882309>`__
 -  ipatests: fix TestIPAMigratewithBackupRestore setup
-   `commit <https://pagure.io/freeipa/c/0b796ce7623d420786e3968697ab8569ed97ae3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b796ce7623d420786e3968697ab8569ed97ae3c>`__
    `#9858 <https://pagure.io/freeipa/issue/9858>`__
 -  ipatests: add xfail for TestKRAinstallAfterCertRenew
-   `commit <https://pagure.io/freeipa/c/92f992a6ec5806676d086c889bc6eca923237a79>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/92f992a6ec5806676d086c889bc6eca923237a79>`__
    `#9763 <https://pagure.io/freeipa/issue/9763>`__
 -  ipatests: exclude TomcatFileCheck when RSN are enabled
-   `commit <https://pagure.io/freeipa/c/0d0a558b79f45dc162b2b60eba0bc305db594673>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0d0a558b79f45dc162b2b60eba0bc305db594673>`__
 -  ipatests: update the Let's Encrypt cert chain
-   `commit <https://pagure.io/freeipa/c/b73d8f18a65a7615e1052aae8c53d58ca67de8fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b73d8f18a65a7615e1052aae8c53d58ca67de8fa>`__
    `#9857 <https://pagure.io/freeipa/issue/9857>`__
 -  azure webui tests: force chromium version
-   `commit <https://pagure.io/freeipa/c/70518cec0d3149e85a1f9dfda49ece36d665affa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70518cec0d3149e85a1f9dfda49ece36d665affa>`__
 -  ipatests: fix test_otp
-   `commit <https://pagure.io/freeipa/c/b0e4cdbf9dcaf8d46002f7b89a714b561ab97e03>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b0e4cdbf9dcaf8d46002f7b89a714b561ab97e03>`__
    `#9849 <https://pagure.io/freeipa/issue/9849>`__
 -  xmlrpc test: fix test_find_orphan_automember_rules
-   `commit <https://pagure.io/freeipa/c/ca29a5a43e1d66f6e25a59009592e58c0f59c393>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ca29a5a43e1d66f6e25a59009592e58c0f59c393>`__
    `#9850 <https://pagure.io/freeipa/issue/9850>`__
 -  ipatests: remove xfail for PKI 11.7
-   `commit <https://pagure.io/freeipa/c/81aadac8c0cae29a322b4e9df99eb275db36d692>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/81aadac8c0cae29a322b4e9df99eb275db36d692>`__
    `#9606 <https://pagure.io/freeipa/issue/9606>`__
 -  ipatests: fix test_certmonger_ipa_responder_jsonrpc
-   `commit <https://pagure.io/freeipa/c/40b24b24c77d54750cda2a090c063f55d961b716>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/40b24b24c77d54750cda2a090c063f55d961b716>`__
    `#9848 <https://pagure.io/freeipa/issue/9848>`__
 -  DNS over TLS: use system trust store
-   `commit <https://pagure.io/freeipa/c/c0994948b55da24eb946550bade3a33efe8801e6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c0994948b55da24eb946550bade3a33efe8801e6>`__
    `#9838 <https://pagure.io/freeipa/issue/9838>`__
 -  Spec file: bump samba version to 4.23.0 in f43 and above
-   `commit <https://pagure.io/freeipa/c/6069147e3bea92059849e0a8c1948a0f1c3c8425>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6069147e3bea92059849e0a8c1948a0f1c3c8425>`__
    `#9843 <https://pagure.io/freeipa/issue/9843>`__
 -  Spec file: use nodejs22 on fedora 41+
-   `commit <https://pagure.io/freeipa/c/52024ed7f394ac5eefebff60b53a2cd938ed7628>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/52024ed7f394ac5eefebff60b53a2cd938ed7628>`__
    `#9836 <https://pagure.io/freeipa/issue/9836>`__
 -  ipatests: fix test_adtrust_install_with_non_ipa_user
-   `commit <https://pagure.io/freeipa/c/2eaba8497a5095b23dac39b759dbf632fa422529>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2eaba8497a5095b23dac39b759dbf632fa422529>`__
    `#9812 <https://pagure.io/freeipa/issue/9812>`__
 -  ipa-idrange-fix: check that IPA server is installed
-   `commit <https://pagure.io/freeipa/c/5323b7701386eb524eb51a9ce62ce151c13b9d58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5323b7701386eb524eb51a9ce62ce151c13b9d58>`__
    `#9809 <https://pagure.io/freeipa/issue/9809>`__
 -  ipatests: fix invalid range creation in test_ipa_idrange_fix.py
-   `commit <https://pagure.io/freeipa/c/3e15108f456768d5ca4cf2ffbbfe090c57d0f988>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3e15108f456768d5ca4cf2ffbbfe090c57d0f988>`__
    `#9801 <https://pagure.io/freeipa/issue/9801>`__
 -  ipatests: fix xfail annotation for test_ipa_healthcheck_fips_enabled
-   `commit <https://pagure.io/freeipa/c/982569fcb3d23d6e6578e5efbaafb99c32542a8d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/982569fcb3d23d6e6578e5efbaafb99c32542a8d>`__
    `#9791 <https://pagure.io/freeipa/issue/9791>`__
 -  ipatests: skip encrypted dns tests on fedora 41
-   `commit <https://pagure.io/freeipa/c/78abf1ffa1316585e658baf309d0ea0699858260>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78abf1ffa1316585e658baf309d0ea0699858260>`__
    `#9799 <https://pagure.io/freeipa/issue/9799>`__
 -  ipa config-mod: fix internalerror when setting an empty
    ipaconfigstring
-   `commit <https://pagure.io/freeipa/c/e4a3d46e89a49e18fa437723370988b165ded4b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e4a3d46e89a49e18fa437723370988b165ded4b5>`__
    `#9794 <https://pagure.io/freeipa/issue/9794>`__
 -  ipatests: test_manual_renewal_master_transfer must wait for
    replication
-   `commit <https://pagure.io/freeipa/c/089e813bf4a981be1e6660c8db9bec6c1a67a777>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/089e813bf4a981be1e6660c8db9bec6c1a67a777>`__
    `#9790 <https://pagure.io/freeipa/issue/9790>`__
 -  azure pipeline: disable InstallDNSSECFirst
-   `commit <https://pagure.io/freeipa/c/6329c3703a3d878fa4cf7a9646746d4ee19fabe6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6329c3703a3d878fa4cf7a9646746d4ee19fabe6>`__
 -  ipatests: add extensions to server certificates for CAless mode
-   `commit <https://pagure.io/freeipa/c/d1abdca13f26cf3c50c7898eb7d034c7dfc6d392>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d1abdca13f26cf3c50c7898eb7d034c7dfc6d392>`__
    `#9787 <https://pagure.io/freeipa/issue/9787>`__
 -  dns install: fix selinux avc relabelto
-   `commit <https://pagure.io/freeipa/c/c2aae876f04c127b7b2eb6dad8677a3ae8ceefb8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c2aae876f04c127b7b2eb6dad8677a3ae8ceefb8>`__
    `#9782 <https://pagure.io/freeipa/issue/9782>`__
 -  PRCI tests: update vagrant image with latest bind package
-   `commit <https://pagure.io/freeipa/c/e3425d0649d10b72e8e5d521296165932967419d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e3425d0649d10b72e8e5d521296165932967419d>`__
 -  Azure CI: use podman instead of docker through emulation
-   `commit <https://pagure.io/freeipa/c/bdfcf8c28199345dfe5c956ed99f80c9e18c2270>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdfcf8c28199345dfe5c956ed99f80c9e18c2270>`__
 -  azure pipeline: skip step disabling conflicting apparmor profile
-   `commit <https://pagure.io/freeipa/c/b08fe8017ea2e8ca21cdd687e73c7c9974f98308>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b08fe8017ea2e8ca21cdd687e73c7c9974f98308>`__
 -  azure pipeline: replace ubuntu-20.04 with 24.04
-   `commit <https://pagure.io/freeipa/c/26c80e8476b288ae3775716d52ff32b0958422fb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26c80e8476b288ae3775716d52ff32b0958422fb>`__
 -  ipatests: fix test_idp
-   `commit <https://pagure.io/freeipa/c/e964b7de94e1616558ca5c2471667c10ab2db5ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e964b7de94e1616558ca5c2471667c10ab2db5ec>`__
    `#9769 <https://pagure.io/freeipa/issue/9769>`__
 -  PRCI: switch testing from f40 and f41 to f41 and f42
-   `commit <https://pagure.io/freeipa/c/f5084adb6dde67fa7eb8dc58cc3dfa5a0a9bdaa3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5084adb6dde67fa7eb8dc58cc3dfa5a0a9bdaa3>`__
 -  PRCI definitions: update vagrant box version for rawhide
-   `commit <https://pagure.io/freeipa/c/940a0bc8c8c310b6f5d89ea62c64dcde508a5c41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/940a0bc8c8c310b6f5d89ea62c64dcde508a5c41>`__
 -  ipatests: update fedora41 vagrant box to 0.0.2
-   `commit <https://pagure.io/freeipa/c/5a63a50d041ccd59a546aa728347b605b44373b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5a63a50d041ccd59a546aa728347b605b44373b5>`__
 -  gating tests: add
    test_ipahealthcheck.py::TestIpaHealthCheckWithADtrust
-   `commit <https://pagure.io/freeipa/c/ed8b4bc3631ae00a9ee687797767fbdb9d02f7ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed8b4bc3631ae00a9ee687797767fbdb9d02f7ea>`__
 -  idrange: use minvalue=0 for baserid and secondarybaserid
-   `commit <https://pagure.io/freeipa/c/140c3b54771fbc636286a70354e7bcd180bb9709>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/140c3b54771fbc636286a70354e7bcd180bb9709>`__
    `#9765 <https://pagure.io/freeipa/issue/9765>`__
 -  ipatest: make test_cert more robust to replication delays
-   `commit <https://pagure.io/freeipa/c/a6060fe5e781fb87bce380763e4417380be365f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6060fe5e781fb87bce380763e4417380be365f3>`__
    `#9762 <https://pagure.io/freeipa/issue/9762>`__
 -  Leapp upgrade: skip systemctl calls
-   `commit <https://pagure.io/freeipa/c/1a7a11c196da4660286a8c499bc9381ca3deab05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a7a11c196da4660286a8c499bc9381ca3deab05>`__
 -  ipatests: adapt error code and message for samba 4.22
-   `commit <https://pagure.io/freeipa/c/cd3b7b9bd506c48714f171490735ecf564ad6b69>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cd3b7b9bd506c48714f171490735ecf564ad6b69>`__
    `#9751 <https://pagure.io/freeipa/issue/9751>`__
 -  WebUI: fix the tooltip for Search Size limit
-   `commit <https://pagure.io/freeipa/c/69ca3e477b2390f1f19ac14452bdca2a55fcea56>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/69ca3e477b2390f1f19ac14452bdca2a55fcea56>`__
    `#9758 <https://pagure.io/freeipa/issue/9758>`__
 -  vault: remove PKIConnection deprecation warning
-   `commit <https://pagure.io/freeipa/c/cbe863bf15ed3c0091256f86e9da3fe382b658f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cbe863bf15ed3c0091256f86e9da3fe382b658f1>`__
    `#9754 <https://pagure.io/freeipa/issue/9754>`__
 -  ipatests: use "sos report" instead of "sosreport" command
-   `commit <https://pagure.io/freeipa/c/d2b5a9b93c3cf95b14dde888605f404edabd3fe9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2b5a9b93c3cf95b14dde888605f404edabd3fe9>`__
    `#9752 <https://pagure.io/freeipa/issue/9752>`__
 -  ipatests: simulate FIPS mode and install replica
-   `commit <https://pagure.io/freeipa/c/50e8c4a1273dc5ba9dace14df8743821127b37fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/50e8c4a1273dc5ba9dace14df8743821127b37fd>`__
    `#9002 <https://pagure.io/freeipa/issue/9002>`__
 -  ipatests: on rhel10 do not install firefox
-   `commit <https://pagure.io/freeipa/c/d9bf35dcc0367b522ba986cc4f0e37a6ffc9c8cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9bf35dcc0367b522ba986cc4f0e37a6ffc9c8cc>`__
 -  ipatests: restart dirsrv after time jumps
-   `commit <https://pagure.io/freeipa/c/6f475294e0868b0b7bf6143260c9b30e00e25efd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f475294e0868b0b7bf6143260c9b30e00e25efd>`__
 -  ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions
-   `commit <https://pagure.io/freeipa/c/1d93e48644960231d72b2c75f7f847a31a62f84f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d93e48644960231d72b2c75f7f847a31a62f84f>`__
    `#9730 <https://pagure.io/freeipa/issue/9730>`__
 -  Nightly tests: add test_ipahelthcheck to 389ds pipeline
-   `commit <https://pagure.io/freeipa/c/3863043fd1a0cccd964daedc3d12928c236d8b4b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3863043fd1a0cccd964daedc3d12928c236d8b4b>`__
 -  ipatests: force the version for uninstall/reinstall
-   `commit <https://pagure.io/freeipa/c/6e26b060871cf7763cca0fd798119b658f4f93df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e26b060871cf7763cca0fd798119b658f4f93df>`__
    `#9723 <https://pagure.io/freeipa/issue/9723>`__
 -  Fix pylint issue in ipatests/i18n.py
-   `commit <https://pagure.io/freeipa/c/31338fea70aae3fdfa0c6117d7652816d03a6f74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31338fea70aae3fdfa0c6117d7652816d03a6f74>`__
 -  ipatests: certbot removed the --manual-public-ip-logging-ok parameter
-   `commit <https://pagure.io/freeipa/c/e13be8a7c535a9d2131ccd1f58bf7e564dc02e7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e13be8a7c535a9d2131ccd1f58bf7e564dc02e7e>`__
    `#9724 <https://pagure.io/freeipa/issue/9724>`__
 -  Temp commit: move to fedora 41
-   `commit <https://pagure.io/freeipa/c/4146d77d2547160df2df31665dc201a7d3118173>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4146d77d2547160df2df31665dc201a7d3118173>`__
 -  Cert renewal: update the trust flags for audit cert
-   `commit <https://pagure.io/freeipa/c/7ec0cb4ced0fe5118077a4804a70b928b2a9f442>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ec0cb4ced0fe5118077a4804a70b928b2a9f442>`__
    `#9705 <https://pagure.io/freeipa/issue/9705>`__
 -  Dogtag instance: add method to create temp password file
-   `commit <https://pagure.io/freeipa/c/1e5eb442adb9b6630b95eaf118e65f110d2087ac>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1e5eb442adb9b6630b95eaf118e65f110d2087ac>`__
    `#9705 <https://pagure.io/freeipa/issue/9705>`__
 -  KRA cert renewal: update ca.connector.KRA.transportCert
-   `commit <https://pagure.io/freeipa/c/10c3464e55eaafff728042bc878938c380c4f9d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/10c3464e55eaafff728042bc878938c380c4f9d5>`__
    `#9692 <https://pagure.io/freeipa/issue/9692>`__
 -  Installation test: KRA on replica after cert renewal
-   `commit <https://pagure.io/freeipa/c/76dfadd95fe23fde4af19249191c285dede4120e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/76dfadd95fe23fde4af19249191c285dede4120e>`__
    `#9692 <https://pagure.io/freeipa/issue/9692>`__
 -  Fix copr build
-   `commit <https://pagure.io/freeipa/c/b9d7137d8aed514c48e9bf3e55b450860276a29b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9d7137d8aed514c48e9bf3e55b450860276a29b>`__
 -  readthedocs: install crypto 43.0.0
-   `commit <https://pagure.io/freeipa/c/b20c3fb60558b538ef13e0e0fe89ae361d529553>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b20c3fb60558b538ef13e0e0fe89ae361d529553>`__
 -  webuitests: adapt to Random Serial Numbers
-   `commit <https://pagure.io/freeipa/c/c8befc9f46b43aec748ede33236ca4f77b2356c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8befc9f46b43aec748ede33236ca4f77b2356c6>`__
    `#9707 <https://pagure.io/freeipa/issue/9707>`__
 -  ipatests: pruning is enabled by default with LMDB
-   `commit <https://pagure.io/freeipa/c/fd222273a544f9e8c7a1749ff797880db7edbf25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd222273a544f9e8c7a1749ff797880db7edbf25>`__
    `#9706 <https://pagure.io/freeipa/issue/9706>`__
 -  ipatests: install master with allow-zone-overlap
-   `commit <https://pagure.io/freeipa/c/411b29db8f2bf9b8390dd021cf464d5cac013e3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/411b29db8f2bf9b8390dd021cf464d5cac013e3b>`__
    `#9697 <https://pagure.io/freeipa/issue/9697>`__
 -  Nightly test def: fix topology for test_IPAMigrateADTrust
-   `commit <https://pagure.io/freeipa/c/2f1ca6db12897c2c89bd64f7353268f45b8468a0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2f1ca6db12897c2c89bd64f7353268f45b8468a0>`__
 -  Tests: migrate to f40/f41
-   `commit <https://pagure.io/freeipa/c/1a47d3a9066ecad4466f8fd4d919b035f1c13f27>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a47d3a9066ecad4466f8fd4d919b035f1c13f27>`__
 -  ipa-migrate man page: fix typos and errors
-   `commit <https://pagure.io/freeipa/c/35fc1470cd0295d8b387e034b7b30f6088eb49b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/35fc1470cd0295d8b387e034b7b30f6088eb49b8>`__
    `#9681 <https://pagure.io/freeipa/issue/9681>`__
 -  test_ipahealthcheck: skip connectivity_and_data check
-   `commit <https://pagure.io/freeipa/c/929dc568808f12917a738b51def45c31fb351ddc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/929dc568808f12917a738b51def45c31fb351ddc>`__
    `#9668 <https://pagure.io/freeipa/issue/9668>`__
 -  Nightly test definition: use master_1repl topology for idrange_fix
-   `commit <https://pagure.io/freeipa/c/df8cdb06f3d5b7ce0b7a91586cdd1f1951c229ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/df8cdb06f3d5b7ce0b7a91586cdd1f1951c229ab>`__
 -  test_adtrust_install: add --use-krb5-ccache to smbclient command
-   `commit <https://pagure.io/freeipa/c/c33e92d8954dd1578c89693e10d59d2bd4f31940>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c33e92d8954dd1578c89693e10d59d2bd4f31940>`__
    `#9666 <https://pagure.io/freeipa/issue/9666>`__
 -  ipatests: provide a ccache to rpcclient deletetrustdom
-   `commit <https://pagure.io/freeipa/c/3203afcc11487730aceb222a54cbdbaaaf371d15>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3203afcc11487730aceb222a54cbdbaaaf371d15>`__
    `#9667 <https://pagure.io/freeipa/issue/9667>`__
 -  azure pipeline: use latest version of DownloadPipelineArtifact task
-   `commit <https://pagure.io/freeipa/c/97718f688c73265c0240fbe6380cf0476e873395>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/97718f688c73265c0240fbe6380cf0476e873395>`__
 -  UnsafeIPAddress: pass flag=0 to IPNetwork
-   `commit <https://pagure.io/freeipa/c/a4a0a142058a45ab2bf614c14c1b037b674cccc9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4a0a142058a45ab2bf614c14c1b037b674cccc9>`__
    `#9645 <https://pagure.io/freeipa/issue/9645>`__
 -  azure tests: move to fedora 40
-   `commit <https://pagure.io/freeipa/c/19651f8ecc1aba69f96817e676e1dd953bc640ec>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/19651f8ecc1aba69f96817e676e1dd953bc640ec>`__
 -  Custodia: in fips mode add -nomac or -nomacver to openssl pkcs12
-   `commit <https://pagure.io/freeipa/c/ce673216639f4516367952609191e87b1b05e0fa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ce673216639f4516367952609191e87b1b05e0fa>`__
    `#9577 <https://pagure.io/freeipa/issue/9577>`__
 -  ipatests: Add missing comma in test_idrange_no_rid_bases_reversed
-   `commit <https://pagure.io/freeipa/c/b9fc303e61e0b073649810a768d8ad5062d81426>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9fc303e61e0b073649810a768d8ad5062d81426>`__
    `#9656 <https://pagure.io/freeipa/issue/9656>`__
 -  HSM: fix the module name
-   `commit <https://pagure.io/freeipa/c/995c4f3597ccd754c5c329eb190691947808faca>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/995c4f3597ccd754c5c329eb190691947808faca>`__
    `#9636 <https://pagure.io/freeipa/issue/9636>`__
 -  trust-add: handle unavailable domain
-   `commit <https://pagure.io/freeipa/c/88123ad2b32fbdd6206028215e4a58575a37dd9e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88123ad2b32fbdd6206028215e4a58575a37dd9e>`__
    `#9488 <https://pagure.io/freeipa/issue/9488>`__
 -  ipatests: skip HSM test if pki < 11.5.9
-   `commit <https://pagure.io/freeipa/c/bbc232e4898673f3cab9f6b12fac0f04292326c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bbc232e4898673f3cab9f6b12fac0f04292326c6>`__
    `#9648 <https://pagure.io/freeipa/issue/9648>`__
 -  ipatests: increase the timeout for test_hsm.py::TestHSMInstall
-   `commit <https://pagure.io/freeipa/c/bfefe5313f31760072f4a4b06ac493ee124e646f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfefe5313f31760072f4a4b06ac493ee124e646f>`__
 -  Replica CA installation: ignore time skew during initial replication
-   `commit <https://pagure.io/freeipa/c/3b21e191a9ff43bb293bc075a4a26b07375485cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b21e191a9ff43bb293bc075a4a26b07375485cc>`__
    `#9635 <https://pagure.io/freeipa/issue/9635>`__
 -  spec file: do not use nodejs-22 on f39 and f40
-   `commit <https://pagure.io/freeipa/c/acb87a8b220ad2fd9f61b98e7eadce48051f0803>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/acb87a8b220ad2fd9f61b98e7eadce48051f0803>`__
    `#9643 <https://pagure.io/freeipa/issue/9643>`__
 -  ipatests: remove xfail for test_ipa_migrate_stage_mode
-   `commit <https://pagure.io/freeipa/c/cf3a46cc00b237d3845481ee1a4737a92aa94636>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cf3a46cc00b237d3845481ee1a4737a92aa94636>`__
    `#9621 <https://pagure.io/freeipa/issue/9621>`__
 -  ipatests: remove xfail for test_ipa_migrate_version_option
-   `commit <https://pagure.io/freeipa/c/5cfc4b404e27d20b786aac8b22e320c510862c52>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5cfc4b404e27d20b786aac8b22e320c510862c52>`__
    `#9620 <https://pagure.io/freeipa/issue/9620>`__
 -  test_replica_install_after_restore: kinit after restore
-   `commit <https://pagure.io/freeipa/c/0be8d040a7e385c17c8ff98fdee805ccab142ca4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0be8d040a7e385c17c8ff98fdee805ccab142ca4>`__
    `#9613 <https://pagure.io/freeipa/issue/9613>`__
 -  Uninstall: stop sssd-kcm before removing KCM ccaches database
-   `commit <https://pagure.io/freeipa/c/88a392cf840a0ca8eae527863e925ca0b4167513>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/88a392cf840a0ca8eae527863e925ca0b4167513>`__
    `#9616 <https://pagure.io/freeipa/issue/9616>`__
 -  ipa-ods-enforcer: stop must also stop the socket
-   `commit <https://pagure.io/freeipa/c/9110050517b6f1059a29ad578963f0f53c58dbd3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9110050517b6f1059a29ad578963f0f53c58dbd3>`__
    `#9613 <https://pagure.io/freeipa/issue/9613>`__
 -  ipatests: fix / permissions for test_nested_group_members
-   `commit <https://pagure.io/freeipa/c/58003600089f1262971c392ca43a9d0767e57c8c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58003600089f1262971c392ca43a9d0767e57c8c>`__
    `#9615 <https://pagure.io/freeipa/issue/9615>`__
 -  ipatests: fix / permissions to allow ssh with private key
-   `commit <https://pagure.io/freeipa/c/7513575c441ea6d625963f67917ad4879144bc11>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7513575c441ea6d625963f67917ad4879144bc11>`__
    `#9607 <https://pagure.io/freeipa/issue/9607>`__
 -  ipatests: mark test_ca_show_error_handling as xfail
-   `commit <https://pagure.io/freeipa/c/1a83d833e9f252208e9922f061a25d2bd0d0ebc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a83d833e9f252208e9922f061a25d2bd0d0ebc0>`__
    `#9606 <https://pagure.io/freeipa/issue/9606>`__
 -  Gating and nightly tests: move to f39/f40
-   `commit <https://pagure.io/freeipa/c/fd93a3b81686f9d8a5cb926541401232049ccb19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd93a3b81686f9d8a5cb926541401232049ccb19>`__
 -  ipatests: add test for PKINIT renewal on hidden replica
-   `commit <https://pagure.io/freeipa/c/70cd9dd161af558b08c3a76403641e8c8995fffc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/70cd9dd161af558b08c3a76403641e8c8995fffc>`__
    `#9611 <https://pagure.io/freeipa/issue/9611>`__
 -  PKINIT certificate: fix renewal on hidden replica
-   `commit <https://pagure.io/freeipa/c/20df6090765f63a280c8cd5d50a997efdf2d46d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/20df6090765f63a280c8cd5d50a997efdf2d46d3>`__
    `#9611 <https://pagure.io/freeipa/issue/9611>`__
 -  ipatests: add test for ticket 9610
-   `commit <https://pagure.io/freeipa/c/78e96707091e42e0b3e96cf04ac15ff3a93cca5b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/78e96707091e42e0b3e96cf04ac15ff3a93cca5b>`__
    `#9610 <https://pagure.io/freeipa/issue/9610>`__
 -  spec file: do not create /etc/ssh/ssh_config.orig if unchanged
-   `commit <https://pagure.io/freeipa/c/8075512338836c82132ee51cb931611d84c9841d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8075512338836c82132ee51cb931611d84c9841d>`__
    `#9610 <https://pagure.io/freeipa/issue/9610>`__
 -  ipa-otptoken-import: open the key file in binary mode
-   `commit <https://pagure.io/freeipa/c/3249b1247f148f648d8b9696e9e80a8237b4d14c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3249b1247f148f648d8b9696e9e80a8237b4d14c>`__
    `#9609 <https://pagure.io/freeipa/issue/9609>`__
 
 .. _frederik_himpe_2:
@@ -1225,9 +1225,9 @@ Frederik Himpe (2)
 
 -  Make path of Samba lock directory configurable and use /run/samba on
    Debian
-   `commit <https://pagure.io/freeipa/c/c7b6f4d00ef380a2835c00ec00ef69d3b928ea3b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c7b6f4d00ef380a2835c00ec00ef69d3b928ea3b>`__
 -  Make name of nobody group configurable and use nogroup on Debian
-   `commit <https://pagure.io/freeipa/c/1937189e605f4301a25c1f0b4a78b300a4fd76e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1937189e605f4301a25c1f0b4a78b300a4fd76e3>`__
    `#9753 <https://pagure.io/freeipa/issue/9753>`__
 
 .. _fco._javier_f._serrador_2:
@@ -1236,9 +1236,9 @@ Fco. Javier F. Serrador (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/e6be53c1e618c93c5f618428f9705d257fbc8e6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6be53c1e618c93c5f618428f9705d257fbc8e6c>`__
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/a7abe5a7946a044fab22bbd3b5b4bd095c4aa15f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7abe5a7946a044fab22bbd3b5b4bd095c4aa15f>`__
 
 
 .. _francisco_trivino_3:
@@ -1247,10 +1247,10 @@ Francisco Trivino (2)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  doc/designs: add encrypted DNS design documents
-   `commit <https://pagure.io/freeipa/c/79c704fb9d8deef822b341b0beab412f9031793d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/79c704fb9d8deef822b341b0beab412f9031793d>`__
    `#9605 <https://pagure.io/freeipa/issue/9605>`__
 -  ipatests: increase delays for WebUI host test
-   `commit <https://pagure.io/freeipa/c/3cd3d175c17a3f581184d52ea0d25368afef075a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3cd3d175c17a3f581184d52ea0d25368afef075a>`__
    `#9721 <https://pagure.io/freeipa/issue/9721>`__
 
 .. _fraser_tweedale_1:
@@ -1259,7 +1259,7 @@ Fraser Tweedale (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Refactor installer cert issuance to use pki python lib
-   `commit <https://pagure.io/freeipa/c/8aea0fd90018c5f55c9b2ed1a6ef055205752789>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8aea0fd90018c5f55c9b2ed1a6ef055205752789>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 
 .. _dmytro_markevych_1:
@@ -1268,7 +1268,7 @@ Dmytro Markevych (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/286b7caf73316818e4bae3699180246f92b81fc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/286b7caf73316818e4bae3699180246f92b81fc1>`__
 
 .. _ian_brown_1:
 
@@ -1276,7 +1276,7 @@ Ian Brown (1)
 ~~~~~~~~~~~~~
 
 -  Replace instances of del os.environ with os.environ.pop
-   `commit <https://pagure.io/freeipa/c/f3ec6ae8d000add0d2af648645d22191012541a4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3ec6ae8d000add0d2af648645d22191012541a4>`__
    `#9450 <https://pagure.io/freeipa/issue/9450>`__
 
 .. _julien_rische_9:
@@ -1285,33 +1285,33 @@ Julien Rische (11)
 ~~~~~~~~~~~~~~~~~
 
 -  ipatests: fix kdcproxy tests against AD
-   `commit <https://pagure.io/freeipa/c/0aced739267530318eb6b0a977f8bbca85c8ec46>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0aced739267530318eb6b0a977f8bbca85c8ec46>`__
 -  ipa-kdb: enforce PAC presence on TGT for TGS-REQ
-   `commit <https://pagure.io/freeipa/c/bf76899127ef39982f67894b23f6124ab50ce585>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bf76899127ef39982f67894b23f6124ab50ce585>`__
 -  Add test for master key upgrade
-   `commit <https://pagure.io/freeipa/c/fb36633e69e76eabcdd32195a1d3ad08604ab199>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb36633e69e76eabcdd32195a1d3ad08604ab199>`__
 -  Use ipaplatform tasks for krb5 enctypes
-   `commit <https://pagure.io/freeipa/c/fb12d9e14eafeaf036951e98e0d291db892afe2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fb12d9e14eafeaf036951e98e0d291db892afe2d>`__
 -  ipa-kdb: support storing multiple KVNO for the same principal
-   `commit <https://pagure.io/freeipa/c/43b1fd77f10cf2752a44b4b5c219660872e5b1de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43b1fd77f10cf2752a44b4b5c219660872e5b1de>`__
    `#9370 <https://pagure.io/freeipa/issue/9370>`__
 -  kdb: keep ipadb_get_connection() from succeeding with null LDAP
    context
-   `commit <https://pagure.io/freeipa/c/56261bbba4355c33a002df98566b290ef9681c0c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56261bbba4355c33a002df98566b290ef9681c0c>`__
    `#9777 <https://pagure.io/freeipa/issue/9777>`__
 -  ipa-sidgen: fix memory leak in ipa_sidgen_add_post_op
-   `commit <https://pagure.io/freeipa/c/9b938b511c6c9e58ca0cd86888d61cfde99c41d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b938b511c6c9e58ca0cd86888d61cfde99c41d3>`__
    `#9772 <https://pagure.io/freeipa/issue/9772>`__
 -  Remove RC4 and 3DES default encryption types on update
-   `commit <https://pagure.io/freeipa/c/1c566104d661679f9babfac12afc9e44a28d5246>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c566104d661679f9babfac12afc9e44a28d5246>`__
    `#9633 <https://pagure.io/freeipa/issue/9633>`__
 -  Unconditionally add MS-PAC to global config on update
-   `commit <https://pagure.io/freeipa/c/0c79ecb163dac9b7a07c2ab48982eb4823cfde0d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0c79ecb163dac9b7a07c2ab48982eb4823cfde0d>`__
    `#9632 <https://pagure.io/freeipa/issue/9632>`__
 -  kdb: apply combinatorial logic for ticket flags
-   `commit <https://pagure.io/freeipa/c/dfd4492efd47d45bcac4ee1d32d21cae91142df8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfd4492efd47d45bcac4ee1d32d21cae91142df8>`__
 -  kdb: fix vulnerability in GCD rules handling
-   `commit <https://pagure.io/freeipa/c/3b58080f67eb940023d612aabd30533f1dc9387f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b58080f67eb940023d612aabd30533f1dc9387f>`__
 
 .. _jonathan_steffan_1:
 
@@ -1319,7 +1319,7 @@ Jonathan Steffan (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  workshop: Increase RAM for VMs to Avoid OOM
-   `commit <https://pagure.io/freeipa/c/ab82b3d8cfb049c4b7f571c7d99770629b69b349>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ab82b3d8cfb049c4b7f571c7d99770629b69b349>`__
    `#9720 <https://pagure.io/freeipa/issue/9720>`__
 
 .. _léane_grasser_1:
@@ -1328,7 +1328,7 @@ Léane GRASSER (1)
 ~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (French)
-   `commit <https://pagure.io/freeipa/c/326b0a247e1221fe4e1aad3c57a99cf20a68466e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/326b0a247e1221fe4e1aad3c57a99cf20a68466e>`__
 
 .. _takahashi_masatsuna_1:
 
@@ -1336,7 +1336,7 @@ TAKAHASHI Masatsuna (1)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa-advise ipa-backup ipa-restore: Fix --v option of the manual.
-   `commit <https://pagure.io/freeipa/c/224c4517c5ca18bba52fd066c7acc19c55bd7f0a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/224c4517c5ca18bba52fd066c7acc19c55bd7f0a>`__
    `#9617 <https://pagure.io/freeipa/issue/9617>`__
 
 .. _shunsuke_matsumoto_1:
@@ -1345,7 +1345,7 @@ Shunsuke matsumoto (1)
 ~~~~~~~~~~~~~~~~~~~~~~
 
 -  The -d option of the ipa-advise command was able to used.
-   `commit <https://pagure.io/freeipa/c/09aecbc775adbb460218c806578358cfca619843>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/09aecbc775adbb460218c806578358cfca619843>`__
    `#9625 <https://pagure.io/freeipa/issue/9625>`__
 
 .. _miro_hrončok_1:
@@ -1354,7 +1354,7 @@ Miro Hrončok (1)
 ~~~~~~~~~~~~~~~~
 
 -  Stop using deprecated pkg_resources
-   `commit <https://pagure.io/freeipa/c/ac791f7372d32d25c75eb61f949f1db38fe2f0d6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac791f7372d32d25c75eb61f949f1db38fe2f0d6>`__
    `#9676 <https://pagure.io/freeipa/issue/9676>`__
 
 .. _michal_polovka_1:
@@ -1363,7 +1363,7 @@ Michal Polovka (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipatests: test_fips: Remove obsolete patch
-   `commit <https://pagure.io/freeipa/c/e8378a0d779be56cea08d0e57ede2b69cb17c5f1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8378a0d779be56cea08d0e57ede2b69cb17c5f1>`__
    `#9810 <https://pagure.io/freeipa/issue/9810>`__
 
 .. _mark_reynolds_14:
@@ -1372,50 +1372,50 @@ Mark Reynolds (14)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipa-migrate - only remove repl state attribute options
-   `commit <https://pagure.io/freeipa/c/878b800e879c460038ab0d3f6aff96a89a22961e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/878b800e879c460038ab0d3f6aff96a89a22961e>`__
    `#9784 <https://pagure.io/freeipa/issue/9784>`__
 -  ipa-migrate - improve suffix replacement
-   `commit <https://pagure.io/freeipa/c/6cdabdacc950e4c334eb4a3e1666b19178072e36>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6cdabdacc950e4c334eb4a3e1666b19178072e36>`__
    `#9776 <https://pagure.io/freeipa/issue/9776>`__
 -  ipa-migrate - do not process AD entgries in staging mode
-   `commit <https://pagure.io/freeipa/c/1fb3e7fedce745cc1f175d86ca3e9ed6145edad3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1fb3e7fedce745cc1f175d86ca3e9ed6145edad3>`__
    `#9776 <https://pagure.io/freeipa/issue/9776>`__
 -  ipa-migrate - remove replication state information
-   `commit <https://pagure.io/freeipa/c/4e06a4179e3a1c5732add61a31ea2404844feda3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4e06a4179e3a1c5732add61a31ea2404844feda3>`__
    `#9776 <https://pagure.io/freeipa/issue/9776>`__
 -  ipa-migrate - do not migrate tombstone entries, ignore
    MidairCollisions, and krbpwdpolicyreference
-   `commit <https://pagure.io/freeipa/c/4b7235c8b307264d56ac3a3bcdbe85966aad8d8e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b7235c8b307264d56ac3a3bcdbe85966aad8d8e>`__
    `#9737 <https://pagure.io/freeipa/issue/9737>`__
 -  ipa-migrate should migrate dns forward zones
-   `commit <https://pagure.io/freeipa/c/0abfb20c34ade85d5c10a358a73ba33626b2f1ef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0abfb20c34ade85d5c10a358a73ba33626b2f1ef>`__
    `#9686 <https://pagure.io/freeipa/issue/9686>`__
 -  ipa-migrate - dryrun write updates crashes when removing values
-   `commit <https://pagure.io/freeipa/c/1f5954260859b8b891065c023316bd326f2a7680>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1f5954260859b8b891065c023316bd326f2a7680>`__
    `#9682 <https://pagure.io/freeipa/issue/9682>`__
 -  Do not let user with an expired OTP token to log in if only OTP is
    allowed
-   `commit <https://pagure.io/freeipa/c/9ab6601c3103cee1341fb3674a62180ebc482789>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9ab6601c3103cee1341fb3674a62180ebc482789>`__
    `#9387 <https://pagure.io/freeipa/issue/9387>`__
 -  ipa-migrate - fix alternate entry search filter
-   `commit <https://pagure.io/freeipa/c/b98b4a886ee0a75c7cf2c1650e4a0c8a699ac808>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b98b4a886ee0a75c7cf2c1650e4a0c8a699ac808>`__
    `#9658 <https://pagure.io/freeipa/issue/9658>`__
 -  ipa-migrate - fix migration issues with entries using ipaUniqueId in
    the RDN
-   `commit <https://pagure.io/freeipa/c/7808fc8398b54a9008872c3d5cb13ccde4ec10bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7808fc8398b54a9008872c3d5cb13ccde4ec10bc>`__
    `#9640 <https://pagure.io/freeipa/issue/9640>`__
 -  ipa-migrate - properly handle invalid certificates
-   `commit <https://pagure.io/freeipa/c/4d075fdd2aa55730dd54bb46eb3477c06eea626e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d075fdd2aa55730dd54bb46eb3477c06eea626e>`__
    `#9642 <https://pagure.io/freeipa/issue/9642>`__
 -  Issue 9621 - ipa-migrate - should not update mapped attributes in
    managed entries
-   `commit <https://pagure.io/freeipa/c/8d2bf9068ca8f81debdca8cb710602055e1f630c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d2bf9068ca8f81debdca8cb710602055e1f630c>`__
    `#9621 <https://pagure.io/freeipa/issue/9621>`__
 -  ipa-migrate - starttls does not work
-   `commit <https://pagure.io/freeipa/c/31645c414d639f17f7f391fc7a8888c9d5809f3f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/31645c414d639f17f7f391fc7a8888c9d5809f3f>`__
    `#9619 <https://pagure.io/freeipa/issue/9619>`__
 -  ipa-migrate - remove -V option
-   `commit <https://pagure.io/freeipa/c/024d41ebeaa875d500050aad39220d68eb70a709>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/024d41ebeaa875d500050aad39220d68eb70a709>`__
    `#9620 <https://pagure.io/freeipa/issue/9620>`__
 
 .. _madhuri_upadhye_1:
@@ -1424,7 +1424,7 @@ Madhuri Upadhye (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: 2FA test cases
-   `commit <https://pagure.io/freeipa/c/163bf3550b761e78294b693dd880022988c8a232>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/163bf3550b761e78294b693dd880022988c8a232>`__
 
 .. _mohammad_rizwan_3:
 
@@ -1432,13 +1432,13 @@ Mohammad Rizwan (3)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: refactor password file handling in TestHSMInstall
-   `commit <https://pagure.io/freeipa/c/a2d498e0cb131c70811868f59596ba3fd85cadd1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a2d498e0cb131c70811868f59596ba3fd85cadd1>`__
 -  ipatests: Verify that SIDgen task continue even if it fails to assign
    sid
-   `commit <https://pagure.io/freeipa/c/dd1bcd178b388e086dc02541b1b960b2788ce2de>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dd1bcd178b388e086dc02541b1b960b2788ce2de>`__
    `#9618 <https://pagure.io/freeipa/issue/9618>`__
 -  ipatests: tests related to --token-password-file
-   `commit <https://pagure.io/freeipa/c/a11c843adcd5947ef124fc418bfb3e0ac0750ae4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a11c843adcd5947ef124fc418bfb3e0ac0750ae4>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 
 .. _n_m_1:
@@ -1447,7 +1447,7 @@ N M (1)
 ~~~~~~~
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/708ef88a95d0ceadc9c621a4c2231dbd13b96bad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/708ef88a95d0ceadc9c621a4c2231dbd13b96bad>`__
 
 .. _weblate_translation_memory_1:
 
@@ -1455,9 +1455,9 @@ Weblate Translation Memory (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/ebc7c54120c2a0d730da5769baad186d9d29f077>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebc7c54120c2a0d730da5769baad186d9d29f077>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/3a5ce9cb2af362d97d598f2198cbc20c4c32710b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3a5ce9cb2af362d97d598f2198cbc20c4c32710b>`__
 
 .. _weblate_1:
 
@@ -1465,9 +1465,9 @@ Weblate (2)
 ~~~~~~~~~~~
 
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/b2eddfa517c1b8225cff1c402d5eba9b55cd0258>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2eddfa517c1b8225cff1c402d5eba9b55cd0258>`__
 -  Update translation files
-   `commit <https://pagure.io/freeipa/c/d4604698599309a744e83a2e929bf516e6b6619c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d4604698599309a744e83a2e929bf516e6b6619c>`__
 
 .. _oğuz_ersen_1:
 
@@ -1475,7 +1475,7 @@ Oğuz Ersen (1)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Turkish)
-   `commit <https://pagure.io/freeipa/c/e82dd41d080627b2d03871115cbf1a8e7d2b4295>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e82dd41d080627b2d03871115cbf1a8e7d2b4295>`__
 
 .. _piotr_drąg_1:
 
@@ -1483,7 +1483,7 @@ Piotr Drąg (1)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Polish)
-   `commit <https://pagure.io/freeipa/c/f248ad4ada9a5884b9b166b784d13d28bc9d174f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f248ad4ada9a5884b9b166b784d13d28bc9d174f>`__
 
 .. _pejman_rezaei_1:
 
@@ -1491,7 +1491,7 @@ Pejman Rezaei (1)
 ~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Persian)
-   `commit <https://pagure.io/freeipa/c/d0ea5b5aab1fb705ab8ef6b2eb8985ddd096361f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0ea5b5aab1fb705ab8ef6b2eb8985ddd096361f>`__
 
 .. _pranav_thube_1:
 
@@ -1500,15 +1500,15 @@ PRANAV THUBE (4)
 
 -  ipatests: Add new test cases with extended automount plugin
    attributes
-   `commit <https://pagure.io/freeipa/c/9441ebfced3b78c4c8622d11a1942679760f3995>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9441ebfced3b78c4c8622d11a1942679760f3995>`__
 -  Port bash sudo tests.
-   `commit <https://pagure.io/freeipa/c/3894ad88cb0041f6bf7eb61a5328bb688143cde4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3894ad88cb0041f6bf7eb61a5328bb688143cde4>`__
 -  Extended eDNS testsuite with Relaxed policy testcases. 1. Relaxed
    policy without certs and including --no-dnssec-validation 2. Relaxed
    policy with external CA and including --no-dnssec-validation
-   `commit <https://pagure.io/freeipa/c/89fb6ad49a4a1a32bf37adac960d87117e562fc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/89fb6ad49a4a1a32bf37adac960d87117e562fc1>`__
 -  ipatests: Ignore /run/log/journal in test_uninstallation.py
-   `commit <https://pagure.io/freeipa/c/397a85cd29eaf30dfa6c41e8277f1d7e38c21aef>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/397a85cd29eaf30dfa6c41e8277f1d7e38c21aef>`__
    `#9788 <https://pagure.io/freeipa/issue/9788>`__
 
 .. _rafael_fontenelle_1:
@@ -1517,7 +1517,7 @@ Rafael Fontenelle (1)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Spanish)
-   `commit <https://pagure.io/freeipa/c/222bf7662622d566a2c293d6baad2cd21e15be63>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/222bf7662622d566a2c293d6baad2cd21e15be63>`__
 
 .. _rob_crittenden_49:
 
@@ -1525,215 +1525,215 @@ Rob Crittenden (73)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Don't assume the server has a CA service when issuing certificates
-   `commit <https://pagure.io/freeipa/c/ffb8fe35414bd6d24f56be841e44364b14efad31>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffb8fe35414bd6d24f56be841e44364b14efad31>`__
    `#9879 <https://pagure.io/freeipa/issue/9879>`__
 -  Revert "Temp commit"
-   `commit <https://pagure.io/freeipa/c/b7c66bf23b214e12161b70f235999f792d0f202d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7c66bf23b214e12161b70f235999f792d0f202d>`__
 -  PR-CI: Run test_installation_TestInstallKeySizes in the nightlies
-   `commit <https://pagure.io/freeipa/c/0b521f7d19cb1682b67287a7c9f754f5b92b8868>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0b521f7d19cb1682b67287a7c9f754f5b92b8868>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Move some functions to installutils to be more independent
-   `commit <https://pagure.io/freeipa/c/d424dc6dd2b23b485f15c7159090fda391ad78fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d424dc6dd2b23b485f15c7159090fda391ad78fc>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Detect the highest API version the remote server supports
-   `commit <https://pagure.io/freeipa/c/d322bbfb3fd745733ae3ecf245f099f1c3ede9a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d322bbfb3fd745733ae3ecf245f099f1c3ede9a7>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Refine restricting CA profiles to known subjects
-   `commit <https://pagure.io/freeipa/c/f74ff2136488be7fae4c3f99c5f25e0ccd18a3b8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f74ff2136488be7fae4c3f99c5f25e0ccd18a3b8>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Sort when comparing tuples in the xmlrpc tests
-   `commit <https://pagure.io/freeipa/c/56620f400adb183ebd9c37ee69876bc108913f30>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56620f400adb183ebd9c37ee69876bc108913f30>`__
 -  Set minimum version of certmonger and PKI for PKI-API
-   `commit <https://pagure.io/freeipa/c/372468511d18e8b609d7724670713373f01defa1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/372468511d18e8b609d7724670713373f01defa1>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Reduce the log level before calling PKI functions
-   `commit <https://pagure.io/freeipa/c/1729aa4e66fbd2ec38e51a90699f1d481cb55995>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1729aa4e66fbd2ec38e51a90699f1d481cb55995>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Retrieve all cert profiles from the CA with --all
-   `commit <https://pagure.io/freeipa/c/1c107542cf1113079c5562b490c2520663153f0f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1c107542cf1113079c5562b490c2520663153f0f>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Configure renewals to use the IPA JSON API
-   `commit <https://pagure.io/freeipa/c/e8425bd88dfe10e0cb4901ac93b87a3110247097>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8425bd88dfe10e0cb4901ac93b87a3110247097>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Use PKIClient instead of deprecated PKIConnection
-   `commit <https://pagure.io/freeipa/c/7a33bccabd11875d5da16680c1f4213c2c12af13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a33bccabd11875d5da16680c1f4213c2c12af13>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Remove the RestClient class
-   `commit <https://pagure.io/freeipa/c/f5fc5e0fdf87c7b8e23e0289f0b6d810d9335aad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5fc5e0fdf87c7b8e23e0289f0b6d810d9335aad>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Use the APIClient instead of direct REST calls for ACME
-   `commit <https://pagure.io/freeipa/c/191aec5a5278368a4af1836178442f08dfc791b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/191aec5a5278368a4af1836178442f08dfc791b2>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Replace REST with PKI python API for cert and LWCA
-   `commit <https://pagure.io/freeipa/c/43f0284080b9ed51d929ce41bc3bc2e891ffecb5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43f0284080b9ed51d929ce41bc3bc2e891ffecb5>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Add config option for RSA key size for HTTP, DS, PKINIT, RA certs
-   `commit <https://pagure.io/freeipa/c/5d55b4efb24f042142b4c25e72b7c5f6ed1fe305>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5d55b4efb24f042142b4c25e72b7c5f6ed1fe305>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Use the pki tool to bootstrap certificates during installation
-   `commit <https://pagure.io/freeipa/c/cdc8054453cb83c9b7fa9628c86f4566a91815f8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cdc8054453cb83c9b7fa9628c86f4566a91815f8>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Temp commit
-   `commit <https://pagure.io/freeipa/c/b94848ccff807951bacfa42886ec91342094e85e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b94848ccff807951bacfa42886ec91342094e85e>`__
 -  Include the HSM token name when creating LWCAs
-   `commit <https://pagure.io/freeipa/c/3b5caf9dbd31117a88421c639c325f58bee5c93c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b5caf9dbd31117a88421c639c325f58bee5c93c>`__
    `#9865 <https://pagure.io/freeipa/issue/9865>`__
 -  Use Augeas when updating dbmodules in krb5.conf
-   `commit <https://pagure.io/freeipa/c/9605ea9a0b1f190f931e0b491b8ccb9146fa409d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9605ea9a0b1f190f931e0b491b8ccb9146fa409d>`__
    `#5913 <https://pagure.io/freeipa/issue/5913>`__,
    `#9862 <https://pagure.io/freeipa/issue/9862>`__
 -  Add support for libpwpolicy credit to password policy
-   `commit <https://pagure.io/freeipa/c/892fea881a6ceef80affd6d6a3fb9b5afafa969b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/892fea881a6ceef80affd6d6a3fb9b5afafa969b>`__
    `#9835 <https://pagure.io/freeipa/issue/9835>`__
 -  Enforce uniqueness across krbprincipalname and krbcanonicalname
-   `commit <https://pagure.io/freeipa/c/b866ec296b1425d9dba8ab27de78c8519ae24428>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b866ec296b1425d9dba8ab27de78c8519ae24428>`__
 -  Catch decoding errors in CertificateSigningRequest parameters
-   `commit <https://pagure.io/freeipa/c/cc459c8c66349a5fecb2e1060f1fd7b98634bc7e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc459c8c66349a5fecb2e1060f1fd7b98634bc7e>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Don't let lack of subca in PKI prevent LDAP deletion
-   `commit <https://pagure.io/freeipa/c/46b7c16be13c755ccbf87ab4252fe511f68dfd3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/46b7c16be13c755ccbf87ab4252fe511f68dfd3a>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Test that password expiration date past 2038 works
-   `commit <https://pagure.io/freeipa/c/f2a8f5cc9f6ff8f1d6af59f3a384fda3ca8aa93a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2a8f5cc9f6ff8f1d6af59f3a384fda3ca8aa93a>`__
    `#2496 <https://pagure.io/freeipa/issue/2496>`__
 -  Test that certificates beyond 2038 can be parsed
-   `commit <https://pagure.io/freeipa/c/9f49a8daa6d5a2af247efb81e6cddbf9a777a17f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9f49a8daa6d5a2af247efb81e6cddbf9a777a17f>`__
    `#2496 <https://pagure.io/freeipa/issue/2496>`__
 -  Add token options to immutables for pki override
-   `commit <https://pagure.io/freeipa/c/6346ca71d7e4ebbd5737a91372849f2c00b3d293>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6346ca71d7e4ebbd5737a91372849f2c00b3d293>`__
 -  Set krbCanonicalName=admin@REALM on the admin user
-   `commit <https://pagure.io/freeipa/c/6b9400c135ed16b10057b350cc9ce42aa0e862d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6b9400c135ed16b10057b350cc9ce42aa0e862d4>`__
 -  Fix some issues identified by a static analyzer
-   `commit <https://pagure.io/freeipa/c/111e0f04bbcffc6b9fcd3c9e15aa56963b6ea42a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/111e0f04bbcffc6b9fcd3c9e15aa56963b6ea42a>`__
    `#9365 <https://pagure.io/freeipa/issue/9365>`__,
    `#9468 <https://pagure.io/freeipa/issue/9468>`__
 -  Add --domain option to ipa-client-automount for DNS discovery
-   `commit <https://pagure.io/freeipa/c/a58479b0b9d8003b9dd77ef05732edffdd34a7e4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a58479b0b9d8003b9dd77ef05732edffdd34a7e4>`__
    `#9780 <https://pagure.io/freeipa/issue/9780>`__
 -  Test: dnf5 handles updating itself differently than dnf4
-   `commit <https://pagure.io/freeipa/c/b7c17c70a18382aa156327618f5c961eb16fc595>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b7c17c70a18382aa156327618f5c961eb16fc595>`__
 -  Make the Azure template work with both dnf4 and dnf5
-   `commit <https://pagure.io/freeipa/c/d271fc1938e0fe12e1f1a450c67fa850de290279>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d271fc1938e0fe12e1f1a450c67fa850de290279>`__
 -  Azure CI: Use F42
-   `commit <https://pagure.io/freeipa/c/7e254aee3dd2ba0018346821fc79bf2e3ff7ec83>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e254aee3dd2ba0018346821fc79bf2e3ff7ec83>`__
 -  Address deprecation warning in ipa-replica-manage
-   `commit <https://pagure.io/freeipa/c/9743fb96f26bd1c216ba81d3689b2718fb081f3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9743fb96f26bd1c216ba81d3689b2718fb081f3a>`__
    `#9771 <https://pagure.io/freeipa/issue/9771>`__
 -  Don't require certificates to have unique ipaCertSubject
-   `commit <https://pagure.io/freeipa/c/f91b677ada376034b25d50e78475237c5976770e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f91b677ada376034b25d50e78475237c5976770e>`__
    `#9652 <https://pagure.io/freeipa/issue/9652>`__
 -  Drop python 2 support in ipaserver/install/ca.py
-   `commit <https://pagure.io/freeipa/c/6d7f51c115e255873f09fc73d5246b2745016a76>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d7f51c115e255873f09fc73d5246b2745016a76>`__
 -  Drop python 2 support in installutils.py
-   `commit <https://pagure.io/freeipa/c/4a9c1dde579bb048e3d90cfafa93dfd8eef359c2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a9c1dde579bb048e3d90cfafa93dfd8eef359c2>`__
 -  Drop python v2 in ipaserver/install/certs.py for lint errors
-   `commit <https://pagure.io/freeipa/c/56be7b460e7fc070847e589435c951dfba84c13d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/56be7b460e7fc070847e589435c951dfba84c13d>`__
    `#9738 <https://pagure.io/freeipa/issue/9738>`__
 -  Log failed auth attempts over LDAP when a user is locked
-   `commit <https://pagure.io/freeipa/c/dfcc25525ac8f2be4a5ecd8b7bcac8f282b9c4cd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dfcc25525ac8f2be4a5ecd8b7bcac8f282b9c4cd>`__
    `#9742 <https://pagure.io/freeipa/issue/9742>`__
 -  Remove the migration of the RA cert from mod_nss to mod_ssl
-   `commit <https://pagure.io/freeipa/c/42a94e9998804de7470eaf943b03297b06110f75>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42a94e9998804de7470eaf943b03297b06110f75>`__
    `#9739 <https://pagure.io/freeipa/issue/9739>`__
 -  Remove migration from mod_nss to mod_ssl
-   `commit <https://pagure.io/freeipa/c/2085b61cf66d55fe34a66c80af3cefd199624c65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2085b61cf66d55fe34a66c80af3cefd199624c65>`__
    `#9739 <https://pagure.io/freeipa/issue/9739>`__
 -  Fix some memory errors identified by a static analyzer
-   `commit <https://pagure.io/freeipa/c/0dee69d771025f9e2780a592f3a3b82bb75032be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0dee69d771025f9e2780a592f3a3b82bb75032be>`__
    `#9698 <https://pagure.io/freeipa/issue/9698>`__
 -  Use new(er) PKI connection API in ipa-pki-wait-running
-   `commit <https://pagure.io/freeipa/c/8fda2e0dc7c9a029ef365fb0b954dbe88e6931c5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8fda2e0dc7c9a029ef365fb0b954dbe88e6931c5>`__
    `#9691 <https://pagure.io/freeipa/issue/9691>`__
 -  Validate the default e-mail domain in the config plugin
-   `commit <https://pagure.io/freeipa/c/018b3d3dc6d26ec50f73aaea675ecfb8813aaea1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/018b3d3dc6d26ec50f73aaea675ecfb8813aaea1>`__
    `#9680 <https://pagure.io/freeipa/issue/9680>`__
 -  Align startup_timeout with the systemd default and document it
-   `commit <https://pagure.io/freeipa/c/4952dff42df78ed57ac397dd8026c191ae3c9453>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4952dff42df78ed57ac397dd8026c191ae3c9453>`__
    `#9743 <https://pagure.io/freeipa/issue/9743>`__
 -  Configure the pki-tomcatd service systemd timeout
-   `commit <https://pagure.io/freeipa/c/11b4ef749c709738454f7fd72083b430808b93dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/11b4ef749c709738454f7fd72083b430808b93dd>`__
    `#9743 <https://pagure.io/freeipa/issue/9743>`__
 -  Suppress spurious failure messages when uninstalling ACME
-   `commit <https://pagure.io/freeipa/c/18c4a2f9e32728765af3044b2c88fec033c43921>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18c4a2f9e32728765af3044b2c88fec033c43921>`__
    `#9740 <https://pagure.io/freeipa/issue/9740>`__
 -  Add a message where the ipa service restarted at end of install
-   `commit <https://pagure.io/freeipa/c/ac931764341a4832ec0245a7bb01ca53cd777cd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ac931764341a4832ec0245a7bb01ca53cd777cd0>`__
    `#9741 <https://pagure.io/freeipa/issue/9741>`__
 -  Write out the PKI admin certificate as a PEM file
-   `commit <https://pagure.io/freeipa/c/66335486954137aa998d5e2ba939e67a5d82f464>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/66335486954137aa998d5e2ba939e67a5d82f464>`__
    `#9735 <https://pagure.io/freeipa/issue/9735>`__
 -  Apply certmonger_timeout to start_tracking and request_cert
-   `commit <https://pagure.io/freeipa/c/c5300a312775676ce64a3aac3cde2d83ae5f2fde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c5300a312775676ce64a3aac3cde2d83ae5f2fde>`__
    `#9725 <https://pagure.io/freeipa/issue/9725>`__
 -  Add 30-second timeout for certmonger request/start tracking
-   `commit <https://pagure.io/freeipa/c/4776a8babdd25b8fa1afa7e826fd8d153b90f31e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4776a8babdd25b8fa1afa7e826fd8d153b90f31e>`__
    `#9725 <https://pagure.io/freeipa/issue/9725>`__
 -  Pass all pkiuser groups as suplementary when validating an HSM
-   `commit <https://pagure.io/freeipa/c/efadc564eb4ff52375d2c80580f4bc82d5cb11df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/efadc564eb4ff52375d2c80580f4bc82d5cb11df>`__
    `#9709 <https://pagure.io/freeipa/issue/9709>`__
 -  Allow looking up constants.Group by gid in addition to name
-   `commit <https://pagure.io/freeipa/c/65ed1aa1ff093de5dc49c5e7e2ee7cf0f71b225a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65ed1aa1ff093de5dc49c5e7e2ee7cf0f71b225a>`__
    `#9709 <https://pagure.io/freeipa/issue/9709>`__
 -  Don't drop certificates in cert-find if the LWCA was removed
-   `commit <https://pagure.io/freeipa/c/0eafb03110b6ae4c80680e5c451661e1cf41db77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0eafb03110b6ae4c80680e5c451661e1cf41db77>`__
    `#9661 <https://pagure.io/freeipa/issue/9661>`__
 -  Enable pruning when Random Serial Numbers are enabled
-   `commit <https://pagure.io/freeipa/c/6f304bac61eadbacf4f176421c6927b92b74685e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f304bac61eadbacf4f176421c6927b92b74685e>`__
    `#9661 <https://pagure.io/freeipa/issue/9661>`__
 -  Set required version of 389-ds for VLV fix on F40/41
-   `commit <https://pagure.io/freeipa/c/2cd2b8fe43036a97f1051c5aa76fd5ed28e7ed6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2cd2b8fe43036a97f1051c5aa76fd5ed28e7ed6c>`__
 -  Add RSN-by-default test to nightly builds
-   `commit <https://pagure.io/freeipa/c/9248e2df86c3a12c277bd783cd8c9ca7e9603286>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9248e2df86c3a12c277bd783cd8c9ca7e9603286>`__
    `#9661 <https://pagure.io/freeipa/issue/9661>`__
 -  ipatests: Test that when lmdb is available, enable RSN
-   `commit <https://pagure.io/freeipa/c/ed70380cbb97a355a4d84ca61fd27120cda902b9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed70380cbb97a355a4d84ca61fd27120cda902b9>`__
    `#9661 <https://pagure.io/freeipa/issue/9661>`__
 -  Change default to RSN when 389-ds uses the mdb backend
-   `commit <https://pagure.io/freeipa/c/3777d2b06299454766ab70ee479a829d5f6b7fc0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3777d2b06299454766ab70ee479a829d5f6b7fc0>`__
    `#9661 <https://pagure.io/freeipa/issue/9661>`__
 -  Small fixup to determine which ACME uninstaller to use
-   `commit <https://pagure.io/freeipa/c/48479d40b24ac532453ff49d4eb9003c73b9b403>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/48479d40b24ac532453ff49d4eb9003c73b9b403>`__
    `#9673 <https://pagure.io/freeipa/issue/9673>`__,
    `#9674 <https://pagure.io/freeipa/issue/9674>`__
 -  Don't rely on removing the CA to uninstall the ACME depoyment
-   `commit <https://pagure.io/freeipa/c/273f68b77b75845cc7194187405d8c8c8203b834>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/273f68b77b75845cc7194187405d8c8c8203b834>`__
    `#9673 <https://pagure.io/freeipa/issue/9673>`__,
    `#9674 <https://pagure.io/freeipa/issue/9674>`__
 -  Fix some resource leaks identified by a static analyzer
-   `commit <https://pagure.io/freeipa/c/15de71ae61b0f97689bc8cf38256446f3e7922c1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15de71ae61b0f97689bc8cf38256446f3e7922c1>`__
    `#9367 <https://pagure.io/freeipa/issue/9367>`__
 -  Ignore TripleDES python-cryptography import warnings
-   `commit <https://pagure.io/freeipa/c/2aa49424ff46a1e388514e8f91dca3b6b7b8b6fe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2aa49424ff46a1e388514e8f91dca3b6b7b8b6fe>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  Correct usage of public_key_algorithm_oid in ipalib/x509
-   `commit <https://pagure.io/freeipa/c/1ef3396647bd0049cbee2dcbe91cd3c536dccc78>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ef3396647bd0049cbee2dcbe91cd3c536dccc78>`__
    `#9641 <https://pagure.io/freeipa/issue/9641>`__
 -  Force a logout in KerberosSession if a login is needed
-   `commit <https://pagure.io/freeipa/c/64937571fdf3534b89d8db9ccb8b5ac1abfb5a6d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64937571fdf3534b89d8db9ccb8b5ac1abfb5a6d>`__
    `#9624 <https://pagure.io/freeipa/issue/9624>`__
 -  Log errors reported by adtrustinstance.check_inst() using logger
-   `commit <https://pagure.io/freeipa/c/1dc84ba7ebf1bb3b2734a9ea0dd1a4ba6660c93b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1dc84ba7ebf1bb3b2734a9ea0dd1a4ba6660c93b>`__
    `#9637 <https://pagure.io/freeipa/issue/9637>`__
 -  ipatests: Fix usage of token_password_file
-   `commit <https://pagure.io/freeipa/c/fd5ce0caf5741aaba1f15296f2b077043a290883>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fd5ce0caf5741aaba1f15296f2b077043a290883>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Run HSM validation as pkiuser to verify token permissions
-   `commit <https://pagure.io/freeipa/c/202de166c6057cdfd9bd024069c8e9e6a87c34d0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/202de166c6057cdfd9bd024069c8e9e6a87c34d0>`__
    `#9626 <https://pagure.io/freeipa/issue/9626>`__
 -  Fix a copy/paste issue when detecting the HSM SELinux subpackage
-   `commit <https://pagure.io/freeipa/c/c40ce0e1ff01cbecf2d83377f48c0ace55fd1ed9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c40ce0e1ff01cbecf2d83377f48c0ace55fd1ed9>`__
    `#9636 <https://pagure.io/freeipa/issue/9636>`__
 -  Include token password options in ipa-kra-install man page
-   `commit <https://pagure.io/freeipa/c/8d5461bea785c43a14725a2fb8f5f705758c54ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d5461bea785c43a14725a2fb8f5f705758c54ed>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Re-organize HSM validation to be more consistent/less duplication
-   `commit <https://pagure.io/freeipa/c/23de845987c0776f77d8b8caeabf51f312bca5a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/23de845987c0776f77d8b8caeabf51f312bca5a6>`__
    `#9603 <https://pagure.io/freeipa/issue/9603>`__
 -  Fix syntax error in the selinux-luna %postun script
-   `commit <https://pagure.io/freeipa/c/d0f15a6d01a592c9f8ecc9a904691fab80ba284b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0f15a6d01a592c9f8ecc9a904691fab80ba284b>`__
    `#9629 <https://pagure.io/freeipa/issue/9629>`__
 -  Use a unique task name for each backend in ipa-backup
-   `commit <https://pagure.io/freeipa/c/65bea69358b07fdd54d4f890a3752548200dd5bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/65bea69358b07fdd54d4f890a3752548200dd5bd>`__
    `#9584 <https://pagure.io/freeipa/issue/9584>`__
 
 .. _ricky_tigg_3:
@@ -1742,11 +1742,11 @@ Ricky Tigg (3)
 ~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/83d22c5e451e46081c23481af321d9b078c11ae9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/83d22c5e451e46081c23481af321d9b078c11ae9>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/ba2985013f0a81e2cebb8eb9bb02f54c367191f0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba2985013f0a81e2cebb8eb9bb02f54c367191f0>`__
 -  Translated using Weblate (Finnish)
-   `commit <https://pagure.io/freeipa/c/05a6e52d4de4f3445c8b7dc46c6ea386391b876c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05a6e52d4de4f3445c8b7dc46c6ea386391b876c>`__
 
 .. _rafael_guterres_jeffman_1:
 
@@ -1754,10 +1754,10 @@ Rafael Guterres Jeffman (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa-idrange-fix: Fix typo when ID under 1000 is present.
-   `commit <https://pagure.io/freeipa/c/c98d1b819e1fc3f4a63a2e61823b69be996e95ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c98d1b819e1fc3f4a63a2e61823b69be996e95ed>`__
    `#9885 <https://pagure.io/freeipa/issue/9885>`__
 -  Use correct capitalization for GitHub and GitLab
-   `commit <https://pagure.io/freeipa/c/9d7689f95913bff472661b5f9e4ad11c07cd405d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9d7689f95913bff472661b5f9e4ad11c07cd405d>`__
    `#9811 <https://pagure.io/freeipa/issue/9811>`__
 
 .. _sam_morris_2:
@@ -1767,11 +1767,11 @@ Sam Morris (2)
 
 -  Fix ipa-client-install failure when a trusted CA's distinguished name
    contains slash characters
-   `commit <https://pagure.io/freeipa/c/64809910912237ff40a18eeda9ed1c9e2e21dfaa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/64809910912237ff40a18eeda9ed1c9e2e21dfaa>`__
    `#8924 <https://pagure.io/freeipa/issue/8924>`__
 -  Fix a couple of instances of the "no-break control character" being
    used inadvertently
-   `commit <https://pagure.io/freeipa/c/2df2066a4ea5113187039371adc25fcd1d4ab7b5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2df2066a4ea5113187039371adc25fcd1d4ab7b5>`__
    `#9665 <https://pagure.io/freeipa/issue/9665>`__
 
 .. _sumit_bose_1:
@@ -1780,7 +1780,7 @@ Sumit Bose (1)
 ~~~~~~~~~~~~~~
 
 -  ipa-otpd: use oidc_child's --client-secret-stdin option
-   `commit <https://pagure.io/freeipa/c/bd844036dd7931ffca9acf4884f17c177625d770>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bd844036dd7931ffca9acf4884f17c177625d770>`__
 
 .. _김인수_2:
 
@@ -1788,9 +1788,9 @@ Sumit Bose (1)
 ~~~~~~~~~~
 
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/4ccde2ed99a544765bc97254de39eb3e16810c9a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4ccde2ed99a544765bc97254de39eb3e16810c9a>`__
 -  Translated using Weblate (Korean)
-   `commit <https://pagure.io/freeipa/c/68cdca3d94e951855d41398ea730a0d92029215b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/68cdca3d94e951855d41398ea730a0d92029215b>`__
 
 .. _stanislav_levin_4:
 
@@ -1798,17 +1798,17 @@ Stanislav Levin (4)
 ~~~~~~~~~~~~~~~~~~~
 
 -  install: make use of shared temp directory for hsm validation
-   `commit <https://pagure.io/freeipa/c/7e436ff6fe3c78f605cd63e98bd560cfefb5a293>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e436ff6fe3c78f605cd63e98bd560cfefb5a293>`__
    `#9831 <https://pagure.io/freeipa/issue/9831>`__
 -  adtrust: add missing ipaAllowedOperations objectclass
-   `commit <https://pagure.io/freeipa/c/e184864a3025a6ccd522556fffa4014e6ae7bbc1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e184864a3025a6ccd522556fffa4014e6ae7bbc1>`__
    `#9471 <https://pagure.io/freeipa/issue/9471>`__,
    `#9712 <https://pagure.io/freeipa/issue/9712>`__
 -  pyca: adapt import paths for TripleDES cipher
-   `commit <https://pagure.io/freeipa/c/bc31c2700c3779cfad688eb098042060bf09df3c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bc31c2700c3779cfad688eb098042060bf09df3c>`__
    `#9708 <https://pagure.io/freeipa/issue/9708>`__
 -  ipatests: make TestDuplicates teardowns order agnostic
-   `commit <https://pagure.io/freeipa/c/18d550a3367710618675b87f0157685165bfe444>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/18d550a3367710618675b87f0157685165bfe444>`__
    `#9571 <https://pagure.io/freeipa/issue/9571>`__
 
 .. _sumedh_sidhaye_2:
@@ -1817,10 +1817,10 @@ Sumedh Sidhaye (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Temp commit
-   `commit <https://pagure.io/freeipa/c/a5132136cd4f0b4ba900784be40a7eccc8debcad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5132136cd4f0b4ba900784be40a7eccc8debcad>`__
 -  Validate message to check if not a trust agent/controller Previously
    the check would return an empty SUCCESS message.
-   `commit <https://pagure.io/freeipa/c/e9a644feb065d9729514cd84407071a758029ac5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e9a644feb065d9729514cd84407071a758029ac5>`__
 
 
 .. _sudhir_menon_23:
@@ -1829,60 +1829,60 @@ Sudhir Menon (22)
 ~~~~~~~~~~~~~~~~~
 
 -  ipatests: Nightly definitions for TestIPAMigratewithBackupRestore
-   `commit <https://pagure.io/freeipa/c/15d5093f6d0856fcd6ad76e03ad78bedfecad972>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/15d5093f6d0856fcd6ad76e03ad78bedfecad972>`__
 -  ipatests: Tests for ipa-migrate tool with ldif file
-   `commit <https://pagure.io/freeipa/c/82fa9f1e887d6b3a83fb4f1edc0a520d7dcfbc2d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/82fa9f1e887d6b3a83fb4f1edc0a520d7dcfbc2d>`__
    `#9776 <https://pagure.io/freeipa/issue/9776>`__
 -  ipatests: prci nightly definitions for 32BitIdranges
-   `commit <https://pagure.io/freeipa/c/43033b0c01234564a826b60f0a00943b92a5ef06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/43033b0c01234564a826b60f0a00943b92a5ef06>`__
 -  ipatests: Tests for 32BitIdranges.
-   `commit <https://pagure.io/freeipa/c/49ae3f15806bb3c160a31898d35078d592b9c5d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/49ae3f15806bb3c160a31898d35078d592b9c5d3>`__
 -  Added TestIPAHealthcheckWithCALess to nightly yaml file.
-   `commit <https://pagure.io/freeipa/c/30e707c4b48ca9c49e07e78114bcbe1ea7922de3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30e707c4b48ca9c49e07e78114bcbe1ea7922de3>`__
 -  ipatests: ipahealthcheck warns for user provided certificates about
    to expire
-   `commit <https://pagure.io/freeipa/c/cca17c67f9e23351ec02b06f723e4980e67025c0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cca17c67f9e23351ec02b06f723e4980e67025c0>`__
 -  ipatests: Tests for krbLastSuccessfulAuth warning
-   `commit <https://pagure.io/freeipa/c/669d8af5dd8dd040317e12c9760d3c69dc5982e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/669d8af5dd8dd040317e12c9760d3c69dc5982e1>`__
 -  ipatests: Test to check dot forwarders are added to unbound.
-   `commit <https://pagure.io/freeipa/c/d2bd254c88ac6dbf8ad2219f5eedf74a2386197d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d2bd254c88ac6dbf8ad2219f5eedf74a2386197d>`__
 -  ipatests: Fix for ipa-healthcheck test in FIPS Mode
-   `commit <https://pagure.io/freeipa/c/6ddf7e94c73fb28c3fa5f4402886c1fdc7b27bd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ddf7e94c73fb28c3fa5f4402886c1fdc7b27bd6>`__
 -  ipatests: Tests to check data in journal log
-   `commit <https://pagure.io/freeipa/c/08450eefe6ef671a11dcc9572cdcec20819c2dd8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/08450eefe6ef671a11dcc9572cdcec20819c2dd8>`__
 -  Fix the typo in ipa_migrate_constants.
-   `commit <https://pagure.io/freeipa/c/1a9ee0d85b1d8b05dcb88e965a003fff466ffdd0>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a9ee0d85b1d8b05dcb88e965a003fff466ffdd0>`__
    `#9715 <https://pagure.io/freeipa/issue/9715>`__
 -  ipatests: Updated nightly definitions for ipa-ipa-migration
-   `commit <https://pagure.io/freeipa/c/e8ed1d70f7080700726b66c67181574972bcfcb7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8ed1d70f7080700726b66c67181574972bcfcb7>`__
 -  ipatests: Tests for ipa-migrate tool
-   `commit <https://pagure.io/freeipa/c/07f33365d8868bf9c62fe1617f97b6073419a14b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/07f33365d8868bf9c62fe1617f97b6073419a14b>`__
 -  ipatests: Test for ipa hbac rule duplication
-   `commit <https://pagure.io/freeipa/c/e1f96ffc2070ba7036c1108c6621450ab8f3f1f5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e1f96ffc2070ba7036c1108c6621450ab8f3f1f5>`__
    `#9640 <https://pagure.io/freeipa/issue/9640>`__
 -  ipatests: Activate ssh in sssd.conf
-   `commit <https://pagure.io/freeipa/c/c37f4d09e2c97ee90a0acebf2c3bc30fed4e85ad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c37f4d09e2c97ee90a0acebf2c3bc30fed4e85ad>`__
    `#9649 <https://pagure.io/freeipa/issue/9649>`__
 -  ipatests: Fixes for ipa-idrange-fix testsuite
-   `commit <https://pagure.io/freeipa/c/26af2164a464f4df544d6850eb1ba21b14df45a6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/26af2164a464f4df544d6850eb1ba21b14df45a6>`__
 -  ipatests: Check Default PAC type is added to config
-   `commit <https://pagure.io/freeipa/c/b07f1d970b2ca4877daa6232acd6786bcebeb5a7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b07f1d970b2ca4877daa6232acd6786bcebeb5a7>`__
    `#9632 <https://pagure.io/freeipa/issue/9632>`__
 -  ipatests: Test to check that the configured value for
    "nsslapd-ignore-time-skew" remains on even after a "force-sync" is
    done
-   `commit <https://pagure.io/freeipa/c/b56d434953b93a0cecd2ee57194862e36b2ae3b2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b56d434953b93a0cecd2ee57194862e36b2ae3b2>`__
    `#9635 <https://pagure.io/freeipa/issue/9635>`__
 -  ipatests: Replace 'usermod -r' command with 'gpasswd -d' in
    test_hsm.py
-   `commit <https://pagure.io/freeipa/c/58c1fdd41681c15f39b59bbb5e39b2e1cf245c6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/58c1fdd41681c15f39b59bbb5e39b2e1cf245c6c>`__
    `#9626 <https://pagure.io/freeipa/issue/9626>`__
 -  ipatests: ipa-migrate tool with -Z option (CACERTFILE)
-   `commit <https://pagure.io/freeipa/c/e8189933c72ee0b312a91ec5d63179e6e75661a5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8189933c72ee0b312a91ec5d63179e6e75661a5>`__
 -  Added new testsuite(ipa_ipa_migration) in prci definitions
-   `commit <https://pagure.io/freeipa/c/565339803cf357aa8f2a04f849d04217efec5b97>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/565339803cf357aa8f2a04f849d04217efec5b97>`__
 -  ipatests: Tests for ipa-ipa migration tool
-   `commit <https://pagure.io/freeipa/c/5fe7cf50a98b7d37f24a900d506249611b9fd241>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5fe7cf50a98b7d37f24a900d506249611b9fd241>`__
 
 .. _temuri_doghonadze_3:
 
@@ -1890,15 +1890,15 @@ Temuri Doghonadze (5)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/458f32ac8a7caf8e9c773be9e56a9d9a4586f9a8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/458f32ac8a7caf8e9c773be9e56a9d9a4586f9a8>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/2ecfce6f3692b44af489f2e17240ca703b0e2a20>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2ecfce6f3692b44af489f2e17240ca703b0e2a20>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/8bc64a26f6fe1302c000dcf1677a89b2bd7826ea>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8bc64a26f6fe1302c000dcf1677a89b2bd7826ea>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/7ab7c808accc957b7bfb0669a81da9f778bb08f2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7ab7c808accc957b7bfb0669a81da9f778bb08f2>`__
 -  Translated using Weblate (Georgian)
-   `commit <https://pagure.io/freeipa/c/deb37ef26e442d82cd646f4e76f81a9a6fa9ca58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deb37ef26e442d82cd646f4e76f81a9a6fa9ca58>`__
 
 .. _thomas_woerner_5:
 
@@ -1906,20 +1906,20 @@ Thomas Woerner (5)
 ~~~~~~~~~~~~~~~~~~
 
 -  Replica: Request cert for DoT before setting up bind
-   `commit <https://pagure.io/freeipa/c/47626a950f343c3ae7c49bc99f4c25d976c0bdb6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/47626a950f343c3ae7c49bc99f4c25d976c0bdb6>`__
    `#9808 <https://pagure.io/freeipa/issue/9808>`__
 -  ipaserver/install/dns.py: Allow to Turn off DNSSEC validation for
    unbound
-   `commit <https://pagure.io/freeipa/c/0bc089681c77c7c65412ca8f02b724ff9088e0f7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0bc089681c77c7c65412ca8f02b724ff9088e0f7>`__
    `#9805 <https://pagure.io/freeipa/issue/9805>`__
 -  ipa-client-install: New --no-dnssec-validation option
-   `commit <https://pagure.io/freeipa/c/4b877c7ccd68a829b3d05aa3b5de01df5730a4dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4b877c7ccd68a829b3d05aa3b5de01df5730a4dd>`__
    `#9805 <https://pagure.io/freeipa/issue/9805>`__
 -  ipa-client-install: Fix nsupdate issues when dns_over_tls is enabled
-   `commit <https://pagure.io/freeipa/c/974a507ee0105fc05e455df6e5316e0e84f3f181>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/974a507ee0105fc05e455df6e5316e0e84f3f181>`__
    `#9806 <https://pagure.io/freeipa/issue/9806>`__
 -  ipa_sidgen: Allow sidgen_task to continue after finding issues
-   `commit <https://pagure.io/freeipa/c/faa0aa5de1b4618bc0f1fcee98f136983e21e735>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faa0aa5de1b4618bc0f1fcee98f136983e21e735>`__
    `#9618 <https://pagure.io/freeipa/issue/9618>`__
 
 .. _vectinx_1:
@@ -1928,7 +1928,7 @@ vectinx (1)
 ~~~~~~~~~~~
 
 -  slapi-plugins: Add replication checking to the Modrdn plugin
-   `commit <https://pagure.io/freeipa/c/a4a218b4ebe490a1d55132e5a19202ca675d393a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4a218b4ebe490a1d55132e5a19202ca675d393a>`__
    `#9867 <https://pagure.io/freeipa/issue/9867>`__
 
 .. _vasily_parfenov_1:
@@ -1937,7 +1937,7 @@ Vasily Parfenov (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  man: fix incorrect groff syntax in man pages
-   `commit <https://pagure.io/freeipa/c/071e5fe3764feba11edb664b718ad0e614b2ea66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/071e5fe3764feba11edb664b718ad0e614b2ea66>`__
 
 .. _wouter_schoot_1:
 
@@ -1945,7 +1945,7 @@ Wouter Schoot (1)
 ~~~~~~~~~~~~~~~~~
 
 -  Update 11-kerberos-ticket-policy.rst
-   `commit <https://pagure.io/freeipa/c/3ade90de022b8b1d6519f0dd020a9e3c05b06e62>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3ade90de022b8b1d6519f0dd020a9e3c05b06e62>`__
 
 .. _yaakov_selkowitz_1:
 
@@ -1953,7 +1953,7 @@ Yaakov Selkowitz (1)
 ~~~~~~~~~~~~~~~~~~~~
 
 -  spec: Use nodejs22 on RHEL 10 and ELN
-   `commit <https://pagure.io/freeipa/c/d9c200aac6aa384b465194de0a4a6eb4faed8afc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d9c200aac6aa384b465194de0a4a6eb4faed8afc>`__
 
 .. _yuri_chornoivan_1:
 
@@ -1961,4 +1961,4 @@ Yuri Chornoivan (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Translated using Weblate (Ukrainian)
-   `commit <https://pagure.io/freeipa/c/30fee9cbb77fb32f18910b09fd3dffbd6694e5cf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/30fee9cbb77fb32f18910b09fd3dffbd6694e5cf>`__

--- a/src/release-notes/4-13-1.rst
+++ b/src/release-notes/4-13-1.rst
@@ -105,7 +105,7 @@ MOHAMMAD SAMI (1)
 ~~~~~~~~~~~~~~~~~
 
 -  Fix incorrect error handling in ipapython/graph.py
-   `commit <https://pagure.io/freeipa/c/f094818347d48606e186e8ad9c6d05ce74c04560>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f094818347d48606e186e8ad9c6d05ce74c04560>`__
    `#9876 <https://pagure.io/freeipa/issue/9876>`__
 
 .. _anuja_more_2:
@@ -114,11 +114,11 @@ Anuja More (2)
 ~~~~~~~~~~~~~~
 
 -  ipatests: sysaccounts: add missing integration/webui/xmlrpc tests
-   `commit <https://pagure.io/freeipa/c/386e9f37af484fc018b174ffcbe5f2e59a783cb4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/386e9f37af484fc018b174ffcbe5f2e59a783cb4>`__
    `#9842 <https://pagure.io/freeipa/issue/9842>`__
 -  sysaccount_mod: Use object.\__setattr\_\_ to set allow_empty_update
    in exception handler
-   `commit <https://pagure.io/freeipa/c/f580f12e5bcace2dbbee493f093bd62937cc2e3a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f580f12e5bcace2dbbee493f093bd62937cc2e3a>`__
 
 .. _antonio_torres_1:
 
@@ -126,7 +126,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/a4617fb04bfb5f5520d52018ee1500d8c86a5776>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a4617fb04bfb5f5520d52018ee1500d8c86a5776>`__
 
 .. _aleksandr_sharov_1:
 
@@ -135,7 +135,7 @@ Aleksandr Sharov (1)
 
 -  Adding option --force-server to specify a server to ipa-certupdate
    tool.
-   `commit <https://pagure.io/freeipa/c/573c9194d9894eb2bea6db77e142cdd899e78bd6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/573c9194d9894eb2bea6db77e142cdd899e78bd6>`__
    `#9839 <https://pagure.io/freeipa/issue/9839>`__
 
 .. _carla_martinez_1:
@@ -144,7 +144,7 @@ Carla Martinez (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Fix: Incorrect auth error message
-   `commit <https://pagure.io/freeipa/c/f39acce91176c043dd531646a2acd0b7678779e2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f39acce91176c043dd531646a2acd0b7678779e2>`__
    `#9891 <https://pagure.io/freeipa/issue/9891>`__
 
 .. _david_hanina_2:
@@ -153,9 +153,9 @@ David Hanina (2)
 ~~~~~~~~~~~~~~~~
 
 -  Update webui to v.0.1.9
-   `commit <https://pagure.io/freeipa/c/250ab5412cc51ed20b9bbd647bb4e8c6c8ed927f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/250ab5412cc51ed20b9bbd647bb4e8c6c8ed927f>`__
 -  Delete modern-ui images for RHEL
-   `commit <https://pagure.io/freeipa/c/ffde59d26020381ffe61da30d20af3d20f7550d3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ffde59d26020381ffe61da30d20af3d20f7550d3>`__
    `#9915 <https://pagure.io/freeipa/issue/9915>`__
 
 .. _florence_blanc_renaud_6:
@@ -164,22 +164,22 @@ Florence Blanc-Renaud (6)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipa-migrate: avoid KeyError before attributes are normalized
-   `commit <https://pagure.io/freeipa/c/9b09e9b7240ccedca60e812ed1b2337ed476e471>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b09e9b7240ccedca60e812ed1b2337ed476e471>`__
    `#9910 <https://pagure.io/freeipa/issue/9910>`__
 -  Upgrade: use openssl_engine on rhel9
-   `commit <https://pagure.io/freeipa/c/6ddd9d978ac1d70acf688667515f916ee4373c42>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6ddd9d978ac1d70acf688667515f916ee4373c42>`__
    `#9913 <https://pagure.io/freeipa/issue/9913>`__
 -  ipatests: do not allow zone overlap for TestInstallWithCA_DNS4
-   `commit <https://pagure.io/freeipa/c/b5458214311abc3ee1fae7133487fb1ad6977011>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5458214311abc3ee1fae7133487fb1ad6977011>`__
    `#9902 <https://pagure.io/freeipa/issue/9902>`__
 -  ipatest: add an integration test for samba upgrade
-   `commit <https://pagure.io/freeipa/c/c03f7eb2b9a0ee36d0ad396f3e4e4e8a6e40ecd2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c03f7eb2b9a0ee36d0ad396f3e4e4e8a6e40ecd2>`__
    `#9892 <https://pagure.io/freeipa/issue/9892>`__
 -  Trust: fix tdo with WITH_FOREST
-   `commit <https://pagure.io/freeipa/c/6f0cd075e5a588628a98d3b4a95e755af59845d7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f0cd075e5a588628a98d3b4a95e755af59845d7>`__
    `#9892 <https://pagure.io/freeipa/issue/9892>`__
 -  Nightly test definitions: configure 4.13 branch
-   `commit <https://pagure.io/freeipa/c/b575e3dc39b84af69fd71ddb77c01fe4b24a2d66>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b575e3dc39b84af69fd71ddb77c01fe4b24a2d66>`__
 
 .. _mohammad_rizwan_1:
 
@@ -187,7 +187,7 @@ Mohammad Rizwan (1)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: allow dns zone overlap where dns is handled externaly
-   `commit <https://pagure.io/freeipa/c/381e00e5db1542fe887324729c042b04fb5d4470>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/381e00e5db1542fe887324729c042b04fb5d4470>`__
 
 .. _pranav_thube_2:
 
@@ -195,9 +195,9 @@ PRANAV THUBE (2)
 ~~~~~~~~~~~~~~~~
 
 -  ipatests: Refactor and port hbac functional tests.
-   `commit <https://pagure.io/freeipa/c/fdfce9ac5239e0296b0bd86030028cecf1f92bfa>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdfce9ac5239e0296b0bd86030028cecf1f92bfa>`__
 -  Extended eDNS testsuite with Enforced DNS policy testcases.
-   `commit <https://pagure.io/freeipa/c/c8c71922255095e67f48cb06e8d27472b175ee51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c8c71922255095e67f48cb06e8d27472b175ee51>`__
 
 .. _rob_crittenden_2:
 
@@ -205,10 +205,10 @@ Rob Crittenden (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  ipa-pwd-extop: Don't manipulate the config if not retrieved
-   `commit <https://pagure.io/freeipa/c/d6f7c0b14c7211b603b47e8fe3851ba0197ed38c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d6f7c0b14c7211b603b47e8fe3851ba0197ed38c>`__
    `#9914 <https://pagure.io/freeipa/issue/9914>`__
 -  ipatests: Add the remote IP before running ipa-migrate
-   `commit <https://pagure.io/freeipa/c/f28c8a2bc39e44b1ec5883fe828625e5a5575adb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f28c8a2bc39e44b1ec5883fe828625e5a5575adb>`__
    `#9884 <https://pagure.io/freeipa/issue/9884>`__
 
 .. _viktor_ashirov_17:
@@ -217,53 +217,53 @@ Viktor Ashirov (17)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipa-pwd-extop: fix valueset memory leak in \`ipapwd_get_cur_kvno()\`
-   `commit <https://pagure.io/freeipa/c/edc00aae575399a6c11f7b9d1ca5bbd833459274>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/edc00aae575399a6c11f7b9d1ca5bbd833459274>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix memory leaks in \`ipapwd_gen_hashes()\` error path
-   `commit <https://pagure.io/freeipa/c/614b3cdc872427e632870413b8f44d6ba1373cc8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/614b3cdc872427e632870413b8f44d6ba1373cc8>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix password history values memory leak
-   `commit <https://pagure.io/freeipa/c/370cdf03572463688445cece88bacbc8b797cc5d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/370cdf03572463688445cece88bacbc8b797cc5d>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix NT hash string memory leak
-   `commit <https://pagure.io/freeipa/c/f5e47c974b4e5fa32e9a00db89df16bee2fd3f84>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f5e47c974b4e5fa32e9a00db89df16bee2fd3f84>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix bind DN memory leaks in pre-op handlers
-   `commit <https://pagure.io/freeipa/c/1545c3fd7dc9c5765dcdf83bbb591c46eb489de3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1545c3fd7dc9c5765dcdf83bbb591c46eb489de3>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix memory leaks in \`ipapwd_pre_add()\`
-   `commit <https://pagure.io/freeipa/c/28979893e620a033878405b9edeaa4bca730f9fc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/28979893e620a033878405b9edeaa4bca730f9fc>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix memory leaks of bind DN
-   `commit <https://pagure.io/freeipa/c/1a7819b2c6145f8686771cf305a43589b5028c51>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1a7819b2c6145f8686771cf305a43589b5028c51>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/8eeccb6dba8861731a786dd1b115a1eac6c1d98d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8eeccb6dba8861731a786dd1b115a1eac6c1d98d>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: free krbcfg in all exit paths
-   `commit <https://pagure.io/freeipa/c/ba9074c9605bed6466580c10657fc7b1341aacbf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba9074c9605bed6466580c10657fc7b1341aacbf>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  topology: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/61bc55c9c3951f7653b6d63be512c654650ffd77>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/61bc55c9c3951f7653b6d63be512c654650ffd77>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-enrollment: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/bfc9552d565dc2bb452ae79e2bc972b419e81cad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bfc9552d565dc2bb452ae79e2bc972b419e81cad>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-extdom-extop: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/4a62d6141af54b77408628877a1027c3ea5a106f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4a62d6141af54b77408628877a1027c3ea5a106f>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-range-check: fix memory leak
-   `commit <https://pagure.io/freeipa/c/0e409d1955d4e2248b05310962671e1f9c8a069e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0e409d1955d4e2248b05310962671e1f9c8a069e>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-sidgen: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/67ea4467eca5fdb6df9b267445cee41dc5d8691e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67ea4467eca5fdb6df9b267445cee41dc5d8691e>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-pwd-extop: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/29699af133ce7c9e1570376c978d4ecce217825f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/29699af133ce7c9e1570376c978d4ecce217825f>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-lockout: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/819fddc3d201e5764538878c78ddf3da7c8c0326>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/819fddc3d201e5764538878c78ddf3da7c8c0326>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__
 -  ipa-graceperiod: fix memory leaks
-   `commit <https://pagure.io/freeipa/c/c173a70c8581bf25e063766039f0ea875c8f5691>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c173a70c8581bf25e063766039f0ea875c8f5691>`__
    `#9895 <https://pagure.io/freeipa/issue/9895>`__

--- a/src/release-notes/4-6-10.rst
+++ b/src/release-notes/4-6-10.rst
@@ -68,7 +68,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.6.10
-   `commit <https://pagure.io/freeipa/c/9c617675d6676fcdb0e9d67fed6bb801e0066bfe>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9c617675d6676fcdb0e9d67fed6bb801e0066bfe>`__
 
 .. _florence_blanc_renaud_2:
 
@@ -76,6 +76,6 @@ Florence Blanc-Renaud (2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Integration tests for verifying Referer header in the UI
-   `commit <https://pagure.io/freeipa/c/c86dcf42bc7109baacb17642753fb6c597c6325a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c86dcf42bc7109baacb17642753fb6c597c6325a>`__
 -  Check the HTTP Referer header on all requests
-   `commit <https://pagure.io/freeipa/c/cc3a1dbdbcbf7f5c73c472068dad68d8abb6b677>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc3a1dbdbcbf7f5c73c472068dad68d8abb6b677>`__

--- a/src/release-notes/4-9-12.rst
+++ b/src/release-notes/4-9-12.rst
@@ -157,24 +157,24 @@ Alexander Bokovoy (6)
 
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
-   `commit <https://pagure.io/freeipa/c/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
    `#9355 <https://pagure.io/freeipa/issue/9355>`__
 -  Fix tox in Azure CI
-   `commit <https://pagure.io/freeipa/c/53ac81765aaad71ef18e720017454c33df0ab27c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/53ac81765aaad71ef18e720017454c33df0ab27c>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Use system-wide chromium for webui tests
-   `commit <https://pagure.io/freeipa/c/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  Don't fail if optional RPM macros file is missing
-   `commit <https://pagure.io/freeipa/c/801308af209167ef84351987cd894c5721e3d853>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/801308af209167ef84351987cd894c5721e3d853>`__
    `#9347 <https://pagure.io/freeipa/issue/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
-   `commit <https://pagure.io/freeipa/c/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
-   `commit <https://pagure.io/freeipa/c/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -183,16 +183,16 @@ Anuja More (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test that non admin user can search hbac rule.
-   `commit <https://pagure.io/freeipa/c/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
    `#5130 <https://pagure.io/freeipa/issue/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
-   `commit <https://pagure.io/freeipa/c/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
    `#6044 <https://pagure.io/freeipa/issue/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
-   `commit <https://pagure.io/freeipa/c/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  Add test for SSH with GSSAPI auth.
-   `commit <https://pagure.io/freeipa/c/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
    `#9316 <https://pagure.io/freeipa/issue/9316>`__
 
 
@@ -201,23 +201,23 @@ Antonio Torres (8)
 ----------------------------------------------------------------------------------------------
 
 -  Extend API documentation
-   `commit <https://pagure.io/freeipa/c/f3d5e11b979e13c40158928302ff23169cd9cc9c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3d5e11b979e13c40158928302ff23169cd9cc9c>`__
 -  doc: allow notes on Param API Reference pages
-   `commit <https://pagure.io/freeipa/c/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
-   `commit <https://pagure.io/freeipa/c/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
-   `commit <https://pagure.io/freeipa/c/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
 -  API doc: add note about ipa show-mappings to usage guide
-   `commit <https://pagure.io/freeipa/c/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
 -  API doc: validate generated reference
-   `commit <https://pagure.io/freeipa/c/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
    `#9287 <https://pagure.io/freeipa/issue/9287>`__
 -  API doc: add basic user management guide
-   `commit <https://pagure.io/freeipa/c/84c4449e93d57f5236f978388cf6561a4866686a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/84c4449e93d57f5236f978388cf6561a4866686a>`__
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/1b7fccd6d44361b9c175d9049313f0a5ac46bb57>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b7fccd6d44361b9c175d9049313f0a5ac46bb57>`__
 
 
 
@@ -225,7 +225,7 @@ Carla Martinez (1)
 ----------------------------------------------------------------------------------------------
 
 -  Update 'Auth indicators' doc string
-   `commit <https://pagure.io/freeipa/c/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
    `#9338 <https://pagure.io/freeipa/issue/9338>`__
 
 
@@ -234,13 +234,13 @@ Christian Heimes (3)
 ----------------------------------------------------------------------------------------------
 
 -  Speed up installer by restarting DS after DNA plugin
-   `commit <https://pagure.io/freeipa/c/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
    `#9358 <https://pagure.io/freeipa/issue/9358>`__
 -  Don't block when kinit_pkinit() fails
-   `commit <https://pagure.io/freeipa/c/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
    `#9333 <https://pagure.io/freeipa/issue/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
-   `commit <https://pagure.io/freeipa/c/f3052c17599c7318c385b27795678b368906fd26>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f3052c17599c7318c385b27795678b368906fd26>`__
    `#9285 <https://pagure.io/freeipa/issue/9285>`__
 
 
@@ -249,7 +249,7 @@ Chris Kelley (1)
 ----------------------------------------------------------------------------------------------
 
 -  Check that CADogtagCertsConfigCheck can handle cert renewal
-   `commit <https://pagure.io/freeipa/c/bed21afd2b7bc43c5acd33ad450d284d04073a71>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bed21afd2b7bc43c5acd33ad450d284d04073a71>`__
 
 
 
@@ -257,9 +257,9 @@ David Pascual (2)
 ----------------------------------------------------------------------------------------------
 
 -  doc: Use case examples for PR-CI checker tool
-   `commit <https://pagure.io/freeipa/c/faa485345cff6a4decbbd4a7542a3f640f2ca097>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/faa485345cff6a4decbbd4a7542a3f640f2ca097>`__
 -  ipatests: fix (prci_checker) duplicated check & error return code
-   `commit <https://pagure.io/freeipa/c/398e091863c8d64271205fb4df26e688dddfe81e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/398e091863c8d64271205fb4df26e688dddfe81e>`__
 
 
 
@@ -268,7 +268,7 @@ Erik Belko (1)
 
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
-   `commit <https://pagure.io/freeipa/c/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
    `#9286 <https://pagure.io/freeipa/issue/9286>`__
 
 
@@ -277,49 +277,49 @@ Florence Blanc-Renaud (16)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: increase timeout for test_trust
-   `commit <https://pagure.io/freeipa/c/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
    `#9326 <https://pagure.io/freeipa/issue/9326>`__
 -  ipatests: remove wrong job definition TestACMEPrune
-   `commit <https://pagure.io/freeipa/c/bdd115239adeae9f84b016207552b60985d65854>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/bdd115239adeae9f84b016207552b60985d65854>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  ipatests: increase timeout for test_acme
-   `commit <https://pagure.io/freeipa/c/67131ae7f93e6ceab9be06d29151c37d74024699>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/67131ae7f93e6ceab9be06d29151c37d74024699>`__
    `#9324 <https://pagure.io/freeipa/issue/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
-   `commit <https://pagure.io/freeipa/c/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
-   `commit <https://pagure.io/freeipa/c/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
    `#9310 <https://pagure.io/freeipa/issue/9310>`__
 -  Tests: force key type in ACME tests
-   `commit <https://pagure.io/freeipa/c/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
    `#9298 <https://pagure.io/freeipa/issue/9298>`__
 -  server install: remove error log about missing bkup file
-   `commit <https://pagure.io/freeipa/c/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
    `#9306 <https://pagure.io/freeipa/issue/9306>`__
 -  ipatests: mark test_smb as xfail
-   `commit <https://pagure.io/freeipa/c/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
-   `commit <https://pagure.io/freeipa/c/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
    `#9135 <https://pagure.io/freeipa/issue/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
-   `commit <https://pagure.io/freeipa/c/f2b4d019881232833e915fedba48537548d2ef60>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2b4d019881232833e915fedba48537548d2ef60>`__
 -  FIPS setup: fix typo filtering camellia encryption
-   `commit <https://pagure.io/freeipa/c/f2a337caaf82fca4a8d7c347454b412ba2b4a0dd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f2a337caaf82fca4a8d7c347454b412ba2b4a0dd>`__
 -  cert utilities: MAC verification is incompatible with FIPS mode
-   `commit <https://pagure.io/freeipa/c/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
 -  ipatests: update the fake fips mode expected message
-   `commit <https://pagure.io/freeipa/c/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
    `#9002 <https://pagure.io/freeipa/issue/9002>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
-   `commit <https://pagure.io/freeipa/c/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
    `#9290 <https://pagure.io/freeipa/issue/9290>`__
 -  webui tests: fix assertion in test_subid.py
-   `commit <https://pagure.io/freeipa/c/3801d0c1c8a3dbec54dead29666137de2649e109>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3801d0c1c8a3dbec54dead29666137de2649e109>`__
    `#9282 <https://pagure.io/freeipa/issue/9282>`__
 -  PRCI: update memory reqs for each topology
-   `commit <https://pagure.io/freeipa/c/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
 
 
 
@@ -327,16 +327,16 @@ mbhalodi (4)
 ----------------------------------------------------------------------------------------------
 
 -  ipatests: Test for sequence processing failures with server context
-   `commit <https://pagure.io/freeipa/c/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
    `#9349 <https://pagure.io/freeipa/issue/9349>`__
 -  ipatests: add missing automember-cli tests
-   `commit <https://pagure.io/freeipa/c/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
    `#9332 <https://pagure.io/freeipa/issue/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/ff50fe5f038be52207bb770179becc31fbc74e17>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ff50fe5f038be52207bb770179becc31fbc74e17>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
-   `commit <https://pagure.io/freeipa/c/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
    `#9320 <https://pagure.io/freeipa/issue/9320>`__
 
 
@@ -345,7 +345,7 @@ Michal Polovka (1)
 ----------------------------------------------------------------------------------------------
 
 -  ipatest: loginscreen: do not use hardcoded password
-   `commit <https://pagure.io/freeipa/c/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
    `#9226 <https://pagure.io/freeipa/issue/9226>`__
 
 
@@ -354,13 +354,13 @@ Rob Crittenden (3)
 ----------------------------------------------------------------------------------------------
 
 -  Wipe the ipa-ca DNS record when updating system records
-   `commit <https://pagure.io/freeipa/c/b9387280543b86444cf4c258a7b720f492357baf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9387280543b86444cf4c258a7b720f492357baf>`__
    `#9195 <https://pagure.io/freeipa/issue/9195>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
-   `commit <https://pagure.io/freeipa/c/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
-   `commit <https://pagure.io/freeipa/c/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
    `#9291 <https://pagure.io/freeipa/issue/9291>`__
 
 
@@ -369,31 +369,31 @@ Stanislav Levin (9)
 ----------------------------------------------------------------------------------------------
 
 -  fastlint: Correct concatenation of file lists
-   `commit <https://pagure.io/freeipa/c/d8418ce63de206967bea5918615ee4471183cd06>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d8418ce63de206967bea5918615ee4471183cd06>`__
    `#9318 <https://pagure.io/freeipa/issue/9318>`__
 -  dns: Fix support for dnspython 1.1x
-   `commit <https://pagure.io/freeipa/c/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
    `#9339 <https://pagure.io/freeipa/issue/9339>`__
 -  tests: webui: Update vendored qunit
-   `commit <https://pagure.io/freeipa/c/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  AP: webui: List installed nodejs packages
-   `commit <https://pagure.io/freeipa/c/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Load qunit only once
-   `commit <https://pagure.io/freeipa/c/958a3958b4835fc2454e8bd71797638dcef9c460>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/958a3958b4835fc2454e8bd71797638dcef9c460>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: webui: Allow file access from files in tests
-   `commit <https://pagure.io/freeipa/c/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
    `#9329 <https://pagure.io/freeipa/issue/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
-   `commit <https://pagure.io/freeipa/c/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
    `#9319 <https://pagure.io/freeipa/issue/9319>`__
 -  spec: Drop no longer used build dependency on paste
-   `commit <https://pagure.io/freeipa/c/ebd4096f039964cfd1d95467630c10559d051e13>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ebd4096f039964cfd1d95467630c10559d051e13>`__
    `#9314 <https://pagure.io/freeipa/issue/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
-   `commit <https://pagure.io/freeipa/c/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
    `#9315 <https://pagure.io/freeipa/issue/9315>`__
 
 
@@ -403,7 +403,7 @@ Sumedh Sidhaye (1)
 
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
-   `commit <https://pagure.io/freeipa/c/e8ef2c2f226704ce510525f07675107179124a95>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e8ef2c2f226704ce510525f07675107179124a95>`__
    `#9238 <https://pagure.io/freeipa/issue/9238>`__
 
 
@@ -412,7 +412,7 @@ Sudhir Menon (1)
 ----------------------------------------------------------------------------------------------
 
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
-   `commit <https://pagure.io/freeipa/c/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
    `#9279 <https://pagure.io/freeipa/issue/9279>`__
 
 
@@ -421,4 +421,4 @@ Thorsten Scherf (1)
 ----------------------------------------------------------------------------------------------
 
 -  external-idp: change idp server name to reference name
-   `commit <https://pagure.io/freeipa/c/b9c6ea67d896e52b61bd40bfd84b8d84b69ec35e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b9c6ea67d896e52b61bd40bfd84b8d84b69ec35e>`__

--- a/src/release-notes/4-9-13.rst
+++ b/src/release-notes/4-9-13.rst
@@ -220,14 +220,14 @@ Alexander Bokovoy (4)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Azure CI: increase memory for forced reenrollment test
-   `commit <https://pagure.io/freeipa/c/1635cba588d4c29ae78d3c706ee01488ad653dad>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1635cba588d4c29ae78d3c706ee01488ad653dad>`__
 -  Increase memory usage for Azure CI upgrade test
-   `commit <https://pagure.io/freeipa/c/274ecc1be6c5a4c447874256acd0345ceca9b174>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/274ecc1be6c5a4c447874256acd0345ceca9b174>`__
 -  support more DateTime attributes in LDAP searches in IPA API
-   `commit <https://pagure.io/freeipa/c/3498ac88e71a6367294761510c937d225dec1140>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3498ac88e71a6367294761510c937d225dec1140>`__
    `#9395 <https://pagure.io/freeipa/issue/9395>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
-   `commit <https://pagure.io/freeipa/c/6a109d91a9256e2d0257d62fb5b555c163642de6>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6a109d91a9256e2d0257d62fb5b555c163642de6>`__
 
 .. _alexandra_nikandrova_1:
 
@@ -235,7 +235,7 @@ Alexandra Nikandrova (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  doc: typo in basic_usage.md
-   `commit <https://pagure.io/freeipa/c/7f080c0cad3327d2bbcc8c0aaddad134580d7c4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7f080c0cad3327d2bbcc8c0aaddad134580d7c4c>`__
 
 .. _anuja_more_1:
 
@@ -244,7 +244,7 @@ Anuja More (1)
 
 -  ipatests: Check that SSSD_PUBCONF_KRB5_INCLUDE_D_DIR is not included
    in krb5.conf
-   `commit <https://pagure.io/freeipa/c/1b51fa4cb07380d1102891233e85a7940f804c72>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/1b51fa4cb07380d1102891233e85a7940f804c72>`__
    `#9267 <https://pagure.io/freeipa/issue/9267>`__
 
 .. _antonio_torres_1:
@@ -253,7 +253,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Back to git snapshots
-   `commit <https://pagure.io/freeipa/c/d01378865add0705a3efad2e0cf268f36a6f3c25>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d01378865add0705a3efad2e0cf268f36a6f3c25>`__
 
 .. _erik_belko_1:
 
@@ -261,7 +261,7 @@ Erik Belko (1)
 ~~~~~~~~~~~~~~
 
 -  test: add tests for descriptive error message in ipa user-add
-   `commit <https://pagure.io/freeipa/c/4d55ee3033641c772c2a8cc8625f7b133ab8416b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4d55ee3033641c772c2a8cc8625f7b133ab8416b>`__
    `#9378 <https://pagure.io/freeipa/issue/9378>`__
 
 .. _florence_blanc_renaud_19:
@@ -270,60 +270,60 @@ Florence Blanc-Renaud (19)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: fix test_ipactl_scenario_check
-   `commit <https://pagure.io/freeipa/c/9b41de8f4bf8689d7aa9c46cec6371a333958846>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9b41de8f4bf8689d7aa9c46cec6371a333958846>`__
    `#9415 <https://pagure.io/freeipa/issue/9415>`__
 -  Covscan issues: Use after free
-   `commit <https://pagure.io/freeipa/c/6d0c1a2f3e692d355c858551709985c5dbb50731>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/6d0c1a2f3e692d355c858551709985c5dbb50731>`__
    `#9431 <https://pagure.io/freeipa/issue/9431>`__
 -  idp: add the ipaidpuser objectclass when needed
-   `commit <https://pagure.io/freeipa/c/7e5740f534893487f5a61907ebd6e3677f0beecc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7e5740f534893487f5a61907ebd6e3677f0beecc>`__
    `#9433 <https://pagure.io/freeipa/issue/9433>`__
 -  Installer: activate nss and pam services in sssd.conf
-   `commit <https://pagure.io/freeipa/c/f38eefd9f7e54470de7c707782114b17aac8762a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f38eefd9f7e54470de7c707782114b17aac8762a>`__
    `#9427 <https://pagure.io/freeipa/issue/9427>`__
 -  ipatests: fix test_topology
-   `commit <https://pagure.io/freeipa/c/fdaad3a45f5674876fd3f6cc7ad1e916ebfc7080>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fdaad3a45f5674876fd3f6cc7ad1e916ebfc7080>`__
 -  ipatests: update expected webui msg for admin deletion
-   `commit <https://pagure.io/freeipa/c/7d62d84bdd3c2acd2f4bf70bb5fabf14c72e8ee7>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7d62d84bdd3c2acd2f4bf70bb5fabf14c72e8ee7>`__
    `#8878 <https://pagure.io/freeipa/issue/8878>`__
 -  xmlrpc tests: add a test for user plugin with non-existing idp
-   `commit <https://pagure.io/freeipa/c/dbcbe9a39c99008c6858bab53e2807b7bf01ba65>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/dbcbe9a39c99008c6858bab53e2807b7bf01ba65>`__
    `#9416 <https://pagure.io/freeipa/issue/9416>`__
 -  User plugin: improve error related to non existing idp
-   `commit <https://pagure.io/freeipa/c/99aa03413421cf2839e89e10ca279ec19233dd01>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/99aa03413421cf2839e89e10ca279ec19233dd01>`__
    `#9416 <https://pagure.io/freeipa/issue/9416>`__
 -  OTP: fix data type to avoid endianness issue
-   `commit <https://pagure.io/freeipa/c/a7e167154b889f75463ccc9cd91a75c1afb22da9>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a7e167154b889f75463ccc9cd91a75c1afb22da9>`__
    `#9402 <https://pagure.io/freeipa/issue/9402>`__
 -  Integration tests: add a test to ipa-server-upgrade
-   `commit <https://pagure.io/freeipa/c/93d97b59600c15e5028ee39b0e98450544165158>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/93d97b59600c15e5028ee39b0e98450544165158>`__
    `#9385 <https://pagure.io/freeipa/issue/9385>`__
 -  Upgrade: fix replica agreement
-   `commit <https://pagure.io/freeipa/c/d29b47512a39ada02fb371521994576cd9815a6c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d29b47512a39ada02fb371521994576cd9815a6c>`__
    `#9385 <https://pagure.io/freeipa/issue/9385>`__
 -  Integration test: add a test for upgrade and PKI drop-in file
-   `commit <https://pagure.io/freeipa/c/356ec5cbfe0876686239f938bdf54892dc30571e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/356ec5cbfe0876686239f938bdf54892dc30571e>`__
    `#9381 <https://pagure.io/freeipa/issue/9381>`__
 -  Upgrade: add PKI drop-in file if missing
-   `commit <https://pagure.io/freeipa/c/86c1426b2d376a390e87b074d3e10d85fa124abf>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/86c1426b2d376a390e87b074d3e10d85fa124abf>`__
    `#9381 <https://pagure.io/freeipa/issue/9381>`__
 -  xmlrpc tests: add test renaming user or group with setattr
-   `commit <https://pagure.io/freeipa/c/a5a4800cbe3e45907f39f78a3da3ded504712982>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/a5a4800cbe3e45907f39f78a3da3ded504712982>`__
    `#9396 <https://pagure.io/freeipa/issue/9396>`__
 -  User and groups: rename with --setattr must check format
-   `commit <https://pagure.io/freeipa/c/ba30addb05d47c36e2857c76ae2aff42d6f3fbb3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/ba30addb05d47c36e2857c76ae2aff42d6f3fbb3>`__
    `#9396 <https://pagure.io/freeipa/issue/9396>`__
 -  webuitests: close notification which hides Add button
-   `commit <https://pagure.io/freeipa/c/f599e2d67bad5945e4dcf99fdd584f01f1e20d1e>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f599e2d67bad5945e4dcf99fdd584f01f1e20d1e>`__
    `#9389 <https://pagure.io/freeipa/issue/9389>`__
 -  ipatest: remove xfail from test_smb
-   `commit <https://pagure.io/freeipa/c/998bafee86a870ad1ea4d6bccf12f0fae64c398c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/998bafee86a870ad1ea4d6bccf12f0fae64c398c>`__
    `#9124 <https://pagure.io/freeipa/issue/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
-   `commit <https://pagure.io/freeipa/c/7a94acca6a9efb546f1cf59f63fcb89f98944ea5>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/7a94acca6a9efb546f1cf59f63fcb89f98944ea5>`__
    `#9383 <https://pagure.io/freeipa/issue/9383>`__
 -  user or group name: explain the supported format
-   `commit <https://pagure.io/freeipa/c/f42a106e84c1fd609350da2540289ce945a7ecbd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f42a106e84c1fd609350da2540289ce945a7ecbd>`__
 
 .. _francisco_trivino_1:
 
@@ -331,7 +331,7 @@ Francisco Trivino (1)
 ~~~~~~~~~~~~~~~~~~~~~
 
 -  Workshop: fix broken Sphinx cross-references.
-   `commit <https://pagure.io/freeipa/c/4709063e2975bc2754783ee3e51f04df94538d41>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4709063e2975bc2754783ee3e51f04df94538d41>`__
 
 .. _julien_rische_2:
 
@@ -339,10 +339,10 @@ Julien Rische (2)
 ~~~~~~~~~~~~~~~~~
 
 -  ipa-kdb: Make AD-SIGNEDPATH optional with krb5 DAL 8 and older
-   `commit <https://pagure.io/freeipa/c/d394afc1210a21378c018d0ff93d400a57324289>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d394afc1210a21378c018d0ff93d400a57324289>`__
    `#9448 <https://pagure.io/freeipa/issue/9448>`__
 -  ipa-kdb: fix error handling of is_master_host()
-   `commit <https://pagure.io/freeipa/c/b5793c854035a122ed4c66f917cc427e5024e46a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/b5793c854035a122ed4c66f917cc427e5024e46a>`__
    `#9422 <https://pagure.io/freeipa/issue/9422>`__
 
 .. _mohammad_rizwan_2:
@@ -351,10 +351,10 @@ Mohammad Rizwan (2)
 ~~~~~~~~~~~~~~~~~~~
 
 -  ipatests: restart ipa services after moving date
-   `commit <https://pagure.io/freeipa/c/4fc28edbe6c9fee1e16d4057f4d83b7910264fdd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/4fc28edbe6c9fee1e16d4057f4d83b7910264fdd>`__
    `#9379 <https://pagure.io/freeipa/issue/9379>`__
 -  ipatests: enable firewall rule for http service on acme client
-   `commit <https://pagure.io/freeipa/c/f68468718c1e01df4a9180e17d7e24d961850e19>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f68468718c1e01df4a9180e17d7e24d961850e19>`__
 
 .. _rob_crittenden_14:
 
@@ -362,46 +362,46 @@ Rob Crittenden (14)
 ~~~~~~~~~~~~~~~~~~~
 
 -  Allow password policy minlength to be removed like other values
-   `commit <https://pagure.io/freeipa/c/d0348612f96e320594f3b9b167ff5aef890a93e1>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d0348612f96e320594f3b9b167ff5aef890a93e1>`__
    `#9297 <https://pagure.io/freeipa/issue/9297>`__
 -  Don't assume KRB5CCNAME is in the environment in replica install
-   `commit <https://pagure.io/freeipa/c/0cf6292f9c5d0cb31d57439e234a4e8640edc64f>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/0cf6292f9c5d0cb31d57439e234a4e8640edc64f>`__
    `#9446 <https://pagure.io/freeipa/issue/9446>`__
 -  Configure affinity during server installation
-   `commit <https://pagure.io/freeipa/c/3af7747364d184c8ef5bad8ea1654b12c529727b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3af7747364d184c8ef5bad8ea1654b12c529727b>`__
    `#9289 <https://pagure.io/freeipa/issue/9289>`__
 -  Remove all references to deleted indirect map from parent map
-   `commit <https://pagure.io/freeipa/c/2c402c46c2652b54adec5e8554ca7dfa00f2d37b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/2c402c46c2652b54adec5e8554ca7dfa00f2d37b>`__
    `#9397 <https://pagure.io/freeipa/issue/9397>`__
 -  Prevent the admin user from being deleted
-   `commit <https://pagure.io/freeipa/c/f215d3f45396fa29bdd69f56096b50842df14908>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/f215d3f45396fa29bdd69f56096b50842df14908>`__
    `#8878 <https://pagure.io/freeipa/issue/8878>`__
 -  Fix memory leak in the OTP last token plugin
-   `commit <https://pagure.io/freeipa/c/9438ce9207445e4ad4a9c7bdf0c9e569cabac571>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9438ce9207445e4ad4a9c7bdf0c9e569cabac571>`__
    `#9403 <https://pagure.io/freeipa/issue/9403>`__
 -  Differentiate location meaning between host and server
-   `commit <https://pagure.io/freeipa/c/af9c89e789e30e12aaeed1d607c2647861ecb3cc>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af9c89e789e30e12aaeed1d607c2647861ecb3cc>`__
    `#9317 <https://pagure.io/freeipa/issue/9317>`__
 -  Use the python-cryptography parser directly in cert-find
-   `commit <https://pagure.io/freeipa/c/d00fd3398c32beb2c3e72f4878c87f9d2c0e833d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/d00fd3398c32beb2c3e72f4878c87f9d2c0e833d>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Revert "cert_find: fix call with --all"
-   `commit <https://pagure.io/freeipa/c/3b1dbcdba2994bf57908f530913998e9ab888e4c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/3b1dbcdba2994bf57908f530913998e9ab888e4c>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Revert "Use the OpenSSL certificate parser in cert-find"
-   `commit <https://pagure.io/freeipa/c/9fe30f21c987bdccf80ef5f6d645fdc59b393bdb>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/9fe30f21c987bdccf80ef5f6d645fdc59b393bdb>`__
    `#9331 <https://pagure.io/freeipa/issue/9331>`__
 -  Don't allow the FQDN to match the domain on server installs
-   `commit <https://pagure.io/freeipa/c/00e8ccda83bffbb571a127d7a8a194496b9a53bd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/00e8ccda83bffbb571a127d7a8a194496b9a53bd>`__
    `#9003 <https://pagure.io/freeipa/issue/9003>`__
 -  Don't allow a group to be converted to POSIX and external
-   `commit <https://pagure.io/freeipa/c/fa321b2cca07dc2bd27ab6fa868e05ddf69637df>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fa321b2cca07dc2bd27ab6fa868e05ddf69637df>`__
    `#8990 <https://pagure.io/freeipa/issue/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
-   `commit <https://pagure.io/freeipa/c/e6f4478b87e441d9e9ad6fdc358f942981996c5a>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e6f4478b87e441d9e9ad6fdc358f942981996c5a>`__
    `#8941 <https://pagure.io/freeipa/issue/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
-   `commit <https://pagure.io/freeipa/c/e859b82677f13149de708006ab4f39b1b45ff66c>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/e859b82677f13149de708006ab4f39b1b45ff66c>`__
    `#9086 <https://pagure.io/freeipa/issue/9086>`__
 
 .. _rafael_guterres_jeffman_1:
@@ -410,7 +410,7 @@ Rafael Guterres Jeffman (1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  Fix typo in "Subordinate ID Selfservice User" role
-   `commit <https://pagure.io/freeipa/c/22db4497512a0fb62920648a732348ee9e8473fd>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/22db4497512a0fb62920648a732348ee9e8473fd>`__
    `#9418 <https://pagure.io/freeipa/issue/9418>`__
 
 .. _sudhir_menon_1:
@@ -419,7 +419,7 @@ Sudhir Menon (1)
 ~~~~~~~~~~~~~~~~
 
 -  ipatests: Skip the test failing due to FIPS policy
-   `commit <https://pagure.io/freeipa/c/21e4cb2e72dabc54f1ad92b6288433da4088ca4d>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/21e4cb2e72dabc54f1ad92b6288433da4088ca4d>`__
 
 .. _viktor_ashirov_1:
 
@@ -427,5 +427,5 @@ Viktor Ashirov (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  WebUI: update favicon.ico
-   `commit <https://pagure.io/freeipa/c/af4fb52bf140c69fb3d52d662aee48d37059721b>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/af4fb52bf140c69fb3d52d662aee48d37059721b>`__
    `#9449 <https://pagure.io/freeipa/issue/9449>`__

--- a/src/release-notes/4-9-14.rst
+++ b/src/release-notes/4-9-14.rst
@@ -87,7 +87,7 @@ Antonio Torres (1)
 ~~~~~~~~~~~~~~~~~~
 
 -  Become IPA 4.9.14
-   `commit <https://pagure.io/freeipa/c/deec13573d02c9e7eabd19201b7adb1e1eccd7e3>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/deec13573d02c9e7eabd19201b7adb1e1eccd7e3>`__
 
 .. _julien_rische_1:
 
@@ -95,7 +95,7 @@ Julien Rische (1)
 ~~~~~~~~~~~~~~~~~
 
 -  ipa-kdb: Detect and block Bronze-Bit attacks
-   `commit <https://pagure.io/freeipa/c/5854b7381c7ee683d1437058cc7632f1034551ed>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/5854b7381c7ee683d1437058cc7632f1034551ed>`__
 
 .. _rob_crittenden_2:
 
@@ -103,6 +103,6 @@ Rob Crittenden (2)
 ~~~~~~~~~~~~~~~~~~
 
 -  Integration tests for verifying Referer header in the UI
-   `commit <https://pagure.io/freeipa/c/51eb02a7758d5be8ad7ae9c402dc44dc19da93ab>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/51eb02a7758d5be8ad7ae9c402dc44dc19da93ab>`__
 -  Check the HTTP Referer header on all requests
-   `commit <https://pagure.io/freeipa/c/fc30a0f0356e632d23e9064d6770234201794781>`__
+   `commit <https://codeberg.org/freeipa/freeipa/commit/fc30a0f0356e632d23e9064d6770234201794781>`__


### PR DESCRIPTION
FreeIPA upstream repo is moving from Pagure to Codeberg. Replace all relevant links with the new repository URL.