### PR TITLE
Replace Pagure issue links with Codeberg

### DIFF
--- a/src/page/Howto/Recover_from_a_deleted_admin_user.rst
+++ b/src/page/Howto/Recover_from_a_deleted_admin_user.rst
@@ -11,10 +11,10 @@ provided an alternate user was member of the admins group.
 
 The deletion of the admin user caused multiple issues (for instance
 breaking the upgrade as seen in 
-`ticket 9500 <https://pagure.io/freeipa/issue/9500>`__).
+`ticket 9500 <https://codeberg.org/freeipa/freeipa/issues/9500>`__).
 
 A mechanism preventing this deletion has been implemented with the fix for
-`ticket 8878 <https://pagure.io/freeipa/issue/8878>`__. The fix is available
+`ticket 8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__. The fix is available
 in versions 4.9.13+ and 4.11.0+, but if your deployment has lost its admin
 user, you need to recreate a new admin user following the procedure detailed
 below.

--- a/src/page/Releases/4.10.0.rst
+++ b/src/page/Releases/4.10.0.rst
@@ -51,19 +51,19 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#2016 <https://pagure.io/freeipa/issue/2016>`__ [RFE] Support random
+-  `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__ [RFE] Support random
    serial numbers in IPA certificates
--  `#2278 <https://pagure.io/freeipa/issue/2278>`__ IPA needs better
+-  `#2278 <https://codeberg.org/freeipa/freeipa/issues/2278>`__ IPA needs better
    sudo option validation or better documentation
--  `#7404 <https://pagure.io/freeipa/issue/7404>`__ Incorrect certs are
+-  `#7404 <https://codeberg.org/freeipa/freeipa/issues/7404>`__ Incorrect certs are
    being updated with "ipa-certupdate"
--  `#8544 <https://pagure.io/freeipa/issue/8544>`__ After reboot:
+-  `#8544 <https://codeberg.org/freeipa/freeipa/issues/8544>`__ After reboot:
    Replication bind with GSSAPI auth failed
--  `#8684 <https://pagure.io/freeipa/issue/8684>`__ [WebUI]
+-  `#8684 <https://codeberg.org/freeipa/freeipa/issues/8684>`__ [WebUI]
    test_hostgroup::test_names_and_button - timeout reached
--  `#9035 <https://pagure.io/freeipa/issue/9035>`__ Nightly failure
+-  `#9035 <https://codeberg.org/freeipa/freeipa/issues/9035>`__ Nightly failure
    (rawhide) in test_installation_client.py::TestInstallClient
--  `#9105 <https://pagure.io/freeipa/issue/9105>`__ Review usage of
+-  `#9105 <https://codeberg.org/freeipa/freeipa/issues/9105>`__ Review usage of
    quiet flag in ipa-join
 
 
@@ -80,24 +80,24 @@ Rob Crittenden (9)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a97f9b40>`__
 -  Add tests for Random Serial Number v3 support
    `commit <https://codeberg.org/freeipa/freeipa/commit/d241d7405>`__
-   `#2016 <https://pagure.io/freeipa/issue/2016>`__
+   `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__
 -  Add support for Random Serial Numbers v3
    `commit <https://codeberg.org/freeipa/freeipa/commit/beaa0562d>`__
-   `#2016 <https://pagure.io/freeipa/issue/2016>`__
+   `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__
 -  Add a new parameter type, SerialNumber, as a subclass of Str
    `commit <https://codeberg.org/freeipa/freeipa/commit/83be923ac>`__
-   `#2016 <https://pagure.io/freeipa/issue/2016>`__
+   `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__
 -  doc/designs: add Random Serial Numbers v3 support
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3481449e>`__
-   `#2016 <https://pagure.io/freeipa/issue/2016>`__
+   `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__
 -  Design for IPA-to-IPA migration
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4859db4e>`__
 -  Re-work the quiet option in ipa-join to not suppress errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/61650c577>`__
-   `#9105 <https://pagure.io/freeipa/issue/9105>`__
+   `#9105 <https://codeberg.org/freeipa/freeipa/issues/9105>`__
 -  Improve sudooption docs, make the option multi-value
    `commit <https://codeberg.org/freeipa/freeipa/commit/47fbe05f7>`__
-   `#2278 <https://pagure.io/freeipa/issue/2278>`__
+   `#2278 <https://codeberg.org/freeipa/freeipa/issues/2278>`__
 -  Design doc to allow LDAP bind using the RADIUS auth type
    `commit <https://codeberg.org/freeipa/freeipa/commit/16ab690bf>`__
 
@@ -144,7 +144,7 @@ Michal Polovka (5)
    configured `commit <https://codeberg.org/freeipa/freeipa/commit/b2bbf8165>`__
 -  test_webui: test_hostgroup: Wait for modal dialog to appear
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0269f236>`__
-   `#8684 <https://pagure.io/freeipa/issue/8684>`__
+   `#8684 <https://codeberg.org/freeipa/freeipa/issues/8684>`__
 -  WebUI: Test if links are opened in new tab correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/89c846a1f>`__
 
@@ -159,7 +159,7 @@ Florence Blanc-Renaud (9)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbc18ff8c>`__
 -  ipatests: update packages in rawhide test test_installation_client.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c61b9266>`__
-   `#9035 <https://pagure.io/freeipa/issue/9035>`__
+   `#9035 <https://codeberg.org/freeipa/freeipa/issues/9035>`__
 -  ipatests: revert wrong commit on gating definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b665ccf2>`__
 -  Design: Integrate SID configuration into base IPA installers
@@ -222,10 +222,10 @@ Christian Heimes (2)
 
 -  Add design for LDAPI autobind
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b8f37f88>`__
-   `#8544 <https://pagure.io/freeipa/issue/8544>`__
+   `#8544 <https://codeberg.org/freeipa/freeipa/issues/8544>`__
 -  LDAP autobind authenticateAsDN for BIND named
    `commit <https://codeberg.org/freeipa/freeipa/commit/16e1cbdc5>`__
-   `#8544 <https://pagure.io/freeipa/issue/8544>`__
+   `#8544 <https://codeberg.org/freeipa/freeipa/issues/8544>`__
 
 
 
@@ -242,10 +242,10 @@ Antonio Torres (2)
 
 -  ipatests: add test for ipa-cacert-manage prune
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a2e6ec32>`__
-   `#7404 <https://pagure.io/freeipa/issue/7404>`__
+   `#7404 <https://codeberg.org/freeipa/freeipa/issues/7404>`__
 -  ipa-cacert-manage: add prune option
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d8cb1dd1>`__
-   `#7404 <https://pagure.io/freeipa/issue/7404>`__
+   `#7404 <https://codeberg.org/freeipa/freeipa/issues/7404>`__
 
 
 

--- a/src/page/Releases/4.10.1.rst
+++ b/src/page/Releases/4.10.1.rst
@@ -96,129 +96,129 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#8803 <https://pagure.io/freeipa/issue/8803>`__ Add support for
+-  `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__ Add support for
    managing IdP references
--  `#8804 <https://pagure.io/freeipa/issue/8804>`__ Extend supported
+-  `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__ Extend supported
    user authentication methods in IPA to allow IdP auth
--  `#8805 <https://pagure.io/freeipa/issue/8805>`__ Extend \`ipa-otpd\`
+-  `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__ Extend \`ipa-otpd\`
    daemon to recognize IdP references
--  `#8946 <https://pagure.io/freeipa/issue/8946>`__ RFE: Add label name
+-  `#8946 <https://codeberg.org/freeipa/freeipa/issues/8946>`__ RFE: Add label name
    to Certificates section in WebUI to enable testing
--  `#8951 <https://pagure.io/freeipa/issue/8951>`__ Test for RFE
+-  `#8951 <https://codeberg.org/freeipa/freeipa/issues/8951>`__ Test for RFE
    ipa-healthcheck tool can include check to see if the system is FIPS
    enabled or not
--  `#9062 <https://pagure.io/freeipa/issue/9062>`__ [ipatests] SID
+-  `#9062 <https://codeberg.org/freeipa/freeipa/issues/9062>`__ [ipatests] SID
    generation and test_xmlrpc/test_user_plugin.py
--  `#9083 <https://pagure.io/freeipa/issue/9083>`__ Support MIT Kerberos
+-  `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__ Support MIT Kerberos
    KDB version 9
--  `#9158 <https://pagure.io/freeipa/issue/9158>`__ Internal error when
+-  `#9158 <https://codeberg.org/freeipa/freeipa/issues/9158>`__ Internal error when
    setting dnsconfig or dnsforwardzone forwarders.
--  `#9160 <https://pagure.io/freeipa/issue/9160>`__
+-  `#9160 <https://codeberg.org/freeipa/freeipa/issues/9160>`__
    cryptography.utils.register_interface is scheduled for removal
--  `#9161 <https://pagure.io/freeipa/issue/9161>`__ Nightly test failure
+-  `#9161 <https://codeberg.org/freeipa/freeipa/issues/9161>`__ Nightly test failure
    in test_selinuxusermap.py::test_selinuxusermap::test_misc
--  `#9179 <https://pagure.io/freeipa/issue/9179>`__
+-  `#9179 <https://codeberg.org/freeipa/freeipa/issues/9179>`__
    test_caless_TestServerCALessToExternalCA_RSN fails in teardown
--  `#9188 <https://pagure.io/freeipa/issue/9188>`__
+-  `#9188 <https://codeberg.org/freeipa/freeipa/issues/9188>`__
    (`rhbz#2098187 <https://bugzilla.redhat.com/show_bug.cgi?id=2098187>`__)
    Add warning for empty targetattr when creating ACI with RBAC
--  `#9192 <https://pagure.io/freeipa/issue/9192>`__
+-  `#9192 <https://codeberg.org/freeipa/freeipa/issues/9192>`__
    (`rhbz#2094672 <https://bugzilla.redhat.com/show_bug.cgi?id=2094672>`__)
    IdM WebUI Pagination Size should not allow empty value
--  `#9198 <https://pagure.io/freeipa/issue/9198>`__ [Tracker] nightly
+-  `#9198 <https://codeberg.org/freeipa/freeipa/issues/9198>`__ [Tracker] nightly
    failure: after ipa trust-add, cred cache contains
    cifs/master.ipa.test@IPA.TEST instead of admin principal
--  `#9204 <https://pagure.io/freeipa/issue/9204>`__ [Tracker] In
+-  `#9204 <https://codeberg.org/freeipa/freeipa/issues/9204>`__ [Tracker] In
    ipa-server-upgrade ca_upgrade_schema() results in unnecessary pki
    restarts
--  `#9206 <https://pagure.io/freeipa/issue/9206>`__
+-  `#9206 <https://codeberg.org/freeipa/freeipa/issues/9206>`__
    (`rhbz#2109236 <https://bugzilla.redhat.com/show_bug.cgi?id=2109236>`__)
    ldap bind occurs when admin user changes password with gracelimit=0
--  `#9207 <https://pagure.io/freeipa/issue/9207>`__ Failure in
+-  `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__ Failure in
    AzurePipeline.freeipa (GATING InstallDNSSECFirst_1_to_5)
--  `#9208 <https://pagure.io/freeipa/issue/9208>`__ ap: Doc build fails
+-  `#9208 <https://codeberg.org/freeipa/freeipa/issues/9208>`__ ap: Doc build fails
    against Sphinx 5.1.0
--  `#9211 <https://pagure.io/freeipa/issue/9211>`__
+-  `#9211 <https://codeberg.org/freeipa/freeipa/issues/9211>`__
    (`rhbz#2109243 <https://bugzilla.redhat.com/show_bug.cgi?id=2109243>`__)
    RFE: Allow grace login limit to be set in IPA WebUI.
--  `#9212 <https://pagure.io/freeipa/issue/9212>`__
+-  `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
    (`rhbz#2115475 <https://bugzilla.redhat.com/show_bug.cgi?id=2115475>`__)
    Nightly test failure in
    test_user.py::test_user::test_password_expiration_notification
--  `#9214 <https://pagure.io/freeipa/issue/9214>`__ Nightly failure in
+-  `#9214 <https://codeberg.org/freeipa/freeipa/issues/9214>`__ Nightly failure in
    webui test
    test_subid.py::test_subid::test_subid_range_deletion_not_allowed
--  `#9218 <https://pagure.io/freeipa/issue/9218>`__
+-  `#9218 <https://codeberg.org/freeipa/freeipa/issues/9218>`__
    (`rhbz#2116966 <https://bugzilla.redhat.com/show_bug.cgi?id=2116966>`__)
    Random failure in test-winsyncmigrate
--  `#9225 <https://pagure.io/freeipa/issue/9225>`__ pytest library
+-  `#9225 <https://codeberg.org/freeipa/freeipa/issues/9225>`__ pytest library
    module rename from quarkus to keycloak
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9227 <https://pagure.io/freeipa/issue/9227>`__ Need test for
+-  `#9227 <https://codeberg.org/freeipa/freeipa/issues/9227>`__ Need test for
    Keycloak Bridge authentication
--  `#9228 <https://pagure.io/freeipa/issue/9228>`__ ipa-client-install
+-  `#9228 <https://codeberg.org/freeipa/freeipa/issues/9228>`__ ipa-client-install
    does not maintain server affinity during installation
--  `#9230 <https://pagure.io/freeipa/issue/9230>`__ build failure
+-  `#9230 <https://codeberg.org/freeipa/freeipa/issues/9230>`__ build failure
    against gcc < 11
--  `#9231 <https://pagure.io/freeipa/issue/9231>`__ /run/ipa/ccaches
+-  `#9231 <https://codeberg.org/freeipa/freeipa/issues/9231>`__ /run/ipa/ccaches
    uses all available tmpfs space
--  `#9237 <https://pagure.io/freeipa/issue/9237>`__ Show order in sudo
+-  `#9237 <https://codeberg.org/freeipa/freeipa/issues/9237>`__ Show order in sudo
    rule list in web interface
--  `#9238 <https://pagure.io/freeipa/issue/9238>`__ Nightly test failure
+-  `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__ Nightly test failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ds_configcheck_passwordstorage
--  `#9243 <https://pagure.io/freeipa/issue/9243>`__
+-  `#9243 <https://codeberg.org/freeipa/freeipa/issues/9243>`__
    (`rhbz#2127833 <https://bugzilla.redhat.com/show_bug.cgi?id=2127833>`__)
    Password Policy Grace login limit allows invalid maximum value
--  `#9244 <https://pagure.io/freeipa/issue/9244>`__ Nightly test failure
+-  `#9244 <https://codeberg.org/freeipa/freeipa/issues/9244>`__ Nightly test failure
    in test_commands.py::TestIPACommand::test_ipa_cacert_manage_prune
--  `#9245 <https://pagure.io/freeipa/issue/9245>`__
+-  `#9245 <https://codeberg.org/freeipa/freeipa/issues/9245>`__
    (`rhbz#2117167 <https://bugzilla.redhat.com/show_bug.cgi?id=2117167>`__)
    \`extdom\` plugin can return object from a wrong domain.
--  `#9246 <https://pagure.io/freeipa/issue/9246>`__ Nightly test failure
+-  `#9246 <https://codeberg.org/freeipa/freeipa/issues/9246>`__ Nightly test failure
    in test_user_permissions.TestInstallClientNoAdmin
--  `#9248 <https://pagure.io/freeipa/issue/9248>`__
+-  `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
    (`rhbz#2124369 <https://bugzilla.redhat.com/show_bug.cgi?id=2124369>`__)
    OTP token sync always returns OK even with random numbers
--  `#9249 <https://pagure.io/freeipa/issue/9249>`__
+-  `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
    (`rhbz#2108630 <https://bugzilla.redhat.com/show_bug.cgi?id=2108630>`__)
    Deprecated feature idnssoaserial in IdM appears when creating reverse
    dns zones
--  `#9250 <https://pagure.io/freeipa/issue/9250>`__ Add basic test for
+-  `#9250 <https://codeberg.org/freeipa/freeipa/issues/9250>`__ Add basic test for
    authenticating as Keycloak user on IPA client
--  `#9252 <https://pagure.io/freeipa/issue/9252>`__
+-  `#9252 <https://codeberg.org/freeipa/freeipa/issues/9252>`__
    (`rhbz#2129895 <https://bugzilla.redhat.com/show_bug.cgi?id=2129895>`__)
    [DDF] The Examples in the RHEL ipa(1) man page show "ipa help
    commands" with content for "ipa halp topics" and "ipa hel
--  `#9254 <https://pagure.io/freeipa/issue/9254>`__ Exclude installed
+-  `#9254 <https://codeberg.org/freeipa/freeipa/issues/9254>`__ Exclude installed
    policy module file from RPM verification
--  `#9255 <https://pagure.io/freeipa/issue/9255>`__ ipapython.dn_ctypes
+-  `#9255 <https://codeberg.org/freeipa/freeipa/issues/9255>`__ ipapython.dn_ctypes
    is not compatible with libldap 2.6
--  `#9257 <https://pagure.io/freeipa/issue/9257>`__
+-  `#9257 <https://codeberg.org/freeipa/freeipa/issues/9257>`__
    (`rhbz#2104185 <https://bugzilla.redhat.com/show_bug.cgi?id=2104185>`__)
    Introduction of URI records for kerberos breaks location
    functionality
--  `#9258 <https://pagure.io/freeipa/issue/9258>`__
+-  `#9258 <https://codeberg.org/freeipa/freeipa/issues/9258>`__
    (`rhbz#2094673 <https://bugzilla.redhat.com/show_bug.cgi?id=2094673>`__)
    Do not add TLS CA configuration to ldap.conf anymore
--  `#9259 <https://pagure.io/freeipa/issue/9259>`__
+-  `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
    (`rhbz#2144737 <https://bugzilla.redhat.com/show_bug.cgi?id=2144737>`__)
    vault interoperability with older RHEL systems is broken
--  `#9264 <https://pagure.io/freeipa/issue/9264>`__ Nightly failure in
+-  `#9264 <https://codeberg.org/freeipa/freeipa/issues/9264>`__ Nightly failure in
    test_integration/test_sso.py::TestSsoBridge::test_ipa_login_with_sso_user
--  `#9269 <https://pagure.io/freeipa/issue/9269>`__
+-  `#9269 <https://codeberg.org/freeipa/freeipa/issues/9269>`__
    (`rhbz#2143224 <https://bugzilla.redhat.com/show_bug.cgi?id=2143224>`__,
    `rhbz#2075452 <https://bugzilla.redhat.com/show_bug.cgi?id=2075452>`__)
    ipa-certupdate does not restart/reload KDC on servers
--  `#9271 <https://pagure.io/freeipa/issue/9271>`__
+-  `#9271 <https://codeberg.org/freeipa/freeipa/issues/9271>`__
    (`rhbz#2143224 <https://bugzilla.redhat.com/show_bug.cgi?id=2143224>`__)
    Support PKINIT with ipa-client-install
--  `#9273 <https://pagure.io/freeipa/issue/9273>`__
+-  `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
    (`rhbz#1405935 <https://bugzilla.redhat.com/show_bug.cgi?id=1405935>`__)
    [RFE] Support IPA CA installation on an HSM
--  `#9274 <https://pagure.io/freeipa/issue/9274>`__ ipa-join: pass the
+-  `#9274 <https://codeberg.org/freeipa/freeipa/issues/9274>`__ ipa-join: pass the
    curl write function by name, not address
 
 
@@ -233,7 +233,7 @@ Armando Neto (1)
 
 -  webui: Do not allow empty pagination size
    `commit <https://codeberg.org/freeipa/freeipa/commit/02d3fb8266d8199fd1ed983de6c57b269546df82>`__
-   `#9192 <https://pagure.io/freeipa/issue/9192>`__
+   `#9192 <https://codeberg.org/freeipa/freeipa/issues/9192>`__
 
 
 
@@ -244,30 +244,30 @@ Alexander Bokovoy (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3c7a4faae8fd58a8d08bf6191d47fefe276ddba>`__
 -  ipa-kdb: fix PAC requester check
    `commit <https://codeberg.org/freeipa/freeipa/commit/88c1293f3a92451b6d5d5f7cb1a81d55a789b793>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: handle empty S4U proxy in allowed_to_delegate
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d4db340461298fed66607bde5fb0ca0f033c5aa>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: handle cross-realm TGT entries when generating PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5ca25003da5906703e8bd12b0759d48bc52e6b2>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: add krb5 1.20 support
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9ae0e350dcee5c9bbcd5a6932b4eb0daa90fea7>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: refactor MS-PAC processing to prepare for krb5 1.20
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0c72dcb87f86b9b00d0c087a959e64ce10eea98>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipaclient: do not set TLS CA options in ldap.conf anymore
    `commit <https://codeberg.org/freeipa/freeipa/commit/93b0e6a96a1aea45adc0d4c8bb26b226ce683573>`__
-   `#9258 <https://pagure.io/freeipa/issue/9258>`__
+   `#9258 <https://codeberg.org/freeipa/freeipa/issues/9258>`__
 -  Remove empty translation for 'si' which breaks linter
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ba166c77ca8011a35f80f2791a211c429a271e>`__
 -  fix canonicalization issue in Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0928fe164712303a7c24ee61500ac7326bd9e4a>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 -  ipa-otpd: initialize local pointers and handle gcc 10
    `commit <https://codeberg.org/freeipa/freeipa/commit/9441d7ed1ac67dc74ca6177b474d10da97b06a2f>`__
-   `#9230 <https://pagure.io/freeipa/issue/9230>`__
+   `#9230 <https://codeberg.org/freeipa/freeipa/issues/9230>`__
 
 
 
@@ -276,7 +276,7 @@ Anuja More (1)
 
 -  ipatests : Test query to AD specific attributes is successful.
    `commit <https://codeberg.org/freeipa/freeipa/commit/db7cd79858ec8fad7d094ca883d8b7d82c7c1ac1>`__
-   `#9127 <https://pagure.io/freeipa/issue/9127>`__
+   `#9127 <https://codeberg.org/freeipa/freeipa/issues/9127>`__
 
 
 
@@ -304,7 +304,7 @@ Alexey Tikhonov (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1360c8b09f0862fe961fbb015f55d6b3cbd9aee9>`__
 -  extdom: make sure result doesn't miss domain part
    `commit <https://codeberg.org/freeipa/freeipa/commit/4685f9d881c09fa317cb68fba1b94c29e48a7a8b>`__
-   `#9245 <https://pagure.io/freeipa/issue/9245>`__
+   `#9245 <https://codeberg.org/freeipa/freeipa/issues/9245>`__
 -  extdom: internal functions should be static
    `commit <https://codeberg.org/freeipa/freeipa/commit/113cb8d715cf7bed8bcc36845940acc20fed8e60>`__
 
@@ -315,25 +315,25 @@ Carla Martinez (7)
 
 -  Update API and VERSION
    `commit <https://codeberg.org/freeipa/freeipa/commit/48b9cc3345f8596904bce14d580cd4b19bfbda15>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  webui: Set 'SOA serial' field as read-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b274bc5d01c58806f18e549b566d93e25b40214>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  ipatest: Remove warning message for 'idnssoaserial'
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d34673b8c04c9ec849f8276876fd8bbd4fe2234>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  Set 'idnssoaserial' to deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/242ed2e500510f33f4595fb1b29adb25b1517982>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  webui: Show 'Sudo order' column
    `commit <https://codeberg.org/freeipa/freeipa/commit/54b81617674be79577b8c3abf0949725d9a428c7>`__
-   `#9237 <https://pagure.io/freeipa/issue/9237>`__
+   `#9237 <https://codeberg.org/freeipa/freeipa/issues/9237>`__
 -  Set pkeys in test_selinuxusermap.py::test_misc::delete_record
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea792e11eb85a5b05b2b78f0215c147a52d2d265>`__
-   `#9161 <https://pagure.io/freeipa/issue/9161>`__
+   `#9161 <https://codeberg.org/freeipa/freeipa/issues/9161>`__
 -  webui: Allow grace login limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a1e1d9f1cb13679c28f12d05b156a08bcc4d856>`__
-   `#9211 <https://pagure.io/freeipa/issue/9211>`__
+   `#9211 <https://codeberg.org/freeipa/freeipa/issues/9211>`__
 
 
 
@@ -386,7 +386,7 @@ Erik (1)
 
 -  ipatests: healthcheck: test if system is FIPS enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/c55185d3dc3c6cd2ffebab77fbf8caa40a32bcd1>`__
-   `#8951 <https://pagure.io/freeipa/issue/8951>`__
+   `#8951 <https://codeberg.org/freeipa/freeipa/issues/8951>`__
 
 
 
@@ -403,41 +403,41 @@ Florence Blanc-Renaud (15)
 
 -  Spec file: bump the selinux-policy version
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e201ec97e5c54ad8d5fa02285e628d1a36d9ea7>`__
-   `#9198 <https://pagure.io/freeipa/issue/9198>`__
+   `#9198 <https://codeberg.org/freeipa/freeipa/issues/9198>`__
 -  webui tests: fix test_subid suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/9936379c9f0d6c888785ccca8766ed7074054270>`__
-   `#9214 <https://pagure.io/freeipa/issue/9214>`__
+   `#9214 <https://codeberg.org/freeipa/freeipa/issues/9214>`__
 -  ipatests: mark xfail tests using dnssec
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d093c66f21c57afeb8cfc242390d0d032509ab3>`__
-   `#9216 <https://pagure.io/freeipa/issue/9216>`__
+   `#9216 <https://codeberg.org/freeipa/freeipa/issues/9216>`__
 -  ipatests: mark xfail tests using sssctl domain-status
    `commit <https://codeberg.org/freeipa/freeipa/commit/40b9c6fc4746cfa32d8bf7c2038745cc037c673b>`__
-   `#9234 <https://pagure.io/freeipa/issue/9234>`__
+   `#9234 <https://codeberg.org/freeipa/freeipa/issues/9234>`__
 -  Tests: test on f37 and f36
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6485d6325585d0f80b659c473b3675728556ce1>`__
 -  ipa man page: format the EXAMPLES section
    `commit <https://codeberg.org/freeipa/freeipa/commit/1546c0b206e02902b4aba631ee83f2f7ba5acb1f>`__
-   `#9252 <https://pagure.io/freeipa/issue/9252>`__
+   `#9252 <https://codeberg.org/freeipa/freeipa/issues/9252>`__
 -  ipatests: add negative test for otptoken-sync
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9f33b7cd7e336be90d889e2db4c4bce18753918>`__
-   `#9248 <https://pagure.io/freeipa/issue/9248>`__
+   `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
 -  ipa otptoken-sync: return error when sync fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/221768f882784755c6449ff70f291fab780cce16>`__
-   `#9248 <https://pagure.io/freeipa/issue/9248>`__
+   `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
 -  ipa-cacert-manage prune: remove all expired certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5bcaab8f1e09ab7a0464f5a532f154d43ffcadb>`__
-   `#9244 <https://pagure.io/freeipa/issue/9244>`__
+   `#9244 <https://codeberg.org/freeipa/freeipa/issues/9244>`__
 -  gitignore: add install/oddjob/org.freeipa.server.config-enable-sid
    `commit <https://codeberg.org/freeipa/freeipa/commit/458dcebd2542de70c987ca89fe49f15d3f40ee82>`__
 -  ipatests: Fix expected object classes
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6520bef2ef05dd87636d8b57e3247d451af81d8>`__
-   `#9062 <https://pagure.io/freeipa/issue/9062>`__
+   `#9062 <https://codeberg.org/freeipa/freeipa/issues/9062>`__
 -  check_repl_update: in progress is a boolean
    `commit <https://codeberg.org/freeipa/freeipa/commit/2003eb6b3d4a27a5de5eaa79418f115dd99886cd>`__
-   `#9218 <https://pagure.io/freeipa/issue/9218>`__
+   `#9218 <https://codeberg.org/freeipa/freeipa/issues/9218>`__
 -  azure tests: disable TestInstallDNSSECFirst
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb9f606ffd1ad3ccd846173c152c52a171be8f86>`__
-   `#9216 <https://pagure.io/freeipa/issue/9216>`__
+   `#9216 <https://codeberg.org/freeipa/freeipa/issues/9216>`__
 -  Nightly tests: fix template for nightly_ipa-4-10_latest.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/4499c7379b5531501bb1a5ea58ab575bf3b08907>`__
 -  ipatests: add nightly definitions for ipa-4-10 branch
@@ -450,10 +450,10 @@ Fraser Tweedale (2)
 
 -  install: suggest --skip-mem-check when mem check fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/cebfb8792006af1a41c4c26c49372f0ea822dbaf>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  man: add --skip-mem-check to man pages
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7bee5b668fee083d8ada167f307857761c25d80>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 
 
 
@@ -462,7 +462,7 @@ Jesse Sandberg (1)
 
 -  Fix ipa-ccache-sweeper activation timer and clean up service file
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6a661bdaf0560eac99ca63ffb25ec739281a19a>`__
-   `#9231 <https://pagure.io/freeipa/issue/9231>`__
+   `#9231 <https://codeberg.org/freeipa/freeipa/issues/9231>`__
 
 
 
@@ -471,7 +471,7 @@ Nikola Knazekova (1)
 
 -  Exclude installed policy module file from RPM verification
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad7bdd46fb64c3fbb8104a9599459795fc193389>`__
-   `#9254 <https://pagure.io/freeipa/issue/9254>`__
+   `#9254 <https://codeberg.org/freeipa/freeipa/issues/9254>`__
 
 
 
@@ -506,34 +506,34 @@ Rob Crittenden (10)
 
 -  Move client certificate request after krb5.conf is created
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3c861b9fcbf7815161b46e5eab582813c1021dc>`__
-   `#9246 <https://pagure.io/freeipa/issue/9246>`__
+   `#9246 <https://codeberg.org/freeipa/freeipa/issues/9246>`__
 -  Defer creating the final krb5.conf on clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cbf2b25422100cc4105dfb09ee8c7bf87232198>`__
-   `#9228 <https://pagure.io/freeipa/issue/9228>`__
+   `#9228 <https://codeberg.org/freeipa/freeipa/issues/9228>`__
 -  Fix upper bound of password policy grace limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c4386ce057a0fd50c7494db43c71405c9674b8f>`__
-   `#9243 <https://pagure.io/freeipa/issue/9243>`__
+   `#9243 <https://codeberg.org/freeipa/freeipa/issues/9243>`__
 -  Set default on group pwpolicy with no grace limit in upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/de6f074538f6641fd9d84bed204a3d4d50eccbe5>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  Set default gracelimit on group password policies to -1
    `commit <https://codeberg.org/freeipa/freeipa/commit/45e6d49b94da78cd82eb016b3266a17a1359a087>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  doc: Update LDAP grace period design with default values
    `commit <https://codeberg.org/freeipa/freeipa/commit/1aa39529cda4ab9620539dbad705cedd23c21b42>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  upgrades: Don't restart the CA on ACME and profile schema change
    `commit <https://codeberg.org/freeipa/freeipa/commit/459b81b196b7bf36100aa2f4e5c4d36b1e4526f6>`__
-   `#9204 <https://pagure.io/freeipa/issue/9204>`__
+   `#9204 <https://codeberg.org/freeipa/freeipa/issues/9204>`__
 -  Disabling gracelimit does not prevent LDAP binds
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bb4ff9ed2313fb3c2bd1418258c5bcec557b6a5>`__
-   `#9206 <https://pagure.io/freeipa/issue/9206>`__
+   `#9206 <https://codeberg.org/freeipa/freeipa/issues/9206>`__
 -  Warn for permissions with read/write/search/compare and no attrs
    `commit <https://codeberg.org/freeipa/freeipa/commit/499f71729b8689d40608d9c99db703eb2c00a934>`__
-   `#9188 <https://pagure.io/freeipa/issue/9188>`__
+   `#9188 <https://codeberg.org/freeipa/freeipa/issues/9188>`__
 -  Only calculate LDAP password grace when the password is expired
    `commit <https://codeberg.org/freeipa/freeipa/commit/33cd62e0daa68fa6a9b3ca495d97ac5ce8713349>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 
 
 
@@ -576,22 +576,22 @@ Stanislav Levin (6)
 
 -  ipapython: Support openldap 2.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/51c31e0ad3387c07aad1035f00871bdcc201812a>`__
-   `#9255 <https://pagure.io/freeipa/issue/9255>`__
+   `#9255 <https://codeberg.org/freeipa/freeipa/issues/9255>`__
 -  x509: Replace removed register_interface with subclassing
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7beaa0b4de6b6b00ee1b5b770f0d2e72fad58df>`__
-   `#9160 <https://pagure.io/freeipa/issue/9160>`__
+   `#9160 <https://codeberg.org/freeipa/freeipa/issues/9160>`__
 -  ap: Constrain supported docutils
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5f7356e7e83b605a821ece9f242ac924925f27e>`__
-   `#9208 <https://pagure.io/freeipa/issue/9208>`__
+   `#9208 <https://codeberg.org/freeipa/freeipa/issues/9208>`__
 -  ap: Rearrange overloaded jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ff0c1a5ee33946202031a8bc83e855216cd0c95>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 -  ap: Disable azure's security daemon
    `commit <https://codeberg.org/freeipa/freeipa/commit/acd1d127938aa9feefbbc7ee325963a2e44ef3c3>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 -  ap: Raise dbus timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/260d6378ec59d244e5f247f4af81f7ae8c72ac87>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 
 
 
@@ -600,15 +600,15 @@ Scott Poore (4)
 
 -  ipatests: add keycloak user login to ipa test
    `commit <https://codeberg.org/freeipa/freeipa/commit/e197c743f3ea1a98d444c0eb01339cc22eab64d5>`__
-   `#9250 <https://pagure.io/freeipa/issue/9250>`__
+   `#9250 <https://codeberg.org/freeipa/freeipa/issues/9250>`__
 -  ipatests: add prci definitions for test_sso jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/db1d05176d8072b05fea179af2ac97caaeb65dd1>`__
 -  ipatests: add Keycloak Bridge test
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac776987d30ecd3444a9b25f49a714fddc3c4232>`__
-   `#9227 <https://pagure.io/freeipa/issue/9227>`__
+   `#9227 <https://codeberg.org/freeipa/freeipa/issues/9227>`__
 -  ipatests: Rename create_quarkus to create_keycloak
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0a104a42c2ccd89394e48c2375bb0eb95183c5b>`__
-   `#9225 <https://pagure.io/freeipa/issue/9225>`__
+   `#9225 <https://codeberg.org/freeipa/freeipa/issues/9225>`__
 
 
 
@@ -618,16 +618,16 @@ Sumedh Sidhaye (3)
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/5477a07d91ef2c506cc943699612e5e27d0c93e4>`__
-   `#9238 <https://pagure.io/freeipa/issue/9238>`__
+   `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__
 -  Additional tests for RSN v3
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfe074ed478c20a9537dc2a714bba50dbc2cd34f>`__
-   `#2016 <https://pagure.io/freeipa/issue/2016>`__
+   `#2016 <https://codeberg.org/freeipa/freeipa/issues/2016>`__
 -  Added a check while removing 'cert_dir'. The teardown method is
    called even if all the tests are skipped since the required PKI
    version is not present. The teardown is trying to remove a
    non-existent directory.
    `commit <https://codeberg.org/freeipa/freeipa/commit/aca97507cd119ad55e0c3c18ca65087cb5576c82>`__
-   `#9179 <https://pagure.io/freeipa/issue/9179>`__
+   `#9179 <https://codeberg.org/freeipa/freeipa/issues/9179>`__
 
 
 
@@ -636,10 +636,10 @@ Sudhir Menon (2)
 
 -  ipatests: ipa-client-install --subid adds entry in nsswitch.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a39af6b7228d8ba85b9e97aa5decbc056d081c77>`__
-   `#9159 <https://pagure.io/freeipa/issue/9159>`__
+   `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
 -  ipatests: WebUI: do not allow subid range deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/38e5bcf719a0e7c7550837ffb14300db8efe09e4>`__
-   `#9150 <https://pagure.io/freeipa/issue/9150>`__
+   `#9150 <https://codeberg.org/freeipa/freeipa/issues/9150>`__
 
 
 
@@ -662,7 +662,7 @@ Thomas Woerner (1)
 
 -  DNSResolver: Fix use of nameservers with ports
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c5530c509793f66a162ed4153d5425a0eda02d6>`__
-   `#9158 <https://pagure.io/freeipa/issue/9158>`__
+   `#9158 <https://codeberg.org/freeipa/freeipa/issues/9158>`__
 
 
 

--- a/src/page/Releases/4.10.2.rst
+++ b/src/page/Releases/4.10.2.rst
@@ -111,178 +111,178 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#5130 <https://pagure.io/freeipa/issue/5130>`__
+-  `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
    (`rhbz#1243261 <https://bugzilla.redhat.com/show_bug.cgi?id=1243261>`__)
    non-admin users cannot search hbac rules
--  `#5444 <https://pagure.io/freeipa/issue/5444>`__ [RFE] Support
+-  `#5444 <https://codeberg.org/freeipa/freeipa/issues/5444>`__ [RFE] Support
    Resource based kerberos constrained delegation
--  `#6044 <https://pagure.io/freeipa/issue/6044>`__
+-  `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
    (`rhbz#1353899 <https://bugzilla.redhat.com/show_bug.cgi?id=1353899>`__)
    ipa-advise: object of type 'type' has no len()
--  `#8941 <https://pagure.io/freeipa/issue/8941>`__ Usage of
+-  `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__ Usage of
    \`/usr/bin/env\` in Python scripts
--  `#8990 <https://pagure.io/freeipa/issue/8990>`__ ipa group-mod should
+-  `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__ ipa group-mod should
    fail properly with --posix and --external options
--  `#9086 <https://pagure.io/freeipa/issue/9086>`__ Have
+-  `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__ Have
    ipa-client-install additionally disable the unscd service if using
    SSSD
--  `#9124 <https://pagure.io/freeipa/issue/9124>`__ Nightly test failure
+-  `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#9164 <https://pagure.io/freeipa/issue/9164>`__ Cross realm
+-  `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__ Cross realm
    s4u2self/s4u2proxy fails
--  `#9195 <https://pagure.io/freeipa/issue/9195>`__
+-  `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
    (`rhbz#2158775 <https://bugzilla.redhat.com/show_bug.cgi?id=2158775>`__)
    Hiding a server does not completely clean up DNS records
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9232 <https://pagure.io/freeipa/issue/9232>`__ ipaserver circular
+-  `#9232 <https://codeberg.org/freeipa/freeipa/issues/9232>`__ ipaserver circular
    import
--  `#9249 <https://pagure.io/freeipa/issue/9249>`__
+-  `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
    (`rhbz#2108630 <https://bugzilla.redhat.com/show_bug.cgi?id=2108630>`__)
    Deprecated feature idnssoaserial in IdM appears when creating reverse
    dns zones
--  `#9259 <https://pagure.io/freeipa/issue/9259>`__
+-  `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
    (`rhbz#2144737 <https://bugzilla.redhat.com/show_bug.cgi?id=2144737>`__)
    vault interoperability with older RHEL systems is broken
--  `#9264 <https://pagure.io/freeipa/issue/9264>`__ Nightly failure in
+-  `#9264 <https://codeberg.org/freeipa/freeipa/issues/9264>`__ Nightly failure in
    test_integration/test_sso.py::TestSsoBridge::test_ipa_login_with_sso_user
--  `#9267 <https://pagure.io/freeipa/issue/9267>`__
+-  `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
    (`rhbz#2188567 <https://bugzilla.redhat.com/show_bug.cgi?id=2188567>`__)
    Unconditionally adding 'includedir
    /var/lib/sss/pubconf/krb5.include.d' to /etc/krb5.conf break Java's
    ability to parse krb5.conf
--  `#9278 <https://pagure.io/freeipa/issue/9278>`__ Pylint 2.15 issues
--  `#9279 <https://pagure.io/freeipa/issue/9279>`__ ipa-otpd@.service:
+-  `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__ Pylint 2.15 issues
+-  `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__ ipa-otpd@.service:
    deprecated syslog setting
--  `#9282 <https://pagure.io/freeipa/issue/9282>`__ Nightly test failure
+-  `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__ Nightly test failure
    in
    test_webui/test_subid.py/test_subid/test_subid_range_deletion_not_allowed
--  `#9285 <https://pagure.io/freeipa/issue/9285>`__ ipa-certupdate
+-  `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__ ipa-certupdate
    restarts HTTPd too early
--  `#9286 <https://pagure.io/freeipa/issue/9286>`__
+-  `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
    (`rhbz#2056009 <https://bugzilla.redhat.com/show_bug.cgi?id=2056009>`__)
    memberManager ACIs aren't allowing group-based manager access due to
    missing upgrade code
--  `#9287 <https://pagure.io/freeipa/issue/9287>`__ [RFE] makeapi should
+-  `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__ [RFE] makeapi should
    validate the generated API doc vs stored doc
--  `#9290 <https://pagure.io/freeipa/issue/9290>`__
+-  `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
    (`rhbz#2149889 <https://bugzilla.redhat.com/show_bug.cgi?id=2149889>`__)
    idm:client is missing dependency on krb5-pkinit.
--  `#9291 <https://pagure.io/freeipa/issue/9291>`__ Nightly test failure
+-  `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__ Nightly test failure
    (rawhide) in test_ipa_dns_systemrecords_check
--  `#9294 <https://pagure.io/freeipa/issue/9294>`__
+-  `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
    (`rhbz#2162677 <https://bugzilla.redhat.com/show_bug.cgi?id=2162677>`__)
    Enable the certificate pruning job in PKI
--  `#9295 <https://pagure.io/freeipa/issue/9295>`__ Nightly test failure
+-  `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__ Nightly test failure
    (sssd) in test_trust.py::TestNonPosixAutoPrivateGroup and
    test_trust.py::TestPosixAutoPrivateGroup
--  `#9298 <https://pagure.io/freeipa/issue/9298>`__ [Tracker] Nightly
+-  `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__ [Tracker] Nightly
    test failure (updates-testing) in
    test_acme.py::TestACME::test_certbot_certonly_standalone
--  `#9299 <https://pagure.io/freeipa/issue/9299>`__ NixOS support for
+-  `#9299 <https://codeberg.org/freeipa/freeipa/issues/9299>`__ NixOS support for
    freeipa in ipaplatform
--  `#9306 <https://pagure.io/freeipa/issue/9306>`__
+-  `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
    (`rhbz#2160389 <https://bugzilla.redhat.com/show_bug.cgi?id=2160389>`__)
    'ERROR Could not remove /tmp/tmpbkw6hawo.ipabkp' can be seen prior to
    'ipa-client-install' command was successful.
--  `#9309 <https://pagure.io/freeipa/issue/9309>`__
+-  `#9309 <https://codeberg.org/freeipa/freeipa/issues/9309>`__
    (`rhbz#2160399 <https://bugzilla.redhat.com/show_bug.cgi?id=2160399>`__)
    get_ranges - [file ipa_sidgen_common.c, line 276]: Failed to convert
    LDAP entry to range struct
--  `#9310 <https://pagure.io/freeipa/issue/9310>`__
+-  `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
    (`rhbz#2162335 <https://bugzilla.redhat.com/show_bug.cgi?id=2162335>`__)
    ipa-trust-add with --range-type=ipa-ad-trust-posix fails while
    creating an ID range
--  `#9313 <https://pagure.io/freeipa/issue/9313>`__ Nightly test failure
+-  `#9313 <https://codeberg.org/freeipa/freeipa/issues/9313>`__ Nightly test failure
    (rawhide): automember-rebuild test
--  `#9314 <https://pagure.io/freeipa/issue/9314>`__ Redundant build
+-  `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__ Redundant build
    dependency on python3-paste (if with lint)
--  `#9315 <https://pagure.io/freeipa/issue/9315>`__ [tests]
+-  `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__ [tests]
    test_ipa_healthcheck_fips_enabled fails on system without
    fips-mode-setup
--  `#9316 <https://pagure.io/freeipa/issue/9316>`__
+-  `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
    (`rhbz#2166324 <https://bugzilla.redhat.com/show_bug.cgi?id=2166324>`__)
    Passwordless (GSSAPI) SSH login with AD user
--  `#9318 <https://pagure.io/freeipa/issue/9318>`__ Incomplete fast
+-  `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__ Incomplete fast
    lint/codestyle check if both Python template files and Python modules
    were changed
--  `#9319 <https://pagure.io/freeipa/issue/9319>`__ [tests]
+-  `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__ [tests]
    TestDNSResolver failures on systems without or empty /etc/resolv.conf
--  `#9320 <https://pagure.io/freeipa/issue/9320>`__
+-  `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
    (`rhbz#2018198 <https://bugzilla.redhat.com/show_bug.cgi?id=2018198>`__)
    RFE - Add a warning note about possible performance impact of the
    Auto Member rebuild task.
--  `#9322 <https://pagure.io/freeipa/issue/9322>`__
+-  `#9322 <https://codeberg.org/freeipa/freeipa/issues/9322>`__
    (`rhbz#2162677 <https://bugzilla.redhat.com/show_bug.cgi?id=2162677>`__)
    Nightly test failure in test_integration/test_acme.py::TestACME
--  `#9323 <https://pagure.io/freeipa/issue/9323>`__ Update the design
+-  `#9323 <https://codeberg.org/freeipa/freeipa/issues/9323>`__ Update the design
    doc for certificate pruning
--  `#9324 <https://pagure.io/freeipa/issue/9324>`__ ipatests: Frequent
+-  `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__ ipatests: Frequent
    timeout of test_acme
--  `#9325 <https://pagure.io/freeipa/issue/9325>`__
+-  `#9325 <https://codeberg.org/freeipa/freeipa/issues/9325>`__
    (`rhbz#2168244 <https://bugzilla.redhat.com/show_bug.cgi?id=2168244>`__)
    requestsearchtimelimit=0 doesn't seems to be work with
    ipa-acme-manage pruning command
--  `#9326 <https://pagure.io/freeipa/issue/9326>`__ ipatests: timeout of
+-  `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__ ipatests: timeout of
    test_trust
--  `#9329 <https://pagure.io/freeipa/issue/9329>`__ Azure test:
+-  `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__ Azure test:
    WebUI_Unit_Tests are failing
--  `#9331 <https://pagure.io/freeipa/issue/9331>`__
+-  `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
    (`rhbz#2164349 <https://bugzilla.redhat.com/show_bug.cgi?id=2164349>`__)
    Better handling of the command line and web UI cert search and/or
    list features
--  `#9332 <https://pagure.io/freeipa/issue/9332>`__ Extend negative test
+-  `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__ Extend negative test
    coverage for automember
--  `#9333 <https://pagure.io/freeipa/issue/9333>`__ ipa-client-install
+-  `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__ ipa-client-install
    --pkinit-identity can block in unattended mode
--  `#9338 <https://pagure.io/freeipa/issue/9338>`__ Update 'Auth
+-  `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__ Update 'Auth
    indicators' doc string to show 'ipd' usage
--  `#9339 <https://pagure.io/freeipa/issue/9339>`__ Broken support for
+-  `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__ Broken support for
    dnspython < 2
--  `#9342 <https://pagure.io/freeipa/issue/9342>`__ Fedora trasiition
+-  `#9342 <https://codeberg.org/freeipa/freeipa/issues/9342>`__ Fedora trasiition
    license from short names to SPDX license expression
--  `#9344 <https://pagure.io/freeipa/issue/9344>`__ ipa-server-install
+-  `#9344 <https://codeberg.org/freeipa/freeipa/issues/9344>`__ ipa-server-install
    fails when the named keytab location is overridden in
    ipaplatform/paths.py
--  `#9347 <https://pagure.io/freeipa/issue/9347>`__ Azure Ci does not
+-  `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__ Azure Ci does not
    work with Fedora Rawhide
--  `#9349 <https://pagure.io/freeipa/issue/9349>`__
+-  `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
    (`rhbz#2180914 <https://bugzilla.redhat.com/show_bug.cgi?id=2180914>`__)
    Sequence processing failures for group_add using server context
--  `#9354 <https://pagure.io/freeipa/issue/9354>`__ Implement
+-  `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__ Implement
    resource-based constrained delegation
--  `#9355 <https://pagure.io/freeipa/issue/9355>`__ support python
+-  `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__ support python
    cryptography 40.0
--  `#9358 <https://pagure.io/freeipa/issue/9358>`__
+-  `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
    update_dna_shared_config sometimes blocks installation for 2 minutes
--  `#9361 <https://pagure.io/freeipa/issue/9361>`__ [ipasphinx]
+-  `#9361 <https://codeberg.org/freeipa/freeipa/issues/9361>`__ [ipasphinx]
    deprecated sphinx.util.progress_message
--  `#9362 <https://pagure.io/freeipa/issue/9362>`__ ipatests: Frequent
+-  `#9362 <https://codeberg.org/freeipa/freeipa/issues/9362>`__ ipatests: Frequent
    timeout of test_ipahealthcheck
--  `#9368 <https://pagure.io/freeipa/issue/9368>`__ Test wrong variable
+-  `#9368 <https://codeberg.org/freeipa/freeipa/issues/9368>`__ Test wrong variable
    in ipadb_get_pac()
--  `#9369 <https://pagure.io/freeipa/issue/9369>`__
+-  `#9369 <https://codeberg.org/freeipa/freeipa/issues/9369>`__
    (`rhbz#2164348 <https://bugzilla.redhat.com/show_bug.cgi?id=2164348>`__)
    Better catch of the IPA web UI event "IPA Error
    4301:CertificateOperationError", and IPA httpd error
    CertificateOperationError
--  `#9371 <https://pagure.io/freeipa/issue/9371>`__
+-  `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
    (`rhbz#2182683 <https://bugzilla.redhat.com/show_bug.cgi?id=2182683>`__)
    Tolerate absence of PAC ticket signature depending of domain and
    servers capabilities
--  `#9372 <https://pagure.io/freeipa/issue/9372>`__
+-  `#9372 <https://codeberg.org/freeipa/freeipa/issues/9372>`__
    (`rhbz#2172107 <https://bugzilla.redhat.com/show_bug.cgi?id=2172107>`__)
    'ipa idview-show idviewname' & IPA WebUI takes longer time to return
    the results in RHEL 8.5
--  `#9373 <https://pagure.io/freeipa/issue/9373>`__
+-  `#9373 <https://codeberg.org/freeipa/freeipa/issues/9373>`__
    (`rhbz#2176406 <https://bugzilla.redhat.com/show_bug.cgi?id=2176406>`__)
    Make sign_authdata() generate extended KDC signature
--  `#9374 <https://pagure.io/freeipa/issue/9374>`__ freeipa fails to
+-  `#9374 <https://codeberg.org/freeipa/freeipa/issues/9374>`__ freeipa fails to
    build with updates-testing repo on f37 and f38
--  `#9377 <https://pagure.io/freeipa/issue/9377>`__ test_commands:
+-  `#9377 <https://codeberg.org/freeipa/freeipa/issues/9377>`__ test_commands:
    pseudo-random failure in test_ssh_key_connection
--  `#9383 <https://pagure.io/freeipa/issue/9383>`__ Random nightly test
+-  `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__ Random nightly test
    failure in test_acme.py::TestACMEPrune::test_prune_cert_manual
 
 
@@ -298,73 +298,73 @@ Alexander Bokovoy (23)
 -  ipa-kdb: be compatible with krb5 1.19 when checking for server
    referral
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b821abca72e0d444c96598799c4947e2173d3f>`__
-   `#9164 <https://pagure.io/freeipa/issue/9164>`__
+   `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
    `commit <https://codeberg.org/freeipa/freeipa/commit/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
 -  ipa-kdb: skip verification of PAC full checksum
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
-   `#9371 <https://pagure.io/freeipa/issue/9371>`__
+   `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
 -  ipa-kdb: process out of realm server lookup during S4U
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
-   `#9164 <https://pagure.io/freeipa/issue/9164>`__
+   `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__
 -  ipa-kdb: postpone ticket checksum configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
 -  ipa-kdb: protect against context corruption
    `commit <https://codeberg.org/freeipa/freeipa/commit/803a44777f901217d634f8fd7feed8b66ece352a>`__
 -  ipa-kdb: hint KDC to use aes256-sha1 for forest trust TGT
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  Change doc theme to 'book'
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c43d914d9a365097a80c5c2278017b91c619266>`__
 -  doc/designs/rbcd.md: document use of S-1-18-\* SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  doc/designs/rbcd.md: add usage examples
    `commit <https://codeberg.org/freeipa/freeipa/commit/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  RBCD: add basic test for RBCD handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  kdb: implement RBCD handling in KDB driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  IPA API changes to support RBCD
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  doc: add design document for Kerberos constrained delegation
    `commit <https://codeberg.org/freeipa/freeipa/commit/18cd909b4ad854147008a1010c97c75640a54177>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  ipa-kdb: search S4U2Proxy ACLs in cn=s4u2proxy,cn=etc,$BASEDN subtree
    only
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
-   `#5444 <https://pagure.io/freeipa/issue/5444>`__
+   `#5444 <https://codeberg.org/freeipa/freeipa/issues/5444>`__
 -  test_xmlrpc: adopt to automember plugin message changes in 389-ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/52e6da9056697e2210736d5528826ae424fec9b1>`__
 -  Ignore empty modification error in case cifs/.. principal already
    added
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7506403a988b98cc3381d2d986b53aee48448cb>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
    `commit <https://codeberg.org/freeipa/freeipa/commit/e07ead943abf070107a9669fc4564c9dc7518832>`__
-   `#9355 <https://pagure.io/freeipa/issue/9355>`__
+   `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__
 -  Fix tox in Azure CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Use system-wide chromium for webui tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Don't fail if optional RPM macros file is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/b93f6b52a29659663fae65be51dafe350606eb6d>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
    `commit <https://codeberg.org/freeipa/freeipa/commit/0206369eec8530e96c66986c4ca501d8962193ce>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
    `commit <https://codeberg.org/freeipa/freeipa/commit/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -373,16 +373,16 @@ Anuja More (4)
 
 -  ipatests: Test that non admin user can search hbac rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/051bbe36dce57837bd1769aa4a88569e39565774>`__
-   `#5130 <https://pagure.io/freeipa/issue/5130>`__
+   `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
    `commit <https://codeberg.org/freeipa/freeipa/commit/983a6516f147ae95a512435cd05d237233d0b5fc>`__
-   `#6044 <https://pagure.io/freeipa/issue/6044>`__
+   `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  Add test for SSH with GSSAPI auth.
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6cb905de74da38d62f9c3bd7957018924282521>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 
 
 
@@ -399,14 +399,14 @@ Antonio Torres (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3eed25e92f951689658f6bbd178a5baca37442c6>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
 -  API doc: add note about ipa show-mappings to usage guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a20acb6f833a22baad214a466848cb5833954532>`__
 -  API doc: validate generated reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
-   `#9287 <https://pagure.io/freeipa/issue/9287>`__
+   `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__
 -  API doc: add basic user management guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
 -  Back to git snapshots
@@ -419,7 +419,7 @@ Carla Martinez (1)
 
 -  Update 'Auth indicators' doc string
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
-   `#9338 <https://pagure.io/freeipa/issue/9338>`__
+   `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__
 
 
 
@@ -428,13 +428,13 @@ Christian Heimes (3)
 
 -  Speed up installer by restarting DS after DNA plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
-   `#9358 <https://pagure.io/freeipa/issue/9358>`__
+   `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
 -  Don't block when kinit_pkinit() fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
-   `#9333 <https://pagure.io/freeipa/issue/9333>`__
+   `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
-   `#9285 <https://pagure.io/freeipa/issue/9285>`__
+   `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__
 
 
 
@@ -462,7 +462,7 @@ Erik Belko (1)
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -480,10 +480,10 @@ Florence Blanc-Renaud (55)
 
 -  ipatest: remove xfail from test_smb
    `commit <https://codeberg.org/freeipa/freeipa/commit/283f5463f091ac9fcc733092fc6becff586ae97f>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6f485fcade619980f6538edadf115dca69e1314>`__
-   `#9383 <https://pagure.io/freeipa/issue/9383>`__
+   `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__
 -  user or group name: explain the supported format
    `commit <https://codeberg.org/freeipa/freeipa/commit/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
 -  azure tests: move to fedora 38
@@ -492,121 +492,121 @@ Florence Blanc-Renaud (55)
    `commit <https://codeberg.org/freeipa/freeipa/commit/12d1aafe60de457815adb822bbef466926626d6f>`__
 -  idview: improve performance of idview-show
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
-   `#9372 <https://pagure.io/freeipa/issue/9372>`__
+   `#9372 <https://codeberg.org/freeipa/freeipa/issues/9372>`__
 -  spec file: force nodejs < 20 on fedora < 39
    `commit <https://codeberg.org/freeipa/freeipa/commit/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
-   `#9374 <https://pagure.io/freeipa/issue/9374>`__
+   `#9374 <https://codeberg.org/freeipa/freeipa/issues/9374>`__
 -  Nightly test: add +15min for test_ipahealthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/717228c908816c72b98cee86abfe7c22cb07c44e>`__
-   `#9362 <https://pagure.io/freeipa/issue/9362>`__
+   `#9362 <https://codeberg.org/freeipa/freeipa/issues/9362>`__
 -  cert_find: fix call with --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  ipatests: mark known failures for autoprivategroup
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
-   `#9295 <https://pagure.io/freeipa/issue/9295>`__
+   `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__
 -  ipatests: fix test definition for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/def07260da883b1d27330b308bd0337205bf53a8>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: increase timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae014c6a3e17da7b0775be79a425d769a2717243>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: adapt for new automembership fixup behavior
    `commit <https://codeberg.org/freeipa/freeipa/commit/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
-   `#9313 <https://pagure.io/freeipa/issue/9313>`__
+   `#9313 <https://codeberg.org/freeipa/freeipa/issues/9313>`__
 -  ipatests: increase timeout for test_acme
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a8a3922487b8029c509635c85b533474008bb9d>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
    `commit <https://codeberg.org/freeipa/freeipa/commit/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
-   `#9310 <https://pagure.io/freeipa/issue/9310>`__
+   `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
 -  Spec file: use %autosetup instead of %setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
 -  Spec file: unify with RHEL9 spec
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
 -  Installer: create RID base before domain object
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
-   `#9309 <https://pagure.io/freeipa/issue/9309>`__
+   `#9309 <https://codeberg.org/freeipa/freeipa/issues/9309>`__
 -  Tests: force key type in ACME tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa95852c935c7b079f8ed966d4f194099217038>`__
-   `#9298 <https://pagure.io/freeipa/issue/9298>`__
+   `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__
 -  server install: remove error log about missing bkup file
    `commit <https://codeberg.org/freeipa/freeipa/commit/894dca12c120f0bfa705307a0609da47326b8fb2>`__
-   `#9306 <https://pagure.io/freeipa/issue/9306>`__
+   `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
 -  ipatests: mark test_smb as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  pylint: disable deprecated-module message
    `commit <https://codeberg.org/freeipa/freeipa/commit/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix comparison-of-constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable comparison-of-constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix consider-iterating-dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: globally disable useless-object-inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable unhashable-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/07111438389fde4a74845f9f797656712335795f>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable invalid-sequence-index
    `commit <https://codeberg.org/freeipa/freeipa/commit/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix deprecated-class SafeConfigParser
    `commit <https://codeberg.org/freeipa/freeipa/commit/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix duplicate-value
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix implicit-str-concat
    `commit <https://codeberg.org/freeipa/freeipa/commit/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable missing-timeout message
    `commit <https://codeberg.org/freeipa/freeipa/commit/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: globally disable unnecessary-lambda-assignment message
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable unnecessary-dunder-call message
    `commit <https://codeberg.org/freeipa/freeipa/commit/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable using-constant-test
    `commit <https://codeberg.org/freeipa/freeipa/commit/5434c12b6012f035528f0b137c1af5c1be113542>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove arguments-renamed warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable modified-iterating-list
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: replace deprecated distutils module
    `commit <https://codeberg.org/freeipa/freeipa/commit/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable used-before-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable redefined-slots-in-subclass
    `commit <https://codeberg.org/freeipa/freeipa/commit/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove useless suppression
    `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove unneeded disable=unused-private-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  azure tests: move to fedora 37
    `commit <https://codeberg.org/freeipa/freeipa/commit/782873a2277ca7defa5554d2b7859f1c14767d68>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/304978924a09677805fd3b73614aad6a2de232a2>`__
-   `#9135 <https://pagure.io/freeipa/issue/9135>`__
+   `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
 -  FIPS setup: fix typo filtering camellia encryption
@@ -615,24 +615,24 @@ Florence Blanc-Renaud (55)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c853cfde56fb56798424bd402012d78ed47647c0>`__
 -  ipatests: update the fake fips mode expected message
    `commit <https://codeberg.org/freeipa/freeipa/commit/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
-   `#9002 <https://pagure.io/freeipa/issue/9002>`__
+   `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__
 -  ipatests: xfail on all fedora for test_ipa_login_with_sso_user
    `commit <https://codeberg.org/freeipa/freeipa/commit/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
-   `#9264 <https://pagure.io/freeipa/issue/9264>`__
+   `#9264 <https://codeberg.org/freeipa/freeipa/issues/9264>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
-   `#9290 <https://pagure.io/freeipa/issue/9290>`__
+   `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
 -  webui tests: fix assertion in test_subid.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
-   `#9282 <https://pagure.io/freeipa/issue/9282>`__
+   `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__
 -  PRCI: update memory reqs for each topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
 -  API reference: update dnszone_add generated doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/660da9ab1d93fd8e561643728ae3821193953433>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  API reference: update vault doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
-   `#9259 <https://pagure.io/freeipa/issue/9259>`__
+   `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
 
 
 
@@ -641,7 +641,7 @@ s1341 (1)
 
 -  ipaplatform: add initial nixos support
    `commit <https://codeberg.org/freeipa/freeipa/commit/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
-   `#9299 <https://pagure.io/freeipa/issue/9299>`__
+   `#9299 <https://codeberg.org/freeipa/freeipa/issues/9299>`__
 
 
 
@@ -650,7 +650,7 @@ Jarl Gullberg (2)
 
 -  install: Fix missing dyndb keytab directive
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
-   `#9344 <https://pagure.io/freeipa/issue/9344>`__
+   `#9344 <https://codeberg.org/freeipa/freeipa/issues/9344>`__
 -  ipaplatform/debian: fix path to ldap.so
    `commit <https://codeberg.org/freeipa/freeipa/commit/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
 
@@ -664,10 +664,10 @@ Julien Rische (3)
 -  Tolerate absence of PAC ticket signature depending of server
    capabilities
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
-   `#9371 <https://pagure.io/freeipa/issue/9371>`__
+   `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
 -  kdb: Use krb5_pac_full_sign_compat() when available
    `commit <https://codeberg.org/freeipa/freeipa/commit/630cda5c06428825dd5604493621b9cbdab70073>`__
-   `#9373 <https://pagure.io/freeipa/issue/9373>`__
+   `#9373 <https://codeberg.org/freeipa/freeipa/issues/9373>`__
 
 
 
@@ -684,19 +684,19 @@ mbhalodi (5)
 
 -  ipatests: add remove automember condition tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: Test for sequence processing failures with server context
    `commit <https://codeberg.org/freeipa/freeipa/commit/304fd550613e83d120c72f0dad89f6a89d31231c>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  ipatests: add missing automember-cli tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/6db9bbd85a837950d9244502507535c1f79ab64a>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd07413cba37150b12d6b279510941aad49b5afb>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/88b9be29036a3580a8bccd31986fc30faa9852df>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 
 
 
@@ -705,10 +705,10 @@ Michal Polovka (2)
 
 -  ipatests: commands: Wait for the SSSD to become available
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc39443211e998d7088571f0ef70233b6e456e1d>`__
-   `#9377 <https://pagure.io/freeipa/issue/9377>`__
+   `#9377 <https://codeberg.org/freeipa/freeipa/issues/9377>`__
 -  ipatest: loginscreen: do not use hardcoded password
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 
 
 
@@ -719,10 +719,10 @@ Mohammad Rizwan (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
 -  ipatests: fix tests in TestACMEPrune
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  ipatests: tests for certificate pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 
 
 
@@ -731,49 +731,49 @@ Rob Crittenden (15)
 
 -  Don't allow a group to be converted to POSIX and external
    `commit <https://codeberg.org/freeipa/freeipa/commit/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
-   `#8990 <https://pagure.io/freeipa/issue/8990>`__
+   `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
    `commit <https://codeberg.org/freeipa/freeipa/commit/325a13196b32c627854c8d7594e23b58167499f0>`__
-   `#8941 <https://pagure.io/freeipa/issue/8941>`__
+   `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/abe71fe145a3d16257043ccfbb43002607458cee>`__
-   `#9086 <https://pagure.io/freeipa/issue/9086>`__
+   `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__
 -  Return the value cert-find failures from the CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
-   `#9369 <https://pagure.io/freeipa/issue/9369>`__
+   `#9369 <https://codeberg.org/freeipa/freeipa/issues/9369>`__
 -  Use the OpenSSL certificate parser in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Enforce sizelimit in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2576670e692117c11987118abd5e9381bb90b1f>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  doc: Update pruning design with implement enable/disable options
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
-   `#9323 <https://pagure.io/freeipa/issue/9323>`__
+   `#9323 <https://codeberg.org/freeipa/freeipa/issues/9323>`__
 -  Wipe the ipa-ca DNS record when updating system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
-   `#9195 <https://pagure.io/freeipa/issue/9195>`__
+   `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
 -  Fix setting values of 0 in ACME pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
-   `#9325 <https://pagure.io/freeipa/issue/9325>`__
+   `#9325 <https://codeberg.org/freeipa/freeipa/issues/9325>`__
 -  tests: add wrapper around ACME RSNv3 test
    `commit <https://codeberg.org/freeipa/freeipa/commit/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
-   `#9322 <https://pagure.io/freeipa/issue/9322>`__
+   `#9322 <https://codeberg.org/freeipa/freeipa/issues/9322>`__
 -  doc: add the --run command for manual job execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  ipa-acme-manage: add certificate/request pruning management
    `commit <https://codeberg.org/freeipa/freeipa/commit/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ca119686aadfa72c0474f72758b63cd671952d4>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  doc: Design for certificate pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 
 
 
@@ -782,10 +782,10 @@ Rafael Guterres Jeffman (2)
 
 -  Fix "no entry" condition when searching PAC info
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
-   `#9368 <https://pagure.io/freeipa/issue/9368>`__
+   `#9368 <https://codeberg.org/freeipa/freeipa/issues/9368>`__
 -  Migrated to SPDX license.
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
-   `#9342 <https://pagure.io/freeipa/issue/9342>`__
+   `#9342 <https://codeberg.org/freeipa/freeipa/issues/9342>`__
 
 
 
@@ -794,68 +794,68 @@ Stanislav Levin (21)
 
 -  ipasphinx: Correct import of progress_message for Sphinx 6.1.0+
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
-   `#9361 <https://pagure.io/freeipa/issue/9361>`__
+   `#9361 <https://codeberg.org/freeipa/freeipa/issues/9361>`__
 -  fastlint: Correct concatenation of file lists
    `commit <https://codeberg.org/freeipa/freeipa/commit/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
-   `#9318 <https://pagure.io/freeipa/issue/9318>`__
+   `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__
 -  dns: Fix support for dnspython 1.1x
    `commit <https://codeberg.org/freeipa/freeipa/commit/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
-   `#9339 <https://pagure.io/freeipa/issue/9339>`__
+   `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__
 -  tests: webui: Update vendored qunit
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  AP: webui: List installed nodejs packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Load qunit only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Allow file access from files in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
    `commit <https://codeberg.org/freeipa/freeipa/commit/d662b125985369181a3ebcbad82a4a43215282f6>`__
-   `#9319 <https://pagure.io/freeipa/issue/9319>`__
+   `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__
 -  spec: Drop no longer used build dependency on paste
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
-   `#9314 <https://pagure.io/freeipa/issue/9314>`__
+   `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
-   `#9315 <https://pagure.io/freeipa/issue/9315>`__
+   `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__
 -  pylint: Replace deprecated cgi module
    `commit <https://codeberg.org/freeipa/freeipa/commit/2009889d763ccc26479c966931ca1b60378496fd>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix useless-object-inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/bccd3c942084c753543d63b4d409ac46f819d314>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix unhashable-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix unnecessary-lambda-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc8c8a7824565178333ef7ae8ac7934467424691>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix modified-iterating-list
    `commit <https://codeberg.org/freeipa/freeipa/commit/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix used-before-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/b12376560da944b0845b9ac0d424adaf5435670f>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Replace deprecated pipes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1261bbf0016d4824f908a589d4943513e98f8b01>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix cyclic-import
    `commit <https://codeberg.org/freeipa/freeipa/commit/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
-   `#9232 <https://pagure.io/freeipa/issue/9232>`__,
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9232 <https://codeberg.org/freeipa/freeipa/issues/9232>`__,
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Replace deprecated extension-pkg-whitelist
    `commit <https://codeberg.org/freeipa/freeipa/commit/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: More allowed C extensions
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9822697659f134146e1dcfce0c48e2279a8becb>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Lint in single process mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 
 
 
@@ -866,7 +866,7 @@ Sudhir Menon (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
-   `#9279 <https://pagure.io/freeipa/issue/9279>`__
+   `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__
 
 
 
@@ -875,7 +875,7 @@ Timo Aaltonen (1)
 
 -  Drop duplicate includedir from krb5.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
-   `#9267 <https://pagure.io/freeipa/issue/9267>`__
+   `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
 
 
 

--- a/src/page/Releases/4.3.3.rst
+++ b/src/page/Releases/4.3.3.rst
@@ -44,60 +44,60 @@ mailing list (http://www.redhat.com/mailman/listinfo/freeipa-users) or
 Resolved tickets
 ----------------
 
--  `#6774 <https://pagure.io/freeipa/issue/6774>`__ FreeIPA client <=
+-  `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__ FreeIPA client <=
    4.4 fail to parse 4.5 cookies
--  `#6561 <https://pagure.io/freeipa/issue/6561>`__ CVE-2016-7030
+-  `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__ CVE-2016-7030
    freeipa: ipa: DoS attack against kerberized services by abusing
    password policy
--  `#6560 <https://pagure.io/freeipa/issue/6560>`__ CVE-2016-9575
+-  `#6560 <https://codeberg.org/freeipa/freeipa/issues/6560>`__ CVE-2016-9575
    freeipa: ipa: Insufficient permission check in certprofile-mod
--  `#6485 <https://pagure.io/freeipa/issue/6485>`__ Document
+-  `#6485 <https://codeberg.org/freeipa/freeipa/issues/6485>`__ Document
    make_delete_command method in UserTracker
--  `#6378 <https://pagure.io/freeipa/issue/6378>`__ Tests: Fix failing
+-  `#6378 <https://codeberg.org/freeipa/freeipa/issues/6378>`__ Tests: Fix failing
    sudo test
--  `#6317 <https://pagure.io/freeipa/issue/6317>`__ backport #6213
+-  `#6317 <https://codeberg.org/freeipa/freeipa/issues/6317>`__ backport #6213
    Incorrect test for DNSForwardPolicyConflictWithEmptyZone warning in
    test_xmlrpc/test_dns_plugin
--  `#6316 <https://pagure.io/freeipa/issue/6316>`__ backport #6199
+-  `#6316 <https://codeberg.org/freeipa/freeipa/issues/6316>`__ backport #6199
    Received ACIError instead of DuplicatedError in stageuser_tests
--  `#6311 <https://pagure.io/freeipa/issue/6311>`__ Fix or remove the
+-  `#6311 <https://codeberg.org/freeipa/freeipa/issues/6311>`__ Fix or remove the
    \`LDAPUpdate.update_from_dict\` method
--  `#6287 <https://pagure.io/freeipa/issue/6287>`__ Refer to nodes in
+-  `#6287 <https://codeberg.org/freeipa/freeipa/issues/6287>`__ Refer to nodes in
    TestWrongClientDomain replica promotion tests as replicas
--  `#6284 <https://pagure.io/freeipa/issue/6284>`__ Tests: avoid
+-  `#6284 <https://codeberg.org/freeipa/freeipa/issues/6284>`__ Tests: avoid
    skipping tests because of missing files when running as outoftree
--  `#6278 <https://pagure.io/freeipa/issue/6278>`__ Use OAEP padding
+-  `#6278 <https://codeberg.org/freeipa/freeipa/issues/6278>`__ Use OAEP padding
    with custodia (to avoid CVE-2016-6298)
--  `#6262 <https://pagure.io/freeipa/issue/6262>`__ Fix integration sudo
+-  `#6262 <https://codeberg.org/freeipa/freeipa/issues/6262>`__ Fix integration sudo
    tests setup and checks
--  `#6254 <https://pagure.io/freeipa/issue/6254>`__ kinit_admin raises
+-  `#6254 <https://codeberg.org/freeipa/freeipa/issues/6254>`__ kinit_admin raises
    an exception if server uninstallation is called from test teardown
    with server not installed
--  `#6244 <https://pagure.io/freeipa/issue/6244>`__ build: add
+-  `#6244 <https://codeberg.org/freeipa/freeipa/issues/6244>`__ build: add
    python-libsss_nss_idmap and python-sss to BuildRequires
--  `#6205 <https://pagure.io/freeipa/issue/6205>`__ The
+-  `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__ The
    ipa-server-upgrade command failed when named-pkcs11 does not happen
    to run during dnf upgrade
--  `#6177 <https://pagure.io/freeipa/issue/6177>`__ ca-less test are
+-  `#6177 <https://codeberg.org/freeipa/freeipa/issues/6177>`__ ca-less test are
    broken - invalid usage of ipautil.run
--  `#6167 <https://pagure.io/freeipa/issue/6167>`__ Incorrect
+-  `#6167 <https://codeberg.org/freeipa/freeipa/issues/6167>`__ Incorrect
    domainlevel info in tests
--  `#6166 <https://pagure.io/freeipa/issue/6166>`__ Subsequent external
+-  `#6166 <https://codeberg.org/freeipa/freeipa/issues/6166>`__ Subsequent external
    CA installation fails
--  `#6147 <https://pagure.io/freeipa/issue/6147>`__ Failing automember
+-  `#6147 <https://codeberg.org/freeipa/freeipa/issues/6147>`__ Failing automember
    tests due to manager output normalization
--  `#6134 <https://pagure.io/freeipa/issue/6134>`__ Command
+-  `#6134 <https://codeberg.org/freeipa/freeipa/issues/6134>`__ Command
    "ipa-replica-prepare" not allowed to create line replication topology
--  `#6120 <https://pagure.io/freeipa/issue/6120>`__ ipa-adtrust-install:
+-  `#6120 <https://codeberg.org/freeipa/freeipa/issues/6120>`__ ipa-adtrust-install:
    when running with --netbios-name="", the NetBIOS name is changed
    without notification
--  `#6076 <https://pagure.io/freeipa/issue/6076>`__ Mulitple domain
+-  `#6076 <https://codeberg.org/freeipa/freeipa/issues/6076>`__ Mulitple domain
    Active Directory Trust conflict
--  `#6056 <https://pagure.io/freeipa/issue/6056>`__ custodia.conf and
+-  `#6056 <https://codeberg.org/freeipa/freeipa/issues/6056>`__ custodia.conf and
    server.keys file is world-readable.
--  `#6016 <https://pagure.io/freeipa/issue/6016>`__ ipa-ca-install on
+-  `#6016 <https://codeberg.org/freeipa/freeipa/issues/6016>`__ ipa-ca-install on
    replica tries to connect to master:8443
--  `#5696 <https://pagure.io/freeipa/issue/5696>`__ Add conflicts with
+-  `#5696 <https://codeberg.org/freeipa/freeipa/issues/5696>`__ Add conflicts with
    bind-chroot to spec.
 
 
@@ -112,20 +112,20 @@ Alexander Bokovoy (5)
 
 -  ipa-kdb: search for password policies globally
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9b919e127c453eda02ea142d7cd80c16aa5ca31>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  ipa-kdb: simplify trusted domain parent search
    `commit <https://codeberg.org/freeipa/freeipa/commit/775c868bacc01286eafc97e8126937d76ee53e1e>`__
-   `#5738 <https://pagure.io/freeipa/issue/5738>`__
+   `#5738 <https://codeberg.org/freeipa/freeipa/issues/5738>`__
 -  trust: make sure ID range is created for the child domain even if it
    exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/4dabab84e02afb15a0bd77f62343392ea17a7102>`__
-   `#5738 <https://pagure.io/freeipa/issue/5738>`__
+   `#5738 <https://codeberg.org/freeipa/freeipa/issues/5738>`__
 -  trust: automatically resolve DNS trust conflicts for triangle trusts
    `commit <https://codeberg.org/freeipa/freeipa/commit/324d5aa1d09431c64d817f628b18b01a12253ccf>`__
-   `#6076 <https://pagure.io/freeipa/issue/6076>`__
+   `#6076 <https://codeberg.org/freeipa/freeipa/issues/6076>`__
 -  ipaserver/dcerpc: reformat to make the code closer to pep8
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc6990ebfe2e0bc4b29b9308682750651e3aaf4a>`__
-   `#6076 <https://pagure.io/freeipa/issue/6076>`__
+   `#6076 <https://codeberg.org/freeipa/freeipa/issues/6076>`__
 
 
 
@@ -134,13 +134,13 @@ Christian Heimes (3)
 
 -  Use RSA-OAEP instead of RSA PKCS#1 v1.5
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e27b7077d280447dbf526b567566101d4c800c7>`__
-   `#6278 <https://pagure.io/freeipa/issue/6278>`__
+   `#6278 <https://codeberg.org/freeipa/freeipa/issues/6278>`__
 -  Secure permissions of Custodia server.keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc3b695b5969992d63fad12cdf9607b8e8a20aff>`__
-   `#6056 <https://pagure.io/freeipa/issue/6056>`__
+   `#6056 <https://codeberg.org/freeipa/freeipa/issues/6056>`__
 -  RedHatCAService should wait for local Dogtag instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/16491d7949d4a0a088bbadf69a80866f491fd5b0>`__
-   `#6016 <https://pagure.io/freeipa/issue/6016>`__
+   `#6016 <https://codeberg.org/freeipa/freeipa/issues/6016>`__
 
 
 
@@ -150,7 +150,7 @@ David Kupka (1)
 -  password policy: Add explicit default password policy for hosts and
    services
    `commit <https://codeberg.org/freeipa/freeipa/commit/42263a5a729096135702c0b974f255a058c0cdaf>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 
 
 
@@ -159,10 +159,10 @@ Fraser Tweedale (2)
 
 -  certprofile-mod: correctly authorise config update
    `commit <https://codeberg.org/freeipa/freeipa/commit/278d7cf4708f1c6ac05d5fcb21db582d9aa7bab3>`__
-   `#6560 <https://pagure.io/freeipa/issue/6560>`__
+   `#6560 <https://codeberg.org/freeipa/freeipa/issues/6560>`__
 -  cert-revoke: fix permission check bypass (CVE-2016-5404)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7eb1502863408d869dc2e706a5e194ad122997bf>`__
-   `#6232 <https://pagure.io/freeipa/issue/6232>`__
+   `#6232 <https://codeberg.org/freeipa/freeipa/issues/6232>`__
 
 
 
@@ -179,10 +179,10 @@ Jan Cholasta (2)
 
 -  Revert "spec: add conflict with bind-chroot to freeipa-server-dns"
    `commit <https://codeberg.org/freeipa/freeipa/commit/56695d969325cb2cb754d0ea549c5b6face89c6f>`__
-   `#5696 <https://pagure.io/freeipa/issue/5696>`__
+   `#5696 <https://codeberg.org/freeipa/freeipa/issues/5696>`__
 -  install: fix external CA cert validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/44401d26c29e35d38bc94a7a87b9f2dd205e0643>`__
-   `#6166 <https://pagure.io/freeipa/issue/6166>`__
+   `#6166 <https://codeberg.org/freeipa/freeipa/issues/6166>`__
 
 
 
@@ -191,22 +191,22 @@ Lenka Doudova (7)
 
 -  Document make_delete_command method in UserTracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/a825540932d8fc2bf7f7e799be2fda0b61763ec3>`__
-   `#6485 <https://pagure.io/freeipa/issue/6485>`__
+   `#6485 <https://codeberg.org/freeipa/freeipa/issues/6485>`__
 -  Tests: Fix integration sudo test
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ebc0d4d7d38f3f59da668aa08fd762e08280d32>`__
-   `#6378 <https://pagure.io/freeipa/issue/6378>`__
+   `#6378 <https://codeberg.org/freeipa/freeipa/issues/6378>`__
 -  Tests: Fix integration sudo tests setup and checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d04220dc3071782cf303b2e94e06da4ee26e512>`__
-   `#6262 <https://pagure.io/freeipa/issue/6262>`__
+   `#6262 <https://codeberg.org/freeipa/freeipa/issues/6262>`__
 -  Tests: Avoid skipping tests due to missing files
    `commit <https://codeberg.org/freeipa/freeipa/commit/d472d26fc06dfe192a5385e620f4c30ca3dcf1be>`__
-   `#6284 <https://pagure.io/freeipa/issue/6284>`__
+   `#6284 <https://codeberg.org/freeipa/freeipa/issues/6284>`__
 -  Raise error when running ipa-adtrust-install with empty netbios--name
    `commit <https://codeberg.org/freeipa/freeipa/commit/6064b122f995ca5e8f9bfcc72a8565d1280f8876>`__
-   `#6120 <https://pagure.io/freeipa/issue/6120>`__
+   `#6120 <https://codeberg.org/freeipa/freeipa/issues/6120>`__
 -  Tests: Fix failing automember tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffe146fbba2e9577a9af5dd1521a110570024455>`__
-   `#6147 <https://pagure.io/freeipa/issue/6147>`__
+   `#6147 <https://codeberg.org/freeipa/freeipa/issues/6147>`__
 -  Tests: Remove DNS configuration from trust tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/40b1459ad0299e95331699be9684682fca02a570>`__
 
@@ -217,7 +217,7 @@ Martin Babinsky (1)
 
 -  add python-libsss_nss_idmap and python-sss to BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0e43d5ec879fc56c38328cd9f01b04d8b6a870d>`__
-   `#6244 <https://pagure.io/freeipa/issue/6244>`__
+   `#6244 <https://codeberg.org/freeipa/freeipa/issues/6244>`__
 
 
 
@@ -230,14 +230,14 @@ Martin Basti (5)
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ce58141cce0a58ec896b93bc1409a56a88c7700>`__
 -  Raise DuplicatedEnrty error when user exists in delete_container
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b551743820f436807811415ab51d6ee238ee971>`__
-   `#6199 <https://pagure.io/freeipa/issue/6199>`__,
-   `#6316 <https://pagure.io/freeipa/issue/6316>`__
+   `#6199 <https://codeberg.org/freeipa/freeipa/issues/6199>`__,
+   `#6316 <https://codeberg.org/freeipa/freeipa/issues/6316>`__
 -  Catch DNS exceptions during emptyzones named.conf upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/93756dc719723bbec93497ecd6e06e325e6eecbd>`__
-   `#6205 <https://pagure.io/freeipa/issue/6205>`__
+   `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__
 -  Start named during configuration upgrade.
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d011b97c8a56d9eabae2ca3d88c30314e0adb58>`__
-   `#6205 <https://pagure.io/freeipa/issue/6205>`__
+   `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__
 
 
 
@@ -246,13 +246,13 @@ Oleg Fayans (3)
 
 -  Changed addressing to the client hosts to be replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ed4a4ba6392deb7972ddc07593d649926065c72>`__
-   `#6287 <https://pagure.io/freeipa/issue/6287>`__
+   `#6287 <https://codeberg.org/freeipa/freeipa/issues/6287>`__
 -  Disabled raiseonerr in kinit call during topology level check
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb6980d2263aae64ee35f2890542ed2b0ded9e02>`__
-   `#6254 <https://pagure.io/freeipa/issue/6254>`__
+   `#6254 <https://codeberg.org/freeipa/freeipa/issues/6254>`__
 -  Fixed incorrect domainlevel determination in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab29e560bdd03f2bb3742dbd122867979e26f108>`__
-   `#6167 <https://pagure.io/freeipa/issue/6167>`__
+   `#6167 <https://codeberg.org/freeipa/freeipa/issues/6167>`__
 
 
 
@@ -261,7 +261,7 @@ Peter Lacko (1)
 
 -  Test URIs in certificate.
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a207dd637748a4c05e54755b755986fbed16d55>`__
-   `#5881 <https://pagure.io/freeipa/issue/5881>`__
+   `#5881 <https://codeberg.org/freeipa/freeipa/issues/5881>`__
 
 
 
@@ -270,15 +270,15 @@ Petr Spacek (3)
 
 -  Tests: fix test_forward_zones in test_xmlrpc/test_dns_plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/505a7da9d4335adc39d06b29fde66e00b758d4a2>`__
-   `#6213 <https://pagure.io/freeipa/issue/6213>`__,
-   `#6317 <https://pagure.io/freeipa/issue/6317>`__
+   `#6213 <https://codeberg.org/freeipa/freeipa/issues/6213>`__,
+   `#6317 <https://codeberg.org/freeipa/freeipa/issues/6317>`__
 -  DNS server upgrade: do not fail when DNS server did not respond
    `commit <https://codeberg.org/freeipa/freeipa/commit/27534f8d7294536364147b18b76ecb2bac67870f>`__
-   `#6205 <https://pagure.io/freeipa/issue/6205>`__
+   `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__
 -  Fix ipa-replica-prepare's error message about missing local CA
    instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/fedee72a5a0e9fbb2b82c4105034857b17f8a5c4>`__
-   `#6134 <https://pagure.io/freeipa/issue/6134>`__
+   `#6134 <https://codeberg.org/freeipa/freeipa/issues/6134>`__
 
 
 
@@ -287,7 +287,7 @@ Petr Vobornik (1)
 
 -  ca-less tests: fix getting cert in pem format from nssdb
    `commit <https://codeberg.org/freeipa/freeipa/commit/42d3ec37f5a2692a51cd7db878b7b745d8d4c846>`__
-   `#6177 <https://pagure.io/freeipa/issue/6177>`__
+   `#6177 <https://codeberg.org/freeipa/freeipa/issues/6177>`__
 
 
 
@@ -296,13 +296,13 @@ Stanislav Laznicka (3)
 
 -  Add debug log in case cookie retrieval went wrong
    `commit <https://codeberg.org/freeipa/freeipa/commit/71475e3153117e554d22a2a27d7882ba4f890be8>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 -  Fix cookie with Max-Age processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d66046e501a4a1a09a0a74a96a499cb88ffb03b>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 -  Remove update_from_dict() method
    `commit <https://codeberg.org/freeipa/freeipa/commit/126c7c6932bba62342eefdc910877df1075e4a70>`__
-   `#6311 <https://pagure.io/freeipa/issue/6311>`__
+   `#6311 <https://codeberg.org/freeipa/freeipa/issues/6311>`__
 
 
 
@@ -311,4 +311,4 @@ Tomas Krizek (1)
 
 -  Keep NSS trust flags of existing certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3e57f789ef7f697f8cc68f180dc8ce292954ed4>`__
-   `#5791 <https://pagure.io/freeipa/issue/5791>`__
+   `#5791 <https://codeberg.org/freeipa/freeipa/issues/5791>`__

--- a/src/page/Releases/4.4.4.rst
+++ b/src/page/Releases/4.4.4.rst
@@ -42,25 +42,25 @@ mailing list (http://www.redhat.com/mailman/listinfo/freeipa-users) or
 Resolved tickets
 ----------------
 
--  `#6776 <https://pagure.io/freeipa/issue/6776>`__ krb5 1.15 broke DAL
+-  `#6776 <https://codeberg.org/freeipa/freeipa/issues/6776>`__ krb5 1.15 broke DAL
    principal free
--  `#6738 <https://pagure.io/freeipa/issue/6738>`__ Ipa-kra-install
+-  `#6738 <https://codeberg.org/freeipa/freeipa/issues/6738>`__ Ipa-kra-install
    fails with weird output when backspace is used during typing
    Directory Manager password
--  `#6713 <https://pagure.io/freeipa/issue/6713>`__ ipa: Insufficient
+-  `#6713 <https://codeberg.org/freeipa/freeipa/issues/6713>`__ ipa: Insufficient
    permission check for ca-del, ca-disable and ca-enable commands
    (CVE-2017-2590)
--  `#6647 <https://pagure.io/freeipa/issue/6647>`__ batch param
+-  `#6647 <https://codeberg.org/freeipa/freeipa/issues/6647>`__ batch param
    compatibility is incorrect
--  `#6608 <https://pagure.io/freeipa/issue/6608>`__ IPA server
+-  `#6608 <https://codeberg.org/freeipa/freeipa/issues/6608>`__ IPA server
    installation should check if IPv6 stack is enabled
--  `#6600 <https://pagure.io/freeipa/issue/6600>`__ Legacy client tests
+-  `#6600 <https://codeberg.org/freeipa/freeipa/issues/6600>`__ Legacy client tests
    doesn't have tree domain role.
--  `#6588 <https://pagure.io/freeipa/issue/6588>`__ replication race
+-  `#6588 <https://codeberg.org/freeipa/freeipa/issues/6588>`__ replication race
    condition prevents IPA to install
--  `#6575 <https://pagure.io/freeipa/issue/6575>`__ ipa-replica-install
+-  `#6575 <https://codeberg.org/freeipa/freeipa/issues/6575>`__ ipa-replica-install
    fails on requesting DS cert when master is not configured with IPv6
--  `#6070 <https://pagure.io/freeipa/issue/6070>`__ ipa-replica-install
+-  `#6070 <https://codeberg.org/freeipa/freeipa/issues/6070>`__ ipa-replica-install
    fails to install when resolv.conf incomplete entries
 
 
@@ -75,7 +75,7 @@ Alexander Bokovoy (1)
 
 -  ipa-kdb: support KDB DAL version 6.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/95daecbae86f51271f5ea48cb628ace72e676351>`__
-   `#6776 <https://pagure.io/freeipa/issue/6776>`__
+   `#6776 <https://codeberg.org/freeipa/freeipa/issues/6776>`__
 
 
 
@@ -84,7 +84,7 @@ David Kupka (1)
 
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
    `commit <https://codeberg.org/freeipa/freeipa/commit/40e1eb695d648a03f45e9c8d6687cb3d8a99fd6d>`__
-   `#6738 <https://pagure.io/freeipa/issue/6738>`__
+   `#6738 <https://codeberg.org/freeipa/freeipa/issues/6738>`__
 
 
 
@@ -93,7 +93,7 @@ Florence Blanc-Renaud (1)
 
 -  Do not configure PKI ajp redirection to use "::1"
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a30e9d53475d60fb76242a098f1d969d6b19f75>`__
-   `#6575 <https://pagure.io/freeipa/issue/6575>`__
+   `#6575 <https://codeberg.org/freeipa/freeipa/issues/6575>`__
 
 
 
@@ -102,10 +102,10 @@ Fraser Tweedale (2)
 
 -  ca: correctly authorise ca-del, ca-enable and ca-disable
    `commit <https://codeberg.org/freeipa/freeipa/commit/1aa314c79648c442473f19344387bfe11ec2141b>`__
-   `#6713 <https://pagure.io/freeipa/issue/6713>`__
+   `#6713 <https://codeberg.org/freeipa/freeipa/issues/6713>`__
 -  Set up DS TLS on replica in CA-less topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdb6ffb779b7e1e563494eb3234b2441ba74d692>`__
-   `#6226 <https://pagure.io/freeipa/issue/6226>`__
+   `#6226 <https://codeberg.org/freeipa/freeipa/issues/6226>`__
 
 
 
@@ -114,7 +114,7 @@ Ganna Kaihorodova (1)
 
 -  Tests: Add tree root domain role in legacy client tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/52527d6323eec1a2ae4bf01dd64412a3822c516d>`__
-   `#6600 <https://pagure.io/freeipa/issue/6600>`__
+   `#6600 <https://codeberg.org/freeipa/freeipa/issues/6600>`__
 
 
 
@@ -123,7 +123,7 @@ Jan Cholasta (1)
 
 -  compat: fix \`Any\` params in \`batch\` and \`dnsrecord\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3b49abfe7a8d9540d77ed355595d9e44a3bdd27>`__
-   `#6647 <https://pagure.io/freeipa/issue/6647>`__
+   `#6647 <https://codeberg.org/freeipa/freeipa/issues/6647>`__
 
 
 
@@ -138,15 +138,15 @@ Martin Basti (7)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7beb9a2ae5349525119ee072eebcc385f01c68e>`__
 -  Bump python-dns to improve processing of non-complete resolv.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/951d27ecc591a71c4a1297623b6920136c01bb4b>`__
-   `#6070 <https://pagure.io/freeipa/issue/6070>`__
+   `#6070 <https://codeberg.org/freeipa/freeipa/issues/6070>`__
 -  Use proper logging for error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/74020d07dbf14202f696a0c8521829abc735d4c7>`__
 -  Wait until HTTPS principal entry is replicated to replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bddcdb47b40baeae7379e00e8d87297ed3f1cd4>`__
-   `#6588 <https://pagure.io/freeipa/issue/6588>`__
+   `#6588 <https://codeberg.org/freeipa/freeipa/issues/6588>`__
 -  wait_for_entry: use only DN as parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d0a0728766aed7245427b9eaf210e31fd40e440>`__
-   `#6588 <https://pagure.io/freeipa/issue/6588>`__
+   `#6588 <https://codeberg.org/freeipa/freeipa/issues/6588>`__
 
 
 
@@ -155,10 +155,10 @@ Stanislav Laznicka (2)
 
 -  Add debug log in case cookie retrieval went wrong
    `commit <https://codeberg.org/freeipa/freeipa/commit/5caade99127ff46141d2f6b7137f7aa62c0ff3bc>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 -  Fix cookie with Max-Age processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/40f3b8f8a3d33864528138e517ce3240da6c9a4a>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 
 
 
@@ -167,7 +167,7 @@ Tomas Krizek (1)
 
 -  server install: require IPv6 stack to be enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/a572e61cb5153df8a040757eaba0c47531f0fe85>`__
-   `#6608 <https://pagure.io/freeipa/issue/6608>`__
+   `#6608 <https://codeberg.org/freeipa/freeipa/issues/6608>`__
 
 
 
@@ -176,4 +176,4 @@ Thorsten Scherf (1)
 
 -  added ssl verification using IPA trust anchor
    `commit <https://codeberg.org/freeipa/freeipa/commit/f784e33b1e2630aaa2e433da904cbb241d76e502>`__
-   `#6686 <https://pagure.io/freeipa/issue/6686>`__
+   `#6686 <https://codeberg.org/freeipa/freeipa/issues/6686>`__

--- a/src/page/Releases/4.5.0.rst
+++ b/src/page/Releases/4.5.0.rst
@@ -69,8 +69,8 @@ containers. Option *--setup-adtrust* has been added to
 *ipa-server-install* and *ipa-replica-install*, and option *--setup-kra*
 has been added to *ipa-server-install*.
 
--  <https://pagure.io/freeipa/issue/6731>
--  <https://pagure.io/freeipa/issue/6630>
+-  <https://codeberg.org/freeipa/freeipa/issues/6731>
+-  <https://codeberg.org/freeipa/freeipa/issues/6630>
 
 
 
@@ -84,7 +84,7 @@ nsupdate command to update records on an external DNS server. For more
 details see this howto
 <https://www.freeipa.org/page/Howto/Updating_FreeIPA_system_DNS_records_on_a_remote_DNS_server>
 
--  <https://pagure.io/freeipa/issue/6585>
+-  <https://codeberg.org/freeipa/freeipa/issues/6585>
 
 
 
@@ -92,11 +92,11 @@ Known Issues
 ----------------------------------------------------------------------------------------------
 
 -  CLI doesn't work after *ipa-restore*
-   <https://pagure.io/freeipa/issue/6748>
+   <https://codeberg.org/freeipa/freeipa/issues/6748>
 -  AD Trust doesn't work with enabled FIPS mode
-   <https://pagure.io/freeipa/issue/6697>
+   <https://codeberg.org/freeipa/freeipa/issues/6697>
 -  *cert-find* does not find all certificates without sizelimit=0
-   <https://pagure.io/freeipa/issue/6716>
+   <https://codeberg.org/freeipa/freeipa/issues/6716>
 
 
 
@@ -125,7 +125,7 @@ In the web UI, the group type label "Normal" has been changed to
 "Non-POSIX" to be compatible with CLI options. The semantics of group
 types is unchanged.
 
--  <https://pagure.io/freeipa/issue/6334>
+-  <https://codeberg.org/freeipa/freeipa/issues/6334>
 
 
 
@@ -161,7 +161,7 @@ containerized applications). Due to this change in behavior, care must
 be taken to specify correct FQDN in host/service principals as no
 attempt to resolve e.g. short names will be made.
 
--  <https://pagure.io/freeipa/issue/6584>
+-  <https://codeberg.org/freeipa/freeipa/issues/6584>
 
 
 
@@ -194,7 +194,7 @@ to be related to the certificate subject base. The *ipa-server-instal*
 and *ipa-ca-install* commands learned the *--ca-subject* and
 *--subject-base* options for configuring these values.
 
--  <https://pagure.io/freeipa/issue/2614>
+-  <https://codeberg.org/freeipa/freeipa/issues/2614>
 
 Upgrading
 ---------
@@ -219,411 +219,411 @@ repository <https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-4-5/>`__.
 Resolved tickets
 ----------------
 
--  `#6764 <https://pagure.io/freeipa/issue/6764>`__ debian: python
+-  `#6764 <https://codeberg.org/freeipa/freeipa/issues/6764>`__ debian: python
    modules should be installed under dist-packages
--  `#6759 <https://pagure.io/freeipa/issue/6759>`__ replica prepare
+-  `#6759 <https://codeberg.org/freeipa/freeipa/issues/6759>`__ replica prepare
    broken on KDC cert export
--  `#6755 <https://pagure.io/freeipa/issue/6755>`__ [certs.py] -
+-  `#6755 <https://codeberg.org/freeipa/freeipa/issues/6755>`__ [certs.py] -
    "ipa-replica-prepare" command fails when trying to unlink
    non-existing "tmpcert.der" file in /var/lib/ipa/
--  `#6750 <https://pagure.io/freeipa/issue/6750>`__ Web page
+-  `#6750 <https://codeberg.org/freeipa/freeipa/issues/6750>`__ Web page
    ipa/config/ssbrowser.html refers to missing ipa/config/ca.crt file
--  `#6739 <https://pagure.io/freeipa/issue/6739>`__ Cannot login to
+-  `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__ Cannot login to
    replica's WebUI
--  `#6735 <https://pagure.io/freeipa/issue/6735>`__ The
+-  `#6735 <https://codeberg.org/freeipa/freeipa/issues/6735>`__ The
    ipa-managed-entries command failed, exception: AttributeError: ldap2
--  `#6734 <https://pagure.io/freeipa/issue/6734>`__ vaultconfig-show
+-  `#6734 <https://codeberg.org/freeipa/freeipa/issues/6734>`__ vaultconfig-show
    throws internal error
--  `#6731 <https://pagure.io/freeipa/issue/6731>`__ ipa-server-install:
+-  `#6731 <https://codeberg.org/freeipa/freeipa/issues/6731>`__ ipa-server-install:
    allow to in install KRA in one step
--  `#6730 <https://pagure.io/freeipa/issue/6730>`__ Harden client HTTPS
+-  `#6730 <https://codeberg.org/freeipa/freeipa/issues/6730>`__ Harden client HTTPS
    connections
--  `#6724 <https://pagure.io/freeipa/issue/6724>`__ [test_csrgen.py] -
+-  `#6724 <https://codeberg.org/freeipa/freeipa/issues/6724>`__ [test_csrgen.py] -
    comparison test scripts not reflected changes in "openssl_base.tmpl"
--  `#6723 <https://pagure.io/freeipa/issue/6723>`__ ipa systemd unit
+-  `#6723 <https://codeberg.org/freeipa/freeipa/issues/6723>`__ ipa systemd unit
    should define Wants=network instead of Requires=network
--  `#6718 <https://pagure.io/freeipa/issue/6718>`__ SessionMaxAge in
+-  `#6718 <https://codeberg.org/freeipa/freeipa/issues/6718>`__ SessionMaxAge in
    /etc/httpd/conf.d/ipa.conf introduces regression
--  `#6717 <https://pagure.io/freeipa/issue/6717>`__ WebUI: change
+-  `#6717 <https://codeberg.org/freeipa/freeipa/issues/6717>`__ WebUI: change
    structure of Identity submenu
--  `#6714 <https://pagure.io/freeipa/issue/6714>`__ ipaclient.csrgen
+-  `#6714 <https://codeberg.org/freeipa/freeipa/issues/6714>`__ ipaclient.csrgen
    depends on ipaplatform
--  `#6713 <https://pagure.io/freeipa/issue/6713>`__ ipa: Insufficient
+-  `#6713 <https://codeberg.org/freeipa/freeipa/issues/6713>`__ ipa: Insufficient
    permission check for ca-del, ca-disable and ca-enable commands
    (CVE-2017-2590)
--  `#6712 <https://pagure.io/freeipa/issue/6712>`__ WebUI: Arbitrary
+-  `#6712 <https://codeberg.org/freeipa/freeipa/issues/6712>`__ WebUI: Arbitrary
    certificates on {user|host|service} details pages are not displayed
    in WebUI
--  `#6707 <https://pagure.io/freeipa/issue/6707>`__ Removal of IPAConfig
+-  `#6707 <https://codeberg.org/freeipa/freeipa/issues/6707>`__ Removal of IPAConfig
    broke Ipsilon's FreeIPA integration
--  `#6701 <https://pagure.io/freeipa/issue/6701>`__ Add SHA256
+-  `#6701 <https://codeberg.org/freeipa/freeipa/issues/6701>`__ Add SHA256
    fingerprints
--  `#6698 <https://pagure.io/freeipa/issue/6698>`__ User with ticket
+-  `#6698 <https://codeberg.org/freeipa/freeipa/issues/6698>`__ User with ticket
    gets GSS failure when calling freeipa CLI command
--  `#6694 <https://pagure.io/freeipa/issue/6694>`__ ipa-client-install
+-  `#6694 <https://codeberg.org/freeipa/freeipa/issues/6694>`__ ipa-client-install
    command failed, TypeError: list found
--  `#6690 <https://pagure.io/freeipa/issue/6690>`__ Plugin schema cache
+-  `#6690 <https://codeberg.org/freeipa/freeipa/issues/6690>`__ Plugin schema cache
    is slow
--  `#6686 <https://pagure.io/freeipa/issue/6686>`__ ipa-replica-install
+-  `#6686 <https://codeberg.org/freeipa/freeipa/issues/6686>`__ ipa-replica-install
    fails promotecustodia.create_replica with cert errors (untrusted)
    after adding externally signed CA cert
--  `#6685 <https://pagure.io/freeipa/issue/6685>`__ logout does not work
+-  `#6685 <https://codeberg.org/freeipa/freeipa/issues/6685>`__ logout does not work
    properly
--  `#6682 <https://pagure.io/freeipa/issue/6682>`__ session logout
+-  `#6682 <https://codeberg.org/freeipa/freeipa/issues/6682>`__ session logout
    should not remove ccache
--  `#6680 <https://pagure.io/freeipa/issue/6680>`__ kra-agent.pem file
+-  `#6680 <https://codeberg.org/freeipa/freeipa/issues/6680>`__ kra-agent.pem file
    is not auto-renewed by certmonger
--  `#6676 <https://pagure.io/freeipa/issue/6676>`__ unable to parse
+-  `#6676 <https://codeberg.org/freeipa/freeipa/issues/6676>`__ unable to parse
    cookie header
--  `#6675 <https://pagure.io/freeipa/issue/6675>`__ KRA_AGENT_PEM file
+-  `#6675 <https://codeberg.org/freeipa/freeipa/issues/6675>`__ KRA_AGENT_PEM file
    is missing
--  `#6674 <https://pagure.io/freeipa/issue/6674>`__ ipactl: noise error
+-  `#6674 <https://codeberg.org/freeipa/freeipa/issues/6674>`__ ipactl: noise error
    from pki-tomcatd start
--  `#6673 <https://pagure.io/freeipa/issue/6673>`__ httpd unit files
+-  `#6673 <https://codeberg.org/freeipa/freeipa/issues/6673>`__ httpd unit files
    deletes root ccache
--  `#6670 <https://pagure.io/freeipa/issue/6670>`__ PKINIT upgrade
+-  `#6670 <https://codeberg.org/freeipa/freeipa/issues/6670>`__ PKINIT upgrade
    process is incomplete
--  `#6661 <https://pagure.io/freeipa/issue/6661>`__ Move ipa session
+-  `#6661 <https://codeberg.org/freeipa/freeipa/issues/6661>`__ Move ipa session
    data from keyring to ccaches
--  `#6659 <https://pagure.io/freeipa/issue/6659>`__ ipa-backup does not
+-  `#6659 <https://codeberg.org/freeipa/freeipa/issues/6659>`__ ipa-backup does not
    include /root/kracert.p12
--  `#6650 <https://pagure.io/freeipa/issue/6650>`__ [vault] Replace nss
+-  `#6650 <https://codeberg.org/freeipa/freeipa/issues/6650>`__ [vault] Replace nss
    crypto with cryptography
--  `#6648 <https://pagure.io/freeipa/issue/6648>`__ Make
+-  `#6648 <https://codeberg.org/freeipa/freeipa/issues/6648>`__ Make
    ipa-cacert-manage man page more clear
--  `#6647 <https://pagure.io/freeipa/issue/6647>`__ batch param
+-  `#6647 <https://codeberg.org/freeipa/freeipa/issues/6647>`__ batch param
    compatibility is incorrect
--  `#6646 <https://pagure.io/freeipa/issue/6646>`__ IdM Server: list all
+-  `#6646 <https://codeberg.org/freeipa/freeipa/issues/6646>`__ IdM Server: list all
    Employees with matching Smart Card
--  `#6643 <https://pagure.io/freeipa/issue/6643>`__ [RFE] Add ipa-whoami
+-  `#6643 <https://codeberg.org/freeipa/freeipa/issues/6643>`__ [RFE] Add ipa-whoami
    command
--  `#6640 <https://pagure.io/freeipa/issue/6640>`__ DS certificate
+-  `#6640 <https://codeberg.org/freeipa/freeipa/issues/6640>`__ DS certificate
    request during replica install fails due to bytes/string mismatch
--  `#6639 <https://pagure.io/freeipa/issue/6639>`__ Rewrite the code
+-  `#6639 <https://codeberg.org/freeipa/freeipa/issues/6639>`__ Rewrite the code
    handling discovery and adding of AD trust agents in AD trust
    installer
--  `#6638 <https://pagure.io/freeipa/issue/6638>`__ AD trust installer
+-  `#6638 <https://codeberg.org/freeipa/freeipa/issues/6638>`__ AD trust installer
    should be able to configure samba instance also without admin
    credentials
--  `#6637 <https://pagure.io/freeipa/issue/6637>`__ Build fails on
+-  `#6637 <https://codeberg.org/freeipa/freeipa/issues/6637>`__ Build fails on
    Fedora 26
--  `#6636 <https://pagure.io/freeipa/issue/6636>`__ UnboundLocalError
+-  `#6636 <https://codeberg.org/freeipa/freeipa/issues/6636>`__ UnboundLocalError
    during ipa-client-install
--  `#6634 <https://pagure.io/freeipa/issue/6634>`__
+-  `#6634 <https://codeberg.org/freeipa/freeipa/issues/6634>`__
    --ignore-last-of-role is not in man page
--  `#6633 <https://pagure.io/freeipa/issue/6633>`__ IPA replica install
+-  `#6633 <https://codeberg.org/freeipa/freeipa/issues/6633>`__ IPA replica install
    log shows password in plain text
--  `#6631 <https://pagure.io/freeipa/issue/6631>`__ Use Python warnings
+-  `#6631 <https://codeberg.org/freeipa/freeipa/issues/6631>`__ Use Python warnings
    for development
--  `#6630 <https://pagure.io/freeipa/issue/6630>`__ Merge AD trust
+-  `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__ Merge AD trust
    installer to server/replica install
--  `#6629 <https://pagure.io/freeipa/issue/6629>`__ Migrate AD trust
+-  `#6629 <https://codeberg.org/freeipa/freeipa/issues/6629>`__ Migrate AD trust
    installer on the new-style installer framework
--  `#6625 <https://pagure.io/freeipa/issue/6625>`__ WSGI fails with
+-  `#6625 <https://codeberg.org/freeipa/freeipa/issues/6625>`__ WSGI fails with
    internal server error when mode != production (locked attribute)
--  `#6623 <https://pagure.io/freeipa/issue/6623>`__ Stageuser is missing
+-  `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__ Stageuser is missing
    -{add,remove}-{cert,principal} commands
--  `#6620 <https://pagure.io/freeipa/issue/6620>`__ Remove
+-  `#6620 <https://codeberg.org/freeipa/freeipa/issues/6620>`__ Remove
    ipa-upgradeconfig command
--  `#6619 <https://pagure.io/freeipa/issue/6619>`__ krb5 1.15 broke DAL
+-  `#6619 <https://codeberg.org/freeipa/freeipa/issues/6619>`__ krb5 1.15 broke DAL
    principal free
--  `#6608 <https://pagure.io/freeipa/issue/6608>`__ IPA server
+-  `#6608 <https://codeberg.org/freeipa/freeipa/issues/6608>`__ IPA server
    installation should check if IPv6 stack is enabled
--  `#6607 <https://pagure.io/freeipa/issue/6607>`__ Deprecate SSLv2 from
+-  `#6607 <https://codeberg.org/freeipa/freeipa/issues/6607>`__ Deprecate SSLv2 from
    API config
--  `#6606 <https://pagure.io/freeipa/issue/6606>`__ Full backup and
+-  `#6606 <https://codeberg.org/freeipa/freeipa/issues/6606>`__ Full backup and
    restore prevents KRA from installing
--  `#6601 <https://pagure.io/freeipa/issue/6601>`__ [RFE] WebUI:
+-  `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__ [RFE] WebUI:
    Certificate Identity Mapping
--  `#6600 <https://pagure.io/freeipa/issue/6600>`__ Legacy client tests
+-  `#6600 <https://codeberg.org/freeipa/freeipa/issues/6600>`__ Legacy client tests
    doesn't have tree domain role.
--  `#6598 <https://pagure.io/freeipa/issue/6598>`__ [webui] Show "CA
+-  `#6598 <https://codeberg.org/freeipa/freeipa/issues/6598>`__ [webui] Show "CA
    replica warning" only if there one or more replicas but only 1 CA
--  `#6597 <https://pagure.io/freeipa/issue/6597>`__
+-  `#6597 <https://codeberg.org/freeipa/freeipa/issues/6597>`__
    ipapython.version.DEFAULT_PLUGINS is not configured
--  `#6596 <https://pagure.io/freeipa/issue/6596>`__ Update ETAs in
+-  `#6596 <https://codeberg.org/freeipa/freeipa/issues/6596>`__ Update ETAs in
    installers
--  `#6588 <https://pagure.io/freeipa/issue/6588>`__ replication race
+-  `#6588 <https://codeberg.org/freeipa/freeipa/issues/6588>`__ replication race
    condition prevents IPA to install
--  `#6586 <https://pagure.io/freeipa/issue/6586>`__ Minor string fixes
+-  `#6586 <https://codeberg.org/freeipa/freeipa/issues/6586>`__ Minor string fixes
    in dsinstance.py
--  `#6585 <https://pagure.io/freeipa/issue/6585>`__ [RFE] nsupdate
+-  `#6585 <https://codeberg.org/freeipa/freeipa/issues/6585>`__ [RFE] nsupdate
    output format in dns-update-system-records command
--  `#6584 <https://pagure.io/freeipa/issue/6584>`__ ipa-client-install
+-  `#6584 <https://codeberg.org/freeipa/freeipa/issues/6584>`__ ipa-client-install
    fails to get CA cert via LDAP when non-FQDN name of IPA server is
    first in /etc/hosts
--  `#6578 <https://pagure.io/freeipa/issue/6578>`__ IPA CLI will
+-  `#6578 <https://codeberg.org/freeipa/freeipa/issues/6578>`__ IPA CLI will
    eventually stop working when invoked in parallel
--  `#6575 <https://pagure.io/freeipa/issue/6575>`__ ipa-replica-install
+-  `#6575 <https://codeberg.org/freeipa/freeipa/issues/6575>`__ ipa-replica-install
    fails on requesting DS cert when master is not configured with IPv6
--  `#6574 <https://pagure.io/freeipa/issue/6574>`__ description of
+-  `#6574 <https://codeberg.org/freeipa/freeipa/issues/6574>`__ description of
    --domain and --realm is confusing
--  `#6573 <https://pagure.io/freeipa/issue/6573>`__ CA-less replica
+-  `#6573 <https://codeberg.org/freeipa/freeipa/issues/6573>`__ CA-less replica
    installation fails due to attempted cert issuance
--  `#6570 <https://pagure.io/freeipa/issue/6570>`__ Duplicate PKINIT
+-  `#6570 <https://codeberg.org/freeipa/freeipa/issues/6570>`__ Duplicate PKINIT
    certificates being tracked after restoring IPA backup on re-installed
    master
--  `#6565 <https://pagure.io/freeipa/issue/6565>`__ FreeIPA server
+-  `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__ FreeIPA server
    install fails (and existing servers probably fail to start) due to
    changes in 'dyndb' feature on merge to upstream BIND
--  `#6564 <https://pagure.io/freeipa/issue/6564>`__ IPA WebUI
+-  `#6564 <https://codeberg.org/freeipa/freeipa/issues/6564>`__ IPA WebUI
    certificates are grayed out on overview page but not on details page
--  `#6559 <https://pagure.io/freeipa/issue/6559>`__ [py3] switch to PY3
+-  `#6559 <https://codeberg.org/freeipa/freeipa/issues/6559>`__ [py3] switch to PY3
    causes warnings from IPA schema cache
--  `#6558 <https://pagure.io/freeipa/issue/6558>`__ [Py3] http session
+-  `#6558 <https://codeberg.org/freeipa/freeipa/issues/6558>`__ [Py3] http session
    cookie doesn't work under Py3
--  `#6551 <https://pagure.io/freeipa/issue/6551>`__ Upgrade Samba
+-  `#6551 <https://codeberg.org/freeipa/freeipa/issues/6551>`__ Upgrade Samba
    configuration to not include keytab prefix
--  `#6550 <https://pagure.io/freeipa/issue/6550>`__ Refactor PKCS #7
+-  `#6550 <https://codeberg.org/freeipa/freeipa/issues/6550>`__ Refactor PKCS #7
    parsing to use pyasn1_modules
--  `#6548 <https://pagure.io/freeipa/issue/6548>`__ [RFE] Mention
+-  `#6548 <https://codeberg.org/freeipa/freeipa/issues/6548>`__ [RFE] Mention
    ipa-backup in warning message before uninstalling IPA server
--  `#6547 <https://pagure.io/freeipa/issue/6547>`__ [RFE] Certificates
+-  `#6547 <https://codeberg.org/freeipa/freeipa/issues/6547>`__ [RFE] Certificates
    issued by externally signed IdM CA should contain full trust chain
--  `#6546 <https://pagure.io/freeipa/issue/6546>`__ Delete option
+-  `#6546 <https://codeberg.org/freeipa/freeipa/issues/6546>`__ Delete option
    shouldn't be available for hosts applied to view.
--  `#6542 <https://pagure.io/freeipa/issue/6542>`__ [RFE] Certificate
+-  `#6542 <https://codeberg.org/freeipa/freeipa/issues/6542>`__ [RFE] Certificate
    Identity Mapping
--  `#6541 <https://pagure.io/freeipa/issue/6541>`__ ipa-replica-install
+-  `#6541 <https://codeberg.org/freeipa/freeipa/issues/6541>`__ ipa-replica-install
    fails to import DS cert from replica file
--  `#6540 <https://pagure.io/freeipa/issue/6540>`__ Migration from
+-  `#6540 <https://codeberg.org/freeipa/freeipa/issues/6540>`__ Migration from
    ipa-3.0 fails due to crashing copy-schema-to-ca.py
--  `#6539 <https://pagure.io/freeipa/issue/6539>`__ ipa vault operations
+-  `#6539 <https://codeberg.org/freeipa/freeipa/issues/6539>`__ ipa vault operations
    are not possible with an older server
--  `#6538 <https://pagure.io/freeipa/issue/6538>`__ KRA: add checks to
+-  `#6538 <https://codeberg.org/freeipa/freeipa/issues/6538>`__ KRA: add checks to
    prevent removing the last instance of KRA in topology
--  `#6534 <https://pagure.io/freeipa/issue/6534>`__ topology should not
+-  `#6534 <https://codeberg.org/freeipa/freeipa/issues/6534>`__ topology should not
    include A<->B segment "both" and B->A "left right" at the same time.
--  `#6532 <https://pagure.io/freeipa/issue/6532>`__ replica installation
+-  `#6532 <https://codeberg.org/freeipa/freeipa/issues/6532>`__ replica installation
    incorrectly sets
    nsds5replicabinddngroup/nsds5replicabinddngroupcheckinterval on IPA
    3.x instance
--  `#6526 <https://pagure.io/freeipa/issue/6526>`__ remove "request
+-  `#6526 <https://codeberg.org/freeipa/freeipa/issues/6526>`__ remove "request
    certificate with subjectaltname" permission
--  `#6522 <https://pagure.io/freeipa/issue/6522>`__
+-  `#6522 <https://codeberg.org/freeipa/freeipa/issues/6522>`__
    ipa-replica-conncheck should check for open ports on all IPs resolved
    from hostname
--  `#6518 <https://pagure.io/freeipa/issue/6518>`__ Can not install IPA
+-  `#6518 <https://codeberg.org/freeipa/freeipa/issues/6518>`__ Can not install IPA
    server when hostname is not DNS resolvable
--  `#6514 <https://pagure.io/freeipa/issue/6514>`__ replica install:
+-  `#6514 <https://codeberg.org/freeipa/freeipa/issues/6514>`__ replica install:
    request_service_cert doesn't raise error when certificate isuance
    failed
--  `#6513 <https://pagure.io/freeipa/issue/6513>`__ \`ipa plugins\`
+-  `#6513 <https://codeberg.org/freeipa/freeipa/issues/6513>`__ \`ipa plugins\`
    command crashes with internal error
--  `#6512 <https://pagure.io/freeipa/issue/6512>`__ Improve the
+-  `#6512 <https://codeberg.org/freeipa/freeipa/issues/6512>`__ Improve the
    robustness FreeIPA's i18n module and its tests
--  `#6510 <https://pagure.io/freeipa/issue/6510>`__ Wrong error message
+-  `#6510 <https://codeberg.org/freeipa/freeipa/issues/6510>`__ Wrong error message
    during failed domainlevel 0 installations without a replica file
--  `#6508 <https://pagure.io/freeipa/issue/6508>`__ ipa-ca-install on
+-  `#6508 <https://codeberg.org/freeipa/freeipa/issues/6508>`__ ipa-ca-install on
    promoted replica hangs on creating a temporary CA admin
--  `#6505 <https://pagure.io/freeipa/issue/6505>`__ Make
+-  `#6505 <https://codeberg.org/freeipa/freeipa/issues/6505>`__ Make
    ipapython.kerberos.Principal.__repr_\_ show the actual principal name
--  `#6504 <https://pagure.io/freeipa/issue/6504>`__ Create a test for
+-  `#6504 <https://codeberg.org/freeipa/freeipa/issues/6504>`__ Create a test for
    uniqueness of CA renewal master
--  `#6503 <https://pagure.io/freeipa/issue/6503>`__ IPA upgrade of
+-  `#6503 <https://codeberg.org/freeipa/freeipa/issues/6503>`__ IPA upgrade of
    replica without DNS fails during restart of named-pkcs11
--  `#6500 <https://pagure.io/freeipa/issue/6500>`__ ipa-server-upgrade
+-  `#6500 <https://codeberg.org/freeipa/freeipa/issues/6500>`__ ipa-server-upgrade
    fails with AttributeError
--  `#6498 <https://pagure.io/freeipa/issue/6498>`__ Build system must
+-  `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__ Build system must
    regenerate file when template changes.
--  `#6497 <https://pagure.io/freeipa/issue/6497>`__ Misleading error
+-  `#6497 <https://codeberg.org/freeipa/freeipa/issues/6497>`__ Misleading error
    message in replica_conn_check()
--  `#6496 <https://pagure.io/freeipa/issue/6496>`__ remove references to
+-  `#6496 <https://codeberg.org/freeipa/freeipa/issues/6496>`__ remove references to
    ds_newinst.pl
--  `#6495 <https://pagure.io/freeipa/issue/6495>`__ DNSSEC:
+-  `#6495 <https://codeberg.org/freeipa/freeipa/issues/6495>`__ DNSSEC:
    ipa-ods-expoter.socket creates incorrect socket and breaks DNSSEC
    signing
--  `#6492 <https://pagure.io/freeipa/issue/6492>`__ Register entry
+-  `#6492 <https://codeberg.org/freeipa/freeipa/issues/6492>`__ Register entry
    points of Custodia plugins
--  `#6490 <https://pagure.io/freeipa/issue/6490>`__ Add local-env
+-  `#6490 <https://codeberg.org/freeipa/freeipa/issues/6490>`__ Add local-env
    subcommand to ipa script
--  `#6489 <https://pagure.io/freeipa/issue/6489>`__ Provide legacy
+-  `#6489 <https://codeberg.org/freeipa/freeipa/issues/6489>`__ Provide legacy
    client test coverage with tree root domain
--  `#6487 <https://pagure.io/freeipa/issue/6487>`__
+-  `#6487 <https://codeberg.org/freeipa/freeipa/issues/6487>`__
    ipa-replica-conncheck fails randomly (race condition)
--  `#6486 <https://pagure.io/freeipa/issue/6486>`__ Add NTP server list
+-  `#6486 <https://codeberg.org/freeipa/freeipa/issues/6486>`__ Add NTP server list
    to ipaplatform
--  `#6481 <https://pagure.io/freeipa/issue/6481>`__ Create a test for
+-  `#6481 <https://codeberg.org/freeipa/freeipa/issues/6481>`__ Create a test for
    instantiating rules with service principals
--  `#6480 <https://pagure.io/freeipa/issue/6480>`__ Update man page for
+-  `#6480 <https://codeberg.org/freeipa/freeipa/issues/6480>`__ Update man page for
    ipa-adtrust-install by removing --no-msdcs option
--  `#6474 <https://pagure.io/freeipa/issue/6474>`__ Remove ipaplatform
+-  `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__ Remove ipaplatform
    dependency from ipa modules
--  `#6472 <https://pagure.io/freeipa/issue/6472>`__ cert-request no
+-  `#6472 <https://codeberg.org/freeipa/freeipa/issues/6472>`__ cert-request no
    longer accepts CSR with extraneous data surrounding PEM data
--  `#6469 <https://pagure.io/freeipa/issue/6469>`__ Use xml.etree
+-  `#6469 <https://codeberg.org/freeipa/freeipa/issues/6469>`__ Use xml.etree
    instead of lxml in odsmgr.py
--  `#6466 <https://pagure.io/freeipa/issue/6466>`__ [abrt] krb5-server:
+-  `#6466 <https://codeberg.org/freeipa/freeipa/issues/6466>`__ [abrt] krb5-server:
    ipadb_change_pwd(): kdb5_util killed by SIGSEGV
--  `#6461 <https://pagure.io/freeipa/issue/6461>`__ LDAP Connection
+-  `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__ LDAP Connection
    Management refactoring
--  `#6460 <https://pagure.io/freeipa/issue/6460>`__ NSSNickname enclosed
+-  `#6460 <https://codeberg.org/freeipa/freeipa/issues/6460>`__ NSSNickname enclosed
    in single quotes causes ipa-server-certinstall failure
--  `#6457 <https://pagure.io/freeipa/issue/6457>`__ ipa dnsrecord-add
+-  `#6457 <https://codeberg.org/freeipa/freeipa/issues/6457>`__ ipa dnsrecord-add
    fails with Keyerror stack trace
--  `#6455 <https://pagure.io/freeipa/issue/6455>`__ Add example of RDN
+-  `#6455 <https://codeberg.org/freeipa/freeipa/issues/6455>`__ Add example of RDN
    order for ipa-server-install --subject
--  `#6451 <https://pagure.io/freeipa/issue/6451>`__ Automate managed
+-  `#6451 <https://codeberg.org/freeipa/freeipa/issues/6451>`__ Automate managed
    replication topology 4.4 features
--  `#6448 <https://pagure.io/freeipa/issue/6448>`__ Tests: Stageuser
+-  `#6448 <https://codeberg.org/freeipa/freeipa/issues/6448>`__ Tests: Stageuser
    tracker creation of user with minimal values, with uid not specified
--  `#6446 <https://pagure.io/freeipa/issue/6446>`__ Create test for
+-  `#6446 <https://codeberg.org/freeipa/freeipa/issues/6446>`__ Create test for
    kerberos over http
--  `#6445 <https://pagure.io/freeipa/issue/6445>`__ Traceback seen in
+-  `#6445 <https://codeberg.org/freeipa/freeipa/issues/6445>`__ Traceback seen in
    error_log when trustdomain-del is run
--  `#6439 <https://pagure.io/freeipa/issue/6439>`__ Members of nested
+-  `#6439 <https://codeberg.org/freeipa/freeipa/issues/6439>`__ Members of nested
    netgroups configured in IdM cannot be seen by getent on clients
--  `#6435 <https://pagure.io/freeipa/issue/6435>`__ Fix zanata.xml
+-  `#6435 <https://codeberg.org/freeipa/freeipa/issues/6435>`__ Fix zanata.xml
    config to skip testing ipa.pot file
--  `#6434 <https://pagure.io/freeipa/issue/6434>`__ Installers: perform
+-  `#6434 <https://codeberg.org/freeipa/freeipa/issues/6434>`__ Installers: perform
    host enrollment also in domain level 0 replica install
--  `#6433 <https://pagure.io/freeipa/issue/6433>`__ Refactor installer
+-  `#6433 <https://codeberg.org/freeipa/freeipa/issues/6433>`__ Refactor installer
    code requesting certificates
--  `#6420 <https://pagure.io/freeipa/issue/6420>`__ Pretty print option
+-  `#6420 <https://codeberg.org/freeipa/freeipa/issues/6420>`__ Pretty print option
    of pytest makes tracker fail when used in ipa console
--  `#6419 <https://pagure.io/freeipa/issue/6419>`__ cert-show default
+-  `#6419 <https://codeberg.org/freeipa/freeipa/issues/6419>`__ cert-show default
    output does not show validity
--  `#6417 <https://pagure.io/freeipa/issue/6417>`__ Skip topology
+-  `#6417 <https://codeberg.org/freeipa/freeipa/issues/6417>`__ Skip topology
    disconnect/last of role checks when uninstalling single domain level
    1 master
--  `#6415 <https://pagure.io/freeipa/issue/6415>`__ replica-install
+-  `#6415 <https://codeberg.org/freeipa/freeipa/issues/6415>`__ replica-install
    creates spurious entries in cn=certificates
--  `#6412 <https://pagure.io/freeipa/issue/6412>`__ Create tests for
+-  `#6412 <https://codeberg.org/freeipa/freeipa/issues/6412>`__ Create tests for
    certs in idoverrides feature
--  `#6410 <https://pagure.io/freeipa/issue/6410>`__ Tests: Verify that
+-  `#6410 <https://codeberg.org/freeipa/freeipa/issues/6410>`__ Tests: Verify that
    cert commands show CA without --all
--  `#6409 <https://pagure.io/freeipa/issue/6409>`__ [RFE] extend
+-  `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__ [RFE] extend
    ipa-getkeytab to support other LDAP bind methods
--  `#6406 <https://pagure.io/freeipa/issue/6406>`__ Use common mechanism
+-  `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__ Use common mechanism
    for setting up initial replication in both domain levels
--  `#6405 <https://pagure.io/freeipa/issue/6405>`__ unify domain
+-  `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__ unify domain
    level-specific mechanisms for replica's DS/HTTP keytab generation
--  `#6402 <https://pagure.io/freeipa/issue/6402>`__ IPA Allows Password
+-  `#6402 <https://codeberg.org/freeipa/freeipa/issues/6402>`__ IPA Allows Password
    Reuse with History value defined when admin resets the password.
--  `#6401 <https://pagure.io/freeipa/issue/6401>`__ Revert expected
+-  `#6401 <https://codeberg.org/freeipa/freeipa/issues/6401>`__ Revert expected
    returncode in replica_promotion test
--  `#6400 <https://pagure.io/freeipa/issue/6400>`__ Add file_exists
+-  `#6400 <https://codeberg.org/freeipa/freeipa/issues/6400>`__ Add file_exists
    method as a member of transport object
--  `#6399 <https://pagure.io/freeipa/issue/6399>`__ Object-Signing cert
+-  `#6399 <https://codeberg.org/freeipa/freeipa/issues/6399>`__ Object-Signing cert
    is unused; don't create it
--  `#6398 <https://pagure.io/freeipa/issue/6398>`__ Refactor certificate
+-  `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__ Refactor certificate
    inspection code to use python-cryptography
--  `#6397 <https://pagure.io/freeipa/issue/6397>`__ WebUI: Services are
+-  `#6397 <https://codeberg.org/freeipa/freeipa/issues/6397>`__ WebUI: Services are
    not displayed correctly after upgrade
--  `#6396 <https://pagure.io/freeipa/issue/6396>`__ Cleanup AD trust
+-  `#6396 <https://codeberg.org/freeipa/freeipa/issues/6396>`__ Cleanup AD trust
    information after tests
--  `#6394 <https://pagure.io/freeipa/issue/6394>`__ WebUI: Update
+-  `#6394 <https://codeberg.org/freeipa/freeipa/issues/6394>`__ WebUI: Update
    Patternfly and Bootstrap to newer versions
--  `#6393 <https://pagure.io/freeipa/issue/6393>`__ Make httpd publish
+-  `#6393 <https://codeberg.org/freeipa/freeipa/issues/6393>`__ Make httpd publish
    CA certificate on Domain Level 1
--  `#6392 <https://pagure.io/freeipa/issue/6392>`__ Installers
+-  `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__ Installers
    refactoring tracker
--  `#6388 <https://pagure.io/freeipa/issue/6388>`__ WebUI: Adder dialog
+-  `#6388 <https://codeberg.org/freeipa/freeipa/issues/6388>`__ WebUI: Adder dialog
    cannot be reopened in case that it is closed using ESC and dropdown
    field was focuseded
--  `#6386 <https://pagure.io/freeipa/issue/6386>`__ Use api.env.nss_dir
+-  `#6386 <https://codeberg.org/freeipa/freeipa/issues/6386>`__ Use api.env.nss_dir
    instead of paths.IPA_NSSDB_DIR
--  `#6384 <https://pagure.io/freeipa/issue/6384>`__ Web UI: Lowercase
+-  `#6384 <https://codeberg.org/freeipa/freeipa/issues/6384>`__ Web UI: Lowercase
    "b" in the "API browser" subtab label
--  `#6381 <https://pagure.io/freeipa/issue/6381>`__ ipa-cacert-manage
+-  `#6381 <https://codeberg.org/freeipa/freeipa/issues/6381>`__ ipa-cacert-manage
    man page should mention to run ipa-certupdate
--  `#6375 <https://pagure.io/freeipa/issue/6375>`__ ipa-replica-install
+-  `#6375 <https://codeberg.org/freeipa/freeipa/issues/6375>`__ ipa-replica-install
    fails when replica file created after ipa-ca-install on domain level
    0
--  `#6372 <https://pagure.io/freeipa/issue/6372>`__ [RFE] allow managing
+-  `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__ [RFE] allow managing
    prioritized list of trusted domains for unqualified ID resolution
--  `#6369 <https://pagure.io/freeipa/issue/6369>`__ [tracker] raise 389
+-  `#6369 <https://codeberg.org/freeipa/freeipa/issues/6369>`__ [tracker] raise 389
    requires when "Total init may fail if the pushed schema is rejected"
    is part of update
--  `#6365 <https://pagure.io/freeipa/issue/6365>`__ Custodia
+-  `#6365 <https://codeberg.org/freeipa/freeipa/issues/6365>`__ Custodia
    compatibility: add iSecStore.span method
--  `#6359 <https://pagure.io/freeipa/issue/6359>`__ test_0003_find_OCSP
+-  `#6359 <https://codeberg.org/freeipa/freeipa/issues/6359>`__ test_0003_find_OCSP
    will never fail
--  `#6358 <https://pagure.io/freeipa/issue/6358>`__ ipa migrate-ds fails
+-  `#6358 <https://codeberg.org/freeipa/freeipa/issues/6358>`__ ipa migrate-ds fails
    when it finds a referral
--  `#6357 <https://pagure.io/freeipa/issue/6357>`__ ipa-server-install
+-  `#6357 <https://codeberg.org/freeipa/freeipa/issues/6357>`__ ipa-server-install
    script option --no_hbac_allow should match other options
--  `#6354 <https://pagure.io/freeipa/issue/6354>`__ regression:
+-  `#6354 <https://codeberg.org/freeipa/freeipa/issues/6354>`__ regression:
    certmap.conf file is not backedup during ipa-server-upgrade
--  `#6352 <https://pagure.io/freeipa/issue/6352>`__ replica promotion
+-  `#6352 <https://codeberg.org/freeipa/freeipa/issues/6352>`__ replica promotion
    with OTP: add additional info to ""Insufficient privileges" error
    message
--  `#6347 <https://pagure.io/freeipa/issue/6347>`__ Tests: provide trust
+-  `#6347 <https://codeberg.org/freeipa/freeipa/issues/6347>`__ Tests: provide trust
    test coverage for tree root domains
--  `#6344 <https://pagure.io/freeipa/issue/6344>`__ [RFE] support URI
+-  `#6344 <https://codeberg.org/freeipa/freeipa/issues/6344>`__ [RFE] support URI
    resource records
--  `#6343 <https://pagure.io/freeipa/issue/6343>`__ [RFE] Allow login to
+-  `#6343 <https://codeberg.org/freeipa/freeipa/issues/6343>`__ [RFE] Allow login to
    WebUI using Kerberos aliases/enterprise principals
--  `#6340 <https://pagure.io/freeipa/issue/6340>`__ IPA client ipv6 -
+-  `#6340 <https://codeberg.org/freeipa/freeipa/issues/6340>`__ IPA client ipv6 -
    invalid --ip-address shows traceback
--  `#6335 <https://pagure.io/freeipa/issue/6335>`__ Set priority as
+-  `#6335 <https://codeberg.org/freeipa/freeipa/issues/6335>`__ Set priority as
    required filed in password policy
--  `#6334 <https://pagure.io/freeipa/issue/6334>`__ "Normal" group type
+-  `#6334 <https://codeberg.org/freeipa/freeipa/issues/6334>`__ "Normal" group type
    in the UI is confusing
--  `#6331 <https://pagure.io/freeipa/issue/6331>`__ Reason is lost when
+-  `#6331 <https://codeberg.org/freeipa/freeipa/issues/6331>`__ Reason is lost when
    CheckedIPAddress returns ValueError in ipa-client-install
--  `#6308 <https://pagure.io/freeipa/issue/6308>`__ [webui] Does not
+-  `#6308 <https://codeberg.org/freeipa/freeipa/issues/6308>`__ [webui] Does not
    handle uppercase authentication indicators.
--  `#6305 <https://pagure.io/freeipa/issue/6305>`__ host/service-mod
+-  `#6305 <https://codeberg.org/freeipa/freeipa/issues/6305>`__ host/service-mod
    with --certificate= (remove all certs) does not revoke certs
--  `#6295 <https://pagure.io/freeipa/issue/6295>`__ cert-request is not
+-  `#6295 <https://codeberg.org/freeipa/freeipa/issues/6295>`__ cert-request is not
    aware of Kerberos principal aliases
--  `#6269 <https://pagure.io/freeipa/issue/6269>`__ cert-find --all does
+-  `#6269 <https://codeberg.org/freeipa/freeipa/issues/6269>`__ cert-find --all does
    not show information about revocation
--  `#6263 <https://pagure.io/freeipa/issue/6263>`__
+-  `#6263 <https://codeberg.org/freeipa/freeipa/issues/6263>`__
    ipa-server-certinstall does not update all certificate stores and
    doesn't set proper trust permissions
--  `#6226 <https://pagure.io/freeipa/issue/6226>`__ ipa-replica-install
+-  `#6226 <https://codeberg.org/freeipa/freeipa/issues/6226>`__ ipa-replica-install
    in CA-less environment does not configure DS TLS - ipa-ca-install
    then fails on replica
--  `#6225 <https://pagure.io/freeipa/issue/6225>`__ [RFE] Web UI: allow
+-  `#6225 <https://codeberg.org/freeipa/freeipa/issues/6225>`__ [RFE] Web UI: allow
    Smart Card authentication - finalization
--  `#6202 <https://pagure.io/freeipa/issue/6202>`__ ipa-client-install -
+-  `#6202 <https://codeberg.org/freeipa/freeipa/issues/6202>`__ ipa-client-install -
    document that --server option expects FQDN
--  `#6178 <https://pagure.io/freeipa/issue/6178>`__ Add options to
+-  `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__ Add options to
    retrieve lightweight CA certificate/chain
--  `#6169 <https://pagure.io/freeipa/issue/6169>`__ ipa
+-  `#6169 <https://codeberg.org/freeipa/freeipa/issues/6169>`__ ipa
    dnsforwardzone-add w/o arguments fails
--  `#6144 <https://pagure.io/freeipa/issue/6144>`__ RPC code should be
+-  `#6144 <https://codeberg.org/freeipa/freeipa/issues/6144>`__ RPC code should be
    agnostic to display layer
--  `#6132 <https://pagure.io/freeipa/issue/6132>`__ Broken setup if 3rd
+-  `#6132 <https://codeberg.org/freeipa/freeipa/issues/6132>`__ Broken setup if 3rd
    party CA certificate conflicts with system-wide CA certificate
--  `#6128 <https://pagure.io/freeipa/issue/6128>`__ Tests: Base tracker
+-  `#6128 <https://codeberg.org/freeipa/freeipa/issues/6128>`__ Tests: Base tracker
    contains leftover attributes from host tracker
--  `#6126 <https://pagure.io/freeipa/issue/6126>`__ Tests: User tracker
+-  `#6126 <https://codeberg.org/freeipa/freeipa/issues/6126>`__ Tests: User tracker
    does not enable creation of user with minimal values
--  `#6125 <https://pagure.io/freeipa/issue/6125>`__ Tests: unaccessible
+-  `#6125 <https://codeberg.org/freeipa/freeipa/issues/6125>`__ Tests: unaccessible
    variable self.attrs for entries that are not created via standard
    create method in Tracker
--  `#6124 <https://pagure.io/freeipa/issue/6124>`__ Tests: remove
+-  `#6124 <https://codeberg.org/freeipa/freeipa/issues/6124>`__ Tests: remove
    --force option from tracker base class
--  `#6123 <https://pagure.io/freeipa/issue/6123>`__ Tests: Tracker
+-  `#6123 <https://codeberg.org/freeipa/freeipa/issues/6123>`__ Tests: Tracker
    enables silent deleting and creating entries
--  `#6114 <https://pagure.io/freeipa/issue/6114>`__ Traceback message
+-  `#6114 <https://codeberg.org/freeipa/freeipa/issues/6114>`__ Traceback message
    seen when ipa is provided with invalid configuration file name
--  `#6088 <https://pagure.io/freeipa/issue/6088>`__ test_installation.py
+-  `#6088 <https://codeberg.org/freeipa/freeipa/issues/6088>`__ test_installation.py
    tests involving KRA installation on replicas fail in domain level 0
--  `#6005 <https://pagure.io/freeipa/issue/6005>`__ Create an automated
+-  `#6005 <https://codeberg.org/freeipa/freeipa/issues/6005>`__ Create an automated
    test for Certs in idoverrides feature
--  `#5949 <https://pagure.io/freeipa/issue/5949>`__ ipa-server-install:
+-  `#5949 <https://codeberg.org/freeipa/freeipa/issues/5949>`__ ipa-server-install:
    improve prompt on interactive installation
--  `#5935 <https://pagure.io/freeipa/issue/5935>`__ [py3]
+-  `#5935 <https://codeberg.org/freeipa/freeipa/issues/5935>`__ [py3]
    DNSName.ToASCII broken with python3
--  `#5742 <https://pagure.io/freeipa/issue/5742>`__ [RFE] [webui]
+-  `#5742 <https://codeberg.org/freeipa/freeipa/issues/5742>`__ [RFE] [webui]
    Configurable page size / User config page
--  `#5695 <https://pagure.io/freeipa/issue/5695>`__ [RFE] FreeIPA on
+-  `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__ [RFE] FreeIPA on
    FIPS enabled systems
--  `#5640 <https://pagure.io/freeipa/issue/5640>`__ Framework does not
+-  `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__ Framework does not
    respect sizelimit passed via webUI in some searches
--  `#5348 <https://pagure.io/freeipa/issue/5348>`__ [tracker] dig +
+-  `#5348 <https://codeberg.org/freeipa/freeipa/issues/5348>`__ [tracker] dig +
    dnssec does not display signature of freshly created root zone
--  `#4821 <https://pagure.io/freeipa/issue/4821>`__ UI drops "Unknown
+-  `#4821 <https://codeberg.org/freeipa/freeipa/issues/4821>`__ UI drops "Unknown
    Error" when the ipa record in /etc/hosts changes
--  `#4189 <https://pagure.io/freeipa/issue/4189>`__ [RFE] Use GSS-Proxy
+-  `#4189 <https://codeberg.org/freeipa/freeipa/issues/4189>`__ [RFE] Use GSS-Proxy
    for the HTTP service
--  `#3461 <https://pagure.io/freeipa/issue/3461>`__ [RFE] Extend
+-  `#3461 <https://codeberg.org/freeipa/freeipa/issues/3461>`__ [RFE] Extend
    freeipa's sudo to support selinux transition roles
--  `#157 <https://pagure.io/freeipa/issue/157>`__ Python 3.2a1 in
+-  `#157 <https://codeberg.org/freeipa/freeipa/issues/157>`__ Python 3.2a1 in
    rawhide
 
 
@@ -660,26 +660,26 @@ Alexander Bokovoy (7)
 
 -  ipaserver/dcerpc.py: use arcfour_encrypt from samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/7657754e02a5fa62265327937a6c7fd19b381610>`__
-   `#6697 <https://pagure.io/freeipa/issue/6697>`__
+   `#6697 <https://codeberg.org/freeipa/freeipa/issues/6697>`__
 -  add whoami command
    `commit <https://codeberg.org/freeipa/freeipa/commit/381c1c7a8fe63526d21cb65decb75fb5ffda676a>`__
-   `#6643 <https://pagure.io/freeipa/issue/6643>`__
+   `#6643 <https://codeberg.org/freeipa/freeipa/issues/6643>`__
 -  pkinit: make sure to have proper dictionary for Kerberos instance on
    upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/14d84daf29543978c6383da10f4f2d913346f013>`__
-   `#6670 <https://pagure.io/freeipa/issue/6670>`__
+   `#6670 <https://codeberg.org/freeipa/freeipa/issues/6670>`__
 -  ipa-kdb: support KDB DAL version 6.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/593ea7da9a732647052cb56c08ad367e40be3912>`__
-   `#6619 <https://pagure.io/freeipa/issue/6619>`__
+   `#6619 <https://codeberg.org/freeipa/freeipa/issues/6619>`__
 -  ipa-kdb: search for password policies globally
    `commit <https://codeberg.org/freeipa/freeipa/commit/73f33569c8893610e246b2f44a7aeaec872b37e6>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  adtrust: remove FILE: prefix from 'dedicated keytab file' in smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/38cc01b1c92da36653e0ce4d8f7066282fd1d102>`__
-   `#6551 <https://pagure.io/freeipa/issue/6551>`__
+   `#6551 <https://codeberg.org/freeipa/freeipa/issues/6551>`__
 -  trustdomain-del: fix the way how subdomain is searched
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8b94ef352400f9045837ed69266686b6b117301>`__
-   `#6445 <https://pagure.io/freeipa/issue/6445>`__
+   `#6445 <https://codeberg.org/freeipa/freeipa/issues/6445>`__
 
 
 
@@ -690,35 +690,35 @@ Abhijeet Kasurde (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc446fb44870592f73af9c0dc2a35c5d37ce7a5c>`__
 -  Update warning message for replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/c913f810715705c560ae8bd05a33084785f59583>`__
-   `#6352 <https://pagure.io/freeipa/issue/6352>`__
+   `#6352 <https://codeberg.org/freeipa/freeipa/issues/6352>`__
 -  Add fix for ipa plugins command
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3c41f21e51e5389d95b5486dcdfdc3f9a8b0424>`__
-   `#6513 <https://pagure.io/freeipa/issue/6513>`__
+   `#6513 <https://codeberg.org/freeipa/freeipa/issues/6513>`__
 -  Update man page of ipa-server-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/08b8bfa9b59b30e1bec1fa8c1cfce992dc80c49f>`__
-   `#6634 <https://pagure.io/freeipa/issue/6634>`__
+   `#6634 <https://codeberg.org/freeipa/freeipa/issues/6634>`__
 -  Remove deprecated ipa-upgradeconfig command
    `commit <https://codeberg.org/freeipa/freeipa/commit/c56e02b3c5257edbfd3709848ca7eda07e271e38>`__
-   `#6620 <https://pagure.io/freeipa/issue/6620>`__
+   `#6620 <https://codeberg.org/freeipa/freeipa/issues/6620>`__
 -  Update warning message for ipa server uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae2d0a221772267ecda30896dc8897a3f4b4a97b>`__
-   `#6548 <https://pagure.io/freeipa/issue/6548>`__
+   `#6548 <https://codeberg.org/freeipa/freeipa/issues/6548>`__
 -  Fix for handling CalledProcessError in authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d52c0fe6acb09f3b8525840dfacc3f0885eac37>`__
-   `#5244 <https://pagure.io/freeipa/issue/5244>`__
+   `#5244 <https://codeberg.org/freeipa/freeipa/issues/5244>`__
 -  Enumerate available options in IPA installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/80c0e5cb8d689cf1ec6a883d2c7000f9dadbf7d8>`__
-   `#5435 <https://pagure.io/freeipa/issue/5435>`__
+   `#5435 <https://codeberg.org/freeipa/freeipa/issues/5435>`__
 -  Provide user hint about IP address in IPA install
    `commit <https://codeberg.org/freeipa/freeipa/commit/28bc54f91dfbd76887180fa67ceecb46977a4fb8>`__
-   `#5949 <https://pagure.io/freeipa/issue/5949>`__
+   `#5949 <https://codeberg.org/freeipa/freeipa/issues/5949>`__
 -  Add fix for no-hbac-allow option in server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/a42059228018839ae2656c27f5b00d96bc935ee3>`__
-   `#6357 <https://pagure.io/freeipa/issue/6357>`__
+   `#6357 <https://codeberg.org/freeipa/freeipa/issues/6357>`__
 -  Added a fix for setting Priority as required field in Password Policy
    Details facet
    `commit <https://codeberg.org/freeipa/freeipa/commit/8149b762b424d1ce7a26847386715ca98038b230>`__
-   `#6335 <https://pagure.io/freeipa/issue/6335>`__
+   `#6335 <https://codeberg.org/freeipa/freeipa/issues/6335>`__
 
 
 
@@ -727,28 +727,28 @@ Ben Lipton (8)
 
 -  csrgen: Support encrypted private keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/ada91c20588046bb147fc701718d3da4d2c080ca>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Allow overriding the CSR generation profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/4350dcdea22fd2284836315d0ae7d38733a7620e>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Automate full cert request flow
    `commit <https://codeberg.org/freeipa/freeipa/commit/39a5d9c5aae77687f67d9be02457733bdfb99ead>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  tests: Add tests for CSR autogeneration
    `commit <https://codeberg.org/freeipa/freeipa/commit/a26cf0d7910dd4c0a4da08682b4be8d3d94ba520>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Use data_sources option to define which fields are rendered
    `commit <https://codeberg.org/freeipa/freeipa/commit/afd7c05d11432304bfdf183832a21d419f363689>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Add a CSR generation profile for user certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1a1c6eca1b294f24174d7b0e1f78de46d9d5b05>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Add CSR generation profile for caIPAserviceCert
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc58eff6a3d7fe805e612b8b002304d8b9cd4ba9>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Add code to generate scripts that generate CSRs
    `commit <https://codeberg.org/freeipa/freeipa/commit/10ef5947860f5098182b1f95c08c1158e2da15f9>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 
 
 
@@ -757,20 +757,20 @@ Christian Heimes (88)
 
 -  Add PYTHON_INSTALL_EXTRA_OPTIONS and --install-layout=deb
    `commit <https://codeberg.org/freeipa/freeipa/commit/b280c7bb0192485dfb622c731e31deb89d517b6f>`__
-   `#6764 <https://pagure.io/freeipa/issue/6764>`__
+   `#6764 <https://codeberg.org/freeipa/freeipa/issues/6764>`__
 -  Make pylint and jsl optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1f63506caf88e4d86ea2bfdc7d25eceaf689bc5>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 -  Ignore ipapython/.DEFAULT_PLUGINS
    `commit <https://codeberg.org/freeipa/freeipa/commit/a30d31b0c6122b44e1b4e84451e4196c3d0d7fe7>`__
-   `#6597 <https://pagure.io/freeipa/issue/6597>`__
+   `#6597 <https://codeberg.org/freeipa/freeipa/issues/6597>`__
 -  Run test_ipaclient test suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/08fc9d7a68220fc147177e6f757387823fea0f43>`__
 -  Chain CSR generator file loaders
    `commit <https://codeberg.org/freeipa/freeipa/commit/177f07e163d6d591a1e609d35e0a6f6f5347551e>`__
 -  Move csrgen templates into ipaclient package
    `commit <https://codeberg.org/freeipa/freeipa/commit/80be18162921268be9c8981495c9e8a4de0c85cd>`__
-   `#6714 <https://pagure.io/freeipa/issue/6714>`__
+   `#6714 <https://codeberg.org/freeipa/freeipa/issues/6714>`__
 -  Use https to get security domain from Dogtag
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1c5d92897d3e262edd2e43295c1270590aebd3d>`__
 -  Cleanup certdb
@@ -792,10 +792,10 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e784336b0fe99baa47cf3e024f744ed56dc12ec>`__
 -  Vault: port key wrapping to python-cryptography
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed7a03a1af8b556247b929635e2972be4f2b32e4>`__
-   `#6650 <https://pagure.io/freeipa/issue/6650>`__
+   `#6650 <https://codeberg.org/freeipa/freeipa/issues/6650>`__
 -  Remove NSPRError exception from platform tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/88fd936a761dfce099c4b03529d679256c9860d6>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove import nss from test_ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/79c0e6d355c9e7bcc7cacc37faaba8e999d56400>`__
 -  certdb: Don't restore_context() of new NSSDB
@@ -806,19 +806,19 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3be696c92f6948ea0ced9784920600b73703e414>`__
 -  Speed up client schema cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/332dbab1ff09eb719eb9e0a7a90bbf5b6e69ddc9>`__
-   `#6690 <https://pagure.io/freeipa/issue/6690>`__
+   `#6690 <https://codeberg.org/freeipa/freeipa/issues/6690>`__
 -  C compilation fixes and hardening
    `commit <https://codeberg.org/freeipa/freeipa/commit/2828a2b92b89932d66b640e5047161448d522e2e>`__
 -  lite-server: validate LDAP connection and cache schema
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcb618152572ca013a447336e13d24399b5f7960>`__
-   `#6679 <https://pagure.io/freeipa/issue/6679>`__
+   `#6679 <https://codeberg.org/freeipa/freeipa/issues/6679>`__
 -  Add --without-ipatests option
    `commit <https://codeberg.org/freeipa/freeipa/commit/2747f2ad782c7640ecc6949098f0d43411182255>`__
 -  Add missing include of stdint.h for uint8_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/20c1eb9844223d892da47da1ea10662d37953ff8>`__
 -  Client-only builds with --disable-server
    `commit <https://codeberg.org/freeipa/freeipa/commit/70554938d4f9ba5b347cd4bc8001428e905198e4>`__
-   `#6517 <https://pagure.io/freeipa/issue/6517>`__
+   `#6517 <https://codeberg.org/freeipa/freeipa/issues/6517>`__
 -  New lite-server implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff6e701b0077d9c8e2aacdcaecf70f885018db92>`__
 -  Explain more performance tricks in doc string
@@ -831,10 +831,10 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b12b1e4c0b19a84ccffcc702ab608d818382a697>`__
 -  Faster JSON encoder/decoder
    `commit <https://codeberg.org/freeipa/freeipa/commit/8159c2883bf66980582d1227c364df4e592bdd7e>`__
-   `#6655 <https://pagure.io/freeipa/issue/6655>`__
+   `#6655 <https://codeberg.org/freeipa/freeipa/issues/6655>`__
 -  Backup /root/kracert.p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/11ef2cacbf2ebb67f80a0cf4a3e7b39da700188b>`__
-   `#6659 <https://pagure.io/freeipa/issue/6659>`__
+   `#6659 <https://codeberg.org/freeipa/freeipa/issues/6659>`__
 -  Ditch version_info and use version number from ipapython.version
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d3bea8accb9814b3a973f4a606110fee78baf72>`__
 -  test_StrEnum: use int as bad type
@@ -845,7 +845,7 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d9bec2e879d60e6bb7b2602084d3314765a6283>`__
 -  Enable additional warnings (BytesWarning, DeprecationWarning)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a33b25dea988aa34844869a8adc57d5cd396d3aa>`__
-   `#6631 <https://pagure.io/freeipa/issue/6631>`__
+   `#6631 <https://codeberg.org/freeipa/freeipa/issues/6631>`__
 -  Print test env information
    `commit <https://codeberg.org/freeipa/freeipa/commit/b20f6fb29478de6b4f25741bc4fd975a5e0be671>`__
 -  Clean / ignore make check artefact
@@ -862,7 +862,7 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3387734e6c6d47a756b5e914e7e515d2610a424f>`__
 -  Silence pylint import errors of ipaserver in ipalib and ipaclient
    `commit <https://codeberg.org/freeipa/freeipa/commit/987d24f784e05e911bf4e87bd1156abb1dd56210>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Relax check for .git to support freeipa in submodules
    `commit <https://codeberg.org/freeipa/freeipa/commit/cac0c2d951e10d49372a038c73f796dc3beb62b9>`__
 -  Ignore backup~ files like config.h.in~
@@ -873,87 +873,87 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4916254e995be1118ab8dbce5b60091305f97fe>`__
 -  Set explicit confdir option for global contexts
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e6a204b4372bbbfb722a00370a5ce4e34406b9f>`__
-   `#6389 <https://pagure.io/freeipa/issue/6389>`__
+   `#6389 <https://codeberg.org/freeipa/freeipa/issues/6389>`__
 -  Remove import of ipaplatform.paths from test_ipalib
    `commit <https://codeberg.org/freeipa/freeipa/commit/98f0077360884da6df31b351caaed7510dec94de>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  Remove BIN_FALSE and BIN_TRUE
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e3b5462b28f2133fd4170645cad762c0a0fbb4f>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  Add pylint guard to import of ipaplatform in ipapython.certdb
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb307ba582d4e7339b7026cbe26c3b170221e249>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  Require python-gssapi >= 1.2.0, take 2
    `commit <https://codeberg.org/freeipa/freeipa/commit/5dc5960e715b378b6090935ba133d6f332427de5>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Backwards compatibility with setuptools 0.9.8
    `commit <https://codeberg.org/freeipa/freeipa/commit/027fc32fe0424659c5aecb4531299fe8d4a503d3>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Require python-cryptography >= 1.3.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/289982e02fa6bef700fe2c1900ddbed864876faa>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Wheel bundles fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/235f68524767c1eb2e12fb6d1d9f6a520414c583>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  Require python-gssapi >= 1.2.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/8559791e0d520f4a3503e35d1975ac31448b1390>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Adjustments for setup requirements
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed9645b2ac58fd4664810f05970ea258c7948420>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  wrap long line
    `commit <https://codeberg.org/freeipa/freeipa/commit/6bbbce44733761fda1fc588397b8baddbc7f8de3>`__
 -  Silence import warnings for Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/fef6f18aa27c3c5286c48dce4419db6ff9ac967b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Fix Python 3 bugs discovered by pylint
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fef9cbec725beed62eb425449083c59416ed975>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Python3 pylint fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/38e8719f728e6d54289507fe2c7f79f9272c45c0>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Add main guards to a couple of Python scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8376a244758494db31341442bc2163e1807b7ac>`__
 -  Break ipaplatform / ipalib import cycle of hell
    `commit <https://codeberg.org/freeipa/freeipa/commit/6409abf1a60f3548203e6607a2b157ff72af2c89>`__
 -  Replace LooseVersion
    `commit <https://codeberg.org/freeipa/freeipa/commit/2cbaf156045769b54150e4d4c3c1071f164a16fb>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Don't ship install subpackages with wheels
    `commit <https://codeberg.org/freeipa/freeipa/commit/526bcea705d04895aa6b09bce996ac340783d1d0>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Minor fixes for IPAVersion class
    `commit <https://codeberg.org/freeipa/freeipa/commit/29947fe1a304ff6f913e5d94d56d8108a7c94087>`__
-   `#6473 <https://pagure.io/freeipa/issue/6473>`__
+   `#6473 <https://codeberg.org/freeipa/freeipa/issues/6473>`__
 -  Pylint: whitelist packages with extension modules
    `commit <https://codeberg.org/freeipa/freeipa/commit/573eee444e1746fd5949897294c96a1793e74511>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Add 'ipa localenv' subcommand
    `commit <https://codeberg.org/freeipa/freeipa/commit/1166fbc4946596fcc2ed51a1ec6990fc7dae8964>`__
-   `#6490 <https://pagure.io/freeipa/issue/6490>`__
+   `#6490 <https://codeberg.org/freeipa/freeipa/issues/6490>`__
 -  ipapython and ipatest no longer require lxml
    `commit <https://codeberg.org/freeipa/freeipa/commit/c93bfda594723357f3ff9f4eb8191f3d76df680f>`__
 -  Register entry points of Custodia plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/9102fb3b02fbe55480428e60fb8df4fd668d7753>`__
-   `#6492 <https://pagure.io/freeipa/issue/6492>`__
+   `#6492 <https://codeberg.org/freeipa/freeipa/issues/6492>`__
 -  Use xml.etree in ipa-client-automount script
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fbd29cc106660865bc6cda225d6a8a338a78d31>`__
 -  Port ipapython.dnssec.odsmgr to xml.etree
    `commit <https://codeberg.org/freeipa/freeipa/commit/64af88fee4a482b3f393d38ff2c7f9494e689a7b>`__
-   `#6469 <https://pagure.io/freeipa/issue/6469>`__
+   `#6469 <https://codeberg.org/freeipa/freeipa/issues/6469>`__
 -  Add install requirements to Python packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/8346e1b067483d4d836627a267805bbe8d6e7efa>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Make api.env.nss_dir relative to api.env.confdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/9006ed34bb1edfaafc3345c1128800dc802c14ff>`__
-   `#6386 <https://pagure.io/freeipa/issue/6386>`__
+   `#6386 <https://codeberg.org/freeipa/freeipa/issues/6386>`__
 -  Don't modify redhat_system_units
    `commit <https://codeberg.org/freeipa/freeipa/commit/94a9dfb9d72ecd25a01316febbf2ffec50912e2e>`__
 -  Use correct classifiers to make setup.py files PyPI compatible
    `commit <https://codeberg.org/freeipa/freeipa/commit/2dd66c6366454f9edd9b89861530e97c75b2d869>`__
 -  Use api.env.nss_dir instead of paths.IPA_NSSDB_DIR
    `commit <https://codeberg.org/freeipa/freeipa/commit/a22a5dd676f581910ac7872c1a20322278fc7d4a>`__
-   `#6386 <https://pagure.io/freeipa/issue/6386>`__
+   `#6386 <https://codeberg.org/freeipa/freeipa/issues/6386>`__
 -  Add \__name_\_ == \__main_\_ guards to setup.pys
    `commit <https://codeberg.org/freeipa/freeipa/commit/91920e7cb48cbf143ae281c9c073df14b2c2dddf>`__
 -  Remove ipapython/ipa.conf
@@ -966,10 +966,10 @@ Christian Heimes (88)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9d68b5c3503bb708f637be6bb173a742b4105b4>`__
 -  Add iSecStore.span
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac94d32c4fd543e33211c0331330c80c619e0058>`__
-   `#6365 <https://pagure.io/freeipa/issue/6365>`__
+   `#6365 <https://codeberg.org/freeipa/freeipa/issues/6365>`__
 -  Use RSA-OAEP instead of RSA PKCS#1 v1.5
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ae4d0d6909e99892442a170288f0eee9610d1c2>`__
-   `#6278 <https://pagure.io/freeipa/issue/6278>`__
+   `#6278 <https://codeberg.org/freeipa/freeipa/issues/6278>`__
 
 
 
@@ -979,55 +979,55 @@ David Kupka (20)
 -  rpcserver: x509_login: Handle unsuccessful certificate login
    gracefully
    `commit <https://codeberg.org/freeipa/freeipa/commit/70889d4d5e7e2bd65ab1d4a28e5eda4a51c9b0c0>`__
-   `#6225 <https://pagure.io/freeipa/issue/6225>`__
+   `#6225 <https://codeberg.org/freeipa/freeipa/issues/6225>`__
 -  Bump required version of gssproxy to 0.7.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/c37254e1b124c95d6ea874f6513979ca165fb31d>`__
-   `#6671 <https://pagure.io/freeipa/issue/6671>`__,
-   `#6698 <https://pagure.io/freeipa/issue/6698>`__
+   `#6671 <https://codeberg.org/freeipa/freeipa/issues/6671>`__,
+   `#6698 <https://codeberg.org/freeipa/freeipa/issues/6698>`__
 -  tests: Add tests for kerberos principal aliases in stageuser
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e139d4b559a6f19d859e078e1940a69d8977fdb>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  tests: kerberos_principal_aliases: Deduplicate tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/9382efde4fbc027dcfb5dc5f22d25296f232e0a6>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  tests: Stageuser-{add,remove}-cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5c98af99db53b5f9453bf70e9fd4c11e219cf3e>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  tests: add-remove-cert: Use harcoded certificates instead of
    requesting them
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b68cc5b08c5563535486d72f37b766209791dbf>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  ipalib.x509: Handle missing SAN gracefully
    `commit <https://codeberg.org/freeipa/freeipa/commit/308c790ee90f00e0bc2c40abf51c30e5250631e9>`__
 -  stageuser: Add stageuser-{add,remove}-principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e2d185ba09382a815e9b0530aeae3d56f9378d1>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  stageuser: Add stageuser-{add,remove}-cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c0e86530ec693606ca4f69e74a9dfe4118a21aa>`__
-   `#6623 <https://pagure.io/freeipa/issue/6623>`__
+   `#6623 <https://codeberg.org/freeipa/freeipa/issues/6623>`__
 -  build: Add missing dependency on libxmlrpc{,_util}
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4088b3a00b3cbd1a0133ac90cba85e501573f76>`__
-   `#6637 <https://pagure.io/freeipa/issue/6637>`__
+   `#6637 <https://codeberg.org/freeipa/freeipa/issues/6637>`__
 -  ipaclient: schema cache: Handle malformed server info data gracefully
    `commit <https://codeberg.org/freeipa/freeipa/commit/d15ccde20fcc97a597180255ee9f5eb38caa206c>`__
-   `#6578 <https://pagure.io/freeipa/issue/6578>`__
+   `#6578 <https://codeberg.org/freeipa/freeipa/issues/6578>`__
 -  schema_cache: Make handling of string compatible with python3
    `commit <https://codeberg.org/freeipa/freeipa/commit/388ed93935de56adbf1db976e9df276327c9a1e4>`__
-   `#6559 <https://pagure.io/freeipa/issue/6559>`__
+   `#6559 <https://codeberg.org/freeipa/freeipa/issues/6559>`__
 -  installer: Stop adding distro-specific NTP servers into ntp.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a15fdea615fa4e1153fbbed234113a235135572e>`__
-   `#6486 <https://pagure.io/freeipa/issue/6486>`__
+   `#6486 <https://codeberg.org/freeipa/freeipa/issues/6486>`__
 -  tests: Expect krbpwdpolicyreference in result of
    {host,service}-{find,show} --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1a20599c4f9fdcd208998694185b65460126703>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  password policy: Add explicit default password policy for hosts and
    services
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f1d927467e7907fd1991f88388d96c67c9bff61>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  ipaclient.plugins: Use api_version from internally called commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/d841a79dc104521f736469eff7154c2f4266082b>`__
-   `#6539 <https://pagure.io/freeipa/issue/6539>`__
+   `#6539 <https://codeberg.org/freeipa/freeipa/issues/6539>`__
 -  tests: Mark 389-ds acceptance tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4225484356426a73cc11211bceda7f06ee23d093>`__
 -  tests: Mark Dogtag acceptance tests
@@ -1035,10 +1035,10 @@ David Kupka (20)
 -  UnsafeIPAddress: Implement \__(g|s)etstate_\_ and to ensure proper
    (un)pickling
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb85230e25bd37a2a02a9d90793f337aad40a037>`__
-   `#6385 <https://pagure.io/freeipa/issue/6385>`__
+   `#6385 <https://codeberg.org/freeipa/freeipa/issues/6385>`__
 -  schema cache: Store and check info for pre-schema servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec2401917456d6f643532c0d0218c9e75172c2d8>`__
-   `#6095 <https://pagure.io/freeipa/issue/6095>`__
+   `#6095 <https://codeberg.org/freeipa/freeipa/issues/6095>`__
 
 
 
@@ -1047,65 +1047,65 @@ Florence Blanc-Renaud (20)
 
 -  Installation must publish CA cert in /usr/share/ipa/html/ca.crt
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4ad2c98aa43f03ecbd8e0a44410888acd83df6e>`__
-   `#6750 <https://pagure.io/freeipa/issue/6750>`__
+   `#6750 <https://codeberg.org/freeipa/freeipa/issues/6750>`__
 -  IdM Server: list all Employees with matching Smart Card
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea34e17a46a60efb9c4dc81dab919a1639dec73b>`__
-   `#6646 <https://pagure.io/freeipa/issue/6646>`__
+   `#6646 <https://codeberg.org/freeipa/freeipa/issues/6646>`__
 -  ipa systemd unit should define Wants=network instead of
    Requires=network
    `commit <https://codeberg.org/freeipa/freeipa/commit/f447489707812643ee918266f99ca1ac82a408af>`__
-   `#6723 <https://pagure.io/freeipa/issue/6723>`__
+   `#6723 <https://codeberg.org/freeipa/freeipa/issues/6723>`__
 -  Support for Certificate Identity Mapping
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e24918c89f30a6d7064844dc0dd848bb35140df>`__
-   `#6542 <https://pagure.io/freeipa/issue/6542>`__
+   `#6542 <https://codeberg.org/freeipa/freeipa/issues/6542>`__
 -  Define template version in certmap.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c49320435ddc67210c0d95be273e971ea8ffad6d>`__
-   `#6354 <https://pagure.io/freeipa/issue/6354>`__
+   `#6354 <https://codeberg.org/freeipa/freeipa/issues/6354>`__
 -  Fix ipa.service unit re. gssproxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/98e3b14a0477232054b02065c857fb1b16ce85a6>`__
-   `#6705 <https://pagure.io/freeipa/issue/6705>`__
+   `#6705 <https://codeberg.org/freeipa/freeipa/issues/6705>`__
 -  Do not configure PKI ajp redirection to use "::1"
    `commit <https://codeberg.org/freeipa/freeipa/commit/eaa87c75b9f57500265b2dc9480b996b2b92e1e3>`__
-   `#6575 <https://pagure.io/freeipa/issue/6575>`__
+   `#6575 <https://codeberg.org/freeipa/freeipa/issues/6575>`__
 -  ipa-kra-install must create directory if it does not exist
    `commit <https://codeberg.org/freeipa/freeipa/commit/066f5b7c904208d0fd79862dfaa7166fff42fd30>`__
-   `#6606 <https://pagure.io/freeipa/issue/6606>`__
+   `#6606 <https://codeberg.org/freeipa/freeipa/issues/6606>`__
 -  ipa-restore must stop tracking PKINIT cert in the preparation phase
    `commit <https://codeberg.org/freeipa/freeipa/commit/ceec512b09002e8cf9388873418644ec584db30a>`__
-   `#6570 <https://pagure.io/freeipa/issue/6570>`__
+   `#6570 <https://codeberg.org/freeipa/freeipa/issues/6570>`__
 -  Increase the timeout waiting for certificate issuance in installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e3c17c6ded868b4261aa76137c703a4fb866578>`__
-   `#6433 <https://pagure.io/freeipa/issue/6433>`__
+   `#6433 <https://codeberg.org/freeipa/freeipa/issues/6433>`__
 -  Check the result of cert request in replica installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbb98765d73519289ee22f3de1a5ccde140f6f5d>`__
-   `#6514 <https://pagure.io/freeipa/issue/6514>`__
+   `#6514 <https://codeberg.org/freeipa/freeipa/issues/6514>`__
 -  Fix ipa-replica-install when upgrade from ca-less to ca-full
    `commit <https://codeberg.org/freeipa/freeipa/commit/044d887e81d433b43c33b076a21fd1054796786e>`__
-   `#6375 <https://pagure.io/freeipa/issue/6375>`__
+   `#6375 <https://codeberg.org/freeipa/freeipa/issues/6375>`__
 -  Fix ipa migrate-ds when it finds a search reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/efb3700389ff46244189fa95779484eb099d63b4>`__
-   `#6358 <https://pagure.io/freeipa/issue/6358>`__
+   `#6358 <https://codeberg.org/freeipa/freeipa/issues/6358>`__
 -  Fix renewal lock issues on installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/198cd5fab3937fd8948bea4b4949e30db4e490a4>`__
-   `#6433 <https://pagure.io/freeipa/issue/6433>`__
+   `#6433 <https://codeberg.org/freeipa/freeipa/issues/6433>`__
 -  Refactor installer code requesting certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/808b1436b4158cb6f926ac2b5bd0979df6ea7e9f>`__
-   `#6433 <https://pagure.io/freeipa/issue/6433>`__
+   `#6433 <https://codeberg.org/freeipa/freeipa/issues/6433>`__
 -  Use autobind instead of host keytab authentication in
    dogtag-ipa-ca-renew-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/7462adec13c5b25b6868d2863dc38062c97d0ff7>`__
 -  Fix ipa-cacert-manage man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb75578cbb2447fc2fafb8a79d8500b27e3edff0>`__
-   `#6381 <https://pagure.io/freeipa/issue/6381>`__
+   `#6381 <https://codeberg.org/freeipa/freeipa/issues/6381>`__
 -  Add cert checks in ipa-server-certinstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c4a91348a57ee941db94b31f59952eb1fcd4565>`__
-   `#6263 <https://pagure.io/freeipa/issue/6263>`__
+   `#6263 <https://codeberg.org/freeipa/freeipa/issues/6263>`__
 -  Fix regression introduced in ipa-certupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd75eb3b2557cbd97e93be3e1ceeef21b948a694>`__
-   `#6288 <https://pagure.io/freeipa/issue/6288>`__
+   `#6288 <https://codeberg.org/freeipa/freeipa/issues/6288>`__
 -  Fix ipa-certupdate for CA-less installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/b36ee723b77a2721f4200d5df02268a9bd6a60b5>`__
-   `#6288 <https://pagure.io/freeipa/issue/6288>`__
+   `#6288 <https://codeberg.org/freeipa/freeipa/issues/6288>`__
 
 
 
@@ -1114,164 +1114,164 @@ Fraser Tweedale (52)
 
 -  rabase.get_certificate: make serial number arg mandatory
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ba0375c831eca673c2df146b565a32dbc03fdb3>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  Extract method to map principal to princpal type
    `commit <https://codeberg.org/freeipa/freeipa/commit/11c9df25774fbc8ed24b30f75c205d12ca3c5b90>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  Remove redundant principal_type argument
    `commit <https://codeberg.org/freeipa/freeipa/commit/2066a80be21258d9311ae374fe124d9ac3b79acd>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  dogtag: remove redundant property definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/49f87f34be5f04f18a6d916276153e9ef1e5852c>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__
 -  ca: correctly authorise ca-del, ca-enable and ca-disable
    `commit <https://codeberg.org/freeipa/freeipa/commit/b81ac59640f0b76fa9f53cf8be441f085a7089c4>`__
-   `#6713 <https://pagure.io/freeipa/issue/6713>`__
+   `#6713 <https://codeberg.org/freeipa/freeipa/issues/6713>`__
 -  replica install: relax domain level check for promotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/f51869bf5214e2d2322f85bf72b7ae86b6893974>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  Fix reference before assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/924794f62b9d3d0f46ca18e4f9338eaed865c03e>`__
-   `#6636 <https://pagure.io/freeipa/issue/6636>`__
+   `#6636 <https://codeberg.org/freeipa/freeipa/issues/6636>`__
 -  private_ccache: yield ccache name
    `commit <https://codeberg.org/freeipa/freeipa/commit/caca181d3b73c045abd72e464a195c6b61c251c7>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  Add sanity checks for use of --ca-subject and --subject-base
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c95a00147b1dd508736dacc847873ddddafb504>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  Indicate that ca subject / subject base uses LDAP RDN order
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f5660973251fe4b178e6486b6b86fbdd162d4d6>`__
-   `#6455 <https://pagure.io/freeipa/issue/6455>`__
+   `#6455 <https://codeberg.org/freeipa/freeipa/issues/6455>`__
 -  Allow full customisability of IPA CA subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d01ec14c6e36fa962d0c54b2e08df0ecd401bd6>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  Reuse self.api when executing ca_enabled_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/09a65df6842411d42966111e50924df3de0b7031>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  dsinstance: extract function for writing certmap.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/f54df62abae4a15064bf297634558eb9be83ce33>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  ipa-ca-install: add missing --subject-base option
    `commit <https://codeberg.org/freeipa/freeipa/commit/46bf0e89ae054b34adc66d08f205a5155e6f3fd6>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  Extract function for computing default subject base
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f3eb85c302f54bec561337e6627c89144b589ff>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  installer: rename --subject to --subject-base
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6db493b06320455a2366945911939a605df2a73>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  installutils: remove hardcoded subject DN assumption
    `commit <https://codeberg.org/freeipa/freeipa/commit/db6674096c598918ea6b12ca33a96cf5e617a434>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  Refactor and relocate set_subject_base_in_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/324183cd63aeadbaa9678d610ba59e1295a606fe>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  dsinstance: minor string fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5fb5f2da1be158cde585a087aaf97eca6218dd7>`__
-   `#6586 <https://pagure.io/freeipa/issue/6586>`__
+   `#6586 <https://codeberg.org/freeipa/freeipa/issues/6586>`__
 -  Set up DS TLS on replica in CA-less topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f7d982fe2e2d2f042e85710b8d8d59167e5796f>`__
-   `#6226 <https://pagure.io/freeipa/issue/6226>`__
+   `#6226 <https://codeberg.org/freeipa/freeipa/issues/6226>`__
 -  Remove "Request Certificate with SubjectAltName" permission
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdbb1c34a2f5ef864cd3a943dcd047cde20de681>`__
-   `#6526 <https://pagure.io/freeipa/issue/6526>`__
+   `#6526 <https://codeberg.org/freeipa/freeipa/issues/6526>`__
 -  Fix DL1 replica installation in CA-less topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/4028ad73e74fe62bd4871e842dbb69ff660125f9>`__
-   `#6573 <https://pagure.io/freeipa/issue/6573>`__
+   `#6573 <https://codeberg.org/freeipa/freeipa/issues/6573>`__
 -  certprofile-mod: correctly authorise config update
    `commit <https://codeberg.org/freeipa/freeipa/commit/fec4c32ff15a96736740cf7d2f713a21af0b227e>`__
-   `#6560 <https://pagure.io/freeipa/issue/6560>`__
+   `#6560 <https://codeberg.org/freeipa/freeipa/issues/6560>`__
 -  Fix regression in test suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/74b8cf2c4a8dd36577d76c35a9ef08352ef025b7>`__
-   `#6178 <https://pagure.io/freeipa/issue/6178>`__
+   `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__
 -  Add options to write lightweight CA cert or chain to file
    `commit <https://codeberg.org/freeipa/freeipa/commit/32b1743e5fb318b226a602ec8d9a4b6ef2a25c9d>`__
-   `#6178 <https://pagure.io/freeipa/issue/6178>`__
+   `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__
 -  certdb: accumulate extracted certs as list of PEMs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc5b88e5d4ac1171374be9ae8e6e60730243dd3d>`__
-   `#6178 <https://pagure.io/freeipa/issue/6178>`__
+   `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__
 -  Add function for extracting PEM certs from PKCS #7
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7ea56c049ec8ab1a5500852eca6faf750b1479f>`__
-   `#6178 <https://pagure.io/freeipa/issue/6178>`__
+   `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__
 -  cert-request: match names against principal aliases
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfbdb5323863e6c3d681c1b33b1eb9d2efefd6c7>`__
-   `#6295 <https://pagure.io/freeipa/issue/6295>`__
+   `#6295 <https://codeberg.org/freeipa/freeipa/issues/6295>`__
 -  Remove references to ds_newinst.pl
    `commit <https://codeberg.org/freeipa/freeipa/commit/687ebd18a1927cd6dcbb6cb884b979096c8a44aa>`__
-   `#6496 <https://pagure.io/freeipa/issue/6496>`__
+   `#6496 <https://codeberg.org/freeipa/freeipa/issues/6496>`__
 -  cert-request: accept CSRs with extraneous data
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1df2e0792a6a423563c4787215b284948f51582>`__
-   `#6472 <https://pagure.io/freeipa/issue/6472>`__
+   `#6472 <https://codeberg.org/freeipa/freeipa/issues/6472>`__
 -  Ensure correct IPA CA nickname in DS and HTTP NSSDBs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdd41e06e6ef97efafd36ee9e4c8d3be9e4099e7>`__
-   `#6415 <https://pagure.io/freeipa/issue/6415>`__
+   `#6415 <https://codeberg.org/freeipa/freeipa/issues/6415>`__
 -  Remove \__main_\_ code from ipalib.x509 and ipalib.pkcs10
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0430b67dc90fddf1e35fde9a0cf2977a07d7cbd>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  x509: use python-cryptography to process certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/db116f73fe5fc199bb2e28103cf5e3e2a24eab4c>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  x509: use pyasn1-modules X.509 specs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c57dc890b2bf447ab575f2e91249179bce3f05d5>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  x509: avoid use of nss.data_to_hex
    `commit <https://codeberg.org/freeipa/freeipa/commit/44c2d685f01eb4c03e4659125e41d73b8be47c19>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  pkcs10: remove pyasn1 PKCS #10 spec
    `commit <https://codeberg.org/freeipa/freeipa/commit/85487281cdc09720f6a0385ebb7157742d762a0c>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  pkcs10: use python-cryptography for CSR processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/66637f766dd0ddc50888013962be2294fd8d0e9a>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  dn: support conversion from python-cryptography Name
    `commit <https://codeberg.org/freeipa/freeipa/commit/9522970bfa28900abc90e959de483f59c79a3e5f>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  cert-show: show validity in default output
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6a3c9dc74ccef6f8e7df4123670d7e11269198c>`__
-   `#6419 <https://pagure.io/freeipa/issue/6419>`__
+   `#6419 <https://codeberg.org/freeipa/freeipa/issues/6419>`__
 -  Do not create Object Signing certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb6bfd82f363405e3377b2a912b1152ba76625ae>`__
-   `#6399 <https://pagure.io/freeipa/issue/6399>`__
+   `#6399 <https://codeberg.org/freeipa/freeipa/issues/6399>`__
 -  Add commentary about CA deletion to plugin doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b8163ab5dfcf28a9eba319ef685046ae9d8b5e8>`__
-   `#6256 <https://pagure.io/freeipa/issue/6256>`__
+   `#6256 <https://codeberg.org/freeipa/freeipa/issues/6256>`__
 -  spec: require Dogtag >= 10.3.5-6
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b3f4984296f3caff8f29490eae3ed1dca64b8c3>`__
-   `#6256 <https://pagure.io/freeipa/issue/6256>`__
+   `#6256 <https://codeberg.org/freeipa/freeipa/issues/6256>`__
 -  sudorule: add SELinux transition examples to plugin doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff490b6c403f9fe14fcc2d1558c43dae5b80f493>`__
-   `#3461 <https://pagure.io/freeipa/issue/3461>`__
+   `#3461 <https://codeberg.org/freeipa/freeipa/issues/3461>`__
 -  Fix cert revocation when removing all certs via host/service-mod
    `commit <https://codeberg.org/freeipa/freeipa/commit/97d4ffc2dc5db00fd7ed10b0b290cc97a506d0ef>`__
-   `#6305 <https://pagure.io/freeipa/issue/6305>`__
+   `#6305 <https://codeberg.org/freeipa/freeipa/issues/6305>`__
 -  cert-request: raise error when request fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f1c93d2b5023f8d491252c605dbcf05c8ecc7e3>`__
-   `#6309 <https://pagure.io/freeipa/issue/6309>`__
+   `#6309 <https://codeberg.org/freeipa/freeipa/issues/6309>`__
 -  Make host/service cert revocation aware of lightweight CAs
    `commit <https://codeberg.org/freeipa/freeipa/commit/daeaf2a8234ba684352d98fbc8d734100e6d63d1>`__
-   `#6221 <https://pagure.io/freeipa/issue/6221>`__
+   `#6221 <https://codeberg.org/freeipa/freeipa/issues/6221>`__
 -  cert-request: raise CertificateOperationError if CA disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/520ad7d865ff147d3ff8819d3e384d7cbd69bfb7>`__
-   `#6260 <https://pagure.io/freeipa/issue/6260>`__
+   `#6260 <https://codeberg.org/freeipa/freeipa/issues/6260>`__
 -  Use Dogtag REST API for certificate requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c35afccf3cf3a5176e598872c4fcff80b416335>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#6260 <https://pagure.io/freeipa/issue/6260>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#6260 <https://codeberg.org/freeipa/freeipa/issues/6260>`__
 -  Add HTTPRequestError class
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5cbc8de89c7d88c443bff937fe9aa965e4c1c94>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#6260 <https://pagure.io/freeipa/issue/6260>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#6260 <https://codeberg.org/freeipa/freeipa/issues/6260>`__
 -  Allow Dogtag RestClient to perform requests without logging in
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a42a7e90eb8154a6722ae93d93f8cf6796f4a21>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#6260 <https://pagure.io/freeipa/issue/6260>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#6260 <https://codeberg.org/freeipa/freeipa/issues/6260>`__
 -  Add ca-disable and ca-enable commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7e0dbc4e174d0bb7577de18cdb2f414f4199c57>`__
-   `#6257 <https://pagure.io/freeipa/issue/6257>`__
+   `#6257 <https://codeberg.org/freeipa/freeipa/issues/6257>`__
 -  Track lightweight CAs on replica installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/08b768313020c45bfa82d67cd214afabf605f4b3>`__
-   `#6019 <https://pagure.io/freeipa/issue/6019>`__
+   `#6019 <https://codeberg.org/freeipa/freeipa/issues/6019>`__
 
 
 
@@ -1280,25 +1280,25 @@ Ganna Kaihorodova (7)
 
 -  Tests: Basic coverage with tree root domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/10494b1bb34b6ff9c1b810cc0739c761b017202c>`__
-   `#6489 <https://pagure.io/freeipa/issue/6489>`__
+   `#6489 <https://codeberg.org/freeipa/freeipa/issues/6489>`__
 -  User Tracker: Test to create user with minimal values
    `commit <https://codeberg.org/freeipa/freeipa/commit/91c050b4e093802d8c6b510a22d6e435faba965f>`__
-   `#6126 <https://pagure.io/freeipa/issue/6126>`__
+   `#6126 <https://codeberg.org/freeipa/freeipa/issues/6126>`__
 -  User Tracker: creation of user with minimal values
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa7aaef1de2c97ac9d24925ca9adb25c7151055f>`__
-   `#6126 <https://pagure.io/freeipa/issue/6126>`__
+   `#6126 <https://codeberg.org/freeipa/freeipa/issues/6126>`__
 -  Stage User: Test to create stage user with minimal values
    `commit <https://codeberg.org/freeipa/freeipa/commit/c391f6ba58a61e046e49e1b4526b62d7ce250301>`__
-   `#6448 <https://pagure.io/freeipa/issue/6448>`__
+   `#6448 <https://codeberg.org/freeipa/freeipa/issues/6448>`__
 -  Tests: Stage User Tracker implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/a336de630e9d1ef95a507cc3ee9200c001ab9193>`__
-   `#6448 <https://pagure.io/freeipa/issue/6448>`__
+   `#6448 <https://codeberg.org/freeipa/freeipa/issues/6448>`__
 -  Tests: Add tree root domain role in legacy client tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/822a119100f8ab93aacdb14b982609f1dc69531d>`__
-   `#6600 <https://pagure.io/freeipa/issue/6600>`__
+   `#6600 <https://codeberg.org/freeipa/freeipa/issues/6600>`__
 -  Unaccessible variable self.attrs in Tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b0b97073304ba6bfdd6292b07533ab3e7fe8bcb>`__
-   `#6125 <https://pagure.io/freeipa/issue/6125>`__
+   `#6125 <https://codeberg.org/freeipa/freeipa/issues/6125>`__
 
 
 
@@ -1309,315 +1309,315 @@ Jan Cholasta (106)
    `commit <https://codeberg.org/freeipa/freeipa/commit/990ce9eef314622440b2036742bbf34f57ba2699>`__
 -  spec file: support client-only build
    `commit <https://codeberg.org/freeipa/freeipa/commit/417f1926c48b426b34b18edb28869f4f06824873>`__
-   `#6517 <https://pagure.io/freeipa/issue/6517>`__
+   `#6517 <https://codeberg.org/freeipa/freeipa/issues/6517>`__
 -  spec file: support build without ipatests
    `commit <https://codeberg.org/freeipa/freeipa/commit/e42a846506ee7ad5e8a395da154bec64f6be3654>`__
-   `#6517 <https://pagure.io/freeipa/issue/6517>`__
+   `#6517 <https://codeberg.org/freeipa/freeipa/issues/6517>`__
 -  slapi plugins: fix CFLAGS
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7329e31f5c985b9721e3a21b1cd1bec6430129d>`__
 -  spec file: add unconditional python-setuptools BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ef4e9eb810063243fcc575434d856c854b14eee>`__
 -  httpinstance: disable system trust module in /etc/httpd/alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/f037bfa48356a5fb28eebdb76f9dbd5cb461c2d2>`__
-   `#6132 <https://pagure.io/freeipa/issue/6132>`__
+   `#6132 <https://codeberg.org/freeipa/freeipa/issues/6132>`__
 -  csrgen: hide cert-get-requestdata in CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/72de679eb445c975ec70cd265d37d4927823ce5b>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  cert: include certificate chain in cert command output
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ed891cb619abd2efd428f767edf760ebf5eec5d>`__
-   `#6547 <https://pagure.io/freeipa/issue/6547>`__
+   `#6547 <https://codeberg.org/freeipa/freeipa/issues/6547>`__
 -  cert: add output file option to cert-request
    `commit <https://codeberg.org/freeipa/freeipa/commit/c60d9c9744b1f8a7b55bcdda65cce8bb36700bf6>`__
-   `#6547 <https://pagure.io/freeipa/issue/6547>`__
+   `#6547 <https://codeberg.org/freeipa/freeipa/issues/6547>`__
 -  Travis CI: run tests in development mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe4489ede2b40902fb7d734d04a1f997c6df86fb>`__
-   `#6625 <https://pagure.io/freeipa/issue/6625>`__
+   `#6625 <https://codeberg.org/freeipa/freeipa/issues/6625>`__
 -  backend plugins: fix crashes in development mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fdd7a9ffc263c1198afa5479cda41d319f11d91>`__
-   `#6625 <https://pagure.io/freeipa/issue/6625>`__
+   `#6625 <https://codeberg.org/freeipa/freeipa/issues/6625>`__
 -  vault: cache the transport certificate on client
    `commit <https://codeberg.org/freeipa/freeipa/commit/98bb5397c535e5e1a6c5ade9f0fb918be1d282c3>`__
-   `#6652 <https://pagure.io/freeipa/issue/6652>`__
+   `#6652 <https://codeberg.org/freeipa/freeipa/issues/6652>`__
 -  rpc: fix crash in verbose mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/8295848bfec6f96410ab8383107fdaf565f02974>`__
-   `#6734 <https://pagure.io/freeipa/issue/6734>`__
+   `#6734 <https://codeberg.org/freeipa/freeipa/issues/6734>`__
 -  install: re-introduce option groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fc9feddd02bb17c3a9eb7efde83277fcf93252c>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install CLI: remove magic option groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/774d8d0a5dc0ac175ab0cecc76001632c2a79744>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client install: split off SSSD options into a separate class
    `commit <https://codeberg.org/freeipa/freeipa/commit/1cfe06c79eb0b98a0f4bd663165156596b59e85f>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  server install: remove duplicate knob definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/94f362d7b0b6c838752eb2f6674149e96d3ae95b>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: add missing space in realm_name description
    `commit <https://codeberg.org/freeipa/freeipa/commit/5efa55c88d73d9f5db77df4be9fedf03f9b323d1>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  server install: remove duplicate -w option
    `commit <https://codeberg.org/freeipa/freeipa/commit/00f49dd7bbf277757902c94990d33758fec56b23>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  certmap: load certificate from file in certmap-match CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/0298ecf441ba38858d7909b8c3b4cc2b4c4e53c4>`__
-   `#6646 <https://pagure.io/freeipa/issue/6646>`__
+   `#6646 <https://codeberg.org/freeipa/freeipa/issues/6646>`__
 -  pylint_plugins: add forbidden import checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d489ac5604ca959cfe439c0594b8739073f3cea>`__
 -  ipapython: fix DEFAULT_PLUGINS in version.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/abf25d3cb6570e6ae7cd094ea6a5f4a1bd75d8a7>`__
-   `#6597 <https://pagure.io/freeipa/issue/6597>`__
+   `#6597 <https://codeberg.org/freeipa/freeipa/issues/6597>`__
 -  config: re-add \`init_config\` and \`config\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c7ca279c78bc23d45582e92bb1638865ec3059e>`__
-   `#6707 <https://pagure.io/freeipa/issue/6707>`__
+   `#6707 <https://codeberg.org/freeipa/freeipa/issues/6707>`__
 -  dns: fix \`dnsrecord_add\` interactive mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e912f5b83166154806e0382f3f028d0eac81731>`__
-   `#6457 <https://pagure.io/freeipa/issue/6457>`__
+   `#6457 <https://codeberg.org/freeipa/freeipa/issues/6457>`__
 -  server install: do not attempt to issue PKINIT cert in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba3c201a03cd0b224b43e45245147e48b7291f9f>`__
-   `#5678 <https://pagure.io/freeipa/issue/5678>`__
+   `#5678 <https://codeberg.org/freeipa/freeipa/issues/5678>`__
 -  compat: fix \`Any\` params in \`batch\` and \`dnsrecord\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/19060db1b8fa9d1d3e8f3ac3fcd1f387e9a39c94>`__
-   `#6647 <https://pagure.io/freeipa/issue/6647>`__
+   `#6647 <https://codeberg.org/freeipa/freeipa/issues/6647>`__
 -  scripts, tests: explicitly set confdir in the rest of server code
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe6f2b6f6effcf9f3c58e1e3f6d0874609c10c25>`__
-   `#6389 <https://pagure.io/freeipa/issue/6389>`__
+   `#6389 <https://codeberg.org/freeipa/freeipa/issues/6389>`__
 -  server upgrade: uninstall ipa_memcached properly
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d34c2169fcd520cc726e58e01d008ae3637aad4>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  server upgrade: always upgrade KRA agent PEM file
    `commit <https://codeberg.org/freeipa/freeipa/commit/0862e320916e0123df7e8505ba61229db0cb1e4a>`__
-   `#6675 <https://pagure.io/freeipa/issue/6675>`__
+   `#6675 <https://codeberg.org/freeipa/freeipa/issues/6675>`__
 -  server upgrade: fix upgrade from pre-4.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/97e838e10da3b42e3605d230e0b8e01b9148876f>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  server upgrade: fix upgrade in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba8a10fbdb39cab672038e1a6dc9c7507070cdf9>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  client install: create /etc/ipa/nssdb with correct mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4fa354f500bcf3ac23ee3805f2c166c6a635b92>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  ipaldap: preserve order of values in LDAPEntry._sync()
    `commit <https://codeberg.org/freeipa/freeipa/commit/e920ae22525d34e1f524e2e59159ac50c603bc8c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  replica install: do not log host OTP
    `commit <https://codeberg.org/freeipa/freeipa/commit/054c1e013aee6fdbee2e9966c32df02d91f0c2c1>`__
-   `#6633 <https://pagure.io/freeipa/issue/6633>`__
+   `#6633 <https://codeberg.org/freeipa/freeipa/issues/6633>`__
 -  tests: add test for PEM certificate files with leading text
    `commit <https://codeberg.org/freeipa/freeipa/commit/89dfbab3ca076812590f371c21abcb51b350170b>`__
 -  ipa-ca-install: do not fail without --subject-base and --ca-subject
    `commit <https://codeberg.org/freeipa/freeipa/commit/87400cdec1054971f50f90a0c63f18ab045f3833>`__
-   `#2614 <https://pagure.io/freeipa/issue/2614>`__
+   `#2614 <https://codeberg.org/freeipa/freeipa/issues/2614>`__
 -  cert: fix search limit handling in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/85834abad655c6aed54c0253bc194ece81d78774>`__
-   `#6564 <https://pagure.io/freeipa/issue/6564>`__
+   `#6564 <https://codeberg.org/freeipa/freeipa/issues/6564>`__
 -  dogtag: search past the first 100 certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/d84edc43e55c2f7c30614a4a5268aeb58e33a087>`__
-   `#6564 <https://pagure.io/freeipa/issue/6564>`__
+   `#6564 <https://codeberg.org/freeipa/freeipa/issues/6564>`__
 -  ipaldap: properly escape raw binary values in LDAP filters
    `commit <https://codeberg.org/freeipa/freeipa/commit/84a9611cb885f04c72cd657c3a3e7bc4aff39d93>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  client install: correctly report all failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/26630db9d0fb1d9c8a02840b71b3fb3e8bdf3e0d>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  cainstance: do not configure renewal guard
    `commit <https://codeberg.org/freeipa/freeipa/commit/926fe2049a1839fd7e68c9fa55f64154ee83c841>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  dogtaginstance: track server certificate with our renew agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad49bda907b3c2ec5b98946a2c4000bb6edaf835>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  renew agent: handle non-replicated certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5af11f65cc2a2d6860579a63a173b67cb12bcf3>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  ca: fix ca-find with --pkey-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/ceb26f5ac428cdbed8ec1fa89e9ed6f1d903a5a0>`__
-   `#6178 <https://pagure.io/freeipa/issue/6178>`__
+   `#6178 <https://codeberg.org/freeipa/freeipa/issues/6178>`__
 -  spec file: revert to the previous Release tag
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb1f05d598d821f8e7eb5b8cfe606f570052f263>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  x509: use PyASN1 to parse PKCS#7
    `commit <https://codeberg.org/freeipa/freeipa/commit/556fc21482e8061847556c653095edba7e7531f1>`__
-   `#6550 <https://pagure.io/freeipa/issue/6550>`__
+   `#6550 <https://codeberg.org/freeipa/freeipa/issues/6550>`__
 -  server install: fix KRA agent PEM file not being created
    `commit <https://codeberg.org/freeipa/freeipa/commit/998c87af2b7b2c704d34dd27fe99bda495a59e23>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  spec file: do not define with_lint inside a comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b85e59ceeb115dfb24e9c6bacb665b935f9543c>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  certdb: fix PKCS#12 import with empty password
    `commit <https://codeberg.org/freeipa/freeipa/commit/a35f5181c0af459e9f054838805628f31316cbe9>`__
-   `#6541 <https://pagure.io/freeipa/issue/6541>`__
+   `#6541 <https://codeberg.org/freeipa/freeipa/issues/6541>`__
 -  server install: fix external CA install
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fff09978eab520d130d87c0112b5caac907e651>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: track the RA agent certificate again
    `commit <https://codeberg.org/freeipa/freeipa/commit/4221266562778806f02748fee2dfbd814261f2b4>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  ipaclient: remove hard dependency on ipaplatform
    `commit <https://codeberg.org/freeipa/freeipa/commit/a260fd8058d757b631dd4eb39ee8a58b91cf2efb>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipaclient: move install modules to the install subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/70c3cd7f482bee7d5ad12062daa7ad6181a29094>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipalib: remove hard dependency on ipapython
    `commit <https://codeberg.org/freeipa/freeipa/commit/d43b57d2ce8552ed4977dcc33667b4226fe3333b>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  constants: remove CACERT
    `commit <https://codeberg.org/freeipa/freeipa/commit/977050c66bccd7b8cf468c115d73250505a01034>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipalib: move certstore to the install subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2c58889735c794cd1e93331c755b6f9ba273773>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipapython: remove hard dependency on ipaplatform
    `commit <https://codeberg.org/freeipa/freeipa/commit/528012fe8a8976961203021ef36353b7a4c3b8a8>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: move file encryption functions to installutils
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e50fae9ec6dea35e12a65dbc46228a1e6276e07>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: move kinit functions to ipalib.install
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d5c680ace7ccea3b0f7f1471cf8dbc07b3da5a1>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: move is_fips_enabled() to ipaplatform.tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/75b70e3f0d52a9c98f443d3fc2f7cef92bdc7b1a>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: remove the timeout argument of run()
    `commit <https://codeberg.org/freeipa/freeipa/commit/d911f493482d29829199cce2f91f88a9b53369e1>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: remove get_domain_name()
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b966e8577fdb56f069cf26a6ab4d6c77b8743b9>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipautil: remove SHARE_DIR and PLUGIN_SHARE_DIR
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6b755e3fcaf32158f4ee36d45e3344b4a03fbc2>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  certdb: use a temporary file to pass password to pk12util
    `commit <https://codeberg.org/freeipa/freeipa/commit/f919ab4ee0ec26d77ee6978e75de5daba4073402>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  certdb: move IPA NSS DB install functions to ipaclient.install
    `commit <https://codeberg.org/freeipa/freeipa/commit/fba6c21da3fbe0a62a96118eb32f205249ab3736>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipapython: move certmonger and sysrestore to ipalib.install
    `commit <https://codeberg.org/freeipa/freeipa/commit/26c46a447f82b4cf37a5076b72cf6328857d5f35>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  ipapython: move dnssec, p11helper and secrets to ipaserver
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1f260d021bf5d018e634438fde6b7c81ebbbcef>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  custodiainstance: automatic restart on config file update
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e5d2c7014ff6371a3b306e666c301aea1f7a488>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  paths: remove DEV_NULL
    `commit <https://codeberg.org/freeipa/freeipa/commit/9117a5d5a6ae7b3b97407e46f81a06c387974d7f>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  install: migrate client install to the new class hierarchy
    `commit <https://codeberg.org/freeipa/freeipa/commit/09423acb6574a3773d7783f9ddec022bed3539c8>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: allow specifying verbosity and console log format in CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/714699a81fa377e6033cbc7564f0f0fd10cd9f1a>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: migrate server installers to the new class hierarchy
    `commit <https://codeberg.org/freeipa/freeipa/commit/225fae841882832668c0842479ab11c89dfcd1a5>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: introduce installer class hierarchy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8fdb8de8248fe24f382e44b05293405b0b309ac>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: fix subclassing of knob groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/08a446a6bc516936497c1e0f278a699148f6330c>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: make knob base declaration explicit
    `commit <https://codeberg.org/freeipa/freeipa/commit/269ca6c4547fc017bb3a88e994ca770047122b3e>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: declare knob CLI names using the argparse convention
    `commit <https://codeberg.org/freeipa/freeipa/commit/043c262ce48a0d667e914c315e21e6e1b3862202>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: use standard Python classes to declare knob types
    `commit <https://codeberg.org/freeipa/freeipa/commit/a929ac333833a5cbf503d1fcbdee150658d933a4>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: introduce updated knob constructor
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fd1981ae8abf720f5234b6049c9beabbb1f2211>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: simplify CLI option parsing
    `commit <https://codeberg.org/freeipa/freeipa/commit/be0c1afa74cdf9a6e7640cd4110519e61250ae93>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: improve CLI positional argument handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/a641e279ff76e09f59c4d5fef1dc1f9355dbacf7>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: use ldaps for pkispawn in ipa-ca-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/87c3c1abecdfb8b5eb227239eeacfbee386a7ed7>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: fix DS restart failure during replica promotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cb315af627d712dd21396164cfa2b5d03ccb466>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: merge KRA agent cert export into KRA install
    `commit <https://codeberg.org/freeipa/freeipa/commit/89bb5ed1ebc0b5952a1d5eae34e0f39c5ba540d7>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: merge RA cert import into CA install
    `commit <https://codeberg.org/freeipa/freeipa/commit/822e1bc82af3a6c1556546c4fbe96eeafad45762>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  server install: do not restart httpd during CA install
    `commit <https://codeberg.org/freeipa/freeipa/commit/2dedfe5d33062fc7121bf36be12d7b423b62120a>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: merge all KRA install code paths into one
    `commit <https://codeberg.org/freeipa/freeipa/commit/0933e080aa9635bba12efc53d904d524b309027f>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  install: merge all CA install code paths into one
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc38d53de1eff71570ec5ef55db6de2c6f9b5bbd>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: use one remote KRA host name everywhere
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e232b5f526168af6bb0b52244f79dfacb43a9b7>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replica install: use one remote CA host name everywhere
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a7e79a7a6fad8dc87c8f148cb5098434f988ea3>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  spec file: bump minimal required version of 389-ds-base
    `commit <https://codeberg.org/freeipa/freeipa/commit/f12abfb852dfb1a7759928b05defde68d5d7a3df>`__
-   `#6369 <https://pagure.io/freeipa/issue/6369>`__
+   `#6369 <https://codeberg.org/freeipa/freeipa/issues/6369>`__
 -  pwpolicy: do not run klist on import
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc5ad6b3f951a6cb8298181690248d680c39922b>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  client: remove unused libcurl build dependency
    `commit <https://codeberg.org/freeipa/freeipa/commit/9477e39b4b267922dbdd86a65869f773d980df8e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  makeapi, makeaci: do not fail on missing imports
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b534238157e003d2d7c3e1a7fd27531ab1dfd25>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  ipaserver: remove ipalib import from setup.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b91735c79a0ba577f9540e946180760a97913a4>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  pylint: enable the import-error check
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d370a959b6b55f995661b2febe55c379065c4d9>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  spec file: do not include BuildRequires for lint by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/1077743d90902fc776f837f8486fa7f08b560673>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  spec file: clean up BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/21395d1724e6bf044438a8bc25ba028ed38cde8c>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  cert: add revocation reason back to cert-find output
    `commit <https://codeberg.org/freeipa/freeipa/commit/16dad1c3cb09acee946bc5b2409447279a8bc0de>`__
-   `#6269 <https://pagure.io/freeipa/issue/6269>`__
+   `#6269 <https://codeberg.org/freeipa/freeipa/issues/6269>`__
 -  test_plugable: update the rest of test_init
    `commit <https://codeberg.org/freeipa/freeipa/commit/09a8f62d12c0be26741c24845cda2be83f14c503>`__
-   `#6313 <https://pagure.io/freeipa/issue/6313>`__
+   `#6313 <https://codeberg.org/freeipa/freeipa/issues/6313>`__
 -  dns: re-introduce --raw in dnsrecord-del
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5f7a612fbfdaa9ee12ef16cef550931011abe4c>`__
-   `#5644 <https://pagure.io/freeipa/issue/5644>`__
+   `#5644 <https://codeberg.org/freeipa/freeipa/issues/5644>`__
 -  client: remove hard dependency on pam_krb5
    `commit <https://codeberg.org/freeipa/freeipa/commit/984ae3858d8fb25d30b886bb953df1b06ab34ec7>`__
-   `#5557 <https://pagure.io/freeipa/issue/5557>`__
+   `#5557 <https://codeberg.org/freeipa/freeipa/issues/5557>`__
 -  cert: fix cert-find --certificate when the cert is not in LDAP
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7b6faf14aaa8ac677ab9ebc2bcbf87e6b2a1146>`__
-   `#6304 <https://pagure.io/freeipa/issue/6304>`__
+   `#6304 <https://codeberg.org/freeipa/freeipa/issues/6304>`__
 -  dns: fix crash in interactive mode against old servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/38a51fa984a6aa92f383d7f8176057de8e057d52>`__
-   `#6203 <https://pagure.io/freeipa/issue/6203>`__
+   `#6203 <https://codeberg.org/freeipa/freeipa/issues/6203>`__
 -  dns: prompt for missing record parts in CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/dce95a14595a37ce83bcf3e28f41feab715d0c81>`__
-   `#6203 <https://pagure.io/freeipa/issue/6203>`__
+   `#6203 <https://codeberg.org/freeipa/freeipa/issues/6203>`__
 -  dns: normalize record type read interactively in dnsrecord_add
    `commit <https://codeberg.org/freeipa/freeipa/commit/afea9616318fbbffc2c296b7c41890db8595e3cc>`__
-   `#6203 <https://pagure.io/freeipa/issue/6203>`__
+   `#6203 <https://codeberg.org/freeipa/freeipa/issues/6203>`__
 -  cli: use full name when executing a command
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3d178b86ddff9335228d99fe06e8fc89a00235a>`__
-   `#6279 <https://pagure.io/freeipa/issue/6279>`__
+   `#6279 <https://codeberg.org/freeipa/freeipa/issues/6279>`__
 
 
 
@@ -1626,74 +1626,74 @@ Lenka Doudova (23)
 
 -  Document make_delete_command method in UserTracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b3bd5424246d8386a33a73f9a98c6958823093e>`__
-   `#6485 <https://pagure.io/freeipa/issue/6485>`__
+   `#6485 <https://codeberg.org/freeipa/freeipa/issues/6485>`__
 -  Tests: Providing trust tests with tree root domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/4df1d9d1a566af57b23d45ca4377ab77ed9e4d60>`__
-   `#6347 <https://pagure.io/freeipa/issue/6347>`__
+   `#6347 <https://codeberg.org/freeipa/freeipa/issues/6347>`__
 -  Tests: Verify that validity info is present in cert-show and
    cert-find command
    `commit <https://codeberg.org/freeipa/freeipa/commit/414ed0d182e55dfe18f31ebbbc97095b989fc162>`__
-   `#6419 <https://pagure.io/freeipa/issue/6419>`__
+   `#6419 <https://codeberg.org/freeipa/freeipa/issues/6419>`__
 -  Add file_exists method as a member of transport object
    `commit <https://codeberg.org/freeipa/freeipa/commit/46aa41444521a1746d584b703054e2a971915dc6>`__
-   `#6400 <https://pagure.io/freeipa/issue/6400>`__
+   `#6400 <https://codeberg.org/freeipa/freeipa/issues/6400>`__
 -  Tests: Provide AD cleanup for legacy client tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3938698e07404acfd7ae84fcaae9c02850d1afa7>`__
-   `#6396 <https://pagure.io/freeipa/issue/6396>`__
+   `#6396 <https://codeberg.org/freeipa/freeipa/issues/6396>`__
 -  Tests: Provide AD cleanup for trust tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a177732afc404a830b75cab03fb420af93fa441>`__
-   `#6396 <https://pagure.io/freeipa/issue/6396>`__
+   `#6396 <https://codeberg.org/freeipa/freeipa/issues/6396>`__
 -  Tests: Fix integration sudo test
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3b7d235d5e59e496f3d99a05e3dd379f845e4ea>`__
-   `#6378 <https://pagure.io/freeipa/issue/6378>`__
+   `#6378 <https://codeberg.org/freeipa/freeipa/issues/6378>`__
 -  Tests: Verify that cert commands show CA without --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/42d1a06bd1e856c14110c06ba0d9d946df36331d>`__
-   `#6410 <https://pagure.io/freeipa/issue/6410>`__
+   `#6410 <https://codeberg.org/freeipa/freeipa/issues/6410>`__
 -  Tests: Certificate revocation
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f04d1a793b8ff01804bc03eac9b7aaa4f7a7f78>`__
-   `#6349 <https://pagure.io/freeipa/issue/6349>`__
+   `#6349 <https://codeberg.org/freeipa/freeipa/issues/6349>`__
 -  Tests: Remove invalid certplugin tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9c92e3a7f4961d91e0395daf17f5aeb34c20178>`__
-   `#6349 <https://pagure.io/freeipa/issue/6349>`__
+   `#6349 <https://codeberg.org/freeipa/freeipa/issues/6349>`__
 -  Tests: Fix failing test_ipalib/test_parameters
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3e3130a35f05348405701731ec2d5b85a772997>`__
-   `#6292 <https://pagure.io/freeipa/issue/6292>`__
+   `#6292 <https://codeberg.org/freeipa/freeipa/issues/6292>`__
 -  Tests: Remove silent deleting and creating entries by tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/74e52e86867372365d1d63561f7d1ff961b89ee0>`__
-   `#6123 <https://pagure.io/freeipa/issue/6123>`__
+   `#6123 <https://codeberg.org/freeipa/freeipa/issues/6123>`__
 -  Tests: Remove usage of krb5 ccache from test_ipaserver/test_ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7c49e455e4f1f06f621f4c634a79b3ae0585cd8>`__
-   `#6323 <https://pagure.io/freeipa/issue/6323>`__
+   `#6323 <https://codeberg.org/freeipa/freeipa/issues/6323>`__
 -  Tests: Fix host attributes in ipa-join host test
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a947e2fd0d62df9a68252c1f7505451347b0c7d>`__
-   `#6326 <https://pagure.io/freeipa/issue/6326>`__
+   `#6326 <https://codeberg.org/freeipa/freeipa/issues/6326>`__
 -  Tests: Update host test with ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0fcfb31ecb2d17c3484d752edf55a42ef04ead7>`__
-   `#6326 <https://pagure.io/freeipa/issue/6326>`__
+   `#6326 <https://codeberg.org/freeipa/freeipa/issues/6326>`__
 -  Tests: Add krb5kdc.service restart to integration trust tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/936a6a38b8e7ece83933090db5840ebd37c26c20>`__
-   `#6322 <https://pagure.io/freeipa/issue/6322>`__
+   `#6322 <https://codeberg.org/freeipa/freeipa/issues/6322>`__
 -  Tests: Remove unnecessary attributes from base tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/522766a565f6845984c98dc3ea67d66a3e00e4c7>`__
-   `#6128 <https://pagure.io/freeipa/issue/6128>`__
+   `#6128 <https://codeberg.org/freeipa/freeipa/issues/6128>`__
 -  Tests: Remove --force options from tracker base class
    `commit <https://codeberg.org/freeipa/freeipa/commit/a07c4bdd4fda0ed1cca93d5a56ef67205be1a9d1>`__
-   `#6124 <https://pagure.io/freeipa/issue/6124>`__
+   `#6124 <https://codeberg.org/freeipa/freeipa/issues/6124>`__
 -  Tests: Remove SSSD restart from integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/361105a3d5b509bafee83934eb31d10f69d512f6>`__
-   `#6338 <https://pagure.io/freeipa/issue/6338>`__
+   `#6338 <https://codeberg.org/freeipa/freeipa/issues/6338>`__
 -  Tests: Fix integration sudo tests setup and checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cac8392036bf6d6bbd74f5a781986dec21149d6>`__
-   `#6262 <https://pagure.io/freeipa/issue/6262>`__
+   `#6262 <https://codeberg.org/freeipa/freeipa/issues/6262>`__
 -  Tests: Fix failing ldap.backend test
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c6f677a166d01a120e6b2a9361d7e5d3888c1c7>`__
-   `#6312 <https://pagure.io/freeipa/issue/6312>`__
+   `#6312 <https://codeberg.org/freeipa/freeipa/issues/6312>`__
 -  Tests: Add cleanup to integration trust tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8240133866bb8fabd3962b44789a0315f2e7dd8>`__
-   `#6306 <https://pagure.io/freeipa/issue/6306>`__
+   `#6306 <https://codeberg.org/freeipa/freeipa/issues/6306>`__
 -  Tests: Fix regex errors in integration trust tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc5a99274c2ea0301a539fe9a8b2dc9b61786a8a>`__
-   `#6285 <https://pagure.io/freeipa/issue/6285>`__
+   `#6285 <https://codeberg.org/freeipa/freeipa/issues/6285>`__
 
 
 
@@ -1702,7 +1702,7 @@ Ludwig Krispenz (1)
 
 -  Check for conflict entries before raising domain level
    `commit <https://codeberg.org/freeipa/freeipa/commit/26bd7ebfa27d15221e5d3fa1e3871a0085c31e0f>`__
-   `#6534 <https://pagure.io/freeipa/issue/6534>`__
+   `#6534 <https://codeberg.org/freeipa/freeipa/issues/6534>`__
 
 
 
@@ -1711,20 +1711,20 @@ Lukas Slebodnik (6)
 
 -  CONFIGURE: Improve detection of xmlrpc_c flags
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a4f7f2cfaf6ac5ffaf4cc2b43fa0e9b5fa3ebe4>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  CONFIGURE: Properly detect libpopt on el7
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fe9166ac9f9a100d69ce37f19ae1ae971bb2ce1>`__
 -  ipa_pwd: remove unnecessary dependency on dirsrv plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/41d7ae54fafc6deb602e1a990eaec37c6ae4880b>`__
 -  SPEC: Fix build in mock
    `commit <https://codeberg.org/freeipa/freeipa/commit/b82d285a4a75e11cc9291ecca12d2fcc26f43ed1>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 -  CONFIGURE: Update help message for jslint
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f91469f327d8d9f3b27e0b67c54a4f47ad845c1>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 -  CONFIGURE: Fix detection of pylint
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c18feaa206bbaee692fc3640b7b79c8d9d6a638>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 
 
 
@@ -1733,129 +1733,129 @@ Martin Babinsky (113)
 
 -  Try out anonymous PKINIT after it is configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1686a90c0cc8c16c89ef1bada7f507729bf3252>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  check for replica's KDC entry on master before requesting PKINIT cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/b45629fc480e61464b402ac2fc52c6f9fc61df0e>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  check that the master requesting PKINIT cert has KDC enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f4abf7bc1607fc44f528b8a443b69cb82269e69>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  Make wait_for_entry raise exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/069948466e81d99a0dd48ffffa32af50351d0189>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  Move PKINIT configuration to a later stage of server/replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd18b5f91e3f98fa877def245c54c1cd33bd372e>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  Request PKINIT cert directly from Dogtag API on first master
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5b23e073e59930e4dcf14ea8031c2c0441e6344>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  Make PKINIT certificate request logic consistent with other
    installers
    `commit <https://codeberg.org/freeipa/freeipa/commit/95768de06fbef78169329af12b29e4d65e4bf157>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__
 -  idviews: correctly handle modification of non-existent view
    `commit <https://codeberg.org/freeipa/freeipa/commit/1cdd5dee006426c996f67240b6cb2c1aa05e5168>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  Re-use trust domain retrieval code in certmap validators
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e5e3eebb223b7f2760e21f22e42775982104b0d>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  idview: add domain_resolution_order attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/544d66b7109300e570fb6849f0f9bab8020f3b66>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  ipaconfig: add the ability to manipulate domain resolution order
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b5f56d15455b6019dd532cb9635fa2c44cb0022>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  Short name resolution: introduce the required schema
    `commit <https://codeberg.org/freeipa/freeipa/commit/594c87daf873ceec0c0cf3464bcb1aadb9f2b92a>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  ipa-managed-entries: only permit running the command on IPA master
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cb98496aa2e1e190219cf2f4a6208a38fa368d5>`__
-   `#6735 <https://pagure.io/freeipa/issue/6735>`__
+   `#6735 <https://codeberg.org/freeipa/freeipa/issues/6735>`__
 -  ipa-managed-entries: use server-mode API
    `commit <https://codeberg.org/freeipa/freeipa/commit/715367506b11549aae69f913594ebc6d9c4d3e76>`__
-   `#6735 <https://pagure.io/freeipa/issue/6735>`__
+   `#6735 <https://codeberg.org/freeipa/freeipa/issues/6735>`__
 -  Allow login to WebUI using Kerberos aliases/enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8d7e37a091c1df4c989b80b8d19e12ab35533c8>`__
-   `#6343 <https://pagure.io/freeipa/issue/6343>`__
+   `#6343 <https://codeberg.org/freeipa/freeipa/issues/6343>`__
 -  Provide basic integration tests for built-in AD trust installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/612ea7f66e102c57c2b213eff99ad8f1c91e59a5>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Update server/replica installer man pages
    `commit <https://codeberg.org/freeipa/freeipa/commit/23cebe1356bbf84ddfde2a622a795061c4924edf>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Fix erroneous short name options in ipa-adtrust-install man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/f62f0b74855beff8db1ad6a24bf76fa66c3c4771>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Merge AD trust configurator into replica installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/eee319dba12a6ab7daa06ca0d7d8ac8fc754f961>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Merge AD trust configurator into server installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa353c5f21bf040579a4aeda6840b56ae93b4309>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  expose AD trust related knobs in composite installers
    `commit <https://codeberg.org/freeipa/freeipa/commit/13b5821fa4d32b5a1cc69a97386853fad44236ec>`__
 -  Add AD trust installer interface for composite installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/77857ea77662e005b1a23039e2f9173c0a9b080b>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  check for installed dependencies when \*not\* in standalone mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/289060dd98a3ed8e2a916ed25eaa1824c795e842>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  print the installation info only in standalone mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef37c42ab9d3530dc78fa4b754cd11c585b69d77>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  adtrust.py: Use logging to emit error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/c17215ea3db58c7a5fe6e30b6b38f4f3012e25d2>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Refactor the code searching and presenting missing trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/9348cfa996ce450bc88a4b35ee3f3bf52adfff39>`__
-   `#6639 <https://pagure.io/freeipa/issue/6639>`__
+   `#6639 <https://codeberg.org/freeipa/freeipa/issues/6639>`__
 -  only check for netbios name when LDAP backend is connected
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5bae577597fbababdd25ab3ae6463c490d90a40>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  Refactor the code checking for missing SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6b968399204aac66d82d917a8cc159e77ad4d>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  use the methods of the parent class to retrieve CIFS kerberos keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/8bac62b7f5d01ceb20388599e8549b1b222f283e>`__
-   `#6638 <https://pagure.io/freeipa/issue/6638>`__
+   `#6638 <https://codeberg.org/freeipa/freeipa/issues/6638>`__
 -  httpinstance: re-use parent's methods to retrieve anonymous keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce3baf28ce81458e1c5bf57188858d3d120ec3dd>`__
-   `#6638 <https://pagure.io/freeipa/issue/6638>`__
+   `#6638 <https://codeberg.org/freeipa/freeipa/issues/6638>`__
 -  Make request_service_keytab into a public method
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c0baa6208c2bf97b5ed7ea6e9836963dced64b0>`__
-   `#6638 <https://pagure.io/freeipa/issue/6638>`__
+   `#6638 <https://codeberg.org/freeipa/freeipa/issues/6638>`__
 -  allow for more flexibility when requesting service keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/af998c4d30175fb3ecc148e1b3a7aca03ef9239a>`__
-   `#6638 <https://pagure.io/freeipa/issue/6638>`__
+   `#6638 <https://codeberg.org/freeipa/freeipa/issues/6638>`__
 -  Move AD trust installation code to a separate module
    `commit <https://codeberg.org/freeipa/freeipa/commit/98bf0cc9663ac281247ac8d9ee8488e3ab8102eb>`__
-   `#6629 <https://pagure.io/freeipa/issue/6629>`__
+   `#6629 <https://codeberg.org/freeipa/freeipa/issues/6629>`__
 -  Replace exit() calls with exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7cfbb870fce40b50f6df2446c864099f8ea833e>`__
-   `#6629 <https://pagure.io/freeipa/issue/6629>`__
+   `#6629 <https://codeberg.org/freeipa/freeipa/issues/6629>`__
 -  Remove unused variables in exception handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/e27f6bfdc31b767be9ded411e869716b76f478ce>`__
-   `#6629 <https://pagure.io/freeipa/issue/6629>`__
+   `#6629 <https://codeberg.org/freeipa/freeipa/issues/6629>`__
 -  ipa-adtrust-install: format the code for PEP-8 compliance
    `commit <https://codeberg.org/freeipa/freeipa/commit/847be3a8a85cd58e5a011c0c2bc7e1123eb4a1aa>`__
-   `#6629 <https://pagure.io/freeipa/issue/6629>`__
+   `#6629 <https://codeberg.org/freeipa/freeipa/issues/6629>`__
 -  Travis CI: Upload the logs from failed jobs to transfer.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/91341f4035e0d78b0adbe9a09ba69e1fd35ec26d>`__
 -  Explicitly handle quoting/unquoting of NSSNickname directive
    `commit <https://codeberg.org/freeipa/freeipa/commit/86f4a93fb3aeb6742acab5abaa1c17b525ea4223>`__
-   `#6460 <https://pagure.io/freeipa/issue/6460>`__
+   `#6460 <https://codeberg.org/freeipa/freeipa/issues/6460>`__
 -  Delegate directive value quoting/unquoting to separate functions
    `commit <https://codeberg.org/freeipa/freeipa/commit/2831b30e9a9de947481c058d8d32e174f951b1c0>`__
-   `#6460 <https://pagure.io/freeipa/issue/6460>`__
+   `#6460 <https://codeberg.org/freeipa/freeipa/issues/6460>`__
 -  installutils: improve directive value parsing in \`get_directive\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/517d43e78b8d8ea0b796a6ff6a379236eaae21df>`__
-   `#6460 <https://pagure.io/freeipa/issue/6460>`__
+   `#6460 <https://codeberg.org/freeipa/freeipa/issues/6460>`__
 -  Fix the installutils.set_directive docstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1ed8b5eff40331ba532d37f3fb08814d8a55b77>`__
-   `#6460 <https://pagure.io/freeipa/issue/6460>`__
+   `#6460 <https://codeberg.org/freeipa/freeipa/issues/6460>`__
 -  disable hostname canonicalization by Kerberos library
    `commit <https://codeberg.org/freeipa/freeipa/commit/566c86a782bfd7d50938866e9f89faf56cea773f>`__
-   `#6584 <https://pagure.io/freeipa/issue/6584>`__
+   `#6584 <https://codeberg.org/freeipa/freeipa/issues/6584>`__
 -  Travis CI: actually return non-zero exit status when the test job
    fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b5b7131502a73fa24dc56c72a9648528c5aceee>`__
@@ -1881,190 +1881,190 @@ Martin Babinsky (113)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d86cae7748a8a629c942f1eafc0a0267f2c9611e>`__
 -  Add a basic test suite for \`kadmin.local\` interface
    `commit <https://codeberg.org/freeipa/freeipa/commit/d95bdbbfd505dde1348413fc7a1233ac834ce344>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  Make \`kadmin\` family of functions return the result of ipautil.run
    `commit <https://codeberg.org/freeipa/freeipa/commit/f59673506493e0199c17000538adb7c80b477aa0>`__
-   `#6561 <https://pagure.io/freeipa/issue/6561>`__
+   `#6561 <https://codeberg.org/freeipa/freeipa/issues/6561>`__
 -  gracefully handle setting replica bind dn group on old masters
    `commit <https://codeberg.org/freeipa/freeipa/commit/95e602598a481f9c4a3b69ce8a861bf3816aa8ba>`__
-   `#6532 <https://pagure.io/freeipa/issue/6532>`__
+   `#6532 <https://codeberg.org/freeipa/freeipa/issues/6532>`__
 -  add missing attribute to ipaca replica during CA topology update
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d0e450c8226a8e23d88cf21487a77db66a2968b>`__
-   `#6508 <https://pagure.io/freeipa/issue/6508>`__
+   `#6508 <https://codeberg.org/freeipa/freeipa/issues/6508>`__
 -  Revert "upgrade: add replica bind DN group check interval to CA
    topology config"
    `commit <https://codeberg.org/freeipa/freeipa/commit/6086a6dbad21d93ed584d508f9844d73f64a4542>`__
-   `#6508 <https://pagure.io/freeipa/issue/6508>`__
+   `#6508 <https://codeberg.org/freeipa/freeipa/issues/6508>`__
 -  bindinstance: use data in named.conf to determine configuration
    status
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0e09c42b76f229486e5dea097cd2b6602999943>`__
-   `#6503 <https://pagure.io/freeipa/issue/6503>`__
+   `#6503 <https://codeberg.org/freeipa/freeipa/issues/6503>`__
 -  Use ipa-docker-test-runner to run tests in Travis CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d6fbc010ec2b607a11e0ff69c8cbdcd3c1d47d9>`__
 -  Configuration file for ipa-docker-test-runner
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ecaea6bc4f49c2665597ca38fc52f4fae8a9d24>`__
 -  Add 'env_confdir' to constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/1300381d45a23073261e62cb031cf4285a34f641>`__
-   `#6389 <https://pagure.io/freeipa/issue/6389>`__
+   `#6389 <https://codeberg.org/freeipa/freeipa/issues/6389>`__
 -  Fix pep-8 transgressions in ipalib/misc.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/64a4be26febf19e427760115912a858a804208a0>`__
-   `#6490 <https://pagure.io/freeipa/issue/6490>`__
+   `#6490 <https://codeberg.org/freeipa/freeipa/issues/6490>`__
 -  Make \`env\` and \`plugins\` commands local again
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ae7bebb7690620b69fd9c84b7a385c2086c1ee1>`__
-   `#6490 <https://pagure.io/freeipa/issue/6490>`__
+   `#6490 <https://codeberg.org/freeipa/freeipa/issues/6490>`__
 -  Revert "Add 'ipa localenv' subcommand"
    `commit <https://codeberg.org/freeipa/freeipa/commit/42307ae2dc4d9be06d3fd9b7e5af2e0761b8d6ad>`__
-   `#6490 <https://pagure.io/freeipa/issue/6490>`__
+   `#6490 <https://codeberg.org/freeipa/freeipa/issues/6490>`__
 -  Enhance \__repr_\_ method of Principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/38cc40ddb5bf965801500bb4f66fd965b12e3c88>`__
-   `#6505 <https://pagure.io/freeipa/issue/6505>`__
+   `#6505 <https://codeberg.org/freeipa/freeipa/issues/6505>`__
 -  replication: ensure bind DN group check interval is set on replica
    config
    `commit <https://codeberg.org/freeipa/freeipa/commit/266b9d9c6c9b9dec10b8a70382445fa2f800dd69>`__
-   `#6508 <https://pagure.io/freeipa/issue/6508>`__
+   `#6508 <https://codeberg.org/freeipa/freeipa/issues/6508>`__
 -  upgrade: add replica bind DN group check interval to CA topology
    config
    `commit <https://codeberg.org/freeipa/freeipa/commit/73d0d03891c8585a925f5b49739990c579999f6e>`__
-   `#6508 <https://pagure.io/freeipa/issue/6508>`__
+   `#6508 <https://codeberg.org/freeipa/freeipa/issues/6508>`__
 -  Improve the robustness FreeIPA's i18n module and its tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/211c944a353dbc241ae6e280c9474145ab48dbe4>`__
-   `#6512 <https://pagure.io/freeipa/issue/6512>`__
+   `#6512 <https://codeberg.org/freeipa/freeipa/issues/6512>`__
 -  Use common procedure to setup initial replication in both domain
    levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce2bb47cca03eda1ff85f4725abb92c639f34ecc>`__
-   `#6406 <https://pagure.io/freeipa/issue/6406>`__
+   `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__
 -  ensure that the initial sync using GSSAPI works agains old masters
    `commit <https://codeberg.org/freeipa/freeipa/commit/8378e1e39f44d49c2c90d2d0e7acd75a4fa95787>`__
-   `#6406 <https://pagure.io/freeipa/issue/6406>`__
+   `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__
 -  replication: refactor the code setting principals as replica bind DNs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf6048a3ba9998a65858993e52bd4895749f2a79>`__
-   `#6406 <https://pagure.io/freeipa/issue/6406>`__
+   `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__
 -  replication: augment setup_promote_replication method
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dc9ab162141c7d2e4affe73f520e1599e9f8c30>`__
-   `#6406 <https://pagure.io/freeipa/issue/6406>`__
+   `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__
 -  Turn replication manager group into ReplicationManager class member
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d7943f3da7fb84975cc8f45047aafee13bf85dc>`__
-   `#6406 <https://pagure.io/freeipa/issue/6406>`__
+   `#6406 <https://codeberg.org/freeipa/freeipa/issues/6406>`__
 -  Fix the naming of ipa-dnskeysyncd service principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ca96b3db03d4f3c5dbf465ca3d36bd563771c47>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  installutils: remove 'install_service_keytab' function
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cd3b1bfa76c846b7ffec18e380b71a6617d97ec>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  domain-level agnostic keytab retrieval in httpinstance
    `commit <https://codeberg.org/freeipa/freeipa/commit/73fc15556d28706b0b9a10480fee8d56b2be9ab7>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  installers: restart DS after KDC is configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e97a0171a862e20089863e4bf0ec88d0ba98a53>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  dsinstance: use keytab retrieval method from parent class
    `commit <https://codeberg.org/freeipa/freeipa/commit/3129b874a2c222ff207f1302e5d85ae12df2eac9>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  use DM credentials to retrieve service keytab only in DLO
    `commit <https://codeberg.org/freeipa/freeipa/commit/6181844c0ce62b8d7d35554032346396b20ad3c0>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  Service: common method for service keytab requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4286f3885b173da9ceeb2d13d66f90336b9ef094>`__
-   `#6405 <https://pagure.io/freeipa/issue/6405>`__
+   `#6405 <https://codeberg.org/freeipa/freeipa/issues/6405>`__
 -  Turn Kerberos-related properties to Service class members
    `commit <https://codeberg.org/freeipa/freeipa/commit/32599987fdc998e104846e8a176f70399cca2af2>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Make service user name a class member of Service
    `commit <https://codeberg.org/freeipa/freeipa/commit/81bf72dc350b9c7daab669aaa796e96aee6ecbb8>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  service installers: clean up the inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/15f282cf2c4a5315aa3e259bd923718685d88245>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  fix incorrect invocation of ipa-getkeytab during DL0 host enrollment
    `commit <https://codeberg.org/freeipa/freeipa/commit/19912796edf5d6427920ff67c33e6288223e0466>`__
-   `#6434 <https://pagure.io/freeipa/issue/6434>`__
+   `#6434 <https://codeberg.org/freeipa/freeipa/issues/6434>`__
 -  do partial host enrollment in domain level 0 replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6ec37255441294285fac58c9bf08129db110fac>`__
-   `#6434 <https://pagure.io/freeipa/issue/6434>`__
+   `#6434 <https://codeberg.org/freeipa/freeipa/issues/6434>`__
 -  Separate function to purge IPA host principals from keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d5161d7e943fc6d4d092d18fc980fd40d21a59f>`__
-   `#6434 <https://pagure.io/freeipa/issue/6434>`__
+   `#6434 <https://codeberg.org/freeipa/freeipa/issues/6434>`__
 -  certs: do not re-create NSS database when requesting service cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e36e030910a4a6ec5ddb37cc19824f37b25ab51>`__
-   `#6429 <https://pagure.io/freeipa/issue/6429>`__
+   `#6429 <https://codeberg.org/freeipa/freeipa/issues/6429>`__
 -  initialize empty /etc/http/alias during server/replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1283c1e56976a3019c81c3be88fa821431ac6a6>`__
-   `#6429 <https://pagure.io/freeipa/issue/6429>`__
+   `#6429 <https://codeberg.org/freeipa/freeipa/issues/6429>`__
 -  CertDB: add API for non-destructive initialization from PKCS#12
    bundle
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fdc2d0cb7fa98992fe6c2070cb5dc34c500ac09>`__
-   `#6429 <https://pagure.io/freeipa/issue/6429>`__
+   `#6429 <https://codeberg.org/freeipa/freeipa/issues/6429>`__
 -  test_ipagetkeytab: use system-wide IPA CA cert location in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ecda74d14066f6609d72422041bcc0c6499de77>`__
-   `#6409 <https://pagure.io/freeipa/issue/6409>`__
+   `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__
 -  Extend keytab retrieval test suite to cover new options
    `commit <https://codeberg.org/freeipa/freeipa/commit/2725e440bf1e4930f9b1d19223424bcb0d4b7066>`__
-   `#6409 <https://pagure.io/freeipa/issue/6409>`__
+   `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__
 -  Modernize ipa-getkeytab test suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/8480d0e3333f6813439e7b3321a0e33ce80d30f1>`__
-   `#6409 <https://pagure.io/freeipa/issue/6409>`__
+   `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__
 -  extend ipa-getkeytab to support other LDAP bind methods
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c68c27e51c2a30265a760382d7d4fab7d21937b>`__
-   `#6409 <https://pagure.io/freeipa/issue/6409>`__
+   `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__
 -  ipa-getkeytab: expose CA cert path as option
    `commit <https://codeberg.org/freeipa/freeipa/commit/294fc3dc5645eeb7942908c3e351c06aa0af329e>`__
-   `#6409 <https://pagure.io/freeipa/issue/6409>`__
+   `#6409 <https://codeberg.org/freeipa/freeipa/issues/6409>`__
 -  server-del: fix incorrect check for one IPA master
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a183bad66b91821a75e2a1cdbd3106fc31dcab4>`__
-   `#6417 <https://pagure.io/freeipa/issue/6417>`__
+   `#6417 <https://codeberg.org/freeipa/freeipa/issues/6417>`__
 -  Revert "Fix install scripts debugging"
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc873007f8616ab9e77f903e235ba49f45ecde37>`__
 -  do not use keys() method when iterating through dictionaries
    `commit <https://codeberg.org/freeipa/freeipa/commit/71f642f75132fe30b40062ce5abc8558a275b9bb>`__
-   `#6391 <https://pagure.io/freeipa/issue/6391>`__
+   `#6391 <https://codeberg.org/freeipa/freeipa/issues/6391>`__
 -  remove trailing newlines form python modules
    `commit <https://codeberg.org/freeipa/freeipa/commit/29829cc55a6be697abf881ea7867ef834bb66be7>`__
-   `#6391 <https://pagure.io/freeipa/issue/6391>`__
+   `#6391 <https://codeberg.org/freeipa/freeipa/issues/6391>`__
 -  mod_nss: use more robust quoting of NSSNickname directive
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee96384c3ed5d93c8042e05461253e0c2ed5f721>`__
-   `#5809 <https://pagure.io/freeipa/issue/5809>`__
+   `#5809 <https://codeberg.org/freeipa/freeipa/issues/5809>`__
 -  Move character escaping function to ipautil
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d994bee60560438178ad9f0215f611ca60e32c3>`__
-   `#5809 <https://pagure.io/freeipa/issue/5809>`__
+   `#5809 <https://codeberg.org/freeipa/freeipa/issues/5809>`__
 -  Make Continuous installer continuous only during execution phase
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7764cda6824a2fe73abe11f6daa28758a185319>`__
-   `#5725 <https://pagure.io/freeipa/issue/5725>`__
+   `#5725 <https://codeberg.org/freeipa/freeipa/issues/5725>`__
 -  use separate exception handlers for executors and validators
    `commit <https://codeberg.org/freeipa/freeipa/commit/347f5ca0e145491d387f60f95b67ef59e7c28316>`__
-   `#5725 <https://pagure.io/freeipa/issue/5725>`__
+   `#5725 <https://codeberg.org/freeipa/freeipa/issues/5725>`__
 -  ipa passwd: use correct normalizer for user principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3f9087ee8d1b1531730cf1e91fe404092e8c81d>`__
-   `#6329 <https://pagure.io/freeipa/issue/6329>`__
+   `#6329 <https://codeberg.org/freeipa/freeipa/issues/6329>`__
 -  trust-fetch-domains: contact forest DCs when fetching trust domain
    info
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0d40b80e8d9a4960296ce70d843ad987657696b>`__
-   `#6328 <https://pagure.io/freeipa/issue/6328>`__
+   `#6328 <https://codeberg.org/freeipa/freeipa/issues/6328>`__
 -  netgroup: avoid extraneous LDAP search when retrieving primary key
    from DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/003b364c5a06a5adc89bac7371f46d534cfb4616>`__
-   `#5855 <https://pagure.io/freeipa/issue/5855>`__
+   `#5855 <https://codeberg.org/freeipa/freeipa/issues/5855>`__
 -  advise: Use \`name\` instead of \`__name__\` to get plugin names
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b9516753cae324126fac7e17b6918c08e210d59>`__
 -  Use Travis-CI for basic sanity checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/37f3ad8867f347289adcadcc473871c54aa9ca9d>`__
 -  ldapupdate: Use proper inheritance in BadSyntax exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/415600fe451fe806cce7dbe39ad1e9f3d676f2f9>`__
-   `#6294 <https://pagure.io/freeipa/issue/6294>`__
+   `#6294 <https://codeberg.org/freeipa/freeipa/issues/6294>`__
 -  raise ValidationError when deprecated param is passed to command
    `commit <https://codeberg.org/freeipa/freeipa/commit/82e754e9c5e46317c7c060d9bc9c00ee259101a1>`__
-   `#6190 <https://pagure.io/freeipa/issue/6190>`__
+   `#6190 <https://codeberg.org/freeipa/freeipa/issues/6190>`__
 -  Always fetch forest info from root DCs when establishing one-way
    trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ca671788cc54a00de6a55a2529df6126da14d88>`__
-   `#6057 <https://pagure.io/freeipa/issue/6057>`__
+   `#6057 <https://codeberg.org/freeipa/freeipa/issues/6057>`__
 -  factor out \`populate_remote_domain\` method into module-level
    function
    `commit <https://codeberg.org/freeipa/freeipa/commit/c789b17b2e28ed9008fee076a0db72fe90f7e93f>`__
-   `#6057 <https://pagure.io/freeipa/issue/6057>`__
+   `#6057 <https://codeberg.org/freeipa/freeipa/issues/6057>`__
 -  Always fetch forest info from root DCs when establishing two-way
    trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/33f8685513e06f6a398036a78407d61c3ac2db86>`__
-   `#6057 <https://pagure.io/freeipa/issue/6057>`__
+   `#6057 <https://codeberg.org/freeipa/freeipa/issues/6057>`__
 
 
 
@@ -2077,212 +2077,212 @@ Martin Basti (134)
    `commit <https://codeberg.org/freeipa/freeipa/commit/474e6a7a71a9e51db80367018927c078f0bf1296>`__
 -  Add copy-schema-to-ca for RHEL6 to contrib/
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca5b53adccdd581bc39233378c422ca448e6edd2>`__
-   `#6540 <https://pagure.io/freeipa/issue/6540>`__
+   `#6540 <https://codeberg.org/freeipa/freeipa/issues/6540>`__
 -  Remove copy-schema-to-ca.py from master branch
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4c7f1dd8a9ce530a8291219a904686ee47e59c7>`__
-   `#6540 <https://pagure.io/freeipa/issue/6540>`__
+   `#6540 <https://codeberg.org/freeipa/freeipa/issues/6540>`__
 -  pylint: bump dependency to version >= 1.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/4514ec150586fb43fa66566cce8a69b3ac15b86c>`__
 -  backup: backup anonymous keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fb61a55fe32438752567bde8af73d6b8230a386>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  tests: use --setup-kra in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/25fa2bb6c9fa1b498330b13c9a6116b646eb75ba>`__
-   `#6731 <https://pagure.io/freeipa/issue/6731>`__
+   `#6731 <https://codeberg.org/freeipa/freeipa/issues/6731>`__
 -  KRA: add --setup-kra to ipa-server-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/4006cbbc02c368ac9e5e3721613158decb34fd37>`__
-   `#6731 <https://pagure.io/freeipa/issue/6731>`__
+   `#6731 <https://codeberg.org/freeipa/freeipa/issues/6731>`__
 -  man: add missing --setup-adtrust option to manpage
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c95f33d37a2c346fc56d9890d594f1e40029c77>`__
-   `#6630 <https://pagure.io/freeipa/issue/6630>`__
+   `#6630 <https://codeberg.org/freeipa/freeipa/issues/6630>`__
 -  ipactl restart: log httplib failues as debug
    `commit <https://codeberg.org/freeipa/freeipa/commit/53c8e9a53f026d83d5328896d1ea0cf72690cf24>`__
-   `#6674 <https://pagure.io/freeipa/issue/6674>`__
+   `#6674 <https://codeberg.org/freeipa/freeipa/issues/6674>`__
 -  Tests: search for disabled users
    `commit <https://codeberg.org/freeipa/freeipa/commit/79b3fbf97d66adb1f5c960e5473b90f85cbe145a>`__
 -  Test: DNS nsupdate from dns-update-system-records
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bd82174233095a3cccfbbf8524622440c31b10c>`__
-   `#6585 <https://pagure.io/freeipa/issue/6585>`__
+   `#6585 <https://codeberg.org/freeipa/freeipa/issues/6585>`__
 -  DNS: dns-update-system-record can create nsupdate file
    `commit <https://codeberg.org/freeipa/freeipa/commit/7eb2ef61905a5c6ddf04237f0aa84e7585e1186d>`__
-   `#6585 <https://pagure.io/freeipa/issue/6585>`__
+   `#6585 <https://codeberg.org/freeipa/freeipa/issues/6585>`__
 -  py3: ipa_generate_password: do not compare None and Int
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd119f8aadb13e95e4db43053bc36c70977b001e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: change_admin_password: use textual mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/69072cb80f8c4b7f6eff0c7cdfe6545fe59ea7b5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: create DNS zonefile: use textual mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/488d01ced715929d47f6766a63b7d6c597125562>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: upgradeinstance: use bytes literals with LDIF operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/47f912e16ba6de2f3579de610b0d902cf3e621a2>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: upgradeinstance: decode data before storing them as backup...
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fd36e4d3651f327a8c3a2f13b92a2a304352dfd>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: upgradeinstance: open dse.ldif in textual mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/f31d73b79aaa1746f7d32576658fcd4136870115>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  custodia: kem.set_keys: replace too-broad exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4aa75d10582443b38447985c3fce8e65fcd48a6>`__
 -  py3: kem.py: user bytes with ldap values
    `commit <https://codeberg.org/freeipa/freeipa/commit/8660b9e96801a764e808ca69c3c14a4a019d4eb8>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: custodia: basedn must be unicode
    `commit <https://codeberg.org/freeipa/freeipa/commit/c27a46177c710fb18bf5b02beab4bd82c191a4bc>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: configparser: use raw keyword
    `commit <https://codeberg.org/freeipa/freeipa/commit/2674a217acc2864a5fed98d7ef1e7031eae4f866>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: modify_s: attribute name must be str not bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/88b192a37ead1538e6d840c2f686f8d21a948542>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ldapupdate: fix logging str(bytes) issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/b24787a67fd8b19b9222979a963a8f28b22153ee>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  DNSSEC: forwarders validation improvement
    `commit <https://codeberg.org/freeipa/freeipa/commit/387a1513bb9dc0dc546753bfaa8a59aae8f30b83>`__
 -  py3: test_ipaserver: fix BytesWarnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5ccdc16cbcec433ef061dfe65515e32c3021ea2>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: get_memberofindirect: fix ByteWarnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/6bb5af7bea21d44b4e5ee20cfaa2f76b12ea0929>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: DN: fix BytesWarning
    `commit <https://codeberg.org/freeipa/freeipa/commit/d38540acd614bcaa489023401fc8db7c02cd3892>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Tests: fix wait_for_replication task
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad1a5551d5ec716dc745f39e82d38cc634229cb0>`__
 -  py3: send Decimal number as string instead of base64 encoded value
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c84341b8bc14cd19a4e2c2df4c13b95ff7eeb05>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipaldap: properly encode DNSName to bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab53d80883320060769b7bfada2a813b345b9e4a>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: \_convert_to_idna: fix bytes/unicode mistmatch
    `commit <https://codeberg.org/freeipa/freeipa/commit/a584758cfb87567a9c640ae107903b0f6c9fec30>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: DNS: get_record_entry_attrs: do not modify dict during iteration
    `commit <https://codeberg.org/freeipa/freeipa/commit/03d0a55e8a21a334ca4dc625527cae93633a7314>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: \_ptrrecord_precallaback: use bytes with labels
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3d3b0ad2537c9d11d9c6108c31e079f0dfcf31c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: remove_entry_from_group: attribute name must be string
    `commit <https://codeberg.org/freeipa/freeipa/commit/a93b2bea5ce88a934ba2ab39bdaa518fb55064c4>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: base64 encoding/decoding returns always bytes don't mix it
    `commit <https://codeberg.org/freeipa/freeipa/commit/caa560ca79e4038b161b27d11e3f144606dbbcdb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  pki-base: use pki-base-python2 as dependency
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd83fdf51621fe777c1f7823dcb13c4dfa26fa8e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  pki: add missing depedency pki-base[-python3]
    `commit <https://codeberg.org/freeipa/freeipa/commit/66fa0585aa3a7219aa3f5b548a0a84f052d62b8e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: x509.py: return principal as unicode string
    `commit <https://codeberg.org/freeipa/freeipa/commit/91ab650ac42d34d4958e33da7ef0641842511a89>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__,
-   `#6640 <https://pagure.io/freeipa/issue/6640>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__,
+   `#6640 <https://codeberg.org/freeipa/freeipa/issues/6640>`__
 -  py3: tests_xmlrpc: do not call str() on bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/5de70e31999eb219bd47aa81b0c003a6c15cf748>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: normalize_certificate: support both bytes and unicode
    `commit <https://codeberg.org/freeipa/freeipa/commit/980c8a5f9e4ccbcd3c11def9cab33d0e61e945ae>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: strip_header: support both bytes and unicode
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8d6524d43dd0667184aebc79fb77a9b8a46939a>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: fingerprint_hex_sha256: fix encoding/decoding
    `commit <https://codeberg.org/freeipa/freeipa/commit/47e76e16ef2e5d714881f3cce204611a95b4e5c8>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: fix CSR encoding inside framework
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5ab0637fe89cbcb61491fe08b7376aeaf7ccdb8>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Principal: validate type of input parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/1023cfebff99af165212dee94290a05754297270>`__
 -  Use dict comprehension
    `commit <https://codeberg.org/freeipa/freeipa/commit/deaf9ae2473833dacb64c4961db3ae9f7c570ebd>`__
 -  py3: can_read: attributelevelrights is already string
    `commit <https://codeberg.org/freeipa/freeipa/commit/b37d18288d40b4ec0b5a8df676456e09ae5f26c1>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: get_effective_rights: values passed to ldap must be bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/49333058c869dd4bd654a7974e6e144ffd3f0dc3>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipaldap: update encode/decode methods
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd3d9f1ca61946ea5d7daa17ba1d8a883922d526>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: rpcserver fix undefined variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa036e5f332ef0b1ebbff6b824e236b1eeaf076e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: WSGI executioners must return bytes in list
    `commit <https://codeberg.org/freeipa/freeipa/commit/cca9aa43e146f15e235eee1197209d0ca88eb39c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: session: fix r/w ccache data
    `commit <https://codeberg.org/freeipa/freeipa/commit/35e135c4e3a7f0bf21ed4c838b8f76b43701a047>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Py3: Fix undefined variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e8eb533752bbf5e2f05ec6bfb0ffefa8e9dcddf>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: rpcserver: decode input because json requires string
    `commit <https://codeberg.org/freeipa/freeipa/commit/9739d0354a8ac5fd357f7d131b3f75aa05df058b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: session.py decode server name to str
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9fec1de1aa2b3c0f4c4ec6eff25ff2e75c774b0>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Use proper logging for error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2ec44f2705fe87b71c6290ae8b35bc0a05f68d2>`__
 -  wait_for_entry: use only DN as parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/38fd8b356d66553d21a3e64374fdc39427a05baf>`__
-   `#6588 <https://pagure.io/freeipa/issue/6588>`__
+   `#6588 <https://codeberg.org/freeipa/freeipa/issues/6588>`__
 -  py3: decode bytes for json.loads()
    `commit <https://codeberg.org/freeipa/freeipa/commit/18337bf7f7c31a47fe0c7280f82fca043b548bd5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  dogtag.py: fix exception logging of JSON data
    `commit <https://codeberg.org/freeipa/freeipa/commit/0eb5a0e0ec2d232d2921ae5f9e8d0885146a5610>`__
 -  py3: convert_attribute_members: don't use bytes as parameter for DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e0f98a146ecedf84b8e3e07fbd41a897ddd399d>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: make_filter_from_attr: use string instead of bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/746d4ffc583a847834a592150644fa4270486c89>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: \__add_acl: use standard ipaldap methods
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b148c8ca3d022020fa6caccf02729c090c8dbcb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: add_entry_to_group: attribute name must be string not bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a1d7f2e01819ad6e4a19d0416b3a01883dea7d0>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: HTTPResponse has no 'dict' attribute in 'msg'
    `commit <https://codeberg.org/freeipa/freeipa/commit/51578882fc8456788d69a57de1a1d45ead58ba14>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: \_httplib_request: don't convert string to bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0b5c6709d9e3a51117994fc8b605ba54e6263d7>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: cainstance: replace mkstemp with NamedTemporaryFile
    `commit <https://codeberg.org/freeipa/freeipa/commit/232ceed5bbfb0afa45078d8e95b84dabe4d7cafd>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: write CA/KRA config into file opened in text mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/2547bca8df69e6c4d5f4c67a63fbc3c06ccc95c6>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: CA/KRA: config parser requires string
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d4074b4f1a57ed6545d819aa5a48e4b35237568>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipautil: open tempfiles in text mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ae5e5f66919141821fdffbd6f8683c6d7afddd7>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ldap modlist must have keys as string, not bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe8849a654ed0764e1834f24d1837df41a79881>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: open temporary ldif file in text mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/63b5d4a8594c5c6bc9ade69996fbbc1bcf19a2bf>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: service.py: replace mkstemp by NamedTemporaryFile
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0641092770530e3b93c00de415172751d031210>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: create_cert_db: write to file in a compatible way
    `commit <https://codeberg.org/freeipa/freeipa/commit/23239bccc18f2fdc10431134a1c6a777f450704e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  \_resolve_records: fix assert, nameserver_ip can be none
    `commit <https://codeberg.org/freeipa/freeipa/commit/ccea23138ba6e9b54c08d472341ddbd64ffc45df>`__
 -  Remove duplicated step from DS install
@@ -2291,92 +2291,92 @@ Martin Basti (134)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d648c6a6925298a1db0c61381d72b6c4d0500c10>`__
 -  Py3: Fix ToASCII method
    `commit <https://codeberg.org/freeipa/freeipa/commit/35ba724de90b270773d91596de310291df745df0>`__
-   `#5935 <https://pagure.io/freeipa/issue/5935>`__
+   `#5935 <https://codeberg.org/freeipa/freeipa/issues/5935>`__
 -  fix: regression in API version comparison
    `commit <https://codeberg.org/freeipa/freeipa/commit/0663faf2585be4af3501965934703da0ede41610>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  ipactl: pass api as argument to services
    `commit <https://codeberg.org/freeipa/freeipa/commit/15351ab6e7c188fb492e6815026d1d75c4d4d29b>`__
 -  DNS: URI records: bump python-dns requirements
    `commit <https://codeberg.org/freeipa/freeipa/commit/a291c6ded91611ea2bd1a1fdb96314721d73a75f>`__
-   `#6344 <https://pagure.io/freeipa/issue/6344>`__
+   `#6344 <https://codeberg.org/freeipa/freeipa/issues/6344>`__
 -  remove Knob function
    `commit <https://codeberg.org/freeipa/freeipa/commit/55b14abcb561422cf48755dae6b0638656535fe5>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  KRA: don't add KRA container when KRA replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/61094a2a20f5cacdb7c87940d0db8d8593a87505>`__
 -  Zanata: exlude testing ipa.pot file
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad32bf147ed6996c0967bb8e8cfb803113ceaf5f>`__
-   `#6435 <https://pagure.io/freeipa/issue/6435>`__
+   `#6435 <https://codeberg.org/freeipa/freeipa/issues/6435>`__
 -  client: use correct code for failed uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/847b6eddab00973740413b4c46f86940cb73d25a>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: use exceptions instead of return states
    `commit <https://codeberg.org/freeipa/freeipa/commit/5249eb817efbb5708d097173a8d5f1e322fb201e>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: move install part to else branch
    `commit <https://codeberg.org/freeipa/freeipa/commit/c38ce49e8d280e52c61f722b0e5ad7aa9f53cc1a>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: move install cleanup from ipa-client-install to module
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3786730e50080fa4dadeffa86388592c10b3a62>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: move clean CCACHE to module
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbad08900bbe8f76e59b159cd2af800f5c089ca1>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: fix script execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cbbb5359155446be22a5efb1e2372e527d2d745>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: Remove useless except in ipa-client-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f65c07524c8cf80996de9f6250a4e19c3a043c9>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: move custom env variable into client module
    `commit <https://codeberg.org/freeipa/freeipa/commit/83fe6b626fd2fb7f43ddf3568aaffca1ce569079>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: extract checks from uninstall to uninstall_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/fcea3b3fb88ede0e9414f83ac2372e000e728587>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: extract checks from install to install_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f690a0a3a7e039183eca1578a3cb13f2c0632ef>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: move checks to client.install_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c226ebc27e2a4e2677549003c4c70a777794296>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: make statestore and fstore consistent with server
    `commit <https://codeberg.org/freeipa/freeipa/commit/33537f555636db935dd809b62498e2415d765e8e>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  IPAChangeConf: use constant for empty line
    `commit <https://codeberg.org/freeipa/freeipa/commit/31a9ef4f8b8e2d6bb11f68ce34a7575ced9816aa>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: import IPAChangeConf directly instead the module
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c9267803c6f41cc7d7485024f8864fbd62c9128>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: remove extra return from hardcode_ldap_server
    `commit <https://codeberg.org/freeipa/freeipa/commit/c30b45ab157f611312c0cd0f4f7c3a12d7a02c11>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: install function: return constant not hardcoded number
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc6efb97985bb93e3cdb2a6c2943d45e1132e122>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: remove unneded return from configure_ipa_conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/49f201e2b2523c83fa2b20fe91c91733e2ee947f>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: remove unneded return configure_krb5_conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c16608a0d5d4abe98319a077917f5424b72d031>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  ipa-client-install: move client install to module
    `commit <https://codeberg.org/freeipa/freeipa/commit/f98faec47847022879b8bceb63839fcfd6e45402>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  CI: Disable KRA install tests on DL0
    `commit <https://codeberg.org/freeipa/freeipa/commit/9408085c58a1e9627c1fb4e1ba0343700e36d7e7>`__
-   `#6088 <https://pagure.io/freeipa/issue/6088>`__
+   `#6088 <https://codeberg.org/freeipa/freeipa/issues/6088>`__
 -  CI: use --setup-kra with replica installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/11d7b774c4d731896e3ab6109b6ed7d5524c1bec>`__
-   `#6088 <https://pagure.io/freeipa/issue/6088>`__
+   `#6088 <https://codeberg.org/freeipa/freeipa/issues/6088>`__
 -  CI: extend replication layouts tests with KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/84ca1fc220c329b58fb6a22c8eb9bf17d3622c55>`__
-   `#6088 <https://pagure.io/freeipa/issue/6088>`__
+   `#6088 <https://codeberg.org/freeipa/freeipa/issues/6088>`__
 -  CI: workaround: wait for dogtag before replica-prepare
    `commit <https://codeberg.org/freeipa/freeipa/commit/91b51e702f1e105329ebea29c633d94516cd673c>`__
-   `#6274 <https://pagure.io/freeipa/issue/6274>`__
+   `#6274 <https://codeberg.org/freeipa/freeipa/issues/6274>`__
 -  Pylint: fix the rest of unused local variables
    `commit <https://codeberg.org/freeipa/freeipa/commit/4628522c532c6df0295308e5f749989c2536caa6>`__
 -  Pylint: remove unused variables in tests
@@ -2387,7 +2387,7 @@ Martin Basti (134)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9375881460d63cdd696bb0705da0ac205db9870>`__
 -  Fix: find OSCP certificate test
    `commit <https://codeberg.org/freeipa/freeipa/commit/95aa9369cb2f84ab71fa84e254d0bb3af264e97e>`__
-   `#6359 <https://pagure.io/freeipa/issue/6359>`__
+   `#6359 <https://codeberg.org/freeipa/freeipa/issues/6359>`__
 -  Pylint: enable check for unused-variables
    `commit <https://codeberg.org/freeipa/freeipa/commit/45e3aee35219c89c07d590003a334f8db658a3b2>`__
 -  Remove unused variables in tests
@@ -2396,56 +2396,56 @@ Martin Basti (134)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f88f8fe889ae4801fc8d5ece1ad51c5246718ac>`__
 -  test_text: add test ipa.pot file for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/452b08754d02b89c0e3117b83d9156e6110943c9>`__
-   `#6333 <https://pagure.io/freeipa/issue/6333>`__
+   `#6333 <https://codeberg.org/freeipa/freeipa/issues/6333>`__
 -  Pylint: enable global-variable-not-assigned check
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b68d2a1f858854bc3cf2d6024f3fd3d79c2f696>`__
 -  Pylint: enable cyclic-import check
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d7d53c9664c9e68d7c6cda1a65cae7551423df7>`__
 -  Test: dont use global variable for iteration in test_cert_plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/929086e0992cc32a654b4dfa435f536ecb0c665b>`__
-   `#5755 <https://pagure.io/freeipa/issue/5755>`__
+   `#5755 <https://codeberg.org/freeipa/freeipa/issues/5755>`__
 -  Use constant for user and group patterns
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f8e3d008f1de91337a83ea6d271662432209767>`__
-   `#5822 <https://pagure.io/freeipa/issue/5822>`__
+   `#5822 <https://codeberg.org/freeipa/freeipa/issues/5822>`__
 -  Fix regexp patterns in parameters to not enforce length
    `commit <https://codeberg.org/freeipa/freeipa/commit/37200806118d39ef8afe84ad5887a294d54e2659>`__
-   `#5822 <https://pagure.io/freeipa/issue/5822>`__
+   `#5822 <https://codeberg.org/freeipa/freeipa/issues/5822>`__
 -  Add check for IP addresses into DNS installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/d13a4c2f395c08b514a51a19eaad3fa7d32e7538>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Fix missing config.ips in promote_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd2c10d7ca97ffc76682159ad58161eab413532d>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Abstract procedures for IP address warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c96ff7a6c7e1733a6492f9b3c93265f5bc8ff5b>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Catch DNS exceptions during emptyzones named.conf upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/271a4f098230112ee0e3ea3ffb3a509977ee7330>`__
-   `#6205 <https://pagure.io/freeipa/issue/6205>`__
+   `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__
 -  Start named during configuration upgrade.
    `commit <https://codeberg.org/freeipa/freeipa/commit/22fd6f020940b5b2a1258f8e0e6058c95f7a1ba5>`__
-   `#6205 <https://pagure.io/freeipa/issue/6205>`__
+   `#6205 <https://codeberg.org/freeipa/freeipa/issues/6205>`__
 -  Tests: extend DNS cmdline tests with lowercased record type
    `commit <https://codeberg.org/freeipa/freeipa/commit/866e59bdcee74ea9aea4e65f193339ae9cab5ce3>`__
-   `#6203 <https://pagure.io/freeipa/issue/6203>`__
+   `#6203 <https://codeberg.org/freeipa/freeipa/issues/6203>`__
 -  Show warning when net/broadcast IP address is used in installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/b232ad463cf43596cdf397e51469df13a89e83fa>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Allow multicast addresses in A/AAAA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3d379071a9af50e38fcc07491bc68b8d3d172a4>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Allow broadcast ip addresses
    `commit <https://codeberg.org/freeipa/freeipa/commit/71ad8d4fc982b5349248d50338e1d16ce45c523e>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Allow network ip addresses
    `commit <https://codeberg.org/freeipa/freeipa/commit/81d64d530cca148198312d3d993502575b288f63>`__
-   `#5814 <https://pagure.io/freeipa/issue/5814>`__
+   `#5814 <https://codeberg.org/freeipa/freeipa/issues/5814>`__
 -  Fix parse errors with link-local addresses
    `commit <https://codeberg.org/freeipa/freeipa/commit/db55bde15dd83a0ed29205a127cefabe691e81b1>`__
-   `#6296 <https://pagure.io/freeipa/issue/6296>`__
+   `#6296 <https://codeberg.org/freeipa/freeipa/issues/6296>`__
 -  Fix ScriptError to always return string from \__str_\_
    `commit <https://codeberg.org/freeipa/freeipa/commit/00d43095da211f542189c95c88fc2e2c32e75565>`__
-   `#6294 <https://pagure.io/freeipa/issue/6294>`__
+   `#6294 <https://codeberg.org/freeipa/freeipa/issues/6294>`__
 -  Bump master IPA devel version to 4.4.90
    `commit <https://codeberg.org/freeipa/freeipa/commit/371254fc4b36cb4d89351edb19c88a85e5a33a1b>`__
 
@@ -2464,16 +2464,16 @@ Milan Kubík (4)
 
 -  ipatests: Fix assert_deepequal outside of pytest process
    `commit <https://codeberg.org/freeipa/freeipa/commit/e54109c167526ae6b1cd4c977915da884482891b>`__
-   `#6420 <https://pagure.io/freeipa/issue/6420>`__
+   `#6420 <https://codeberg.org/freeipa/freeipa/issues/6420>`__
 -  ipatests: Implement tests with CSRs requesting SAN
    `commit <https://codeberg.org/freeipa/freeipa/commit/10b4b155b6b411ab339bce92c1a335b4914cfc1c>`__
-   `#6366 <https://pagure.io/freeipa/issue/6366>`__
+   `#6366 <https://codeberg.org/freeipa/freeipa/issues/6366>`__
 -  ipatests: Fix name property on a service tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/7eb78aa8dbc167c36869ddd6cfa525139aff7bbc>`__
-   `#6366 <https://pagure.io/freeipa/issue/6366>`__
+   `#6366 <https://codeberg.org/freeipa/freeipa/issues/6366>`__
 -  ipatests: provide context manager for keytab usage in RPC tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f8e212c428b1fff63f38ea15d7ce9f230085c5c>`__
-   `#6366 <https://pagure.io/freeipa/issue/6366>`__
+   `#6366 <https://codeberg.org/freeipa/freeipa/issues/6366>`__
 
 
 
@@ -2482,7 +2482,7 @@ Michal Reznik (1)
 
 -  test_csrgen: adjusted comparison test scripts for CSRGenerator
    `commit <https://codeberg.org/freeipa/freeipa/commit/83e2c2b65eeb5a3aa4a59c0535e9177aac5e4637>`__
-   `#6724 <https://pagure.io/freeipa/issue/6724>`__
+   `#6724 <https://codeberg.org/freeipa/freeipa/issues/6724>`__
 
 
 
@@ -2499,12 +2499,12 @@ Nathaniel McCallum (3)
 
 -  Migrate OTP import script to python-cryptography
    `commit <https://codeberg.org/freeipa/freeipa/commit/d00ae870dda2889545c9d93e82e44526bfd4f431>`__
-   `#5192 <https://pagure.io/freeipa/issue/5192>`__
+   `#5192 <https://codeberg.org/freeipa/freeipa/issues/5192>`__
 -  Use RemoveOnStop to cleanup systemd sockets
    `commit <https://codeberg.org/freeipa/freeipa/commit/d05d1115e409962fee3576a4bfc5cecfacef4fd3>`__
 -  Properly handle LDAP socket closures in ipa-otpd
    `commit <https://codeberg.org/freeipa/freeipa/commit/0756ce7d53133793b82674757e125524eede4721>`__
-   `#6368 <https://pagure.io/freeipa/issue/6368>`__
+   `#6368 <https://codeberg.org/freeipa/freeipa/issues/6368>`__
 
 
 
@@ -2513,37 +2513,37 @@ Oleg Fayans (45)
 
 -  Test: uniqueness of certificate renewal master
    `commit <https://codeberg.org/freeipa/freeipa/commit/fad87a9962ee33cfebc4fa59aba589e98b076cea>`__
-   `#6504 <https://pagure.io/freeipa/issue/6504>`__
+   `#6504 <https://codeberg.org/freeipa/freeipa/issues/6504>`__
 -  Test: basic kerberos over http functionality
    `commit <https://codeberg.org/freeipa/freeipa/commit/503d0929e9265dfc0c6c28ac49146b72a0a7edea>`__
-   `#6446 <https://pagure.io/freeipa/issue/6446>`__
+   `#6446 <https://codeberg.org/freeipa/freeipa/issues/6446>`__
 -  Test: made kinit_admin a returning function
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7fd46e42a9f5b4676415910b800e0340f77dc88>`__
 -  tests: Added basic tests for certs in idoverrides
    `commit <https://codeberg.org/freeipa/freeipa/commit/452dc97aba12288a23c20f519f4c1c0d4408b765>`__
-   `#6412 <https://pagure.io/freeipa/issue/6412>`__
+   `#6412 <https://codeberg.org/freeipa/freeipa/issues/6412>`__
 -  Created idview tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/ccd3677b50eab2223ddf1e1b6682c20fc695ad24>`__
-   `#6412 <https://pagure.io/freeipa/issue/6412>`__
+   `#6412 <https://codeberg.org/freeipa/freeipa/issues/6412>`__
 -  Test for installing rules with service principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/232a0391d33429a71da865c55be582ebdbc5b3db>`__
-   `#6481 <https://pagure.io/freeipa/issue/6481>`__
+   `#6481 <https://codeberg.org/freeipa/freeipa/issues/6481>`__
 -  Test: integration tests for certs in idoverrides feature
    `commit <https://codeberg.org/freeipa/freeipa/commit/91c8911a9efc32024cb8bf29af26f61cf3a24e28>`__
-   `#6005 <https://pagure.io/freeipa/issue/6005>`__
+   `#6005 <https://codeberg.org/freeipa/freeipa/issues/6005>`__
 -  Added interface to certutil
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1c9c56f40b542068b512e2010d40e87a2dd83df>`__
 -  Automated ipa-replica-manage del tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc58f8f2a17adc642ae6f32fe9c9eb05d993c9d0>`__
 -  tests: Automated clean-ruv subcommand tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d812a0d52ff89dd337aac50c1a107c9dddce73f>`__
-   `#6451 <https://pagure.io/freeipa/issue/6451>`__
+   `#6451 <https://codeberg.org/freeipa/freeipa/issues/6451>`__
 -  Reverted the essertion for replica uninstall returncode
    `commit <https://codeberg.org/freeipa/freeipa/commit/5710ecddcaea7b00fbbc2ee24b845f7a4ac90f57>`__
-   `#6401 <https://pagure.io/freeipa/issue/6401>`__
+   `#6401 <https://codeberg.org/freeipa/freeipa/issues/6401>`__
 -  Test: disabled wrong client domain tests for domlevel 0
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b0faa25d1c47f605bc6c91933469bb2370276c1>`__
-   `#6382 <https://pagure.io/freeipa/issue/6382>`__
+   `#6382 <https://codeberg.org/freeipa/freeipa/issues/6382>`__
 -  tests: Fixed code styling in caless tests to make pep8 happy
    `commit <https://codeberg.org/freeipa/freeipa/commit/47c808afa35f0708ca00ac8e98851c9f8d75badc>`__
 -  tests: Reverted erroneous asserts in 4 tests
@@ -2600,24 +2600,24 @@ Oleg Fayans (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f6ffa326adb4d4e9152463ffa733d559f7be2af>`__
 -  tests: Fixed method failures during second call for the method
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbac233b5ee487ab0e035cf0b861144769a0b738>`__
-   `#5880 <https://pagure.io/freeipa/issue/5880>`__
+   `#5880 <https://codeberg.org/freeipa/freeipa/issues/5880>`__
 -  Xfailed a test that fails due to 6250
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e4740f788aee00ae03a61d39238f605779fcece>`__
-   `#6250 <https://pagure.io/freeipa/issue/6250>`__
+   `#6250 <https://codeberg.org/freeipa/freeipa/issues/6250>`__
 -  Fixed segment naming in topology tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/49fbbb0641df2adab28fd3440686cb7430645c85>`__
 -  Xfailed the tests due to a known bug with replica preparation
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e484d010b653b8ac06425ca602ba5c9e950ed89>`__
-   `#6274 <https://pagure.io/freeipa/issue/6274>`__
+   `#6274 <https://codeberg.org/freeipa/freeipa/issues/6274>`__
 -  Changed addressing to the client hosts to be replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac78d191ded6721cf1051413cdd6862c0362e66b>`__
-   `#6287 <https://pagure.io/freeipa/issue/6287>`__
+   `#6287 <https://codeberg.org/freeipa/freeipa/issues/6287>`__
 -  Several fixes in replica_promotion tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/39c15ecdcdcbc2a0b651b0f89080789dd806e998>`__
-   `#6301 <https://pagure.io/freeipa/issue/6301>`__
+   `#6301 <https://codeberg.org/freeipa/freeipa/issues/6301>`__
 -  Removed incorrect check for returncode
    `commit <https://codeberg.org/freeipa/freeipa/commit/22b0e8a9eb9eb3d47131c6784d70dd409d5b889b>`__
-   `#6300 <https://pagure.io/freeipa/issue/6300>`__
+   `#6300 <https://codeberg.org/freeipa/freeipa/issues/6300>`__
 
 
 
@@ -2626,7 +2626,7 @@ Petr Čech (1)
 
 -  ipatests: nested netgroups (intg)
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc99d3c04e43b08d2364209a641b8b9111e5986c>`__
-   `#6439 <https://pagure.io/freeipa/issue/6439>`__
+   `#6439 <https://codeberg.org/freeipa/freeipa/issues/6439>`__
 
 
 
@@ -2635,361 +2635,361 @@ Petr Spacek (126)
 
 -  ipa_generate_password algorithm change
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb7c111ac13510609e2cba14ecf88cd2ed291a4b>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove named-pkcs11 workarounds from DNSSEC tests.
    `commit <https://codeberg.org/freeipa/freeipa/commit/8bc677512296a7e94c29edd0c1a96aa7273f352a>`__
-   `#5348 <https://pagure.io/freeipa/issue/5348>`__
+   `#5348 <https://codeberg.org/freeipa/freeipa/issues/5348>`__
 -  Build: forbid builds in working directories containing white spaces
    `commit <https://codeberg.org/freeipa/freeipa/commit/19aba7c555edf065b9f2fa95142da81b92396264>`__
-   `#6537 <https://pagure.io/freeipa/issue/6537>`__
+   `#6537 <https://codeberg.org/freeipa/freeipa/issues/6537>`__
 -  Build: always use Pylint from Python version used for rest of the
    build
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c87c39e65547004031284080749bc66dab1a8f9>`__
-   `#157 <https://pagure.io/freeipa/issue/157>`__
+   `#157 <https://codeberg.org/freeipa/freeipa/issues/157>`__
 -  Build: specify BuildRequires for Python 3 pylint
    `commit <https://codeberg.org/freeipa/freeipa/commit/21a0987601dc4fa9de3fe63a18a604337a5edb7b>`__
-   `#157 <https://pagure.io/freeipa/issue/157>`__
+   `#157 <https://codeberg.org/freeipa/freeipa/issues/157>`__
 -  Build: makerpms.sh generates Python 2 & 3 packages at the same time
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7d70baee73c64898de91e2fa59b3f9f417c8e01>`__
-   `#157 <https://pagure.io/freeipa/issue/157>`__
+   `#157 <https://codeberg.org/freeipa/freeipa/issues/157>`__
 -  Accept server host names resolvable only using /etc/hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e093f938d8126f11fed920b7381ba6e3d07da5b>`__
-   `#6518 <https://pagure.io/freeipa/issue/6518>`__
+   `#6518 <https://codeberg.org/freeipa/freeipa/issues/6518>`__
 -  Build: properly integrate ipa.pot into build system tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/a89f63c5a62c4a02fc248a095f539a099a9c28c5>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: properly integrate ipasetup.py into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/6aa360775a781bee5a2fdd884cbfa33b545fcbb4>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: properly integrate version.py into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fcfe689f47a02df023de69f62c889d9b4dc26fe>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: properly integrate loader.js into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/89739a6c910461a3cac3abc1bf2ff162c7c5bc82>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: properly integrate freeipa.spec.in into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/6857de02f3a9c2d7e99e33863be3c65f71fa0d58>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: properly integrate ipa-version.h.in into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba6ae666acaf8b930d18f45efc7c9c9faad3526b>`__
-   `#6498 <https://pagure.io/freeipa/issue/6498>`__
+   `#6498 <https://codeberg.org/freeipa/freeipa/issues/6498>`__
 -  Build: workaround bug while calling parallel make from rpmbuild
    `commit <https://codeberg.org/freeipa/freeipa/commit/132b475c2586f3ced68724355e9c45722dccf604>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove ipa.pot from Git as it can be re-generated at any time
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c133837d149352a68e1d6cbefbb28e4ae048755>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: integrate translation system tests again
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a7962585069d7b0ff7e8d87ce094f07c16b3cd4>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: automatically generate list of files to be translated in
    configure
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ef5a7de781f2508c2925225533973417458d0ea>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: clean in po/ removes \*~ files as well
    `commit <https://codeberg.org/freeipa/freeipa/commit/166257ec5b33dd2c95bbaf8463867c77fd6ef5db>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: support strip-po target for translations
    `commit <https://codeberg.org/freeipa/freeipa/commit/d40c376ccc1ec9292df0306134c7bfdfd096566e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: use standard infrastructure for translations
    `commit <https://codeberg.org/freeipa/freeipa/commit/4842231074683ff68be50b147560f5383aa305b6>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix path in ipa-ods-exporter.socket unit file
    `commit <https://codeberg.org/freeipa/freeipa/commit/5862eaa1a0e3fbced79d6c209016c1138e692888>`__
-   `#6495 <https://pagure.io/freeipa/issue/6495>`__
+   `#6495 <https://codeberg.org/freeipa/freeipa/issues/6495>`__
 -  Build: fix file dependencies for make-css.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b9977f04199bf161d7171aedae9f97648c415c8>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: update makerpms.sh to use same paths as rpmbuild
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2060e8e5562ed6a4fe760eba1babb5c1761576a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove incorrect use of MAINTAINERCLEANFILES
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5683726d290b71eb44ab3b3150381f062e74df1>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: enable silent build in makerpms.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/1cbd823990da0e931b666c4bc5c72f10d9de8115>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: support --enable-silent-rules for Python packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/46b6b9e3091d08412912c37f46af497ddd0b8afb>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: workaround bug 1005235 related to Python paths in
    auto-generated Requires
    `commit <https://codeberg.org/freeipa/freeipa/commit/27e7a89a6289d0d3009f5f7feb9802b7db171a15>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: document what should be in %install section of SPEC file
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a5373464fa67289c9a178b1c0569f585dc6dc34>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: move web UI file installation from SPEC to Makefile.am
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fa0ed954bb45b6e3858c1c54470b1d16ab204d9>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: move server directory handling from SPEC to Makefile.am
    `commit <https://codeberg.org/freeipa/freeipa/commit/20918579acb43391d5d04ee8050b37142a55df76>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: move client directory handling from SPEC to Makefile.am
    `commit <https://codeberg.org/freeipa/freeipa/commit/636aaa7dbc649e685233f382cb8dd424345bebd3>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Update man page for ipa-adtrust-install by removing --no-msdcs option
    `commit <https://codeberg.org/freeipa/freeipa/commit/623cc428cfd79ea228bda6e88dc48bad9aaf61aa>`__
-   `#6480 <https://pagure.io/freeipa/issue/6480>`__
+   `#6480 <https://codeberg.org/freeipa/freeipa/issues/6480>`__
 -  Build: pass down %{release} from SPEC to configure
    `commit <https://codeberg.org/freeipa/freeipa/commit/961773bd0455e6fc723dbbed4f53e4b483360c32>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: update IPA_VERSION_IS_GIT_SNAPSHOT to comply with PEP440
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c81c6c5b8ea62addbc175308a4e357c75d65ef0>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add make srpms target
    `commit <https://codeberg.org/freeipa/freeipa/commit/0023fb59240cb53a541763a89db038c186312154>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: IPA_VERSION_IS_GIT_SNAPSHOT re-generates version number on RPM
    build
    `commit <https://codeberg.org/freeipa/freeipa/commit/a691b7d1837595fecd37bf88a875cb0753f7e698>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: use POSIX 1003.1-1988 (ustar) file format for tar archives
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dc5d2c6f9a0fc134616c615634ae505ef753f77>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: IPA_VERSION_IS_GIT_SNAPSHOT checks if source directory is Git
    repo
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6f5708a5ac56392f7a4b82f63c5e16cc1f1fd99>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove unused and redundant code from configure.ac and
    po/Makefile.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/394edf5f055766fa0cdf70afab6d263f75d0d065>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix make clean to remove build artifacts from top-level
    directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/d20f6a5ef2467e780026f1040f5a11a7a77594ca>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix make clean for web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0674e89d1e6b5abd82cf3b7bf8054eec0fa6418>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add polint target for i18n tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4498998f1763d673056423a73d3b3ff22f94954f>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add makeapi lint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3b537af18afa03b1f04530b42cdba5c1fc3ff97>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add makeaci lint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/b54e9e86dfaed1320f7ccce560f82c233f67bf1a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add JS lint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/f31a489d246e01250536b7187225fb7ca6398ba5>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add Python lint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/14c1c8dfd0aa894af2d60dfa4f2ce2510d791328>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove obsolete instructions about BuildRequires from
    BUILD.txt
    `commit <https://codeberg.org/freeipa/freeipa/commit/2df98772556de0d964028bbb78a9efbdd13ecd40>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: add make rpms target and convenience script makerpms.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/fee9bbd85afeac3593abd791de2d002bed300c8e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix KDC proxy installation and remove unused kdcproxy.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/75a944e980c64061e51f4ec7215033c118f39863>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove unused dirs /var/cache/ipa/{sysupgrade,sysrestore} from
    SPEC
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ce3aa3b12004ca4eb29e4bbca415a585fbd432f>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: do not compress manual pages at install time
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc5699a8a40dd27ffd25d9ad3185ba40d93ec95b>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: distribute doc directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc6382550fcf32bd4b843c922c10c5a5d247dd38>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: create /var/run directories at install time
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cb0271509fe95ae38fc743f2a13faf32fe29a99>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: integrate init and init/systemd into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/288d624336d502a7df9856cdc2f6543b6e7c0b79>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove init/SystemV directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/a027bf739848371fa91b5ba9766e031c9003d322>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: integrate contrib directory into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3cab75d7e79fbc89ef08df3e6d2b1e28b4ef163>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove ancient checks/check-ra.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ffd3bdf142f0f852918186ce0a338a7818bbe8e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: integrate daemons/dnssec into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/312e780041fc9025ca3c189e6c9fcb54c7340714>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/topology files
    `commit <https://codeberg.org/freeipa/freeipa/commit/f229bb56b73487758ed9bd9c7f0a4cc74134992b>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-winsync
    files
    `commit <https://codeberg.org/freeipa/freeipa/commit/39b17ef2abd885ab87c1a39d3036f762b6b084c8>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-sidgen files
    `commit <https://codeberg.org/freeipa/freeipa/commit/74820fe3d8774244476357036406014680d54211>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-pwd-extop
    files
    `commit <https://codeberg.org/freeipa/freeipa/commit/53cd71a63c7d6ba97a5593e5a8922af71c5a4b6f>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of
    daemons/ipa-slapi-plugins/ipa-otp-lasttoken files
    `commit <https://codeberg.org/freeipa/freeipa/commit/278cda7ede3777f61f31ec77199d02954512e133>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-otp-counter
    files
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1652f92af6bea13ecd96c0ad7be38784e2faeb5>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-exdom-extop
    files
    `commit <https://codeberg.org/freeipa/freeipa/commit/14bce67cf0cad1aecc132a2c67ad2dc686bcd2af>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemons/ipa-slapi-plugins/ipa-cldap files
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fb2f535ca73dd16738ce4a3b692931fb26227aa>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of ipa-slapi-plugins/common files
    `commit <https://codeberg.org/freeipa/freeipa/commit/684a2c6a58b99a72f68e4c7f827d6601007cea26>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of daemon/ipa-kdb files
    `commit <https://codeberg.org/freeipa/freeipa/commit/125bf25577e58d11252cb41d34065d49f581e0ac>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of client header file
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d5fe1dba0459b09bc7518d34c58444c96435801>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of asn1/asn1c files
    `commit <https://codeberg.org/freeipa/freeipa/commit/c951a491a9082b8b5931782f45f82e251eb93c3c>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of install/REDME.schema file
    `commit <https://codeberg.org/freeipa/freeipa/commit/886d9167eb939a3ab5226ca420c404a9810186cf>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of oddjob files
    `commit <https://codeberg.org/freeipa/freeipa/commit/dabc65f6b1989fb8f938e4b7249fcf5d41706e17>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: Remove spurious EXTRA_DIST from install/share/Makefile.am
    `commit <https://codeberg.org/freeipa/freeipa/commit/a125370becb045b6e757df88e520ef3f8ab4ca09>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: cleanup unused LDIFs from install/share
    `commit <https://codeberg.org/freeipa/freeipa/commit/deec97abaec933709718464c4aa233a04de1844a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution of libexec scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/04be25082c60da01552d5e7c73d12930b10bd02e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution and installation of update LDIFs
    `commit <https://codeberg.org/freeipa/freeipa/commit/b910683e19356390351a6b82240762969ecf89c0>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Web UI: Remove offline version of Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/24525fd086450616d4edd2aaf26dec868ff80ea9>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  Build: fix distribution of static files for web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/441acf7797b2069e8d9a123aa11bb33fd42d9187>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: stop build when a step in web UI build fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/f95098b2b645a62497dc6e1d66be2b7397567d25>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distribution and installation of static files in top-level
    directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/021a52d6801b74ded03cfdf6c7fb73bd1cab978f>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix man page distribution
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f6712893be5e66260a169c367a4607be6043d11>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix distdir target for translations
    `commit <https://codeberg.org/freeipa/freeipa/commit/7282776c05c2fb254ae65b63977ba604be316038>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: rename project from ipa-server to freeipa
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa8a468dba0ed866497669bd9c08b7de3a2cfbe3>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove non-existing README files from Makefile.am
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8d81ba3a12d93c38c4a0a8d439845746a32ae35>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix Makefile.am files to separate source and build directories
    `commit <https://codeberg.org/freeipa/freeipa/commit/24feae47f26f40f757fbdd711399128d88c9b62c>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: respect --prefix for systemdsystemunitdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/820fd4c7ce6ccc80272f45d6f64227567692dd39>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix make install in asn1 subdirectory
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a41b3bb8860cf73fef7efd54db2da5ecbd608d5>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix ipaplatform detection for out-of-tree builds
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d6b8f8bdd5568c44d293cba960209941e4d2545>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: Makefiles for Python packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/8de11b091fc705f235b1304fb101c27a82dcda6f>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: fix module name in ipaserver/setup.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/81da45ffb13d126c9b56a2022d88ba8bed2ee18c>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: replace hand-made Makefile with one generated by Automake
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a17155e5b0434d4cab4d1696fac7f5ef88f0808>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: move version handling from Makefile to configure
    `commit <https://codeberg.org/freeipa/freeipa/commit/c48e5fd811326dc64e19490f88003e442815a052>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Docs: update docs about ipaplatform to match reality
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e79d8ad4aef1f62372a2169699df345348ba3e9>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: replace ipaplatform magic with symlinks generated by configure
    `commit <https://codeberg.org/freeipa/freeipa/commit/c70a2873f8a4447f8b38ad7b8468fc78c91bbb63>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build docs: update platform selection instructions
    `commit <https://codeberg.org/freeipa/freeipa/commit/c954d0e1ba2a9ba8e8da679bc7246788d086d976>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: split out egg-info Makefile target from version-update target
    `commit <https://codeberg.org/freeipa/freeipa/commit/f25c0cb0c5f309944904fd32e781c27ae7e45a62>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: split API/ACI checks into separate Makefile targets
    `commit <https://codeberg.org/freeipa/freeipa/commit/38628e46f05bde5ccc0fbb997f79364860713b48>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: use default error handling for PKG_CHECK_MODULES
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a4f287931edf0f3a76e97875f4af622716475af>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: use libutil convenience library for client
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8be979b3263723a9ab7b3c71efbe85b42d981e9>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: cleanup INI library detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/8acb1f37f581e92a56951c069c990c77e83f3c42>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: modernize XMLRPC-client library detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e0143c159134337a00a91d4ae64e614f72da62e>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: modernize CURL library detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/b12da59a6cde3580f97e4ceb7303bc85857faf4d>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: modernize SASL library detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd3176a72951a2baece36620341991feb94b230a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: modernize POPT library detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f1648691de6687e748c5b8267f43cf196bd7cc9>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: merge client/configure.ac into top-level configure.ac
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d7d6f3904287bb4903ffaa9d8c61e7593ae76d6>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove Transifex support
    `commit <https://codeberg.org/freeipa/freeipa/commit/881ab4edffa5e9c6c8bd8fb9762e04d776c4a573>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: move translations from install/po/ to top-level po/
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d37619db41abddabdd313f036f453821f438c8a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: merge install/configure.ac into top-level configure.ac
    `commit <https://codeberg.org/freeipa/freeipa/commit/927ddcb95aeb5c9bcc0cb08c5f08cecdccd0acb8>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: merge ipatests/man/configure.ac to top-level configure.ac
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e028b59bcd3c485cc034f491a0171f26b03ce3a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: merge asn1/configure.ac to top-level configure.ac
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e1d777d2878de1e90e1dab4949075d31ffb0d52>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: transform util directory to libutil convenience library
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0cb6afa2308b9d96456f0355771ecbef0ca7263>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: promote daemons/configure.ac to top-level configure.ac
    `commit <https://codeberg.org/freeipa/freeipa/commit/25dab77301f9e0289b94b0a672aed5067384c8ce>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: adjust include paths in daemons/ipa-kdb/tests/ipa_kdb_tests.c
    `commit <https://codeberg.org/freeipa/freeipa/commit/41da8732051c193166fa69cd9bc1152d39ad8720>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: pass down LIBDIR definition from RPM SPEC to Makefile
    `commit <https://codeberg.org/freeipa/freeipa/commit/329f080e6ac832ffd568e79ebca9907771f8ad61>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Build: remove deprecated AC_STDC_HEADERS macro
    `commit <https://codeberg.org/freeipa/freeipa/commit/7de597425f8fb6d8c5cadc8fc039729368c43ddf>`__
 -  Build: require Python >= 2.7
@@ -3010,10 +3010,10 @@ Petr Spacek (126)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf96b80200c3e8d1795a913db4e0222ea558e609>`__
 -  DNS: Support URI resource record type
    `commit <https://codeberg.org/freeipa/freeipa/commit/f363dfbeed7aeba51d694a60b29389d94c7bda44>`__
-   `#6344 <https://pagure.io/freeipa/issue/6344>`__
+   `#6344 <https://codeberg.org/freeipa/freeipa/issues/6344>`__
 -  Fix compatibility with python-dns 1.15.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e02652e7c889ce7d32b592b5235917a0f519503>`__
-   `#6390 <https://pagure.io/freeipa/issue/6390>`__
+   `#6390 <https://codeberg.org/freeipa/freeipa/issues/6390>`__
 -  Raise errors from service.py:_ldap_mod() by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/c56256e2a29f076e6afa559225a66f58b0773eb5>`__
 
@@ -3025,10 +3025,10 @@ Petr Vobornik (6)
 -  permissions: add permissions for read and mod of external group
    members
    `commit <https://codeberg.org/freeipa/freeipa/commit/da5487c407bee9bce41f4012d07970916b9456c1>`__
-   `#5504 <https://pagure.io/freeipa/issue/5504>`__
+   `#5504 <https://codeberg.org/freeipa/freeipa/issues/5504>`__
 -  webui: do not warn about CAs if there is only one master
    `commit <https://codeberg.org/freeipa/freeipa/commit/6027a8111fa9ed7a058fb222f4f96b12039deb8b>`__
-   `#6598 <https://pagure.io/freeipa/issue/6598>`__
+   `#6598 <https://codeberg.org/freeipa/freeipa/issues/6598>`__
 -  webui: fixes normalization of value in attributes widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/56a2642af0a29328df4defef138b9fa65624335a>`__
 -  Change README to use Markdown
@@ -3045,144 +3045,144 @@ Pavel Vomacka (69)
 
 -  Remove allow_constrained_delegation from gssproxy.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4cd61f3011877fc9cc2a809438059b07362b0aa>`__
-   `#6225 <https://pagure.io/freeipa/issue/6225>`__
+   `#6225 <https://codeberg.org/freeipa/freeipa/issues/6225>`__
 -  WebUI: Add support for management of user short name resolution
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c194d793cd588d595c5ff639fbf5dac93e50e23>`__
-   `#6372 <https://pagure.io/freeipa/issue/6372>`__
+   `#6372 <https://codeberg.org/freeipa/freeipa/issues/6372>`__
 -  WebUI: add link to login page which for login using certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/585547ee9478ea0173106d88d40d7807baab8bcf>`__
-   `#6225 <https://pagure.io/freeipa/issue/6225>`__
+   `#6225 <https://codeberg.org/freeipa/freeipa/issues/6225>`__
 -  Support certificate login after installation and upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/75c592d3b9081474cae51c929e6af29c7a0eebb6>`__
-   `#6225 <https://pagure.io/freeipa/issue/6225>`__
+   `#6225 <https://codeberg.org/freeipa/freeipa/issues/6225>`__
 -  TESTS WebUI: Vaults management
    `commit <https://codeberg.org/freeipa/freeipa/commit/f95275748465ffacecfbf55ca2cd2fc54f3860b7>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  TESTS: Add support for sidebar with facets
    `commit <https://codeberg.org/freeipa/freeipa/commit/0808504ba1ab743acdf4231876d49c26dbae6621>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  TESTS: Add support for KRA in ui_driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab8c69f4c602c0eaefbb058c108428ca30a80e98>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  WebUI: add vault management
    `commit <https://codeberg.org/freeipa/freeipa/commit/39d7ef3de4b0345274b4b8e8f6918e3b714879ad>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  WebUI: allow to show rows with same pkey in tables
    `commit <https://codeberg.org/freeipa/freeipa/commit/587b7324fb1f6899deb151c30662362c18c5258e>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  WebUI: search facet's default actions might be overriden
    `commit <https://codeberg.org/freeipa/freeipa/commit/de4d4a51b542b8e473919dbc14f7a0810944b544>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Add possibility to hide only one tab in sidebar
    `commit <https://codeberg.org/freeipa/freeipa/commit/8dfe692251d38934a21ad3bc648d839d83e27caa>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Possibility to set list of table attributes which will be added to
    \_del command
    `commit <https://codeberg.org/freeipa/freeipa/commit/039a6f7b4ff392974408cb9e274f8a3777e009fd>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Extend \_show command after \_find command in table facets
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e6e0698865e7d530c6ebf87a12e46f990ac1d87>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Add possibility to pass url parameter to update command of details
    page
    `commit <https://codeberg.org/freeipa/freeipa/commit/042e113db9bc66dcd0da0d5e8b8d025212695705>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Add property which allows refresh command to use url value
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbca1d9219bfab9f204cb0217495cbd94b7098be>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Added optional option in refreshing after modifying association table
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d1374f7f82d144b8aa361e9e637c5388f8f7edb>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Possibility to skip checking writable according to metadata
    `commit <https://codeberg.org/freeipa/freeipa/commit/93a7f4c88db159664664bd82d1d00e5e0033ac22>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Allow to set another other_entity name
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec63456b7c1fba6bd8d9073e63c27ef685f08c60>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  Additional option to add and del operations can be set
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3115fa617fb049ba48d356d280fdb23c312ebca>`__
-   `#5426 <https://pagure.io/freeipa/issue/5426>`__
+   `#5426 <https://codeberg.org/freeipa/freeipa/issues/5426>`__
 -  WebUI: Add cermapmatch module
    `commit <https://codeberg.org/freeipa/freeipa/commit/61cd4372e142662c06c881886709fe1b573102a9>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Add Adapter for certmap_match result table
    `commit <https://codeberg.org/freeipa/freeipa/commit/358caa7da44c997b505f54ec70cb6be58d188751>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Possibility to choose object when API call returns list of
    objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d6cc35c03669ea67d9e9ee9ca0ff62401d1b157>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Add possibility to turn of autoload when details.load is
    called
    `commit <https://codeberg.org/freeipa/freeipa/commit/6be32edde0ae16473d4d109747adae78f9d725e4>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: don't change casing of Auth Indicators values
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad3451067ad474ea52872913d6789b1652f9a9c4>`__
-   `#6308 <https://pagure.io/freeipa/issue/6308>`__
+   `#6308 <https://codeberg.org/freeipa/freeipa/issues/6308>`__
 -  WebUI: Allow disabling lowering text in custom_checkbox_widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/0220fc8986e4fef017185bde675dc9cf0f90afd8>`__
-   `#6308 <https://pagure.io/freeipa/issue/6308>`__
+   `#6308 <https://codeberg.org/freeipa/freeipa/issues/6308>`__
 -  Add support for custom table pagination size
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1dfc51e48050ac1ad431d56003dc26e17ca653e>`__
-   `#5742 <https://pagure.io/freeipa/issue/5742>`__
+   `#5742 <https://codeberg.org/freeipa/freeipa/issues/5742>`__
 -  Make singleton from config module
    `commit <https://codeberg.org/freeipa/freeipa/commit/f78cc8932626de667c6e3a4461141a10a5d9c2e6>`__
-   `#5742 <https://pagure.io/freeipa/issue/5742>`__
+   `#5742 <https://codeberg.org/freeipa/freeipa/issues/5742>`__
 -  Add javascript integer validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b699105a52d4d8c26a73044ba182d752b4a9833>`__
-   `#5742 <https://pagure.io/freeipa/issue/5742>`__
+   `#5742 <https://codeberg.org/freeipa/freeipa/issues/5742>`__
 -  WebUI: Add certmap module
    `commit <https://codeberg.org/freeipa/freeipa/commit/19426f32ff99feb7c64a4174728cd2b6b946a49a>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Add Custom command multivalued adder dialog
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3700275c1b63aeeab13c7dd9e09249bc2c8e4d7>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Create non editable row widget for mutlivalued widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/fba318b83337b71ccb3421690071a130171fbdfe>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Add possibility to set field always writable
    `commit <https://codeberg.org/freeipa/freeipa/commit/27027bbc9cf7faa29c3c94686635559cbcbde98a>`__
-   `#6601 <https://pagure.io/freeipa/issue/6601>`__
+   `#6601 <https://codeberg.org/freeipa/freeipa/issues/6601>`__
 -  WebUI: Change structure of Identity submenu
    `commit <https://codeberg.org/freeipa/freeipa/commit/070bc48dd6c9bce32caa0f0f2de8d44b4e5bbbb1>`__
-   `#6717 <https://pagure.io/freeipa/issue/6717>`__
+   `#6717 <https://codeberg.org/freeipa/freeipa/issues/6717>`__
 -  WebUI: add sizelimit:0 to cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa8530b7af8f04a4ba868f73ea9f171911162638>`__
-   `#6712 <https://pagure.io/freeipa/issue/6712>`__
+   `#6712 <https://codeberg.org/freeipa/freeipa/issues/6712>`__
 -  WebUI: fix incorrect behavior of ESC button on combobox
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c6c68df544ac1046741d91dfdc59ef8d96b863c>`__
-   `#6388 <https://pagure.io/freeipa/issue/6388>`__
+   `#6388 <https://codeberg.org/freeipa/freeipa/issues/6388>`__
 -  WebUI: add default on_cancel function in adder_dialog
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a96e7f9e737941480436269668ccde0a50395f9>`__
-   `#6388 <https://pagure.io/freeipa/issue/6388>`__
+   `#6388 <https://codeberg.org/freeipa/freeipa/issues/6388>`__
 -  Coverity: removed useless semicolon which ends statement earlier
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d2ef64fb9e1357dc4a3cde8d93c796daefd2f6e>`__
 -  Coverity: Fix possibility of access to attribute of undefined
    `commit <https://codeberg.org/freeipa/freeipa/commit/a69c4448c58b2438952fd806e2515eea7575b27b>`__
 -  Change activity text while loading metadata
    `commit <https://codeberg.org/freeipa/freeipa/commit/be7865bf4f9b6774a17f31380e96b76d0473f982>`__
-   `#6144 <https://pagure.io/freeipa/issue/6144>`__
+   `#6144 <https://codeberg.org/freeipa/freeipa/issues/6144>`__
 -  Refactoring of rpc module
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a950aeb29963ed22a2c3c1b80723589ac4097de>`__
-   `#6144 <https://pagure.io/freeipa/issue/6144>`__
+   `#6144 <https://codeberg.org/freeipa/freeipa/issues/6144>`__
 -  WebUI: update Patternfly and Bootstrap
    `commit <https://codeberg.org/freeipa/freeipa/commit/18425dbbe7b7c311cf947074d505225b235df769>`__
-   `#6394 <https://pagure.io/freeipa/issue/6394>`__
+   `#6394 <https://codeberg.org/freeipa/freeipa/issues/6394>`__
 -  WebUI: Hide incorrectly shown buttons on hosts tab in ID Views
    `commit <https://codeberg.org/freeipa/freeipa/commit/17392b0ef754781775a10973b2fee8a6d1697f5d>`__
-   `#6546 <https://pagure.io/freeipa/issue/6546>`__
+   `#6546 <https://codeberg.org/freeipa/freeipa/issues/6546>`__
 -  Lowered the version of gettext
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5686c0ccb4a71fa0ab460fd45280d9adba91cca>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Add python-pyasn1-modules into dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8b7dbff8ac660a28faf7ef43c7a0952171423b8>`__
-   `#6398 <https://pagure.io/freeipa/issue/6398>`__
+   `#6398 <https://codeberg.org/freeipa/freeipa/issues/6398>`__
 -  Adjustments for setup requirements v2
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f301b00ce50814d098e7e42324ef741c71b6853>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  TESTS: Update group type name
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e475988e1ec1b89d44b495cd667a444526733a7>`__
-   `#6334 <https://pagure.io/freeipa/issue/6334>`__
+   `#6334 <https://codeberg.org/freeipa/freeipa/issues/6334>`__
 -  Coverity - null pointer dereference
    `commit <https://codeberg.org/freeipa/freeipa/commit/2644c955489ee5b22ecc0227c5cd8ed1e90ee648>`__
 -  Coverity - accessing attribute of variable which can point to null
@@ -3211,33 +3211,33 @@ Pavel Vomacka (69)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2525ff64518038eaa64b0d855154a984030f7f3>`__
 -  WebUI: services without canonical name are shown correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f760dffa011a3656b6072c74088b497ff416a8d>`__
-   `#6397 <https://pagure.io/freeipa/issue/6397>`__
+   `#6397 <https://codeberg.org/freeipa/freeipa/issues/6397>`__
 -  WebUI: fix API Browser menu label
    `commit <https://codeberg.org/freeipa/freeipa/commit/28c7644980186f50ee007cd5c2f2edcf103eb942>`__
-   `#6384 <https://pagure.io/freeipa/issue/6384>`__
+   `#6384 <https://codeberg.org/freeipa/freeipa/issues/6384>`__
 -  Add tooltip to all fields in DNS record adder dialog
    `commit <https://codeberg.org/freeipa/freeipa/commit/51af7a15981eca753dfbda133cc557d0512f6e95>`__
 -  WebUI: hide buttons in certificate widget according to acl
    `commit <https://codeberg.org/freeipa/freeipa/commit/81ead980fb808b70d7590800518b655abe64948b>`__
-   `#6341 <https://pagure.io/freeipa/issue/6341>`__
+   `#6341 <https://codeberg.org/freeipa/freeipa/issues/6341>`__
 -  WebUI: Change group name from 'normal' to 'Non-POSIX'
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e6d6e403255649538224c409a0a279aaf9d5181>`__
-   `#6334 <https://pagure.io/freeipa/issue/6334>`__
+   `#6334 <https://codeberg.org/freeipa/freeipa/issues/6334>`__
 -  WebUI: Add handling for HTTP error 404
    `commit <https://codeberg.org/freeipa/freeipa/commit/b18a35145df92522ae990e020513d1a77e311493>`__
-   `#4821 <https://pagure.io/freeipa/issue/4821>`__
+   `#4821 <https://codeberg.org/freeipa/freeipa/issues/4821>`__
 -  Add 'Restore' option to action dropdown menu
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3374c6e16a10e8780401c58c04dcf8d95ea1a4d>`__
-   `#5818 <https://pagure.io/freeipa/issue/5818>`__
+   `#5818 <https://codeberg.org/freeipa/freeipa/issues/5818>`__
 -  WebUI add support for sub-CAs while revoking certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fea3914fbfc0748f26dfe41445b5f0d12f406e6>`__
-   `#6216 <https://pagure.io/freeipa/issue/6216>`__
+   `#6216 <https://codeberg.org/freeipa/freeipa/issues/6216>`__
 -  WebUI: Fix showing certificates issued by sub-CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/64ac981dddcecf1176585b6e7b729cf38b24bcea>`__
-   `#6238 <https://pagure.io/freeipa/issue/6238>`__
+   `#6238 <https://codeberg.org/freeipa/freeipa/issues/6238>`__
 -  Add support for additional options taken from table facet
    `commit <https://codeberg.org/freeipa/freeipa/commit/40f923f56b4777e3e18c9f76ba1a745ed69ef0a6>`__
-   `#6238 <https://pagure.io/freeipa/issue/6238>`__
+   `#6238 <https://codeberg.org/freeipa/freeipa/issues/6238>`__
 
 
 
@@ -3254,89 +3254,89 @@ Simo Sorce (31)
 
 -  Store session cookie in a ccache option
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cab95955539b5f9596dcda5886ea3d9755fb193>`__
-   `#6661 <https://pagure.io/freeipa/issue/6661>`__
+   `#6661 <https://codeberg.org/freeipa/freeipa/issues/6661>`__
 -  Add support for searching policies in cn=accounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e5cc369fd8b9d780697a9a286429cc2ca0f448a>`__
-   `#6568 <https://pagure.io/freeipa/issue/6568>`__
+   `#6568 <https://codeberg.org/freeipa/freeipa/issues/6568>`__
 -  Add code to retrieve results from multiple bases
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f13b330aaec468a018472dce5fc77131277de94>`__
 -  Use GSS-SPNEGO if connecting locally
    `commit <https://codeberg.org/freeipa/freeipa/commit/adf8aabf10a57383aa6216625921503b83575757>`__
-   `#6656 <https://pagure.io/freeipa/issue/6656>`__
+   `#6656 <https://codeberg.org/freeipa/freeipa/issues/6656>`__
 -  Limit sessions to 30 minutes by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5e7a57e5b25b9cecb7a65096487a65374ad860d>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Remove non-sensical kdestroy on https stop
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8f304c66994ae82ea484a4e8bd057d4ccf1e6bd>`__
-   `#6673 <https://pagure.io/freeipa/issue/6673>`__
+   `#6673 <https://codeberg.org/freeipa/freeipa/issues/6673>`__
 -  Fix session logout
    `commit <https://codeberg.org/freeipa/freeipa/commit/908d2eaba46f5f123b49af400a8b696545c62b54>`__
-   `#6685 <https://pagure.io/freeipa/issue/6685>`__
+   `#6685 <https://codeberg.org/freeipa/freeipa/issues/6685>`__
 -  Deduplicate session cookies in headers
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0642bfa55e9c24429675f623bc0e35824bc9fb0>`__
-   `#6676 <https://pagure.io/freeipa/issue/6676>`__
+   `#6676 <https://codeberg.org/freeipa/freeipa/issues/6676>`__
 -  Change session logout to kill only the cookie
    `commit <https://codeberg.org/freeipa/freeipa/commit/b895f4a34bcbd0b1787d2bfc1db25f34c3584b9c>`__
-   `#6682 <https://pagure.io/freeipa/issue/6682>`__
+   `#6682 <https://codeberg.org/freeipa/freeipa/issues/6682>`__
 -  Insure removal of session on identity change
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4d462ad53597fd5410aa4e94a57bb15b92a3f13>`__
-   `#6543 <https://pagure.io/freeipa/issue/6543>`__
+   `#6543 <https://codeberg.org/freeipa/freeipa/issues/6543>`__
 -  Explicitly pass down ccache names for connections
    `commit <https://codeberg.org/freeipa/freeipa/commit/09c92e2bc1ca9db5b73d5ab8483b42dbd6b9a0e9>`__
-   `#6543 <https://pagure.io/freeipa/issue/6543>`__
+   `#6543 <https://codeberg.org/freeipa/freeipa/issues/6543>`__
 -  Allow rpc callers to pass ccache and service names
    `commit <https://codeberg.org/freeipa/freeipa/commit/41c1efc44a6b809445facd4772574595029553b1>`__
-   `#6543 <https://pagure.io/freeipa/issue/6543>`__
+   `#6543 <https://codeberg.org/freeipa/freeipa/issues/6543>`__
 -  Fix uninstall stopping ipa.service
    `commit <https://codeberg.org/freeipa/freeipa/commit/00a9d2f94dee17e28e39cdae0c32acc3d1fe51ed>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Rationalize creation of RA and HTTPD NSS databases
    `commit <https://codeberg.org/freeipa/freeipa/commit/4bd2d6ad46c9151e11f9223dd5383555fdedb249>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Add a new user to run the framework code
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fd89833ee5421b05c10329d627d0e0fc8496046>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Always use /etc/ipa/ca.crt as CA cert file
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2b1b2a36200b50babfda1eca37fb4b51fefa9c6>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Simplify NSSDatabase password file handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/f648c5631afa5e7954eee9a84fb1222d3bce3bf1>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Separate RA cert store from the HTTP cert store
    `commit <https://codeberg.org/freeipa/freeipa/commit/d124e307f3b7d88bca53784f030ed6043b224432>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Configure HTTPD to work via Gss-Proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2f5fc304f1938d23171ae330fa20b213ceed54e>`__
-   `#4189 <https://pagure.io/freeipa/issue/4189>`__,
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#4189 <https://codeberg.org/freeipa/freeipa/issues/4189>`__,
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Use Anonymous user to obtain FAST armor ccache
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6741d81e187fc84177c12ef8ad900d3b5cda6a4>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Drop use of kinit_as_http from trust code
    `commit <https://codeberg.org/freeipa/freeipa/commit/b109f5d850ce13585d4392ca48896dc069a746e5>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Generate tmpfiles config at install time
    `commit <https://codeberg.org/freeipa/freeipa/commit/38c66896de1769077cd5b057133606ec5eeaf62b>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Change session handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/c894ebefc5c4c4c7ea340d6ddc4cd3c081917e4a>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Use the tar Posix option for tarballs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bc01ec5b4a91a805912bdada429a91ab08ed196>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  Add compatibility code to retrieve headers
    `commit <https://codeberg.org/freeipa/freeipa/commit/397f2be9dfd6475127742c0b710b37b443d97d67>`__
-   `#6558 <https://pagure.io/freeipa/issue/6558>`__
+   `#6558 <https://codeberg.org/freeipa/freeipa/issues/6558>`__
 -  Configure Anonymous PKINIT on server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca4e6c1fdfac9b545b26f885dc4865f22ca36ae6>`__
-   `#5678 <https://pagure.io/freeipa/issue/5678>`__
+   `#5678 <https://codeberg.org/freeipa/freeipa/issues/5678>`__
 -  Properly handle multiple cookies in rpc lib.
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1678693713dc2a573493e325e93f6f557a5ad5a>`__
 -  Properly handle multiple cookies in rpcclient
    `commit <https://codeberg.org/freeipa/freeipa/commit/560ab9e3176af8e59163155207cc2c1d631915dd>`__
 -  Support DAL version 5 and version 6
    `commit <https://codeberg.org/freeipa/freeipa/commit/2775042787be4ea236c0b99dd75337414e24b89d>`__
-   `#6466 <https://pagure.io/freeipa/issue/6466>`__
+   `#6466 <https://codeberg.org/freeipa/freeipa/issues/6466>`__
 -  Fix install scripts debugging
    `commit <https://codeberg.org/freeipa/freeipa/commit/d650c54fe4e327f95ffcb834418a5b6af59b212c>`__
 -  Fix error message encoding
@@ -3349,237 +3349,237 @@ Stanislav Laznicka (78)
 
 -  Remove pkinit from ipa-replica-prepare
    `commit <https://codeberg.org/freeipa/freeipa/commit/46d4d534c08d14756b989e157e87a078d174ad5c>`__
-   `#6759 <https://pagure.io/freeipa/issue/6759>`__
+   `#6759 <https://codeberg.org/freeipa/freeipa/issues/6759>`__
 -  Backup KDC certificate pair
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee6d031a6a0939c1f51a874b1f8f9b19ec727203>`__
-   `#6748 <https://pagure.io/freeipa/issue/6748>`__
+   `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__
 -  Don't fail more if cert req/cert creation failed
    `commit <https://codeberg.org/freeipa/freeipa/commit/8980f4098ebf6b62556e24f090718802d1e495d3>`__
-   `#6755 <https://pagure.io/freeipa/issue/6755>`__
+   `#6755 <https://codeberg.org/freeipa/freeipa/issues/6755>`__
 -  Fix ipa-replica-prepare server-cert creation
    `commit <https://codeberg.org/freeipa/freeipa/commit/992e6ecd1ff33f4f872e8f174bd426507c55f5c4>`__
-   `#6755 <https://pagure.io/freeipa/issue/6755>`__
+   `#6755 <https://codeberg.org/freeipa/freeipa/issues/6755>`__
 -  Don't allow standalone KRA uninstalls
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d3a0e6758866239c886e998a6d89c5a4b150184>`__
-   `#6538 <https://pagure.io/freeipa/issue/6538>`__
+   `#6538 <https://codeberg.org/freeipa/freeipa/issues/6538>`__
 -  Add message about last KRA to WebUI Topology view
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e8db4b5c7a55dac0008ad9b9bf5802ba30e8c2a>`__
-   `#6538 <https://pagure.io/freeipa/issue/6538>`__
+   `#6538 <https://codeberg.org/freeipa/freeipa/issues/6538>`__
 -  Add check to prevent removal of last KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/670f8fb1db109ec2c9ab7e5d2189325988220b23>`__
-   `#6538 <https://pagure.io/freeipa/issue/6538>`__
+   `#6538 <https://codeberg.org/freeipa/freeipa/issues/6538>`__
 -  Don't use weak ciphers for client HTTPS connections
    `commit <https://codeberg.org/freeipa/freeipa/commit/fda22c33441d3b2c541a272e411ac1503a20fb01>`__
-   `#6730 <https://pagure.io/freeipa/issue/6730>`__
+   `#6730 <https://codeberg.org/freeipa/freeipa/issues/6730>`__
 -  We don't offer no quickies
    `commit <https://codeberg.org/freeipa/freeipa/commit/30d7c210a4d153fcb5007651a80d8d53512abba3>`__
 -  Fix cookie with Max-Age processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/24eeb4d6a3be678d652247a4a862ffde037514da>`__
-   `#6718 <https://pagure.io/freeipa/issue/6718>`__
+   `#6718 <https://codeberg.org/freeipa/freeipa/issues/6718>`__
 -  Fix CA-less upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7c8077ce8f72eee26e8f5d4362239313ffdae3d>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Fix replica with --setup-ca issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/052de4308c64b126bee440e970be4cf8449c5ebc>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Moving ipaCert from HTTPD_ALIAS_DIR
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ab85b365ae886558b1f077b0d039a0d24bebfa7>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__,
-   `#6680 <https://pagure.io/freeipa/issue/6680>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__,
+   `#6680 <https://codeberg.org/freeipa/freeipa/issues/6680>`__
 -  Added a PEMFileHandler for Custodia store
    `commit <https://codeberg.org/freeipa/freeipa/commit/24b134c633390343ba76e4091fa612650976280a>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Refactor certmonger for OpenSSL certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/51a2b1372936106ff95d5a45afc813f146653ae4>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Workaround for certmonger's "Subject" representations
    `commit <https://codeberg.org/freeipa/freeipa/commit/595f9b64e31dc9e4f035119e834db7e6cb152dce>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove ipapython.nsslib as it is not used anymore
    `commit <https://codeberg.org/freeipa/freeipa/commit/76e8d7b35d110e5cf5494898950ab3607799c031>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove NSSConnection from otptoken plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a9d1fb7d9dda0299c6f7cd75a715182d15e04df>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove pkcs12 handling functions from CertDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/afea026a5c45ce24f3bf6da499b4d334eea3ca78>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove NSSConnection from Dogtag
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a54fac02cecad3b9e3bf8ad0c8a44df3b701857>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Move publishing of CA cert to cainstance creation on master
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b074ad833a12acbd4643795b2150fa7f019d6b2>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Don't run kra.configure_instance if not necessary
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e89d28aaf3a0a4b48fc09a5d98262f1000c52a3>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Move RA agent certificate file export to a different location
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a1494c9aef2e2b5c06e427e689787e5a2c4dc7f>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__,
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__,
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Remove NSSConnection from the Python RPC module
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfd560a190cb2ab13f34ed9e21c5fb5c6e793f18>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove md5_fingerprints from IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2d1b21c5049f68d0336dcaf3f8657b214a34e2b>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove DM password files after successfull pkispawn run
    `commit <https://codeberg.org/freeipa/freeipa/commit/a39effed7603d66acd238e3142f4df8081ff7bc8>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Remove ra_db argument from CAInstance init
    `commit <https://codeberg.org/freeipa/freeipa/commit/728a6bd4229ba170b2e94f216127b19d5d94e2ba>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Fix ipa-server-upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/32076df10231b381a80c9ef850c2c31d7a25feb8>`__
-   `#5959 <https://pagure.io/freeipa/issue/5959>`__
+   `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__
 -  Use newer Certificate.serial_number in krainstance.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c2cd66269d7be976ae7fc990343ed8e9b5282a3>`__
 -  Fix error in ca_cert_files validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fffeabe0249d9c3c11e522fccf22ddeb1197b64>`__
-   `#6694 <https://pagure.io/freeipa/issue/6694>`__
+   `#6694 <https://codeberg.org/freeipa/freeipa/issues/6694>`__
 -  Don't prepend option names with additional '--'
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ac068ad04a2323192f9447986a3d1c5431f1e50>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Bump python-cryptography version in ipasetup.py.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/66867319d903f7693a535471d3b81716a258ce9d>`__
-   `#6631 <https://pagure.io/freeipa/issue/6631>`__
+   `#6631 <https://codeberg.org/freeipa/freeipa/issues/6631>`__
 -  custodiainstance: don't use IPA-specific CertDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/b20b0489ea06931bfa7d46bdbd6623bc3f09219b>`__
 -  Add password to certutil calls in NSSDatabase
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca457eb5ce12291f555f1bf771114d6d7d191987>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Explicitly remove support of SSLv2/3
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac6f573a3014aa09811ca1559d470afe75eadbec>`__
-   `#6607 <https://pagure.io/freeipa/issue/6607>`__
+   `#6607 <https://codeberg.org/freeipa/freeipa/issues/6607>`__
 -  Add FIPS-token password of HTTPD NSS database
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b9b6b52d7f2e64a52ef8fd570839711311fa254>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Bump required python-cryptography version
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b56952a547277fab4c68da02f213d40f931a4ca>`__
-   `#6631 <https://pagure.io/freeipa/issue/6631>`__
+   `#6631 <https://codeberg.org/freeipa/freeipa/issues/6631>`__
 -  Remove is_fips_enabled checks in installers and ipactl
    `commit <https://codeberg.org/freeipa/freeipa/commit/08c71703a44d8aec308781351c3a9dd4a4ba94a7>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Generate sha256 ssh pubkey fingerprints for hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/721105c53de6fbc0abc7799ec7f48920e02089bd>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Unify password generation across FreeIPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/8db5b277a079fdfe5efbd7d49311f14489cee0e8>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Clarify meaning of --domain and --realm in installers
    `commit <https://codeberg.org/freeipa/freeipa/commit/25a6ddcce8e7b9effaf19431c421dc5b3497fa22>`__
-   `#6574 <https://pagure.io/freeipa/issue/6574>`__
+   `#6574 <https://codeberg.org/freeipa/freeipa/issues/6574>`__
 -  replicainstall: give correct error message on DL mismatch
    `commit <https://codeberg.org/freeipa/freeipa/commit/2dcbc9416f1de708336a9afe92a138da9360ec5b>`__
-   `#6510 <https://pagure.io/freeipa/issue/6510>`__
+   `#6510 <https://codeberg.org/freeipa/freeipa/issues/6510>`__
 -  Fix permission-find with sizelimit set
    `commit <https://codeberg.org/freeipa/freeipa/commit/a77627dd8cca43bd1131a7e186de0ab159763761>`__
-   `#5640 <https://pagure.io/freeipa/issue/5640>`__
+   `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__
 -  Generalize filter generation in LDAPSearch
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c044cb084780ee45860169dd5d12689cf05fa49>`__
-   `#5640 <https://pagure.io/freeipa/issue/5640>`__
+   `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__
 -  permission-find: fix a sizelimit off-by-one bug
    `commit <https://codeberg.org/freeipa/freeipa/commit/2663a966dad138160a850e6af97c38a88ec83f93>`__
-   `#5640 <https://pagure.io/freeipa/issue/5640>`__
+   `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__
 -  fix permission_find fail on low search size limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/29aa4877eec89894cc3a6e50c4b6817a713d3177>`__
-   `#5640 <https://pagure.io/freeipa/issue/5640>`__
+   `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__
 -  Make get_entries() not ignore its limit arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/0df65b6d035331322998ce5a15bdaae1bfd97c67>`__
-   `#5640 <https://pagure.io/freeipa/issue/5640>`__
+   `#5640 <https://codeberg.org/freeipa/freeipa/issues/5640>`__
 -  Do not log DM password in ca/kra installation logs
    `commit <https://codeberg.org/freeipa/freeipa/commit/e617f895e70e6812836870f504af6e22a5dc7def>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  Fix CA replica install on DL1
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c742b1539591b49474fe8ec871e1b523e9898bd>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Offer more general way to check domain level in replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e6366bc9f10de66de84b9506341f021fb3650d9>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Use same means of checking replication agreements on both DLs
    `commit <https://codeberg.org/freeipa/freeipa/commit/37578cfc2bbec99d75b19c94c337c406bf6a6ef7>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replicainstall: move common checks to common_check()
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc2e3386e7fa30211a46c0c2284d901cc2509147>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Take advantage of the ca/kra code cleanup in replica installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/835923750bff4f26d9b90df9870a961d16728488>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Use updated CA certs in replica installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/606cac1c9e85633f54b1cc1c9fc1351e6d1a545f>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Use os.path.join instead of concatenation
    `commit <https://codeberg.org/freeipa/freeipa/commit/928a4aa6f281df55e0f655d5cbf5a327794507b6>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Remove redundant CA cert file existance check
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b68899779e4500d231e974f11e428f8a3577538>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Use host keytab to connect to remote server on DL0
    `commit <https://codeberg.org/freeipa/freeipa/commit/e40d6a2a53a931b4d2be3e45c84da99950e60a84>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Split install_http_certs() into two functions
    `commit <https://codeberg.org/freeipa/freeipa/commit/2de43e7aca7d4d4873ad3e5053ad75311e81dc68>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  First step of merging replica installation of both DLs
    `commit <https://codeberg.org/freeipa/freeipa/commit/500327b7754e032738ab88ae19fad287f2d8cdab>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Properly bootstrap replica promotion api
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fc128b05fd13a3f400346cc6d2e7fb5f66875ac>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Move the pki-tomcat restart to cainstance creation
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba4df6449aaa0843ab43a1a2b3cb1df8bb022c24>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Move httpd restart to DNS installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/bde1d82ebe32be339c30c85048fd18e1ce99867d>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Import just IPAChangeConf instead of the whole module
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c9def4e982bcc90e9ece0900993ace53777906>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Added file permissions option to IPAChangeConf.newConf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b068d3336ad65748881d0dc74505f41dac9f0f13>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Fix to ipachangeconf docstrings
    `commit <https://codeberg.org/freeipa/freeipa/commit/990e1acb1a667b90619e7799bb96e2cd81e97e61>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  replicainstall: Unify default.conf file creation
    `commit <https://codeberg.org/freeipa/freeipa/commit/0914a3aeb778986dea4020ddf8ca550ebef02bad>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Replaced EMPTY_LINE constant with a function call
    `commit <https://codeberg.org/freeipa/freeipa/commit/bddd4fac462c07458297d1cea5272bde97fb3707>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  client: Making the configure functions more readable
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf1c4e84e74ea15fe5cf7219872cf131bd53281e>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Moved update of DNA plugin among update plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/7279ef1d0f28dae9f3203362ca9e2245e56e111f>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Move ds.replica_populate to an update plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/83e72d704630b9cc5a1f713dfee30601950eb5e9>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Remove redundant dsinstance restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/eac6f52957c361c219ad6048b515ddb62da31154>`__
-   `#6392 <https://pagure.io/freeipa/issue/6392>`__
+   `#6392 <https://codeberg.org/freeipa/freeipa/issues/6392>`__
 -  Fix missing file that fails DL1 replica installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/842bf3d09f4b2de7d4b52005ac970594345455e0>`__
-   `#6393 <https://pagure.io/freeipa/issue/6393>`__
+   `#6393 <https://codeberg.org/freeipa/freeipa/issues/6393>`__
 -  Make httpd publish its CA certificate on DL1
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d15626b4db8f5e777e037680623badc86b6c31d>`__
-   `#6393 <https://pagure.io/freeipa/issue/6393>`__
+   `#6393 <https://codeberg.org/freeipa/freeipa/issues/6393>`__
 -  Make installer quit more nicely on external CA installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/889f0863b80a0c13a14aa69cd8563b5adde984b2>`__
-   `#6230 <https://pagure.io/freeipa/issue/6230>`__
+   `#6230 <https://codeberg.org/freeipa/freeipa/issues/6230>`__
 -  Fix test_util.test_assert_deepequal test
    `commit <https://codeberg.org/freeipa/freeipa/commit/d70d71846d6eb7d8e6a730965e54e737e7b49f15>`__
-   `#6373 <https://pagure.io/freeipa/issue/6373>`__
+   `#6373 <https://codeberg.org/freeipa/freeipa/issues/6373>`__
 -  Pretty-print structures in assert_deepequal
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecd6cb4e45096f8d6653c6bb2e4701e683ce4e61>`__
-   `#6212 <https://pagure.io/freeipa/issue/6212>`__
+   `#6212 <https://codeberg.org/freeipa/freeipa/issues/6212>`__
 -  Remove update_from_dict() method
    `commit <https://codeberg.org/freeipa/freeipa/commit/330a3ca93101bcec82ec5d3add14586871864bdd>`__
-   `#6311 <https://pagure.io/freeipa/issue/6311>`__
+   `#6311 <https://codeberg.org/freeipa/freeipa/issues/6311>`__
 -  Updated help/man information about hostname
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e0afab5f2a47149580b4bc79093cdbb77f489c3>`__
-   `#5754 <https://pagure.io/freeipa/issue/5754>`__
+   `#5754 <https://codeberg.org/freeipa/freeipa/issues/5754>`__
 
 
 
@@ -3589,7 +3589,7 @@ Thierry Bordaz (1)
 -  IPA Allows Password Reuse with History value defined when admin
    resets the password.
    `commit <https://codeberg.org/freeipa/freeipa/commit/c223130d5f429278202aaf8bf87af53911a3b448>`__
-   `#6402 <https://pagure.io/freeipa/issue/6402>`__
+   `#6402 <https://codeberg.org/freeipa/freeipa/issues/6402>`__
 
 
 
@@ -3620,51 +3620,51 @@ Tomas Krizek (68)
 
 -  installer: update time estimates
    `commit <https://codeberg.org/freeipa/freeipa/commit/09c6b7578046fed0824fc0f0d9040be69c0f0eb6>`__
-   `#6596 <https://pagure.io/freeipa/issue/6596>`__
+   `#6596 <https://codeberg.org/freeipa/freeipa/issues/6596>`__
 -  server install: require IPv6 stack to be enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecb450308d0a49afffb31dda1e405ad40552e70e>`__
-   `#6608 <https://pagure.io/freeipa/issue/6608>`__
+   `#6608 <https://codeberg.org/freeipa/freeipa/issues/6608>`__
 -  Add SHA256 fingerprints for certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/a06c71b1268850e485e89049ed3654f893edff0b>`__
-   `#6701 <https://pagure.io/freeipa/issue/6701>`__
+   `#6701 <https://codeberg.org/freeipa/freeipa/issues/6701>`__
 -  man: update ipa-cacert-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/223a48b6d9916069971f79ab324ead26fa21c79d>`__
-   `#6648 <https://pagure.io/freeipa/issue/6648>`__
+   `#6648 <https://codeberg.org/freeipa/freeipa/issues/6648>`__
 -  test_config: fix fips_mode key in Env
    `commit <https://codeberg.org/freeipa/freeipa/commit/5055b34cefd6e3f9b707aed076a49ae97b38aa3c>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Env \__setitem__: replace assert with exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/770d4cda430803f8e020c57971c4dd8e802dc417>`__
 -  FIPS: perform replica installation check
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf25ea7e300cdada57bd964acb4393cc11ad333e>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  replicainstall: add context manager for rpc client
    `commit <https://codeberg.org/freeipa/freeipa/commit/397ca71e897b42a23ed4ef294fca367c1542a2aa>`__
 -  check_remote_version: update exception and docstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/62e884ff7f037a28a15d61cc9fa9c46e5c40cda5>`__
 -  test_config: fix tests for env.fips_mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/7292890042677ae40faa44753ebf570db6c19e7c>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Add fips_mode variable to env
    `commit <https://codeberg.org/freeipa/freeipa/commit/3372ad2766c0d182fa88c8bc28cf43477dc4cb3b>`__
-   `#5695 <https://pagure.io/freeipa/issue/5695>`__
+   `#5695 <https://codeberg.org/freeipa/freeipa/issues/5695>`__
 -  Bump required version of bind-dyndb-ldap to 11.0-2
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cb7bca68486a5ae4be6f93c1acacb7b9890ba9a>`__
-   `#6565 <https://pagure.io/freeipa/issue/6565>`__
+   `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__
 -  bindinstance: fix named.conf parsing regexs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f4442fff52090bad95a9b1f4f078e4d9acc8069>`__
-   `#6565 <https://pagure.io/freeipa/issue/6565>`__
+   `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__
 -  PEP8: fix line length for regexs in bindinstance
    `commit <https://codeberg.org/freeipa/freeipa/commit/52582ae9284b80c22a272f0793f0cddfb761f6dc>`__
 -  bump required version of BIND, bind-dyndb-ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/5de7065fe5769e5c3d90205b0ecc963d96f4db58>`__
-   `#6565 <https://pagure.io/freeipa/issue/6565>`__
+   `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__
 -  named.conf template: update API for bind 9.11
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8a2abd548b594e6f22f38445ee32bcaa7f27303>`__
-   `#6565 <https://pagure.io/freeipa/issue/6565>`__
+   `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__
 -  Remove obsolete serial_autoincrement from named.conf parsing
    `commit <https://codeberg.org/freeipa/freeipa/commit/c26dd805bdb020b12346d8cb66638883c1f46b9e>`__
-   `#6565 <https://pagure.io/freeipa/issue/6565>`__
+   `#6565 <https://codeberg.org/freeipa/freeipa/issues/6565>`__
 -  certdb: remove unused valid_months property
    `commit <https://codeberg.org/freeipa/freeipa/commit/36f46a5301ce62b5549899e5d693fca0b88946fb>`__
 -  certdb: remove unused keysize property
@@ -3673,148 +3673,148 @@ Tomas Krizek (68)
    `commit <https://codeberg.org/freeipa/freeipa/commit/49855ca9dea9241ccd88e3a89b499b6fed4493c9>`__
 -  ipautil: check for open ports on all resolved IPs
    `commit <https://codeberg.org/freeipa/freeipa/commit/a24cd01304aaef77b66d0e178585c9ec8bbce9b5>`__
-   `#6522 <https://pagure.io/freeipa/issue/6522>`__
+   `#6522 <https://codeberg.org/freeipa/freeipa/issues/6522>`__
 -  replica-conncheck: improve message logging
    `commit <https://codeberg.org/freeipa/freeipa/commit/de981d348efed6dc58b2e355e65244853f06ebc1>`__
-   `#6497 <https://pagure.io/freeipa/issue/6497>`__
+   `#6497 <https://codeberg.org/freeipa/freeipa/issues/6497>`__
 -  replica-conncheck: improve error message during replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb6905bbb45d246f9beddeea69da2236cf67bc68>`__
-   `#6497 <https://pagure.io/freeipa/issue/6497>`__
+   `#6497 <https://codeberg.org/freeipa/freeipa/issues/6497>`__
 -  ipa-replica-conncheck: fix race condition
    `commit <https://codeberg.org/freeipa/freeipa/commit/a44974cdf8a6c53f2e86dac92aa579ba45f666e4>`__
-   `#6487 <https://pagure.io/freeipa/issue/6487>`__
+   `#6487 <https://codeberg.org/freeipa/freeipa/issues/6487>`__
 -  ipa-replica-conncheck: do not close listening ports until required
    `commit <https://codeberg.org/freeipa/freeipa/commit/af0ba661889c2e2c9a35d4cff9681c2abab73649>`__
-   `#6487 <https://pagure.io/freeipa/issue/6487>`__
+   `#6487 <https://codeberg.org/freeipa/freeipa/issues/6487>`__
 -  upgrade: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/0914fc6a6043846159f6d1c4bb433dcfe9ee3f46>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  services: replace admin_conn with api.Backend.ldap2
    `commit <https://codeberg.org/freeipa/freeipa/commit/68295bf8cfd57333deb50f58df1b336a4b48ffe7>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  upgrade: do not explicitly set principal for services
    `commit <https://codeberg.org/freeipa/freeipa/commit/2793cdc8593c40d8318ec3685408ade6bf9a5320>`__
-   `#6500 <https://pagure.io/freeipa/issue/6500>`__
+   `#6500 <https://codeberg.org/freeipa/freeipa/issues/6500>`__
 -  Build: ignore rpmbuild for lint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/28c5e128c823f32787a4bde87e6b248928a2cd0a>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  cainstance: use correct certificate for replica install check
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6300dca285acaad296f6271421c23999e3c1071>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  dns: check if container exists using ldapi
    `commit <https://codeberg.org/freeipa/freeipa/commit/f183f70e0183e51d569ada972bd3ec73cad76a30>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: remove do_bind from LDAPClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/a68c95d11612108375877ff45bdb53ce6fc8fbe4>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  gitignore: ignore tar ball
    `commit <https://codeberg.org/freeipa/freeipa/commit/9bb6d8643f4eb7214897de28821839a14a3bcb37>`__
-   `#6418 <https://pagure.io/freeipa/issue/6418>`__
+   `#6418 <https://codeberg.org/freeipa/freeipa/issues/6418>`__
 -  libexec scripts: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/33f7b8dc32bc95e0db067ac4df49807ee2b5120e>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ldap2: modify arguments for create_connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/41098e3f7bb517f7445ed34d555bc3fb2083c6ce>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  replicainstall: use ldap_uri in ReplicationManager
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9585ec563d1e54c3cd7de14789457f72cd00843>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  replicainstall: correct hostname in ReplicationManager
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d028992ea2c2bf6acabe79f101621bdebbf9dbc>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install tools: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/922062eb559d1bb82a9d787763aacb31c0cf9b8d>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ldap2: change default bind_dn
    `commit <https://codeberg.org/freeipa/freeipa/commit/36d95472d983ff342a43a5df36d932b9de8c32ac>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipa-adtrust-install: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/1240262a0b01ff8408c06058d6d4d61fc5cde548>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install: remove adhoc dis/connect from services
    `commit <https://codeberg.org/freeipa/freeipa/commit/03d113cdd7c5f943d8937eb4fec1086bfe47e909>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ldapupdate: use ldapi in LDAPUpdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/c51b04fae77149a09e921495c5b3c9802d199076>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  replicainstall: properly close adhoc connection in promote
    `commit <https://codeberg.org/freeipa/freeipa/commit/49ff159a5f0cfd2f9d037ad00e75d8ac5bfba585>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/df86efdc69271cca0774868ab85b5be7df529136>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install: remove adhoc api.Backend.ldap2 (dis)connect
    `commit <https://codeberg.org/freeipa/freeipa/commit/a77469f5984b12e201a3d349efad1ca2925ee5af>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install: add restart_dirsrv for directory server restarts
    `commit <https://codeberg.org/freeipa/freeipa/commit/e05bdeb6cf4505ef84e485b95b37aabba625160b>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  upgradeinstance: ldap conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8aa2627c7a3dcb0b0745e656ea58ccbbccd38fb>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  dsinstance: conn management
    `commit <https://codeberg.org/freeipa/freeipa/commit/8934d03b3b5bbf02e9e20a1644ef31d27fa0f483>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ldap2: change default time/size limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2780b2106a6e6bab0cb3f3d3ec06482cde9d374>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  cainstall: add dm_password to CA installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a1c0db989cf59a778676635e160f73ebc610694>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  replicainstall: set ldapi uri in replica promotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fca820b6bc2144cd827bddba69cb53f8ba3f42a>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  dsinstance: enable ldapi and autobind in ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/24baccbd6ac8a19ba52619a3cc59366220c4ca1f>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  install: remove dirman_pw from services
    `commit <https://codeberg.org/freeipa/freeipa/commit/9340a1417acf120fed3e9ffbe9d658d3456743a1>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: merge IPAdmin to LDAPClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b81dbfda1e4f0799d4ce87e9987a896af3ff299>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: merge gssapi_bind to LDAPClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f1a6a177666c475156f496d3f7719b37e66a7b0>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: merge external_bind into LDAPClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/60e38ecc7ff6b983f4f3af0a66c08eb3a3fda22d>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: merge simple_bind into LDAPClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/de58a5c60596de8b45c8016c3318bac78305477a>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipaldap: remove wait/timeout during binds
    `commit <https://codeberg.org/freeipa/freeipa/commit/5760b7e983da6bda8f5383d9079551e4acb4c2da>`__
-   `#6461 <https://pagure.io/freeipa/issue/6461>`__
+   `#6461 <https://codeberg.org/freeipa/freeipa/issues/6461>`__
 -  ipa: check if provided config file exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/0dea726466b5971cf74b9e8b7e33af0618e5842c>`__
-   `#6114 <https://pagure.io/freeipa/issue/6114>`__
+   `#6114 <https://codeberg.org/freeipa/freeipa/issues/6114>`__
 -  ipa: allow relative paths for config file
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7a2dfddbc2dc9ae4cea7d65e56d61a6a4d2b928>`__
-   `#6114 <https://pagure.io/freeipa/issue/6114>`__
+   `#6114 <https://codeberg.org/freeipa/freeipa/issues/6114>`__
 -  Prompt for forwarder in dnsforwardzone-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef9c718e3a82fcbd5944cc993e2c9f3f1237f85c>`__
-   `#6169 <https://pagure.io/freeipa/issue/6169>`__
+   `#6169 <https://codeberg.org/freeipa/freeipa/issues/6169>`__
 -  Update man/help for --server option
    `commit <https://codeberg.org/freeipa/freeipa/commit/07ff1f619c001181563886b5a0b5f1886b6638a1>`__
-   `#6202 <https://pagure.io/freeipa/issue/6202>`__
+   `#6202 <https://codeberg.org/freeipa/freeipa/issues/6202>`__
 -  Update ipa-server-install man page for hostname
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e880f7ce96bc160af2383880b9c11e66c660a5a>`__
-   `#6330 <https://pagure.io/freeipa/issue/6330>`__
+   `#6330 <https://codeberg.org/freeipa/freeipa/issues/6330>`__
 -  Add help info about certificate revocation reasons
    `commit <https://codeberg.org/freeipa/freeipa/commit/75f77e0f2a55de4802b2ab74a0e6f50eaf728dc8>`__
-   `#6327 <https://pagure.io/freeipa/issue/6327>`__
+   `#6327 <https://codeberg.org/freeipa/freeipa/issues/6327>`__
 -  Add log messages for IP checks during client install
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6f6a291da5926217ac3acbbb959fd23227c7bd2>`__
-   `#6331 <https://pagure.io/freeipa/issue/6331>`__
+   `#6331 <https://codeberg.org/freeipa/freeipa/issues/6331>`__
 -  Show error message for invalid IPs in client install
    `commit <https://codeberg.org/freeipa/freeipa/commit/ddf48f2fef344784b9e1918d2f2ee6feef9d4c04>`__
-   `#6340 <https://pagure.io/freeipa/issue/6340>`__
+   `#6340 <https://codeberg.org/freeipa/freeipa/issues/6340>`__
 -  Keep NSS trust flags of existing certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bc70a5d5f5eb953969e7341179c5083c147221a>`__
-   `#5791 <https://pagure.io/freeipa/issue/5791>`__
+   `#5791 <https://codeberg.org/freeipa/freeipa/issues/5791>`__
 -  Don't show error messages in bash completion
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d49b4c7e740fb909d8955d23aeb50b5d73d0b23>`__
-   `#6273 <https://pagure.io/freeipa/issue/6273>`__
+   `#6273 <https://codeberg.org/freeipa/freeipa/issues/6273>`__
 
 
 
@@ -3823,7 +3823,7 @@ Thorsten Scherf (2)
 
 -  added ssl verification using IPA trust anchor
    `commit <https://codeberg.org/freeipa/freeipa/commit/16dac0252e52c8de07fd8a6a86ec0896074cbe9d>`__
-   `#6686 <https://pagure.io/freeipa/issue/6686>`__
+   `#6686 <https://codeberg.org/freeipa/freeipa/issues/6686>`__
 -  added help about default value for --external-ca-type option
    `commit <https://codeberg.org/freeipa/freeipa/commit/573a0f1ffe5035b75fb88ee7752029e34c6b37af>`__
 

--- a/src/page/Releases/4.5.1.rst
+++ b/src/page/Releases/4.5.1.rst
@@ -13,12 +13,12 @@ Enhancements
 ----------------------------------------------------------------------------------------------
 
 -  HBAC rule names can be renamed
-   (`#6784 <https://pagure.io/freeipa/issue/6784>`__)
+   (`#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__)
 
 HBAC rules can now be renamed.
 
 -  SUDO rules can be renamed
-   (`#2466 <https://pagure.io/freeipa/issue/2466>`__)
+   (`#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__)
 
 The attribute "rdn_is_primary_key" of the LDAPObject class was renamed
 to "allow_rename" because the name of the former did not reflect the
@@ -58,211 +58,211 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#6950 <https://pagure.io/freeipa/issue/6950>`__ ipa-server-install
+-  `#6950 <https://codeberg.org/freeipa/freeipa/issues/6950>`__ ipa-server-install
    --uninstall fails with ERROR 'tuple' object has no attribute 'append'
--  `#6934 <https://pagure.io/freeipa/issue/6934>`__ ipa-kra-install
+-  `#6934 <https://codeberg.org/freeipa/freeipa/issues/6934>`__ ipa-kra-install
    timeouts on replica
--  `#6925 <https://pagure.io/freeipa/issue/6925>`__ KRA installation
+-  `#6925 <https://codeberg.org/freeipa/freeipa/issues/6925>`__ KRA installation
    fails on server that was originally installed as CA-less
--  `#6924 <https://pagure.io/freeipa/issue/6924>`__ Fix SELinux contex
+-  `#6924 <https://codeberg.org/freeipa/freeipa/issues/6924>`__ Fix SELinux contex
    of http.keytab during upgrade
--  `#6923 <https://pagure.io/freeipa/issue/6923>`__ Update warning
+-  `#6923 <https://codeberg.org/freeipa/freeipa/issues/6923>`__ Update warning
    message when KRA installation fails
--  `#6922 <https://pagure.io/freeipa/issue/6922>`__ Update man page of
+-  `#6922 <https://codeberg.org/freeipa/freeipa/issues/6922>`__ Update man page of
    ipa-kra-install
--  `#6921 <https://pagure.io/freeipa/issue/6921>`__ ipa-server-install
+-  `#6921 <https://codeberg.org/freeipa/freeipa/issues/6921>`__ ipa-server-install
    with external CA fails in issue_selfsigned_pkinit_certs
--  `#6920 <https://pagure.io/freeipa/issue/6920>`__ Upgrade from ipa-4.1
+-  `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__ Upgrade from ipa-4.1
    fails when enabling KDC proxy
--  `#6916 <https://pagure.io/freeipa/issue/6916>`__ ipa-client-install:
+-  `#6916 <https://codeberg.org/freeipa/freeipa/issues/6916>`__ ipa-client-install:
    extra space in pkinit_anchors definition
--  `#6911 <https://pagure.io/freeipa/issue/6911>`__ error adding
+-  `#6911 <https://codeberg.org/freeipa/freeipa/issues/6911>`__ error adding
    authenticator indicators to host
--  `#6907 <https://pagure.io/freeipa/issue/6907>`__ ipa vault-add raises
+-  `#6907 <https://codeberg.org/freeipa/freeipa/issues/6907>`__ ipa vault-add raises
    TypeError
--  `#6904 <https://pagure.io/freeipa/issue/6904>`__
+-  `#6904 <https://codeberg.org/freeipa/freeipa/issues/6904>`__
    pki_client_database_password is shown in ipaserver-install.log
--  `#6902 <https://pagure.io/freeipa/issue/6902>`__ ipa restore fails to
+-  `#6902 <https://codeberg.org/freeipa/freeipa/issues/6902>`__ ipa restore fails to
    restore IPA user
--  `#6900 <https://pagure.io/freeipa/issue/6900>`__ otptoken-add-yubikey
+-  `#6900 <https://codeberg.org/freeipa/freeipa/issues/6900>`__ otptoken-add-yubikey
    KeyError: 'ipatokenotpdigits'
--  `#6899 <https://pagure.io/freeipa/issue/6899>`__ ipa vault: archival
+-  `#6899 <https://codeberg.org/freeipa/freeipa/issues/6899>`__ ipa vault: archival
    and retrival is broken in IPA 4.5.0
--  `#6897 <https://pagure.io/freeipa/issue/6897>`__ ipa-server-install
+-  `#6897 <https://codeberg.org/freeipa/freeipa/issues/6897>`__ ipa-server-install
    with external-ca fails in FIPS mode
--  `#6896 <https://pagure.io/freeipa/issue/6896>`__ Update
+-  `#6896 <https://codeberg.org/freeipa/freeipa/issues/6896>`__ Update
    get_attr_filter in LDAPSearch to handle nsaccountlock user searches
--  `#6895 <https://pagure.io/freeipa/issue/6895>`__ ipa-kra-install
+-  `#6895 <https://codeberg.org/freeipa/freeipa/issues/6895>`__ ipa-kra-install
    fails when primary KRA server has been decommissioned
--  `#6894 <https://pagure.io/freeipa/issue/6894>`__ DNS forwarder
+-  `#6894 <https://codeberg.org/freeipa/freeipa/issues/6894>`__ DNS forwarder
    address added during IPA installation shouldn't add IP-Address
    '0.0.0.0'
--  `#6892 <https://pagure.io/freeipa/issue/6892>`__ ipa-[ca|kra]-install
+-  `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__ ipa-[ca|kra]-install
    with invalid DM password break replica
--  `#6883 <https://pagure.io/freeipa/issue/6883>`__ ipa cert-show raises
+-  `#6883 <https://codeberg.org/freeipa/freeipa/issues/6883>`__ ipa cert-show raises
    stack traces when --certificate-out=/tmp
--  `#6881 <https://pagure.io/freeipa/issue/6881>`__
+-  `#6881 <https://codeberg.org/freeipa/freeipa/issues/6881>`__
    ipa.ipaserver.install.plugins.adtrust.update_tdo_gidnumber: ERROR
    Default SMB Group not found
--  `#6878 <https://pagure.io/freeipa/issue/6878>`__ Replica install
+-  `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__ Replica install
    fails during migration from older IPA master
--  `#6876 <https://pagure.io/freeipa/issue/6876>`__ GET in
+-  `#6876 <https://codeberg.org/freeipa/freeipa/issues/6876>`__ GET in
    KerberosSession.finalize_kerberos_acquisition() must use FreeIPA CA
--  `#6875 <https://pagure.io/freeipa/issue/6875>`__ Correct wheel
+-  `#6875 <https://codeberg.org/freeipa/freeipa/issues/6875>`__ Correct wheel
    package dependencies
--  `#6872 <https://pagure.io/freeipa/issue/6872>`__ ipa server install
+-  `#6872 <https://codeberg.org/freeipa/freeipa/issues/6872>`__ ipa server install
    fails with --external-ca option
--  `#6869 <https://pagure.io/freeipa/issue/6869>`__ CA-less pkinit not
+-  `#6869 <https://codeberg.org/freeipa/freeipa/issues/6869>`__ CA-less pkinit not
    installable with --pkinit-cert-file option
--  `#6866 <https://pagure.io/freeipa/issue/6866>`__ ipa
+-  `#6866 <https://codeberg.org/freeipa/freeipa/issues/6866>`__ ipa
    trust-fetch-domains: ValidationError: invalid 'Credentials': Missing
    credentials for cross-forest communication
--  `#6864 <https://pagure.io/freeipa/issue/6864>`__ minor spelling
+-  `#6864 <https://codeberg.org/freeipa/freeipa/issues/6864>`__ minor spelling
    mistake #2
--  `#6862 <https://pagure.io/freeipa/issue/6862>`__ WebUI cert auth
+-  `#6862 <https://codeberg.org/freeipa/freeipa/issues/6862>`__ WebUI cert auth
    fails after ipa-adtrust-install
--  `#6861 <https://pagure.io/freeipa/issue/6861>`__ uninstall ipa client
+-  `#6861 <https://codeberg.org/freeipa/freeipa/issues/6861>`__ uninstall ipa client
    automount failed with RuntimeWarning
--  `#6860 <https://pagure.io/freeipa/issue/6860>`__ Add the name of URL
+-  `#6860 <https://codeberg.org/freeipa/freeipa/issues/6860>`__ Add the name of URL
    parameter which will be check for username during cert login
--  `#6859 <https://pagure.io/freeipa/issue/6859>`__ Console output
+-  `#6859 <https://codeberg.org/freeipa/freeipa/issues/6859>`__ Console output
    message while adding trust should be mapped with texts changed in
    Samba.
--  `#6854 <https://pagure.io/freeipa/issue/6854>`__ CA less setup is
+-  `#6854 <https://codeberg.org/freeipa/freeipa/issues/6854>`__ CA less setup is
    broken
--  `#6853 <https://pagure.io/freeipa/issue/6853>`__ Conversion of
+-  `#6853 <https://codeberg.org/freeipa/freeipa/issues/6853>`__ Conversion of
    CA-less server to CA fails on CA instance spawn
--  `#6850 <https://pagure.io/freeipa/issue/6850>`__ Use /usr/bin/env
+-  `#6850 <https://codeberg.org/freeipa/freeipa/issues/6850>`__ Use /usr/bin/env
    python for ipaclient via pypi / macOS fixes for ipaclient
--  `#6846 <https://pagure.io/freeipa/issue/6846>`__ Do not link libkrad,
+-  `#6846 <https://codeberg.org/freeipa/freeipa/issues/6846>`__ Do not link libkrad,
    liblber, libldap_r and libsss_nss_idmap to every binary in IPA
--  `#6839 <https://pagure.io/freeipa/issue/6839>`__
+-  `#6839 <https://codeberg.org/freeipa/freeipa/issues/6839>`__
    [ipa-replica-install] - IncorrectPasswordException: Incorrect client
    security database password
--  `#6838 <https://pagure.io/freeipa/issue/6838>`__
+-  `#6838 <https://codeberg.org/freeipa/freeipa/issues/6838>`__
    [ipa-replica-install] - 406 Client Error: Failed to validate message:
    Incorrect number of results (0) searching forpublic key for host
--  `#6833 <https://pagure.io/freeipa/issue/6833>`__ Avoid arch-specific
+-  `#6833 <https://codeberg.org/freeipa/freeipa/issues/6833>`__ Avoid arch-specific
    path in /etc/krb5.conf.d/ipa-certmap
--  `#6831 <https://pagure.io/freeipa/issue/6831>`__ Extend
+-  `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__ Extend
    ipa-server-certinstall and ipa-certupdate to handle PKINIT
    certificates/anchors
--  `#6830 <https://pagure.io/freeipa/issue/6830>`__ Configure local
+-  `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__ Configure local
    PKINIT on DL0 or when '--no-pkinit' option is used
--  `#6828 <https://pagure.io/freeipa/issue/6828>`__ error: implicit
+-  `#6828 <https://codeberg.org/freeipa/freeipa/issues/6828>`__ error: implicit
    declaration of function ‘sss_nss_getlistbycert’
--  `#6827 <https://pagure.io/freeipa/issue/6827>`__ ipasam: gidNumber
+-  `#6827 <https://codeberg.org/freeipa/freeipa/issues/6827>`__ ipasam: gidNumber
    attribute is not created in the trusted domain entry
--  `#6826 <https://pagure.io/freeipa/issue/6826>`__ IdM Server Smart
+-  `#6826 <https://codeberg.org/freeipa/freeipa/issues/6826>`__ IdM Server Smart
    Cards: extdom: improve cert request
--  `#6825 <https://pagure.io/freeipa/issue/6825>`__ Allow erasing
+-  `#6825 <https://codeberg.org/freeipa/freeipa/issues/6825>`__ Allow erasing
    ipaDomainResolutionOrder attribute
--  `#6824 <https://pagure.io/freeipa/issue/6824>`__ Add workaround for
+-  `#6824 <https://codeberg.org/freeipa/freeipa/issues/6824>`__ Add workaround for
    pki_pin for FIPS
--  `#6823 <https://pagure.io/freeipa/issue/6823>`__ Bump packages
+-  `#6823 <https://codeberg.org/freeipa/freeipa/issues/6823>`__ Bump packages
    versions for certificate login
--  `#6821 <https://pagure.io/freeipa/issue/6821>`__ Deadlock between
+-  `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__ Deadlock between
    topology and schema-compat plugins
--  `#6819 <https://pagure.io/freeipa/issue/6819>`__ Login into WebUI
+-  `#6819 <https://codeberg.org/freeipa/freeipa/issues/6819>`__ Login into WebUI
    using certificate does not work - mod_wsgi returns error
--  `#6817 <https://pagure.io/freeipa/issue/6817>`__ 4.5 replica install
+-  `#6817 <https://codeberg.org/freeipa/freeipa/issues/6817>`__ 4.5 replica install
    fails against <4.5 master due to rejected PKINIT cert request
--  `#6816 <https://pagure.io/freeipa/issue/6816>`__
+-  `#6816 <https://codeberg.org/freeipa/freeipa/issues/6816>`__
    BUILD_IPA_CERTAUTH_PLUGIN broke configure --disable-server
--  `#6813 <https://pagure.io/freeipa/issue/6813>`__ Renewal of IPA RA
+-  `#6813 <https://codeberg.org/freeipa/freeipa/issues/6813>`__ Renewal of IPA RA
    fails on replica
--  `#6812 <https://pagure.io/freeipa/issue/6812>`__ WebUI: in
+-  `#6812 <https://codeberg.org/freeipa/freeipa/issues/6812>`__ WebUI: in
    self-service Vault menu item is shown even if KRA is not installed
--  `#6808 <https://pagure.io/freeipa/issue/6808>`__ ipa cert-find runs a
+-  `#6808 <https://codeberg.org/freeipa/freeipa/issues/6808>`__ ipa cert-find runs a
    large number of searches, so IPA WebUI is slow to display user
    details page
--  `#6807 <https://pagure.io/freeipa/issue/6807>`__ Server CA-less
+-  `#6807 <https://codeberg.org/freeipa/freeipa/issues/6807>`__ Server CA-less
    impossible option check
--  `#6806 <https://pagure.io/freeipa/issue/6806>`__ CA-less installation
+-  `#6806 <https://codeberg.org/freeipa/freeipa/issues/6806>`__ CA-less installation
    fails on publishing CA certificate
--  `#6803 <https://pagure.io/freeipa/issue/6803>`__ Master tree fails to
+-  `#6803 <https://codeberg.org/freeipa/freeipa/issues/6803>`__ Master tree fails to
    install
--  `#6801 <https://pagure.io/freeipa/issue/6801>`__ Remove
+-  `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__ Remove
    pkinit-related options from server/replica-install on DL0
--  `#6799 <https://pagure.io/freeipa/issue/6799>`__ ipa-replica-install
+-  `#6799 <https://codeberg.org/freeipa/freeipa/issues/6799>`__ ipa-replica-install
    with DL0 fails to get annonymous keytab
--  `#6798 <https://pagure.io/freeipa/issue/6798>`__ Changes to
+-  `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__ Changes to
    ipa-run-tests broke helper test tools
--  `#6797 <https://pagure.io/freeipa/issue/6797>`__ As a ID user I
+-  `#6797 <https://codeberg.org/freeipa/freeipa/issues/6797>`__ As a ID user I
    cannot call a command with --rights option
--  `#6795 <https://pagure.io/freeipa/issue/6795>`__ man
+-  `#6795 <https://codeberg.org/freeipa/freeipa/issues/6795>`__ man
    ipa-cacert-manage install needs clarification
--  `#6792 <https://pagure.io/freeipa/issue/6792>`__ Upgrade to FreeIPA
+-  `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__ Upgrade to FreeIPA
    4.5.0 does not configure anonymous principal for PKINIT
--  `#6787 <https://pagure.io/freeipa/issue/6787>`__ Make KRA cert cache
+-  `#6787 <https://codeberg.org/freeipa/freeipa/issues/6787>`__ Make KRA cert cache
    concurrency safe
--  `#6786 <https://pagure.io/freeipa/issue/6786>`__ make sure that
+-  `#6786 <https://codeberg.org/freeipa/freeipa/issues/6786>`__ make sure that
    runtime hostname result is consistent with the configuration in AD
    trust
--  `#6784 <https://pagure.io/freeipa/issue/6784>`__ [RFE] HBAC rule
+-  `#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__ [RFE] HBAC rule
    names command rename
--  `#6777 <https://pagure.io/freeipa/issue/6777>`__ ipa-replica-install
+-  `#6777 <https://codeberg.org/freeipa/freeipa/issues/6777>`__ ipa-replica-install
    can't install replica file produced by ipa-replica-prepare on 4.5
--  `#6775 <https://pagure.io/freeipa/issue/6775>`__ [ipalib/rpc.py] -
+-  `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__ [ipalib/rpc.py] -
    "maximum recursion depth exceeded" with ipa vault commands
--  `#6773 <https://pagure.io/freeipa/issue/6773>`__ systemctl
+-  `#6773 <https://codeberg.org/freeipa/freeipa/issues/6773>`__ systemctl
    daemon-reload needs to be called after httpd.service.d/ipa.conf is
    manipulated
--  `#6772 <https://pagure.io/freeipa/issue/6772>`__ WebUI: Adding
+-  `#6772 <https://codeberg.org/freeipa/freeipa/issues/6772>`__ WebUI: Adding
    certificate mapping data using certificate fails
--  `#6771 <https://pagure.io/freeipa/issue/6771>`__ Set GssProxy options
+-  `#6771 <https://codeberg.org/freeipa/freeipa/issues/6771>`__ Set GssProxy options
    to enable caching of ldap tickets
--  `#6768 <https://pagure.io/freeipa/issue/6768>`__ debian:
+-  `#6768 <https://codeberg.org/freeipa/freeipa/issues/6768>`__ debian:
    daemons/dnssec/\*.service.in hardcode user/groupnames
--  `#6757 <https://pagure.io/freeipa/issue/6757>`__ Tracebacks seen from
+-  `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__ Tracebacks seen from
    dogtag-ipa-ca-renew-agent-submit helper when installing replica
--  `#6748 <https://pagure.io/freeipa/issue/6748>`__ CLI doesn't work
+-  `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__ CLI doesn't work
    after ipa-restore
--  `#6743 <https://pagure.io/freeipa/issue/6743>`__ [copr] Replica
+-  `#6743 <https://codeberg.org/freeipa/freeipa/issues/6743>`__ [copr] Replica
    install failing
--  `#6716 <https://pagure.io/freeipa/issue/6716>`__ cert-find does not
+-  `#6716 <https://codeberg.org/freeipa/freeipa/issues/6716>`__ cert-find does not
    find all certificates without sizelimit=0
--  `#6715 <https://pagure.io/freeipa/issue/6715>`__ Uninstall fails with
+-  `#6715 <https://codeberg.org/freeipa/freeipa/issues/6715>`__ Uninstall fails with
    No such file or directory: '/var/run/ipa/services.list'
--  `#6697 <https://pagure.io/freeipa/issue/6697>`__ [Tracker] FIPS mode
+-  `#6697 <https://codeberg.org/freeipa/freeipa/issues/6697>`__ [Tracker] FIPS mode
    for trust to AD feature
--  `#6688 <https://pagure.io/freeipa/issue/6688>`__ [tracker]
+-  `#6688 <https://codeberg.org/freeipa/freeipa/issues/6688>`__ [tracker]
    ipa-replica-install fails with 406 Client Error: Key name
    ca/caSigningCert%20cert-pki-ca does not match subject
    ca/caSigningCert cert-pki-ca
--  `#6671 <https://pagure.io/freeipa/issue/6671>`__ Privilege separation
+-  `#6671 <https://codeberg.org/freeipa/freeipa/issues/6671>`__ Privilege separation
    in IPA framework broke trust-add
--  `#6641 <https://pagure.io/freeipa/issue/6641>`__ RPC client should
+-  `#6641 <https://codeberg.org/freeipa/freeipa/issues/6641>`__ RPC client should
    use HTTP persistent connection
--  `#6618 <https://pagure.io/freeipa/issue/6618>`__ "Truncated search
+-  `#6618 <https://codeberg.org/freeipa/freeipa/issues/6618>`__ "Truncated search
    results" pop-up appears in user details in WebUI
--  `#6549 <https://pagure.io/freeipa/issue/6549>`__ replica install
+-  `#6549 <https://codeberg.org/freeipa/freeipa/issues/6549>`__ replica install
    against IPA v3 master fails with ACIError
--  `#6494 <https://pagure.io/freeipa/issue/6494>`__ Enumerate all
+-  `#6494 <https://codeberg.org/freeipa/freeipa/issues/6494>`__ Enumerate all
    available request type options in ipa cert-request help
--  `#6404 <https://pagure.io/freeipa/issue/6404>`__ Need to have
+-  `#6404 <https://codeberg.org/freeipa/freeipa/issues/6404>`__ Need to have
    validation for idrange names
--  `#6370 <https://pagure.io/freeipa/issue/6370>`__ [RFE] Web UI must
+-  `#6370 <https://codeberg.org/freeipa/freeipa/issues/6370>`__ [RFE] Web UI must
    check OCSP and CRL during smartcard login
--  `#6319 <https://pagure.io/freeipa/issue/6319>`__ ipa cert-request
+-  `#6319 <https://codeberg.org/freeipa/freeipa/issues/6319>`__ ipa cert-request
    limits key size to 1024,2048,3072,4096 bits
--  `#6183 <https://pagure.io/freeipa/issue/6183>`__ ipa-replica-install
+-  `#6183 <https://codeberg.org/freeipa/freeipa/issues/6183>`__ ipa-replica-install
    may suggest --force-join option which does not exist
--  `#5959 <https://pagure.io/freeipa/issue/5959>`__ The framework needs
+-  `#5959 <https://codeberg.org/freeipa/freeipa/issues/5959>`__ The framework needs
    to run in a spearate process
--  `#5952 <https://pagure.io/freeipa/issue/5952>`__ Add git commit
+-  `#5952 <https://codeberg.org/freeipa/freeipa/issues/5952>`__ Add git commit
    template
--  `#5799 <https://pagure.io/freeipa/issue/5799>`__ Errors from AD when
+-  `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__ Errors from AD when
    trying to sign ipa.csr, conflicting template on
--  `#5734 <https://pagure.io/freeipa/issue/5734>`__ cert-request: PKCS
+-  `#5734 <https://codeberg.org/freeipa/freeipa/issues/5734>`__ cert-request: PKCS
    #10 only is supported but \`--request-type' option suggests otherwise
--  `#5313 <https://pagure.io/freeipa/issue/5313>`__ [RFE] disable last
+-  `#5313 <https://codeberg.org/freeipa/freeipa/issues/5313>`__ [RFE] disable last
    successful authentication by default in ipa.
--  `#4639 <https://pagure.io/freeipa/issue/4639>`__ ipa-server-install
+-  `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__ ipa-server-install
    does not clean /etc/httpd/alias
--  `#3242 <https://pagure.io/freeipa/issue/3242>`__ [RFE] IPA WebUI
+-  `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__ [RFE] IPA WebUI
    login for AD Trusted User fails
--  `#2466 <https://pagure.io/freeipa/issue/2466>`__ [RFE] Support SUDO
+-  `#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__ [RFE] Support SUDO
    command rename
 
 
@@ -279,18 +279,18 @@ Alexander Bokovoy (5)
    `commit <https://codeberg.org/freeipa/freeipa/commit/45e1998c51e281c8371ae31762016cb1ddec406f>`__
 -  ipaserver/dcerpc: unify error processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbb23fc87a51218960d54f9eccc23405c5c5ded6>`__
-   `#6859 <https://pagure.io/freeipa/issue/6859>`__
+   `#6859 <https://codeberg.org/freeipa/freeipa/issues/6859>`__
 -  adtrust: make sure that runtime hostname result is consistent with
    the configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/e430699024df06e1e6f819824548986eb0fa5fd2>`__
-   `#6786 <https://pagure.io/freeipa/issue/6786>`__
+   `#6786 <https://codeberg.org/freeipa/freeipa/issues/6786>`__
 -  server: make sure we test for sss_nss_getlistbycert
    `commit <https://codeberg.org/freeipa/freeipa/commit/8be6987da72dff0ebd4e02c946b45b5b1705d880>`__
-   `#6828 <https://pagure.io/freeipa/issue/6828>`__
+   `#6828 <https://codeberg.org/freeipa/freeipa/issues/6828>`__
 -  ldap2: use LDAP whoami operation to retrieve bind DN for current
    connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d48fb841a23e9f036f3d449d80623d1225c820a>`__
-   `#6797 <https://pagure.io/freeipa/issue/6797>`__
+   `#6797 <https://codeberg.org/freeipa/freeipa/issues/6797>`__
 
 
 
@@ -299,11 +299,11 @@ Abhijeet Kasurde (2)
 
 -  Hide PKI Client database password in log file
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d911fc2186da1c6566648f94a6819c4e7a2a72b>`__
-   `#6904 <https://pagure.io/freeipa/issue/6904>`__
+   `#6904 <https://codeberg.org/freeipa/freeipa/issues/6904>`__
 -  Hide request_type doc string in cert-request help
    `commit <https://codeberg.org/freeipa/freeipa/commit/535e8610c556ab1a0eb83e9798e7e182355d8396>`__
-   `#5734 <https://pagure.io/freeipa/issue/5734>`__,
-   `#6494 <https://pagure.io/freeipa/issue/6494>`__
+   `#5734 <https://codeberg.org/freeipa/freeipa/issues/5734>`__,
+   `#6494 <https://codeberg.org/freeipa/freeipa/issues/6494>`__
 
 
 
@@ -312,64 +312,64 @@ Christian Heimes (21)
 
 -  Correct PyPI package dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/b91ee1294bb3139f3d9df62c75dd429a5821bf40>`__
-   `#6875 <https://pagure.io/freeipa/issue/6875>`__
+   `#6875 <https://codeberg.org/freeipa/freeipa/issues/6875>`__
 -  Vault: Explicitly default to 3DES CBC
    `commit <https://codeberg.org/freeipa/freeipa/commit/e94a1d18653fe2e9558ac0b70bdf2ddd1f78d150>`__
-   `#6899 <https://pagure.io/freeipa/issue/6899>`__
+   `#6899 <https://codeberg.org/freeipa/freeipa/issues/6899>`__
 -  Use entry_points for ipa CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e1e4e8ef2d2486068e17228c8a0f8b1a2b099f5>`__
-   `#6653 <https://pagure.io/freeipa/issue/6653>`__,
-   `#6850 <https://pagure.io/freeipa/issue/6850>`__
+   `#6653 <https://codeberg.org/freeipa/freeipa/issues/6653>`__,
+   `#6850 <https://codeberg.org/freeipa/freeipa/issues/6850>`__
 -  Skip test_session_storage in ipaclient unittest mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/c80adf6e0d16f807f90479660af22540cd92d774>`__
 -  Add make devcheck for developers
    `commit <https://codeberg.org/freeipa/freeipa/commit/89ab24f1fbb58feb603d60503c685ebad41a4237>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 -  Python 3: Fix session storage
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1d731a79c384c7406c52232ff291644137e100b>`__
 -  Use Custodia 0.3.1 features
    `commit <https://codeberg.org/freeipa/freeipa/commit/403263df7a3be61086c87c5577698cf32a912065>`__
 -  Simplify KRA transport cert cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/2723b5fa5edc75901c8fbaf110a37c87df0aec87>`__
-   `#6787 <https://pagure.io/freeipa/issue/6787>`__
+   `#6787 <https://codeberg.org/freeipa/freeipa/issues/6787>`__
 -  Constrain wheel package versions
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c93a518c8b6fb0e3a85bc1ae0ee807c71168213>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Move remaining util functions to tasks module
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd791843da478625f51e98c502b65e186373a9fa>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Ship ipatests.pytest_plugins.integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/87b60f3cfb5e43fa0c37a09051872b496ad72829>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move function run_repeatedly to tasks module
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c62c4138c443f78757bd519fad143729af27e53>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move hosts module to ipatests.pytest_plugins.integration.hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/6789dac7a09706036dd13555b4ff2ce244551bc6>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move tasks module to ipatests.pytest_plugins.integration.tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/321437cc72b38bc055c74f0a4bdf54520afb57aa>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move env_config module to
    ipatests.pytest_plugins.integration.env_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/e257bbd805b319ed85e5bf8ce6eeac80e7c4139c>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move config module to ipatests.pytest_plugins.integration.config
    `commit <https://codeberg.org/freeipa/freeipa/commit/025a19c3bf2b446de5c9430142e75eac5887fb04>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move helper code for integration plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/1199416d4e2dd1a653a7c1255e446970412fe1d6>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Increase Apache HTTPD's default keep alive timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b426fbfa2dc83f1f43abbc2b9396bd9f1b07f74>`__
 -  Add debug logging for keep-alive
    `commit <https://codeberg.org/freeipa/freeipa/commit/f78439439c3c2ef6491fd5275de9d40b4b40a9b7>`__
 -  Use connection keep-alive
    `commit <https://codeberg.org/freeipa/freeipa/commit/25cf4a2e76ff976fe15029f9da7e4e3555f203d4>`__
-   `#6641 <https://pagure.io/freeipa/issue/6641>`__
+   `#6641 <https://codeberg.org/freeipa/freeipa/issues/6641>`__
 -  Add options to run only ipaclient unittests
    `commit <https://codeberg.org/freeipa/freeipa/commit/29b885a8fac82e963f5ab98d178e81854056930e>`__
-   `#6517 <https://pagure.io/freeipa/issue/6517>`__
+   `#6517 <https://codeberg.org/freeipa/freeipa/issues/6517>`__
 
 
 
@@ -379,35 +379,35 @@ David Kupka (10)
 -  ipapython.ipautil.run: Add option to set umask before executing
    command
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cf5395eb51ff5ec8164075a5ee573abe76bc15e>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  otptoken-add-yubikey: When --digits not provided use default value
    `commit <https://codeberg.org/freeipa/freeipa/commit/749fc90d1fde0d012acb05ba64309f4a6ed63124>`__
-   `#6900 <https://pagure.io/freeipa/issue/6900>`__
+   `#6900 <https://codeberg.org/freeipa/freeipa/issues/6900>`__
 -  Bump version of ipa.conf file
    `commit <https://codeberg.org/freeipa/freeipa/commit/76e5ac59579f36f28bb247bf3173e95e57ee4af4>`__
-   `#6860 <https://pagure.io/freeipa/issue/6860>`__
+   `#6860 <https://codeberg.org/freeipa/freeipa/issues/6860>`__
 -  Create system users for FreeIPA services during package installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8a429d9e170955919f2e53e66b580be95e908d9>`__
-   `#6743 <https://pagure.io/freeipa/issue/6743>`__
+   `#6743 <https://codeberg.org/freeipa/freeipa/issues/6743>`__
 -  WebUI: cert login: Configure name of parameter used to pass username
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9721e529e7a02eeb40d29cb7820e69cd86d9337>`__
-   `#6860 <https://pagure.io/freeipa/issue/6860>`__
+   `#6860 <https://codeberg.org/freeipa/freeipa/issues/6860>`__
 -  httpinstance.disable_system_trust: Don't fail if module 'Root Certs'
    is not available
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a499551ca5ddf2596cc19a77f47c34e9f5c10c5>`__
-   `#6803 <https://pagure.io/freeipa/issue/6803>`__
+   `#6803 <https://codeberg.org/freeipa/freeipa/issues/6803>`__
 -  spec file: Bump requires to make Certificate Login in WebUI work
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa24ed88006925e6d7e44567b087364b0116db9c>`__
-   `#6823 <https://pagure.io/freeipa/issue/6823>`__
+   `#6823 <https://codeberg.org/freeipa/freeipa/issues/6823>`__
 -  rpcserver.login_x509: Actually return reply from \__call_\_ method
    `commit <https://codeberg.org/freeipa/freeipa/commit/c80941e98bfd00c1c6e530aa4a592354adff8d90>`__
-   `#6819 <https://pagure.io/freeipa/issue/6819>`__
+   `#6819 <https://codeberg.org/freeipa/freeipa/issues/6819>`__
 -  Create temporaty directories at the begining of uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0a395776f3c9e4f4612fa16bb6af40646c3cdbf>`__
-   `#6715 <https://pagure.io/freeipa/issue/6715>`__
+   `#6715 <https://codeberg.org/freeipa/freeipa/issues/6715>`__
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f0c7df198f8dd6ae742b099b3258c2383007c30>`__
-   `#6738 <https://pagure.io/freeipa/issue/6738>`__
+   `#6738 <https://codeberg.org/freeipa/freeipa/issues/6738>`__
 
 
 
@@ -416,7 +416,7 @@ felipe (1)
 
 -  Fixing replica install: fix ldap connection in domlvl 0
    `commit <https://codeberg.org/freeipa/freeipa/commit/af4531d26ea1082acf17252e7e81cb3cd4b0c12c>`__
-   `#6549 <https://pagure.io/freeipa/issue/6549>`__
+   `#6549 <https://codeberg.org/freeipa/freeipa/issues/6549>`__
 
 
 
@@ -425,7 +425,7 @@ Felipe Volpone (1)
 
 -  Fixing adding authenticator indicators to host
    `commit <https://codeberg.org/freeipa/freeipa/commit/81ae5f4d655bb052c6c0961760dba34e70dcd3c3>`__
-   `#6911 <https://pagure.io/freeipa/issue/6911>`__
+   `#6911 <https://codeberg.org/freeipa/freeipa/issues/6911>`__
 
 
 
@@ -434,7 +434,7 @@ Fabiano Fidêncio (1)
 
 -  Allow erasing ipaDomainResolutionOrder attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/08a921cc08b5b841260caa2e45653a704b88542c>`__
-   `#6825 <https://pagure.io/freeipa/issue/6825>`__
+   `#6825 <https://codeberg.org/freeipa/freeipa/issues/6825>`__
 
 
 
@@ -443,54 +443,54 @@ Florence Blanc-Renaud (16)
 
 -  ipa-ca-install: append CA cert chain into /etc/ipa/ca.crt
    `commit <https://codeberg.org/freeipa/freeipa/commit/653d2f412012bcef04599b512938f06084d267b1>`__
-   `#6925 <https://pagure.io/freeipa/issue/6925>`__
+   `#6925 <https://codeberg.org/freeipa/freeipa/issues/6925>`__
 -  ipa-kra-install: fix pkispawn setting for
    pki_security_domain_hostname
    `commit <https://codeberg.org/freeipa/freeipa/commit/592cdf05413c0981d2085919357cc4e891306b79>`__
-   `#6895 <https://pagure.io/freeipa/issue/6895>`__
+   `#6895 <https://codeberg.org/freeipa/freeipa/issues/6895>`__
 -  ipa-server-install: fix uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/752e167497eca87632261dec7bbb352cd0e599c8>`__
-   `#6950 <https://pagure.io/freeipa/issue/6950>`__
+   `#6950 <https://codeberg.org/freeipa/freeipa/issues/6950>`__
 -  ipa-kra-install manpage: document domain-level 1
    `commit <https://codeberg.org/freeipa/freeipa/commit/72d2e9e4c312576e1a62e210b4e5d9696bc70609>`__
-   `#6922 <https://pagure.io/freeipa/issue/6922>`__
+   `#6922 <https://codeberg.org/freeipa/freeipa/issues/6922>`__
 -  ipa-kra-install: fix check_host_keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/b90dce88e227174aa33270beee9b3d6ff51cce59>`__
-   `#6934 <https://pagure.io/freeipa/issue/6934>`__
+   `#6934 <https://codeberg.org/freeipa/freeipa/issues/6934>`__
 -  ipa-server-install with external CA: fix pkinit cert issuance
    `commit <https://codeberg.org/freeipa/freeipa/commit/8107125e177ac9f378d149d7b0fa1d3774c9be3a>`__
-   `#6921 <https://pagure.io/freeipa/issue/6921>`__
+   `#6921 <https://codeberg.org/freeipa/freeipa/issues/6921>`__
 -  ipa-client-install: remove extra space in pkinit_anchors definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c4e70650dbcd5dd3f00a7b2fecc051afeebec0>`__
-   `#6916 <https://pagure.io/freeipa/issue/6916>`__
+   `#6916 <https://codeberg.org/freeipa/freeipa/issues/6916>`__
 -  vault: piped input for ipa vault-add fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8ca0f89a68b5d57c56344fdeb12fd436976c726>`__
-   `#6907 <https://pagure.io/freeipa/issue/6907>`__
+   `#6907 <https://codeberg.org/freeipa/freeipa/issues/6907>`__
 -  upgrade: adtrust update_tdo_gidnumber plugin must check if adtrust is
    installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/c05bd60585fb80e061b8582a648a65204c709f51>`__
-   `#6881 <https://pagure.io/freeipa/issue/6881>`__
+   `#6881 <https://codeberg.org/freeipa/freeipa/issues/6881>`__
 -  tests: add non-reg for idrange-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab2706721db217d55ae549d50a95ace571e65aa6>`__
-   `#6404 <https://pagure.io/freeipa/issue/6404>`__
+   `#6404 <https://codeberg.org/freeipa/freeipa/issues/6404>`__
 -  Upgrade: add gidnumber to trusted domain entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/eddd29f1d52d63ea702437b0dd2a2826df52bc26>`__
-   `#6827 <https://pagure.io/freeipa/issue/6827>`__
+   `#6827 <https://codeberg.org/freeipa/freeipa/issues/6827>`__
 -  ipa-sam: create the gidNumber attribute in the trusted domain entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/91d36941653476abfff6a54ba7cb5a9f2c12c22d>`__
-   `#6827 <https://pagure.io/freeipa/issue/6827>`__
+   `#6827 <https://codeberg.org/freeipa/freeipa/issues/6827>`__
 -  idrange-add: properly handle empty --dom-name option
    `commit <https://codeberg.org/freeipa/freeipa/commit/077a61524d79ac5ab6f0eb46450c82ad5594bd2b>`__
-   `#6404 <https://pagure.io/freeipa/issue/6404>`__
+   `#6404 <https://codeberg.org/freeipa/freeipa/issues/6404>`__
 -  ipa-ca-install man page: Add domain level 1 help
    `commit <https://codeberg.org/freeipa/freeipa/commit/262723b1be894e5d75cccdd92da838f544a3b222>`__
-   `#5831 <https://pagure.io/freeipa/issue/5831>`__
+   `#5831 <https://codeberg.org/freeipa/freeipa/issues/5831>`__
 -  dogtag-ipa-ca-renew-agent-submit: fix the is_replicated() function
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f738f1ea9f86a921e3dc0fd02e57419f3173ed9>`__
-   `#6813 <https://pagure.io/freeipa/issue/6813>`__
+   `#6813 <https://codeberg.org/freeipa/freeipa/issues/6813>`__
 -  man ipa-cacert-manage install needs clarification
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb53a9ab6dce023dd51c2a434fd8597eab5bc0d0>`__
-   `#6795 <https://pagure.io/freeipa/issue/6795>`__
+   `#6795 <https://codeberg.org/freeipa/freeipa/issues/6795>`__
 
 
 
@@ -499,7 +499,7 @@ Fraser Tweedale (1)
 
 -  Support 8192-bit RSA keys in default cert profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/9118c08455d42f4e7f43370be1a858595a60bc9a>`__
-   `#6319 <https://pagure.io/freeipa/issue/6319>`__
+   `#6319 <https://codeberg.org/freeipa/freeipa/issues/6319>`__
 
 
 
@@ -508,120 +508,120 @@ Jan Cholasta (38)
 
 -  server certinstall: support PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/e27b3e139ffff16f6e238ef6f9ff7d2ed02492bc>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  cacert manage: support PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f900ec60a426a2b97823d4612949a953fa6d49b>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  replica install: respect --pkinit-cert-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/77ef29ef30086c714025d97328507bd51e3f0421>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  server install: fix KDC certificate validation in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbdf6693cc8707dda9c1db42fb05dc5b1d70b7af>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__,
-   `#6869 <https://pagure.io/freeipa/issue/6869>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__,
+   `#6869 <https://codeberg.org/freeipa/freeipa/issues/6869>`__
 -  certs: do not export CA certs in install_pem_from_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc8deb118dce93fc380793c75090d9108ce61541>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__,
-   `#6869 <https://pagure.io/freeipa/issue/6869>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__,
+   `#6869 <https://codeberg.org/freeipa/freeipa/issues/6869>`__
 -  certs: do not export keys world-readable in install_key_from_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6497f099c09dfa60bd6ae98e4692e99b7381752>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  server install: fix KDC PKINIT configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/b83ebe0e3ff692de37f28834d09a423d04e6ad68>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  install: introduce generic Kerberos Augeas lens
    `commit <https://codeberg.org/freeipa/freeipa/commit/523a82652e2f95704a07ac25cc829a0782b9e22a>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  client install: fix client PKINIT configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/63c4cbd619f81f16e0c08d3786b69d348c9dcfd7>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  install: trust IPA CA for PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/16b295c5a8580accfbbab016f3cc4eef0a704163>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb: use custom object for trust flags
    `commit <https://codeberg.org/freeipa/freeipa/commit/e68812331526269f3b556c339f65077f649110d3>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb, certs: make trust flags argument mandatory
    `commit <https://codeberg.org/freeipa/freeipa/commit/749d504f4335c375cf86bf44814177f03be61b52>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb: add named trust flag constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/6338dbe47313a70b93bbf53855db451145d24544>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  ipa-cacert-manage: add --external-ca-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/c56d12aeaccb455a193271a31362b7412b2d2e60>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: get rid of virtual profiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb952827b84d7b47ffd77549b3a7c9da2fe537ae>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: always export CSR on IPA CA certificate renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/25b0a9cf6c60c709cacb74ad188cd6e91d4b60ea>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: allow reusing existing certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/920d56a8f0321c4b092da6c173961c82aa1d6bd3>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  cainstance: use correct profile for lightweight CA certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a01114f1e49fd73e88e2d9f1512a11cbab0176e>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  server upgrade: always fix certmonger tracking request
    `commit <https://codeberg.org/freeipa/freeipa/commit/b55dd9cee5c2161002f56c63d7e0ae86e792fbbd>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: respect CA renewal master setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/36fc44b90ceb9e98abd93a3abb1e5b8d18df6ff0>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  spec file: bump python-netaddr Requires
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecccd6cb843c44093449cc45a7d94bb14fa65513>`__
-   `#6894 <https://pagure.io/freeipa/issue/6894>`__
+   `#6894 <https://codeberg.org/freeipa/freeipa/issues/6894>`__
 -  spec file: bump krb5 Requires for certauth fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec3a2a6063beb4ec96796b66abb82476a5c7bd0f>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  configure: fix AC_CHECK_LIB usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/207864a61a748a9032e67bf0f1782379e44fb5aa>`__
-   `#6846 <https://pagure.io/freeipa/issue/6846>`__
+   `#6846 <https://codeberg.org/freeipa/freeipa/issues/6846>`__
 -  cert: defer cert-find result post-processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/49f9d799c171c7ae2ac546a33a353c2c40b4719c>`__
-   `#6808 <https://pagure.io/freeipa/issue/6808>`__
+   `#6808 <https://codeberg.org/freeipa/freeipa/issues/6808>`__
 -  renew agent, restart scripts: connect to LDAP after kinit
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9168e80ddb6066114f9438fa6a7a11b0eaa02cf>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  renew agent: revert to host keytab authentication
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a7db624857c46a2c1c091ed4b8d7902a4486596>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  install: request service certs after host keytab is set up
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb141b0eb3950bcae1950e6190ba3573f348b1f2>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  dsinstance, httpinstance: consolidate certificate request code
    `commit <https://codeberg.org/freeipa/freeipa/commit/3317e172227fd72ad9049f7893d3018043201b3c>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  httpinstance: avoid httpd restart during certificate request
    `commit <https://codeberg.org/freeipa/freeipa/commit/029da956be22c9e05a53c7c30e3afcb2c851ad86>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  dsinstance: reconnect ldap2 after DS is restarted by certmonger
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a3cd01161b618dd6836fda7df935dd39adc117b>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  httpinstance: make sure NSS database is backed up
    `commit <https://codeberg.org/freeipa/freeipa/commit/471dfcbe1cc3f319da788add3661cb6d63e3c0f0>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  spec file: bump libsss_nss_idmap-devel BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/127f7ce699677d8c689099eac350a54293a5009d>`__
-   `#6828 <https://pagure.io/freeipa/issue/6828>`__
+   `#6828 <https://codeberg.org/freeipa/freeipa/issues/6828>`__
 -  spec file: bump krb5-devel BuildRequires for certauth
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d246000ef2d715fab464b8ef71fdb3731da127e>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  cert: do not limit internal searches in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/6382f9eee335907362a5ccb44b892f59de7d3751>`__
-   `#6716 <https://pagure.io/freeipa/issue/6716>`__
+   `#6716 <https://codeberg.org/freeipa/freeipa/issues/6716>`__
 -  replica prepare: fix wrong IPA CA nickname in replica file
    `commit <https://codeberg.org/freeipa/freeipa/commit/df60e88e1bca6efd5ebf2a88e7825a5fd2631f08>`__
-   `#6777 <https://pagure.io/freeipa/issue/6777>`__
+   `#6777 <https://codeberg.org/freeipa/freeipa/issues/6777>`__
 -  httpinstance: clean up /etc/httpd/alias on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/f788e3e36bcaefc7d94c92895916246681e64291>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  certs: do not implicitly create DS pin.txt
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf188c8513c6b36a0724866025ddc220683de8dc>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  tasks: run \`systemctl daemon-reload\` after httpd.service.d updates
    `commit <https://codeberg.org/freeipa/freeipa/commit/62c41219acdd0e82201168aea5cb22879c655742>`__
-   `#6773 <https://pagure.io/freeipa/issue/6773>`__
+   `#6773 <https://codeberg.org/freeipa/freeipa/issues/6773>`__
 
 
 
@@ -632,50 +632,50 @@ Martin Babinsky (16)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b58854bb8df46b7e0ac0a35bf473bc9d8ad607>`__
 -  Do not test anonymous PKINIT after install/upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/d497c4589cc7506ef9a88b691b8b1d97ad1f1009>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Upgrade: configure local/full PKINIT depending on the master status
    `commit <https://codeberg.org/freeipa/freeipa/commit/2452e6e5f3a7e7a25eadf5243a28da75a47f9d2c>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Use local anchor when armoring password requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/5031929b6d710336f6308d7f46779c9e8e98103a>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Stop requesting anonymous keytab and purge all references of it
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fcc794dac6ffb1f1cc6c92a588ea0911be5ba14>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Use only anonymous PKINIT to fetch armor ccache
    `commit <https://codeberg.org/freeipa/freeipa/commit/fca378c9a65f582ac3dcda4b6201e8847ed9e512>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  API for retrieval of master's PKINIT status and publishing it in LDAP
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0e2a09292ffa2adbf97c2e7e4facc9693dbc311>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Allow for configuration of all three PKINIT variants when deploying
    KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/b49e075c90a7ab43e82f422aa11dc7540e2fb2c0>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  separate function to set ipaConfigString values on service entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/31a24436592304db6e84270e4a95df34d1e0af46>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Revert "Store GSSAPI session key in /var/run/ipa"
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4e1ab6c893182b8b3610c0b45120194be4a0376>`__
-   `#6880 <https://pagure.io/freeipa/issue/6880>`__
+   `#6880 <https://codeberg.org/freeipa/freeipa/issues/6880>`__
 -  Remove duplicate functionality in upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fcd56533a00c28f9f8f800c77b8c2c580cb3a8f>`__
-   `#6799 <https://pagure.io/freeipa/issue/6799>`__
+   `#6799 <https://codeberg.org/freeipa/freeipa/issues/6799>`__
 -  Always check and create anonymous principal during KDC install
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce94f7fa7b4eca296d2f9692d35c2558bfeddb46>`__
-   `#6799 <https://pagure.io/freeipa/issue/6799>`__
+   `#6799 <https://codeberg.org/freeipa/freeipa/issues/6799>`__
 -  Ensure KDC is propery configured after upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/89fc0a126be67755d4a687b427a6c67b3cbc4337>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Split out anonymous PKINIT test to a separate method
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1393029b6a853cc2cb874f4f93706368627d7c4>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Remove unused variable from failed anonymous PKINIT handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b2b1d33157963a8b3d8229d1edd573dcbb93fb5>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Upgrade: configure PKINIT after adding anonymous principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9002bf6273151cb480dfba7ffa7480d037984ee>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 
 
 
@@ -690,31 +690,31 @@ Martin Basti (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8f4938fe4e85cd344f966aa4d154368eb012e6b>`__
 -  ipasetup: fix dependencies handling based on python version
    `commit <https://codeberg.org/freeipa/freeipa/commit/c49e146a69a66cda894687f39f3d77ff3ad9c33b>`__
-   `#6875 <https://pagure.io/freeipa/issue/6875>`__
+   `#6875 <https://codeberg.org/freeipa/freeipa/issues/6875>`__
 -  ipaclient: fix missing RPM ownership
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d0975319daa34a16d4163669474af89e987457e>`__
-   `#6927 <https://pagure.io/freeipa/issue/6927>`__
+   `#6927 <https://codeberg.org/freeipa/freeipa/issues/6927>`__
 -  ca_status: add HTTP timeout 30 seconds
    `commit <https://codeberg.org/freeipa/freeipa/commit/68ce9aa2addb6048333e723f771132f5da7dd38f>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  http_request: add timeout option
    `commit <https://codeberg.org/freeipa/freeipa/commit/48bb3cb69c000cea3f28bd5b44072d0fe9caa7a2>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Use proper SELinux context with http.keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/bda733db9ede3307595963a8c086e1b700c41e25>`__
-   `#6924 <https://pagure.io/freeipa/issue/6924>`__
+   `#6924 <https://codeberg.org/freeipa/freeipa/issues/6924>`__
 -  Store GSSAPI session key in /var/run/ipa
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2aa3ed0bc9f5385ab6e8b1720d9f1d33136e5dc>`__
-   `#6880 <https://pagure.io/freeipa/issue/6880>`__
+   `#6880 <https://codeberg.org/freeipa/freeipa/issues/6880>`__
 -  Fix PKCS11 helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6b2ed6b68589ff7ee39b95559836af54f39e2de>`__
-   `#6692 <https://pagure.io/freeipa/issue/6692>`__
+   `#6692 <https://codeberg.org/freeipa/freeipa/issues/6692>`__
 -  Remove surplus 'the' in output of ipa-adtrust-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/e85795d4546847969ce8d0a38e6ac97c4366cfc7>`__
-   `#6864 <https://pagure.io/freeipa/issue/6864>`__
+   `#6864 <https://codeberg.org/freeipa/freeipa/issues/6864>`__
 -  Set "KDC:Disable Last Success" by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/fdcd5f486839d9279dcba74b74f7756ace5812fa>`__
-   `#5313 <https://pagure.io/freeipa/issue/5313>`__
+   `#5313 <https://codeberg.org/freeipa/freeipa/issues/5313>`__
 -  Set zanata version to ipa-4-5
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1f2754f18f93752f97d14168b74fb0f299d795d>`__
 
@@ -725,10 +725,10 @@ Michal Reznik (2)
 
 -  test_caless: mark TestCertinstall intermediate CA tests as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9bf76e1f3b39495a9ad61513d842844b89201dc>`__
-   `#6959 <https://pagure.io/freeipa/issue/6959>`__
+   `#6959 <https://codeberg.org/freeipa/freeipa/issues/6959>`__
 -  test_caless: add pkinit option and test it
    `commit <https://codeberg.org/freeipa/freeipa/commit/cea42421bc17317f69143061173e8b9a5c0e153e>`__
-   `#6854 <https://pagure.io/freeipa/issue/6854>`__
+   `#6854 <https://codeberg.org/freeipa/freeipa/issues/6854>`__
 
 
 
@@ -737,7 +737,7 @@ Oliver Gutierrez (1)
 
 -  Added plugins directory to ipaclient subpackages
    `commit <https://codeberg.org/freeipa/freeipa/commit/3605f8ba9a2545680cd46ff02c282d03f84bb366>`__
-   `#6927 <https://pagure.io/freeipa/issue/6927>`__
+   `#6927 <https://codeberg.org/freeipa/freeipa/issues/6927>`__
 
 
 
@@ -747,13 +747,13 @@ Petr Vobornik (3)
 -  kerberos session: use CA cert with full cert chain for obtaining
    cookie
    `commit <https://codeberg.org/freeipa/freeipa/commit/82679c11f1fc0701d753433d1f2d14c3ee0279af>`__
-   `#6876 <https://pagure.io/freeipa/issue/6876>`__
+   `#6876 <https://codeberg.org/freeipa/freeipa/issues/6876>`__
 -  restore: restart/reload gssproxy after restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/04ed1fa3acdf002ecc37dde4f5d226c0fbe5aa30>`__
-   `#6902 <https://pagure.io/freeipa/issue/6902>`__
+   `#6902 <https://codeberg.org/freeipa/freeipa/issues/6902>`__
 -  automount install: fix checking of SSSD functionality on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff513d6b20ee0a2ca90b06b8c114386f1e5751d9>`__
-   `#6861 <https://pagure.io/freeipa/issue/6861>`__
+   `#6861 <https://codeberg.org/freeipa/freeipa/issues/6861>`__
 
 
 
@@ -762,28 +762,28 @@ Pavel Vomacka (8)
 
 -  Turn on NSSOCSP check in mod_nss conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/4aa7e70fcd1851394f943da669d6af4e11b60940>`__
-   `#6370 <https://pagure.io/freeipa/issue/6370>`__
+   `#6370 <https://codeberg.org/freeipa/freeipa/issues/6370>`__
 -  WebUI: Allow to add certs to certmapping with CERT LINES around
    `commit <https://codeberg.org/freeipa/freeipa/commit/eda23a9847197513555f6237b46c658365dfc12d>`__
-   `#6772 <https://pagure.io/freeipa/issue/6772>`__
+   `#6772 <https://codeberg.org/freeipa/freeipa/issues/6772>`__
 -  WebUI: Fix showing vault in selfservice view
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b3cb1ccad28a1fd17803bdd7dd245bdfee9a046>`__
-   `#6812 <https://pagure.io/freeipa/issue/6812>`__
+   `#6812 <https://codeberg.org/freeipa/freeipa/issues/6812>`__
 -  WebUI: suppress truncation warning in select widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/697a5779b377a5d76c1cb212514b6feb46326f71>`__
-   `#6618 <https://pagure.io/freeipa/issue/6618>`__
+   `#6618 <https://codeberg.org/freeipa/freeipa/issues/6618>`__
 -  WebUI: Add support for suppressing warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/422c9058d9a6be69db4eab7db654b9184ae5eab6>`__
-   `#6618 <https://pagure.io/freeipa/issue/6618>`__
+   `#6618 <https://codeberg.org/freeipa/freeipa/issues/6618>`__
 -  WebUI: Add support for login for AD users
    `commit <https://codeberg.org/freeipa/freeipa/commit/228e039e7d718ced7dce7c32cca3a89404c0a16e>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 -  WebUI: add method for disabling item in user dropdown menu
    `commit <https://codeberg.org/freeipa/freeipa/commit/01a0a38bdf53821bc420f01dc98fae577f83eabb>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 -  WebUI: check principals in lowercase
    `commit <https://codeberg.org/freeipa/freeipa/commit/bee9c9f090e7808a2381054fa63c1d036743296c>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 
 
 
@@ -793,7 +793,7 @@ Gabe (1)
 -  Update get_attr_filter in LDAPSearch to handle nsaccountlock user
    searches
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc4d60c9665408666ab3dfab7023a578c34d65a2>`__
-   `#6896 <https://pagure.io/freeipa/issue/6896>`__
+   `#6896 <https://codeberg.org/freeipa/freeipa/issues/6896>`__
 
 
 
@@ -802,24 +802,24 @@ Sumit Bose (7)
 
 -  IPA-KDB: use relative path in ipa-certmap config snippet
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa46a01c37021e7b2b57fd3092383100e39792fb>`__
-   `#6833 <https://pagure.io/freeipa/issue/6833>`__
+   `#6833 <https://codeberg.org/freeipa/freeipa/issues/6833>`__
 -  extdom: improve cert request
    `commit <https://codeberg.org/freeipa/freeipa/commit/a510a3d7e9f37e89acee84bed2363cb7f57fe88e>`__
-   `#6826 <https://pagure.io/freeipa/issue/6826>`__
+   `#6826 <https://codeberg.org/freeipa/freeipa/issues/6826>`__
 -  extdom: do reverse search for domain separator
    `commit <https://codeberg.org/freeipa/freeipa/commit/8046f9baab1e93b8b8e11d05088c8cdabdd47281>`__
 -  ipa-kdb: do not depend on certauth_plugin.h
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fde0b88d7c9360e16820d6086eba3e3ca0eee1e>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  configure: fix --disable-server with certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/203d5416ce807f5cdcf9e2431feef84d49b3df61>`__
-   `#6816 <https://pagure.io/freeipa/issue/6816>`__
+   `#6816 <https://codeberg.org/freeipa/freeipa/issues/6816>`__
 -  IPA certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a1ce1fbaa6c7a85bd1bee2a70b8b22509ede7c7>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  ipa-kdb: add ipadb_fetch_principals_with_extra_filter()
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfaaf4e821338dbc146dd49d3c22978165d2e329>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 
 
 
@@ -828,25 +828,25 @@ Simo Sorce (7)
 
 -  Make sure remote hosts have our keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f8d1119fe38807e86930af50d3680e28efe68eb>`__
-   `#6838 <https://pagure.io/freeipa/issue/6838>`__
+   `#6838 <https://codeberg.org/freeipa/freeipa/issues/6838>`__
 -  Fix s4u2self with adtrust
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5114070ae55bcc7ec1abe57b4c303cee4822930>`__
-   `#6862 <https://pagure.io/freeipa/issue/6862>`__
+   `#6862 <https://codeberg.org/freeipa/freeipa/issues/6862>`__
 -  Prevent churn on ccaches
    `commit <https://codeberg.org/freeipa/freeipa/commit/e94575f3466bbb8d4959ad0a1c436dcf745e3036>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Work around issues fetching session data
    `commit <https://codeberg.org/freeipa/freeipa/commit/0912185b18599414e4f9302b1a80c6c7e9876821>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Handle failed authentication via cookie
    `commit <https://codeberg.org/freeipa/freeipa/commit/f41c9f476d678f9ecc4ca3338c7a58de0182f76f>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Avoid growing FILE ccaches unnecessarily
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba828a53a4736ed326d95e30856daba2c060439c>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Add options to allow ticket caching
    `commit <https://codeberg.org/freeipa/freeipa/commit/62d39385e20b3e1b059466f37cc063833355551e>`__
-   `#6771 <https://pagure.io/freeipa/issue/6771>`__
+   `#6771 <https://codeberg.org/freeipa/freeipa/issues/6771>`__
 
 
 
@@ -855,104 +855,104 @@ Stanislav Laznicka (33)
 
 -  cert-show: writable files does not mean dirs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2410023ce6ef3255ddbaaf8939a928e733297d62>`__
-   `#6883 <https://pagure.io/freeipa/issue/6883>`__
+   `#6883 <https://codeberg.org/freeipa/freeipa/issues/6883>`__
 -  Fix wrong message on Dogtag instances stop
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b44c4caa1e7a1f90b3b3537de9cc1529f0891e8>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Make CA/KRA fail when they don't start
    `commit <https://codeberg.org/freeipa/freeipa/commit/81f97cb89e17e63b3dcb8925a373970ac61764c2>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Remove the cachedproperty class
    `commit <https://codeberg.org/freeipa/freeipa/commit/9de343987e6d76d2edeba372c73c1060657aef59>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  Refresh Dogtag RestClient.ca_host property
    `commit <https://codeberg.org/freeipa/freeipa/commit/32981a0f9d0ff699e3d16da8f5a37c112871ba3a>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  Fix CA/server cert validation in FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/651d132b701b773b2bbeb41496d6c5ddbf6d19b3>`__
-   `#6897 <https://pagure.io/freeipa/issue/6897>`__
+   `#6897 <https://codeberg.org/freeipa/freeipa/issues/6897>`__
 -  compat plugin: Update link to slapi-nis project
    `commit <https://codeberg.org/freeipa/freeipa/commit/efe096040aefdeea37afcf2671506982d8522f47>`__
 -  compat: ignore cn=topology,cn=ipa,cn=etc subtree
    `commit <https://codeberg.org/freeipa/freeipa/commit/e691877c24e722d4fc91fed34cd31cc102879c1a>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  Move the compat plugin setup at the end of install
    `commit <https://codeberg.org/freeipa/freeipa/commit/7364c1360c4e2271667f3a08d8d504b3cd813e2f>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  compat-manage: behave the same for all users
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fa7718c6ad03a7cf534313d5c50d78d4863fe6e>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  Fix CAInstance.import_ra_cert for empty passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3f2878909c1f92a0d92ed2a8ce00c96135e1346>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  Fix RA cert import during DL0 replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f70baf2a4811e3eee341aee6da99dfa80c092e6>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  ext. CA: correctly write the cert chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6af0033a4d0af387eebdd6500eb1e74c5c29ce7>`__
-   `#6872 <https://pagure.io/freeipa/issue/6872>`__
+   `#6872 <https://codeberg.org/freeipa/freeipa/issues/6872>`__
 -  server-install: No double Kerberos install
    `commit <https://codeberg.org/freeipa/freeipa/commit/2144eaf25ef1148c9353dfb2680f8811fd8c21aa>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  Fix CA-less to CA-full upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a6f78bab8f9f76bf37fb105ec2537676d889cc2>`__
-   `#6853 <https://pagure.io/freeipa/issue/6853>`__
+   `#6853 <https://codeberg.org/freeipa/freeipa/issues/6853>`__
 -  replicainstall: better client install exception handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/534df55ea5ae736db832e0885520a6dfbd09299a>`__
-   `#6183 <https://pagure.io/freeipa/issue/6183>`__
+   `#6183 <https://codeberg.org/freeipa/freeipa/issues/6183>`__
 -  Add the force-join option to replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/72f0ecde783be7d304044eff60c8c85e160d65d8>`__
-   `#6183 <https://pagure.io/freeipa/issue/6183>`__
+   `#6183 <https://codeberg.org/freeipa/freeipa/issues/6183>`__
 -  server-install: remove broken no-pkinit check
    `commit <https://codeberg.org/freeipa/freeipa/commit/1eb681ec7d4f6f42e733463f29374f0fecee4e68>`__
-   `#6807 <https://pagure.io/freeipa/issue/6807>`__
+   `#6807 <https://codeberg.org/freeipa/freeipa/issues/6807>`__
 -  Add pki_pin only when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/f53c76b1055d4f7b26fc127852a66f942845cbae>`__
-   `#6839 <https://pagure.io/freeipa/issue/6839>`__
+   `#6839 <https://codeberg.org/freeipa/freeipa/issues/6839>`__
 -  Remove publish_ca_cert() method from NSSDatabase
    `commit <https://codeberg.org/freeipa/freeipa/commit/99389748beb0158811505efa606c27e1e2e0bc7b>`__
-   `#6806 <https://pagure.io/freeipa/issue/6806>`__
+   `#6806 <https://codeberg.org/freeipa/freeipa/issues/6806>`__
 -  Get correct CA cert nickname in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebf24e783604952e59e557b5537c6d0de6146ce4>`__
-   `#6806 <https://pagure.io/freeipa/issue/6806>`__
+   `#6806 <https://codeberg.org/freeipa/freeipa/issues/6806>`__
 -  Remove redundant option check for cert files
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f7b6c349f4e81e88ef36f014e26de6b1f3f3e41>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  replica-prepare man: remove pkinit option refs
    `commit <https://codeberg.org/freeipa/freeipa/commit/85720b6bdc764b98dd471799ccc1045e1379709e>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Don't allow setting pkinit-related options on DL0
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1ad1ffa3540da4b5d5c1963b3818d9c9260e1a2>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Fix the order of cert-files check
    `commit <https://codeberg.org/freeipa/freeipa/commit/497e766427b3ced865ff88a51cd0c2c96e8b24f9>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Generate PIN for PKI to help Dogtag in FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/39eac72faef5f44c9fb2cad943ad58d23fe60cf3>`__
-   `#6824 <https://pagure.io/freeipa/issue/6824>`__
+   `#6824 <https://codeberg.org/freeipa/freeipa/issues/6824>`__
 -  Backup CA cert from kerberos folder
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fdc27ba3594e921d21d664fc5728292e52ac350>`__
-   `#6748 <https://pagure.io/freeipa/issue/6748>`__
+   `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__
 -  Allow renaming of the sudorule objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d3229bfb88f0fdc559245c8741563faba716106>`__
-   `#2466 <https://pagure.io/freeipa/issue/2466>`__
+   `#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__
 -  Allow renaming of the HBAC rule objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/85f2a19f88eef94ff080a42246658f572b5275f4>`__
-   `#6784 <https://pagure.io/freeipa/issue/6784>`__
+   `#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__
 -  Reworked the renaming mechanism
    `commit <https://codeberg.org/freeipa/freeipa/commit/28db6cd40100c6301121e3f82c074624fe53729c>`__
-   `#2466 <https://pagure.io/freeipa/issue/2466>`__,
-   `#6784 <https://pagure.io/freeipa/issue/6784>`__
+   `#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__,
+   `#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__
 -  Bump samba version for FIPS and priv. separation
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ff57b81807f6747b098f1ed2c281031e22bbae>`__
-   `#6671 <https://pagure.io/freeipa/issue/6671>`__,
-   `#6697 <https://pagure.io/freeipa/issue/6697>`__
+   `#6671 <https://codeberg.org/freeipa/freeipa/issues/6671>`__,
+   `#6697 <https://codeberg.org/freeipa/freeipa/issues/6697>`__
 -  Backup ipa-specific httpd unit-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/59342a7f6fffe2aaf0b8ce4e10bb41444d8fa25f>`__
-   `#6748 <https://pagure.io/freeipa/issue/6748>`__
+   `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__
 -  Add debug log in case cookie retrieval went wrong
    `commit <https://codeberg.org/freeipa/freeipa/commit/c59729d783993f60582f5cc6ca018545231df22b>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 
 
 
@@ -970,22 +970,22 @@ Tomas Krizek (7)
 
 -  ca, kra install: validate DM password
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8bcaa61ec6c9effcf029f82ca21685b692e0b7f>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  installutils: add DM password validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c12b71717b2ca1d4af5018f77c07f8f4b4feca5>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  ca install: merge duplicated code for DM password
    `commit <https://codeberg.org/freeipa/freeipa/commit/282fc0c86474bafcb28234eabbd807b99a98adec>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  upgrade: add missing suffix to http instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/d10d5066aa60288703f2cf4b1a8dd7ed0aab8842>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  installer service: fix typo in service entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/1662b0ef2fff6ee002afd99f86b9075a603b6027>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  python2-ipalib: add missing python dependency
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdefa3030fba0f9a79f65f91aec84a44795c17f5>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  kra install: update installation failure message
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4410b41f8dc58b81f02ccc42483dcfe63ddede9>`__
-   `#6923 <https://pagure.io/freeipa/issue/6923>`__
+   `#6923 <https://codeberg.org/freeipa/freeipa/issues/6923>`__

--- a/src/page/Releases/4.5.2.rst
+++ b/src/page/Releases/4.5.2.rst
@@ -49,64 +49,64 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7020 <https://pagure.io/freeipa/issue/7020>`__ Installation of KRA
+-  `#7020 <https://codeberg.org/freeipa/freeipa/issues/7020>`__ Installation of KRA
    replica fails
--  `#7015 <https://pagure.io/freeipa/issue/7015>`__ allow to modify list
+-  `#7015 <https://codeberg.org/freeipa/freeipa/issues/7015>`__ allow to modify list
    of UPNs of a trusted forest
--  `#7001 <https://pagure.io/freeipa/issue/7001>`__ Do not send Max-Age
+-  `#7001 <https://codeberg.org/freeipa/freeipa/issues/7001>`__ Do not send Max-Age
    in ipa_session cookie to avoid breaking older clients
--  `#7000 <https://pagure.io/freeipa/issue/7000>`__ Provide a simple
+-  `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__ Provide a simple
    command to issue KDC certificates on a IPA master
--  `#6993 <https://pagure.io/freeipa/issue/6993>`__ certauth: use
+-  `#6993 <https://codeberg.org/freeipa/freeipa/issues/6993>`__ certauth: use
    canonical principal for lookups
--  `#6982 <https://pagure.io/freeipa/issue/6982>`__ Provide a tooling
+-  `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__ Provide a tooling
    automating the configuration of Smart Card authentication on a
    FreeIPA master
--  `#6981 <https://pagure.io/freeipa/issue/6981>`__ Enabling OCSP checks
+-  `#6981 <https://codeberg.org/freeipa/freeipa/issues/6981>`__ Enabling OCSP checks
    in mod_nss breaks certificate issuance when ipa-ca records are not
    resolvable
--  `#6977 <https://pagure.io/freeipa/issue/6977>`__ Simple service
+-  `#6977 <https://codeberg.org/freeipa/freeipa/issues/6977>`__ Simple service
    uninstallers must be able to handle missing service files gracefully
--  `#6972 <https://pagure.io/freeipa/issue/6972>`__ Replica installation
+-  `#6972 <https://codeberg.org/freeipa/freeipa/issues/6972>`__ Replica installation
    grants HTTP principal access in WebUI
--  `#6966 <https://pagure.io/freeipa/issue/6966>`__ Document that port
+-  `#6966 <https://codeberg.org/freeipa/freeipa/issues/6966>`__ Document that port
    8080 needs to be open on IPA masters for cert-find
--  `#6965 <https://pagure.io/freeipa/issue/6965>`__ ipa-replica-manage
+-  `#6965 <https://codeberg.org/freeipa/freeipa/issues/6965>`__ ipa-replica-manage
    del replica.name fails
--  `#6963 <https://pagure.io/freeipa/issue/6963>`__ ipa certmaprule
+-  `#6963 <https://codeberg.org/freeipa/freeipa/issues/6963>`__ ipa certmaprule
    change not reflected in krb5kdc workers
--  `#6958 <https://pagure.io/freeipa/issue/6958>`__ [tracker] SELinux
+-  `#6958 <https://codeberg.org/freeipa/freeipa/issues/6958>`__ [tracker] SELinux
    policy denies IPA framework to perform anonymous PKINIT on localhost
    during FAST armoring
--  `#6948 <https://pagure.io/freeipa/issue/6948>`__ services entries
+-  `#6948 <https://codeberg.org/freeipa/freeipa/issues/6948>`__ services entries
    missing krbCanonicalName attribute.
--  `#6937 <https://pagure.io/freeipa/issue/6937>`__ Provide an API
+-  `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__ Provide an API
    command to retrieve PKINIT status in the FreeIPA topology
--  `#6936 <https://pagure.io/freeipa/issue/6936>`__ Deprecate \`ipa
+-  `#6936 <https://codeberg.org/freeipa/freeipa/issues/6936>`__ Deprecate \`ipa
    pkinit-anonymous\` command in FreeIPA 4.5+
--  `#6935 <https://pagure.io/freeipa/issue/6935>`__
+-  `#6935 <https://codeberg.org/freeipa/freeipa/issues/6935>`__
    ipa-replica-conncheck fails when there is no ssh executable on the
    master
--  `#6885 <https://pagure.io/freeipa/issue/6885>`__ ipa cert-show does
+-  `#6885 <https://codeberg.org/freeipa/freeipa/issues/6885>`__ ipa cert-show does
    not raise error if no file name specified
--  `#6867 <https://pagure.io/freeipa/issue/6867>`__
+-  `#6867 <https://codeberg.org/freeipa/freeipa/issues/6867>`__
    [ipa-replica-install] - KDC has no support for encryption type
--  `#6800 <https://pagure.io/freeipa/issue/6800>`__ Investigate how
+-  `#6800 <https://codeberg.org/freeipa/freeipa/issues/6800>`__ Investigate how
    privilege separation feature will work after DL0->DL1 update
--  `#6796 <https://pagure.io/freeipa/issue/6796>`__ WSGI fails with
+-  `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__ WSGI fails with
    recursion error in GSSAPI
--  `#6749 <https://pagure.io/freeipa/issue/6749>`__ "ipa: ERROR: an
+-  `#6749 <https://codeberg.org/freeipa/freeipa/issues/6749>`__ "ipa: ERROR: an
    internal error has occurred" on executing command "ipa cert-request
    --add" after upgrade
--  `#6736 <https://pagure.io/freeipa/issue/6736>`__ Add pkinit_indicator
+-  `#6736 <https://codeberg.org/freeipa/freeipa/issues/6736>`__ Add pkinit_indicator
    option to KDC configuration
--  `#6572 <https://pagure.io/freeipa/issue/6572>`__ server-del doesn't
+-  `#6572 <https://codeberg.org/freeipa/freeipa/issues/6572>`__ server-del doesn't
    remove dns-server configuration from ldap
--  `#5860 <https://pagure.io/freeipa/issue/5860>`__ depracate --no-sssd
+-  `#5860 <https://codeberg.org/freeipa/freeipa/issues/5860>`__ depracate --no-sssd
    option
--  `#5788 <https://pagure.io/freeipa/issue/5788>`__ user-add
+-  `#5788 <https://codeberg.org/freeipa/freeipa/issues/5788>`__ user-add
    postcallback is not efficient when --noprivate flag is set
--  `#5406 <https://pagure.io/freeipa/issue/5406>`__ ipa-client-install
+-  `#5406 <https://codeberg.org/freeipa/freeipa/issues/5406>`__ ipa-client-install
    should not use hardcoded admin principal
 
 
@@ -121,17 +121,17 @@ Alexander Bokovoy (4)
 
 -  trust-mod: allow modifying list of UPNs of a trusted forest
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a31b21bff7c83219a4973adf815c900628ab620>`__
-   `#7015 <https://pagure.io/freeipa/issue/7015>`__
+   `#7015 <https://codeberg.org/freeipa/freeipa/issues/7015>`__
 -  ipa-kdb: add pkinit authentication indicator in case of a successful
    certauth
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca02cea8dfd63290e4821833fc2ac7d457290e9f>`__
-   `#6736 <https://pagure.io/freeipa/issue/6736>`__
+   `#6736 <https://codeberg.org/freeipa/freeipa/issues/6736>`__
 -  Fix index definition for ipaAnchorUUID
    `commit <https://codeberg.org/freeipa/freeipa/commit/8410823e1811ac9e004cc79556334abd429d480d>`__
-   `#6975 <https://pagure.io/freeipa/issue/6975>`__
+   `#6975 <https://codeberg.org/freeipa/freeipa/issues/6975>`__
 -  krb5: make sure KDC certificate is readable
    `commit <https://codeberg.org/freeipa/freeipa/commit/db7967061b9b7d001c923ce3da9d6c6036627253>`__
-   `#6973 <https://pagure.io/freeipa/issue/6973>`__
+   `#6973 <https://codeberg.org/freeipa/freeipa/issues/6973>`__
 
 
 
@@ -140,7 +140,7 @@ David Kupka (1)
 
 -  kra: promote: Get ticket before calling custodia
    `commit <https://codeberg.org/freeipa/freeipa/commit/15076a1c2b0fb31dce3903e5f50cab9edf68ad07>`__
-   `#7020 <https://pagure.io/freeipa/issue/7020>`__
+   `#7020 <https://codeberg.org/freeipa/freeipa/issues/7020>`__
 
 
 
@@ -150,10 +150,10 @@ Felipe Volpone (2)
 -  Changing cert-find to go through the proxy instead of using the port
    8080
    `commit <https://codeberg.org/freeipa/freeipa/commit/960b9a3f1b1637c0ea5b11d6d7f671a09a3e89da>`__
-   `#6966 <https://pagure.io/freeipa/issue/6966>`__
+   `#6966 <https://codeberg.org/freeipa/freeipa/issues/6966>`__
 -  Changing cert-find to do not use only primary key to search in LDAP.
    `commit <https://codeberg.org/freeipa/freeipa/commit/df1276e9daf9ee8db05538f47706855cb3d11e01>`__
-   `#6948 <https://pagure.io/freeipa/issue/6948>`__
+   `#6948 <https://codeberg.org/freeipa/freeipa/issues/6948>`__
 
 
 
@@ -162,7 +162,7 @@ Florence Blanc-Renaud (1)
 
 -  ipa-replica-conncheck: handle ssh not installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/bacccb70a2e91efa22ee19aec9cca75bac94bd95>`__
-   `#6935 <https://pagure.io/freeipa/issue/6935>`__
+   `#6935 <https://codeberg.org/freeipa/freeipa/issues/6935>`__
 
 
 
@@ -171,16 +171,16 @@ Jan Cholasta (4)
 
 -  server upgrade: do not enable PKINIT by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb9353d6e0fbc0912dd20bf29e3835a7740d1af6>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  pkinit manage: introduce ipa-pkinit-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/c072135340bc8e75f621e2b9163b1347b9eb528f>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  server certinstall: update KDC master entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b62e5aac9d9668604e82879c020bff310fa549f>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  httpinstance: wait until the service entry is replicated
    `commit <https://codeberg.org/freeipa/freeipa/commit/9871bc08f8b8f51e2a05c4dfa18d844f9c141b8d>`__
-   `#6867 <https://pagure.io/freeipa/issue/6867>`__
+   `#6867 <https://codeberg.org/freeipa/freeipa/issues/6867>`__
 
 
 
@@ -189,35 +189,35 @@ Martin Babinsky (10)
 
 -  Prepare advise plugin for smart card auth configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/84ca9761bd47f28b72581d1fe6bd8cfa824b6df3>`__
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  Extend the advice printing code by some useful abstractions
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ea7ee4326679c098d3e4e4d6a2bc743707708ca>`__
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  fix incorrect suffix handling in topology checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/d651a9877d0e2f9dd1b057630508b488678bb86e>`__
-   `#6965 <https://pagure.io/freeipa/issue/6965>`__
+   `#6965 <https://codeberg.org/freeipa/freeipa/issues/6965>`__
 -  only stop/disable simple service if it is installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/6114150de20a7d8371c7383f619cd0fefe339cbf>`__
-   `#6977 <https://pagure.io/freeipa/issue/6977>`__
+   `#6977 <https://codeberg.org/freeipa/freeipa/issues/6977>`__
 -  test_serverroles: Get rid of MockLDAP and use ldap2 instead
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fa29a33765cb5d6ce86846f37766e5d3322f25f>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add \`pkinit-status\` command
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b815aae7174693b4952f2c60e7201d99e7b9684>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add the list of PKINIT servers as a virtual attribute to global
    config
    `commit <https://codeberg.org/freeipa/freeipa/commit/733cef9d5b0ae83127893ffff71689939902d257>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add an attribute reporting client PKINIT-capable servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbccb748a1c85b7ed67946ba7a11a960b839bcc9>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Refactor the role/attribute member reporting code
    `commit <https://codeberg.org/freeipa/freeipa/commit/753f8cf3aff07d22b35005b973e8518665d1fe6f>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Allow for multivalued server attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4aa3a17694b1ad8f9c60c98a95d217c01fc736c>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 
 
 
@@ -226,14 +226,14 @@ Martin Basti (4)
 
 -  Only warn when specified server IP addresses don't match intf
    `commit <https://codeberg.org/freeipa/freeipa/commit/6206ac8bd23250bda0f8eb628f422671b9b99ad1>`__
-   `#2715 <https://pagure.io/freeipa/issue/2715>`__,
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#2715 <https://codeberg.org/freeipa/freeipa/issues/2715>`__,
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Add remote_plugins subdirectories to RPM
    `commit <https://codeberg.org/freeipa/freeipa/commit/359e3f261705976229bace2d0a22546670181603>`__
-   `#6927 <https://pagure.io/freeipa/issue/6927>`__
+   `#6927 <https://codeberg.org/freeipa/freeipa/issues/6927>`__
 -  custodia dep: require explictly python2 version
    `commit <https://codeberg.org/freeipa/freeipa/commit/444107a00bf995aca62aba74ea02b52e577ab791>`__
-   `#6962 <https://pagure.io/freeipa/issue/6962>`__
+   `#6962 <https://codeberg.org/freeipa/freeipa/issues/6962>`__
 -  4.5 set back to git snapshot
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a3d3e8b2358a536a5ef80e97a8605d7e334c750>`__
 
@@ -244,17 +244,17 @@ Pavel Vomacka (4)
 
 -  WebUI: add support for changing trust UPN suffixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/e22b61832bb5b52eb9daadcbc12ca41e0923503c>`__
-   `#7015 <https://pagure.io/freeipa/issue/7015>`__
+   `#7015 <https://codeberg.org/freeipa/freeipa/issues/7015>`__
 -  Bump version of python-gssapi
    `commit <https://codeberg.org/freeipa/freeipa/commit/15d5ddd417d801a2356dcb043feef1aed8f76a25>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  Turn off OCSP check
    `commit <https://codeberg.org/freeipa/freeipa/commit/51b361f475b3e25ace982873beb05cafcba95808>`__
-   `#6981 <https://pagure.io/freeipa/issue/6981>`__,
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6981 <https://codeberg.org/freeipa/freeipa/issues/6981>`__,
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  Change python-cryptography to python2-cryptography
    `commit <https://codeberg.org/freeipa/freeipa/commit/14ff94a0d481051613338a512260b6a473671538>`__
-   `#6749 <https://pagure.io/freeipa/issue/6749>`__
+   `#6749 <https://codeberg.org/freeipa/freeipa/issues/6749>`__
 
 
 
@@ -263,10 +263,10 @@ Sumit Bose (2)
 
 -  ipa-kdb: use canonical principal in certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8d8aab469ca634f4ec38b869767316806c739f1>`__
-   `#6993 <https://pagure.io/freeipa/issue/6993>`__
+   `#6993 <https://codeberg.org/freeipa/freeipa/issues/6993>`__
 -  ipa-kdb: reload certificate mapping rules periodically
    `commit <https://codeberg.org/freeipa/freeipa/commit/d59694a93c3a734915d4ac05bb4e02a40f9cb08a>`__
-   `#6963 <https://pagure.io/freeipa/issue/6963>`__
+   `#6963 <https://codeberg.org/freeipa/freeipa/issues/6963>`__
 
 
 
@@ -275,10 +275,10 @@ Simo Sorce (3)
 
 -  Revert setting sessionMaxAge for old clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/728e2f681a938f25d091a8480ec6db3961ebfc98>`__
-   `#7001 <https://pagure.io/freeipa/issue/7001>`__
+   `#7001 <https://codeberg.org/freeipa/freeipa/issues/7001>`__
 -  Add code to be able to set default kinit lifetime
    `commit <https://codeberg.org/freeipa/freeipa/commit/0def2ec653ac29210414aa09499b309dd1c3ac7d>`__
-   `#7001 <https://pagure.io/freeipa/issue/7001>`__
+   `#7001 <https://codeberg.org/freeipa/freeipa/issues/7001>`__
 -  Fix rare race condition with missing ccache file
    `commit <https://codeberg.org/freeipa/freeipa/commit/90b432b93d71c795eaa4f92d3a9e1d322dce1802>`__
 
@@ -289,22 +289,22 @@ Stanislav Laznicka (6)
 
 -  rpc: avoid possible recursion in create_connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb6c93dad044c724ba2cedbff49bf71aea939418>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  rpc: preparations for recursion fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8aab383a39a22cc613cf64e5d66ce69111d97df>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  Avoid possible endless recursion in RPC call
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5b413b72e224120acde09d1c877be11b3f61b6b>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  kdc.key should not be visible to all
    `commit <https://codeberg.org/freeipa/freeipa/commit/37be8e9ac3b46d6d31199227216b5a5a8d5d5614>`__
-   `#6973 <https://pagure.io/freeipa/issue/6973>`__
+   `#6973 <https://codeberg.org/freeipa/freeipa/issues/6973>`__
 -  Remove pkinit-anonymous command
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e878c3dc6f72cae4e7b4cb2ef45f2f4e91ac287>`__
-   `#6936 <https://pagure.io/freeipa/issue/6936>`__
+   `#6936 <https://codeberg.org/freeipa/freeipa/issues/6936>`__
 -  ca/cert-show: check certificate_out in options
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ce5d6bf36e669f40099a8468f3a664795df06b4>`__
-   `#6885 <https://pagure.io/freeipa/issue/6885>`__
+   `#6885 <https://codeberg.org/freeipa/freeipa/issues/6885>`__
 
 
 
@@ -313,13 +313,13 @@ Tibor Dudlák (3)
 
 -  server.py: Removes dns-server configuration from ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/005c92868ce36770ce89e87ef3cdeae62d11ece4>`__
-   `#6572 <https://pagure.io/freeipa/issue/6572>`__
+   `#6572 <https://codeberg.org/freeipa/freeipa/issues/6572>`__
 -  sssd.py: Deprecating no-sssd option.
    `commit <https://codeberg.org/freeipa/freeipa/commit/f984cef6ed49e04a4e3754d2f3214d64715d26df>`__
-   `#5860 <https://pagure.io/freeipa/issue/5860>`__
+   `#5860 <https://codeberg.org/freeipa/freeipa/issues/5860>`__
 -  client.py: Replace hardcoded 'admin' with options.principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bef8c7ff16c95a43312a3d162ff354625ecd198>`__
-   `#5406 <https://pagure.io/freeipa/issue/5406>`__
+   `#5406 <https://codeberg.org/freeipa/freeipa/issues/5406>`__
 
 
 
@@ -328,7 +328,7 @@ Tibor Dudlák (1)
 
 -  user.py: replace user_mod with ldap.update_entry()
    `commit <https://codeberg.org/freeipa/freeipa/commit/daeac31ba54d88159b46d61fc443ccd45902f8f2>`__
-   `#5788 <https://pagure.io/freeipa/issue/5788>`__
+   `#5788 <https://codeberg.org/freeipa/freeipa/issues/5788>`__
 
 
 

--- a/src/page/Releases/4.5.3.rst
+++ b/src/page/Releases/4.5.3.rst
@@ -49,29 +49,29 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7039 <https://pagure.io/freeipa/issue/7039>`__ FreeIPA upgrade
+-  `#7039 <https://codeberg.org/freeipa/freeipa/issues/7039>`__ FreeIPA upgrade
    script requires network to be up, but network is not up during
    upgrade when using dnf system-upgrade
--  `#7037 <https://pagure.io/freeipa/issue/7037>`__ Replica installation
+-  `#7037 <https://codeberg.org/freeipa/freeipa/issues/7037>`__ Replica installation
    grants HTTP principal access in WebUI
--  `#7036 <https://pagure.io/freeipa/issue/7036>`__ Advice plugins for
+-  `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__ Advice plugins for
    smart card configuration produce scripts that configure the feature
    incompletely
--  `#7029 <https://pagure.io/freeipa/issue/7029>`__ Fix inconsistent
+-  `#7029 <https://codeberg.org/freeipa/freeipa/issues/7029>`__ Fix inconsistent
    reporting of server roles/attributes in \*config-show commands
--  `#7026 <https://pagure.io/freeipa/issue/7026>`__ ipaserver
+-  `#7026 <https://codeberg.org/freeipa/freeipa/issues/7026>`__ ipaserver
    installation fails in FIPS mode: OpenSSL internal error, assertion
    failed: Digest MD4 forbidden in FIPS mode!
--  `#7021 <https://pagure.io/freeipa/issue/7021>`__ ipa-server-install
+-  `#7021 <https://codeberg.org/freeipa/freeipa/issues/7021>`__ ipa-server-install
    failure on checking matching interfaces - invalid format of netmas
--  `#7007 <https://pagure.io/freeipa/issue/7007>`__ Use
+-  `#7007 <https://codeberg.org/freeipa/freeipa/issues/7007>`__ Use
    CommonNameToSANDefault in default profile (new installs only)
--  `#6877 <https://pagure.io/freeipa/issue/6877>`__ ipasam needs changes
+-  `#6877 <https://codeberg.org/freeipa/freeipa/issues/6877>`__ ipasam needs changes
    for Samba 4.7
--  `#6838 <https://pagure.io/freeipa/issue/6838>`__
+-  `#6838 <https://codeberg.org/freeipa/freeipa/issues/6838>`__
    [ipa-replica-install] - 406 Client Error: Failed to validate message:
    Incorrect number of results (0) searching forpublic key for host
--  `#4317 <https://pagure.io/freeipa/issue/4317>`__ Allow --ip-address
+-  `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__ Allow --ip-address
    even when not present in local interface
 
 
@@ -86,10 +86,10 @@ Alexander Bokovoy (2)
 
 -  ipa-sam: use smbldap_set_bind_callback for Samba 4.7 or later
    `commit <https://codeberg.org/freeipa/freeipa/commit/933cfcb86417c8428d27c540d015288476cc87da>`__
-   `#6877 <https://pagure.io/freeipa/issue/6877>`__
+   `#6877 <https://codeberg.org/freeipa/freeipa/issues/6877>`__
 -  ipa-sam: use own private structure, not ldapsam_privates
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbc9c737fe99b542eb3799754612871a0c9b3263>`__
-   `#6877 <https://pagure.io/freeipa/issue/6877>`__
+   `#6877 <https://codeberg.org/freeipa/freeipa/issues/6877>`__
 
 
 
@@ -98,7 +98,7 @@ Fraser Tweedale (1)
 
 -  Add CommonNameToSANDefault to default cert profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/33aa4c25a2c3d158e43978d8699c3776d0e06599>`__
-   `#7007 <https://pagure.io/freeipa/issue/7007>`__
+   `#7007 <https://codeberg.org/freeipa/freeipa/issues/7007>`__
 
 
 
@@ -107,50 +107,50 @@ Martin Babinsky (15)
 
 -  replica install: drop-in IPA specific config to tmpfiles.d
    `commit <https://codeberg.org/freeipa/freeipa/commit/76cc115c53c3a9c5f594083ff4c4452479070021>`__
-   `#7053 <https://pagure.io/freeipa/issue/7053>`__
+   `#7053 <https://codeberg.org/freeipa/freeipa/issues/7053>`__
 -  Do not remove the old masters when setting the attribute fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/03a30c0fb2748d5724112e702567c71cbd19d624>`__
-   `#7029 <https://pagure.io/freeipa/issue/7029>`__
+   `#7029 <https://codeberg.org/freeipa/freeipa/issues/7029>`__
 -  \*config-show: Do not show empty roles/attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/2431c76775a1e314a3a03f608bb7aa776d3c8bf2>`__
-   `#7029 <https://pagure.io/freeipa/issue/7029>`__
+   `#7029 <https://codeberg.org/freeipa/freeipa/issues/7029>`__
 -  smart-card-advises: ensure that krb5-pkinit is installed on client
    `commit <https://codeberg.org/freeipa/freeipa/commit/1114e113d5cc558f13398af8bc5a179b33f9354b>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart card advise: use password when changing trust flags on HTTP
    cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/e14194e171be82d43ad16b4a585502a9c28aace3>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart card advises: use a wrapper around Bash \`for\` loops
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5e4c0a484412e11cc414ca80dc230b0000c00d7>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Use the compound statement formatting API for configuring PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/08f56c3c8ccde61146baec16085b325726582752>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Fix indentation of statements in Smart card advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/61f6cb7e6fa632db08628534c512a22e35682dc1>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  delegate formatting of compound Bash statements to dedicated classes
    `commit <https://codeberg.org/freeipa/freeipa/commit/2be45a1d95b7033ee25a643fdd74f5f30c41fea5>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  advise: add an infrastructure for formatting Bash compound statements
    `commit <https://codeberg.org/freeipa/freeipa/commit/666c2da3afcc461870d423409db4298e7ead6493>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  delegate the indentation handling in advises to dedicated class
    `commit <https://codeberg.org/freeipa/freeipa/commit/9561e3f8a2be66c1c236ac7fe296a8c8cbbac5c1>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  add a class that tracks the indentation in the generated advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5f31e35d3d17b5871cb39ebe55b413ba0dca489>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Allow to pass in multiple CA cert paths to the smart card advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ebab27ded06a72d807c10b1ba521c6406df1ab4>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart-card advises: add steps to store smart card signing CA cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef2ab942d2dee4a7a902f70a7eaf1c35cf88bee6>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart-card advises: configure systemwide NSS DB also on master
    `commit <https://codeberg.org/freeipa/freeipa/commit/23917c71f72ba899054bc5dc72c36d5308ead94c>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 
 
 
@@ -159,28 +159,28 @@ Martin Basti (8)
 
 -  python-netifaces: update to reflect upstream changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/56d04b3dccc967630d869006dfbd0003fcfedabe>`__
-   `#7021 <https://pagure.io/freeipa/issue/7021>`__
+   `#7021 <https://codeberg.org/freeipa/freeipa/issues/7021>`__
 -  Remove network and broadcast address warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c961161873c37cb29a51baeeed0e782cd4a1d4d>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  replica install: add missing check for non-local IP address
    `commit <https://codeberg.org/freeipa/freeipa/commit/93ef10292ca674842c79da0dab6de6fb63261881>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Remove ip_netmask from option parser
    `commit <https://codeberg.org/freeipa/freeipa/commit/217905a20071b55b50568e8fbb36a8ecde974432>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  CheckedIPAddress: remove match_local param
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a924dd8cc27507a70f4ec5020d97417e149e350>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  refactor CheckedIPAddress class
    `commit <https://codeberg.org/freeipa/freeipa/commit/0aa0041149f359f1954409baf886d4b31fdadc16>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  ipa-dns-install: remove check for local ip address
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d06f0c52200a4345db36dae3fdbc178f18f2f01>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Fix local IP address validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/d010191d170c0ebb5f46bac2fc528f788e8ffc41>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 
 
 
@@ -189,10 +189,10 @@ Sumit Bose (2)
 
 -  ipa_pwd_extop: do not generate NT hashes in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/79a5f3bf321f15e4c120d16b8988ed0cdb0ae64c>`__
-   `#7026 <https://pagure.io/freeipa/issue/7026>`__
+   `#7026 <https://codeberg.org/freeipa/freeipa/issues/7026>`__
 -  ipa-sam: replace encode_nt_key() with E_md4hash()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b63b6790efc82c87398c39ba4f55330756b7b3cf>`__
-   `#7026 <https://pagure.io/freeipa/issue/7026>`__
+   `#7026 <https://codeberg.org/freeipa/freeipa/issues/7026>`__
 
 
 
@@ -211,7 +211,7 @@ Stanislav Laznicka (1)
 
 -  Ensure network is online prior to an upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ca6942fda4cea7a78569eb83031e7e6032ace47>`__
-   `#7039 <https://pagure.io/freeipa/issue/7039>`__
+   `#7039 <https://codeberg.org/freeipa/freeipa/issues/7039>`__
 
 
 
@@ -220,7 +220,7 @@ Tibor Dudlák (1)
 
 -  topology.py: Removes error message from dictionary.
    `commit <https://codeberg.org/freeipa/freeipa/commit/0571e3840b0a5a70cf18ce5136acaf2235bab907>`__
-   `#6533 <https://pagure.io/freeipa/issue/6533>`__
+   `#6533 <https://codeberg.org/freeipa/freeipa/issues/6533>`__
 
 
 

--- a/src/page/Releases/4.5.4.rst
+++ b/src/page/Releases/4.5.4.rst
@@ -44,80 +44,80 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7179 <https://pagure.io/freeipa/issue/7179>`__ In case full PKINIT
+-  `#7179 <https://codeberg.org/freeipa/freeipa/issues/7179>`__ In case full PKINIT
    configuration is failing during server/replica install the error
    message should be more meaningful.
--  `#7175 <https://pagure.io/freeipa/issue/7175>`__ [Backport 7143 to
+-  `#7175 <https://codeberg.org/freeipa/freeipa/issues/7175>`__ [Backport 7143 to
    ipa-4-5] "unknown command 'undefined'" error when changing user's
    password via the web UI
--  `#7173 <https://pagure.io/freeipa/issue/7173>`__ Switch from
+-  `#7173 <https://codeberg.org/freeipa/freeipa/issues/7173>`__ Switch from
    externally-signed to self-signed CA fails
--  `#7172 <https://pagure.io/freeipa/issue/7172>`__ Enterprise
+-  `#7172 <https://codeberg.org/freeipa/freeipa/issues/7172>`__ Enterprise
    principals should be able to trigger a refresh of the trusted domain
    data in the KDC
--  `#7146 <https://pagure.io/freeipa/issue/7146>`__
+-  `#7146 <https://codeberg.org/freeipa/freeipa/issues/7146>`__
    ipa_otptoken_import.py fails to parse the correct suite defined under
    the AlrgorithmParameters
--  `#7144 <https://pagure.io/freeipa/issue/7144>`__ pkinit-status
+-  `#7144 <https://codeberg.org/freeipa/freeipa/issues/7144>`__ pkinit-status
    command fails after an upgrade from a pre-4.5 IPA
--  `#7141 <https://pagure.io/freeipa/issue/7141>`__ Updating from RHEL
+-  `#7141 <https://codeberg.org/freeipa/freeipa/issues/7141>`__ Updating from RHEL
    7.3 fails with Server-Cert not found (ipa-server-upgrade)
--  `#7127 <https://pagure.io/freeipa/issue/7127>`__ sssd.conf not
+-  `#7127 <https://codeberg.org/freeipa/freeipa/issues/7127>`__ sssd.conf not
    updated after promoting client to promotion
--  `#7126 <https://pagure.io/freeipa/issue/7126>`__ FreeIPA/IdM
+-  `#7126 <https://codeberg.org/freeipa/freeipa/issues/7126>`__ FreeIPA/IdM
    installations which were upgraded from versions with 389 DS prior to
    1.3.3.0 doesn't have whomai plugin enabled and thus startup of Web UI
    fails
--  `#7125 <https://pagure.io/freeipa/issue/7125>`__ ipa-server-upgrade
+-  `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__ ipa-server-upgrade
    failes with "This entry already exists"
--  `#7123 <https://pagure.io/freeipa/issue/7123>`__ External CA renewal
+-  `#7123 <https://codeberg.org/freeipa/freeipa/issues/7123>`__ External CA renewal
    fails when IPA CA subject DN does not match "CN=Certificate
    Authority, {subject-base}"
--  `#7120 <https://pagure.io/freeipa/issue/7120>`__ Unable to set ca
+-  `#7120 <https://codeberg.org/freeipa/freeipa/issues/7120>`__ Unable to set ca
    renewal master on replica
--  `#7116 <https://pagure.io/freeipa/issue/7116>`__ dnssec: fix
+-  `#7116 <https://codeberg.org/freeipa/freeipa/issues/7116>`__ dnssec: fix
    localhsm.py with openhsm >= 2.2.0
--  `#7112 <https://pagure.io/freeipa/issue/7112>`__ user-show command
+-  `#7112 <https://codeberg.org/freeipa/freeipa/issues/7112>`__ user-show command
    fails when sizelimit is configured to number <= number of entity
    which is user member of
--  `#7108 <https://pagure.io/freeipa/issue/7108>`__ ipa-backup broken
+-  `#7108 <https://codeberg.org/freeipa/freeipa/issues/7108>`__ ipa-backup broken
    because of cyclic import
--  `#7106 <https://pagure.io/freeipa/issue/7106>`__ TypeError in
+-  `#7106 <https://codeberg.org/freeipa/freeipa/issues/7106>`__ TypeError in
    renew_ca_cert prevents from swiching back to self-signed CA
--  `#7086 <https://pagure.io/freeipa/issue/7086>`__ [ipatests] - add
+-  `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__ [ipatests] - add
    caless to cafull tests
--  `#7083 <https://pagure.io/freeipa/issue/7083>`__ failed
+-  `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__ failed
    ipa-server-upgrade , time out from dogtag services , custodia errors
--  `#7074 <https://pagure.io/freeipa/issue/7074>`__ IPA shouldn't allow
+-  `#7074 <https://codeberg.org/freeipa/freeipa/issues/7074>`__ IPA shouldn't allow
    objectclass if not all in lower case
--  `#7066 <https://pagure.io/freeipa/issue/7066>`__ WebUI: All columns
+-  `#7066 <https://codeberg.org/freeipa/freeipa/issues/7066>`__ WebUI: All columns
    of user in group table are clickable
--  `#7035 <https://pagure.io/freeipa/issue/7035>`__ ipa-otptoken-import
+-  `#7035 <https://codeberg.org/freeipa/freeipa/issues/7035>`__ ipa-otptoken-import
    - XML file is missing PBKDF2 parameters!
--  `#7017 <https://pagure.io/freeipa/issue/7017>`__ NULL LDAP context in
+-  `#7017 <https://codeberg.org/freeipa/freeipa/issues/7017>`__ NULL LDAP context in
    call to ldap_search_ext_s during search in
    cn=ad,cn=trusts,dc=example,dc=com
--  `#6999 <https://pagure.io/freeipa/issue/6999>`__ ipa command throws
+-  `#6999 <https://codeberg.org/freeipa/freeipa/issues/6999>`__ ipa command throws
    backtrace instead of showing help with wrong syntax
--  `#6979 <https://pagure.io/freeipa/issue/6979>`__ Suggest user to
+-  `#6979 <https://codeberg.org/freeipa/freeipa/issues/6979>`__ Suggest user to
    install libyubikey package instead of traceback
--  `#6952 <https://pagure.io/freeipa/issue/6952>`__ Suggest CA
+-  `#6952 <https://codeberg.org/freeipa/freeipa/issues/6952>`__ Suggest CA
    installation command in KRA installation warning
--  `#6622 <https://pagure.io/freeipa/issue/6622>`__ [tests]
+-  `#6622 <https://codeberg.org/freeipa/freeipa/issues/6622>`__ [tests]
    ipatests.util.unlock_principal_password does not respect configured
    ldap_uri
--  `#6605 <https://pagure.io/freeipa/issue/6605>`__ make lint + make
+-  `#6605 <https://codeberg.org/freeipa/freeipa/issues/6605>`__ make lint + make
    modifies PO files in place
--  `#6592 <https://pagure.io/freeipa/issue/6592>`__ [tracker] SELinux
+-  `#6592 <https://codeberg.org/freeipa/freeipa/issues/6592>`__ [tracker] SELinux
    policy tracker for 4.5
--  `#6582 <https://pagure.io/freeipa/issue/6582>`__ Web UI: Change "Host
+-  `#6582 <https://codeberg.org/freeipa/freeipa/issues/6582>`__ Web UI: Change "Host
    Based" and "Role Based" to "Host-Based" and "Role-Based"
--  `#6447 <https://pagure.io/freeipa/issue/6447>`__ [WebUI] Remove
+-  `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__ [WebUI] Remove
    offline version of WebUI
--  `#6261 <https://pagure.io/freeipa/issue/6261>`__ Replace ERROR:
+-  `#6261 <https://codeberg.org/freeipa/freeipa/issues/6261>`__ Replace ERROR:
    cannot connect to 'http://localhost:8888/ipa/json': [Errno 111]
    Connection refused with 'IPA is not configured on this system'
--  `#6176 <https://pagure.io/freeipa/issue/6176>`__ Updating of dns
+-  `#6176 <https://codeberg.org/freeipa/freeipa/issues/6176>`__ Updating of dns
    system records rapidly slowdown uninstallation
 
 
@@ -132,10 +132,10 @@ Alexander Bokovoy (2)
 
 -  Make sure upgrade also checks for IPv6 stack
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdf9a34dffdf4d7925208e5df9f69e3927b88858>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 -  OTP import: support hash names with HMAC- prefix
    `commit <https://codeberg.org/freeipa/freeipa/commit/496936ed656c5dcb52f485476eb9adc27505228f>`__
-   `#7146 <https://pagure.io/freeipa/issue/7146>`__
+   `#7146 <https://codeberg.org/freeipa/freeipa/issues/7146>`__
 
 
 
@@ -144,7 +144,7 @@ Abhijeet Kasurde (1)
 
 -  Vault testcase improvement
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4b24692204ffa00be45cd7a15de86f4597c4231>`__
-   `#7098 <https://pagure.io/freeipa/issue/7098>`__
+   `#7098 <https://codeberg.org/freeipa/freeipa/issues/7098>`__
 
 
 
@@ -153,7 +153,7 @@ Alexander Koksharov (1)
 
 -  kra-install: better warning message
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fb25bfffd9324021b3951a1418fa84d5ac20f00>`__
-   `#6952 <https://pagure.io/freeipa/issue/6952>`__
+   `#6952 <https://codeberg.org/freeipa/freeipa/issues/6952>`__
 
 
 
@@ -162,10 +162,10 @@ Aleksei Slaikovskii (2)
 
 -  ipaclient.plugins.dns: Cast DNS name to unicode.
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3f390d2264f71cf4b87123fdcabd007075704ab>`__
-   `#7185 <https://pagure.io/freeipa/issue/7185>`__
+   `#7185 <https://codeberg.org/freeipa/freeipa/issues/7185>`__
 -  Less confusing message for PKINIT configuration during install
    `commit <https://codeberg.org/freeipa/freeipa/commit/c79cdccfa2361f013fb51e8225b4630abab8b557>`__
-   `#7179 <https://pagure.io/freeipa/issue/7179>`__
+   `#7179 <https://codeberg.org/freeipa/freeipa/issues/7179>`__
 
 
 
@@ -174,7 +174,7 @@ Christian Heimes (1)
 
 -  Block PyOpenSSL to prevent SELinux execmem in wsgi
    `commit <https://codeberg.org/freeipa/freeipa/commit/e527dd17e89c0826d55d4a214c176fb00e383eef>`__
-   `#5442 <https://pagure.io/freeipa/issue/5442>`__
+   `#5442 <https://codeberg.org/freeipa/freeipa/issues/5442>`__
 
 
 
@@ -193,40 +193,40 @@ David Kupka (11)
 
 -  tests: Add LDAP URI to ldappasswd explicitly
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0a73195ced8c541712142482ff50d41af81a61d>`__
-   `#6622 <https://pagure.io/freeipa/issue/6622>`__
+   `#6622 <https://codeberg.org/freeipa/freeipa/issues/6622>`__
 -  tests: certmap: Add test for user-{add,remove}-certmap
    `commit <https://codeberg.org/freeipa/freeipa/commit/12f951b84164089c6f7390aeabac103d643ebd96>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapdataMixin tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/80f555179849e5799a87a837c0bf5cb8a53a7f1c>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Add test for certmapconfig-{mod,show}
    `commit <https://codeberg.org/freeipa/freeipa/commit/9bad6526bca42db591f53d70b4f0fdf1d9847ffc>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapconfigTracker to tests certmapconfig-\*
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d44657696545605162ccd480bdc867e8cd2d0d3>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Test permissions for certmap
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d9ba56d0953690890dd6543fb23639a867b56d5>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Add basic tests for certmaprule commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/bec002eefae7dd4acacb3f759970a0b6fa6fdd95>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapTracker for testing certmap-\* commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/7aac39b473f8a3e1de5682e17f3851b361e6c1ac>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add ConfigurationTracker to test \*config-{mod,show}
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/62c9bf793b921ab2b193d398351437bc8ae8e70d>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add EnableTracker to test \*-{enable,disable}
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6ba6973ba507a5086bd6e6d4b817d4f276ceceb>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Split Tracker into one-purpose Trackers
    `commit <https://codeberg.org/freeipa/freeipa/commit/0052a3312ccfa17d5c3f291e12c5b97d3922c18b>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 
 
 
@@ -235,17 +235,17 @@ Felipe Volpone (4)
 
 -  Changing idoverrideuser-\* to treat objectClass case insensitively
    `commit <https://codeberg.org/freeipa/freeipa/commit/61e8b4936f1fd73f8d4c359348cf83f37da35fef>`__
-   `#7074 <https://pagure.io/freeipa/issue/7074>`__
+   `#7074 <https://codeberg.org/freeipa/freeipa/issues/7074>`__
 -  Fixing how sssd.conf is updated when promoting a client to replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/79570804b0ffaae14b5db11b2d6e45dceff51aba>`__
-   `#7127 <https://pagure.io/freeipa/issue/7127>`__
+   `#7127 <https://codeberg.org/freeipa/freeipa/issues/7127>`__
 -  Removing part of circular dependency of ipalib in ipaplaform
    `commit <https://codeberg.org/freeipa/freeipa/commit/361566c5eae4716ca0c17796e116667852462123>`__
-   `#7108 <https://pagure.io/freeipa/issue/7108>`__
+   `#7108 <https://codeberg.org/freeipa/freeipa/issues/7108>`__
 -  Changing how commands handles error when it can't connect to IPA
    server
    `commit <https://codeberg.org/freeipa/freeipa/commit/73b381e21183dc2058c9a6ac4620928230a2dce8>`__
-   `#6261 <https://pagure.io/freeipa/issue/6261>`__
+   `#6261 <https://codeberg.org/freeipa/freeipa/issues/6261>`__
 
 
 
@@ -254,20 +254,20 @@ Florence Blanc-Renaud (5)
 
 -  ipa-cacert-manage renew: switch from ext-signed CA to self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/22e285fb6d17aad83caaa04674861bdea662f94d>`__
-   `#7173 <https://pagure.io/freeipa/issue/7173>`__
+   `#7173 <https://codeberg.org/freeipa/freeipa/issues/7173>`__
 -  Backport 4-5: Fix ipa-server-upgrade with server cert tracking
    `commit <https://codeberg.org/freeipa/freeipa/commit/52853875e298e38a1e5a9a56c02aac9e30916044>`__
-   `#7141 <https://pagure.io/freeipa/issue/7141>`__
+   `#7141 <https://codeberg.org/freeipa/freeipa/issues/7141>`__
 -  Backport PR 1008 to ipa-4-5 Fix ipa-server-upgrade: This entry
    already exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9035a045bece8c9a205c078a8cdd2e1f101590b>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Backport PR 988 to ipa-4-5 Fix Certificate renewal (with ext ca)
    `commit <https://codeberg.org/freeipa/freeipa/commit/85d5611119b9e3d616589d2a8e7447055184592b>`__
-   `#7106 <https://pagure.io/freeipa/issue/7106>`__
+   `#7106 <https://codeberg.org/freeipa/freeipa/issues/7106>`__
 -  Fix ipa config-mod --ca-renewal-master
    `commit <https://codeberg.org/freeipa/freeipa/commit/770fb59637affc22c76256478b53bbe831b3ec88>`__
-   `#7120 <https://pagure.io/freeipa/issue/7120>`__
+   `#7120 <https://codeberg.org/freeipa/freeipa/issues/7120>`__
 
 
 
@@ -276,10 +276,10 @@ Fraser Tweedale (2)
 
 -  Fix external renewal for CA with non-default subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b9f7c9ab593f7633da3e932e5583b3a93555347>`__
-   `#7123 <https://pagure.io/freeipa/issue/7123>`__
+   `#7123 <https://codeberg.org/freeipa/freeipa/issues/7123>`__
 -  Restore old version of caIPAserviceCert for upgrade only
    `commit <https://codeberg.org/freeipa/freeipa/commit/87393daba6b414e3afe6e22e77c9b20e561e5302>`__
-   `#7097 <https://pagure.io/freeipa/issue/7097>`__
+   `#7097 <https://codeberg.org/freeipa/freeipa/issues/7097>`__
 
 
 
@@ -288,7 +288,7 @@ Martin Basti (1)
 
 -  DNS update: reduce timeout for CA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b3b94f3c15aef57830bd81b9580d31d2e837612>`__
-   `#6176 <https://pagure.io/freeipa/issue/6176>`__
+   `#6176 <https://codeberg.org/freeipa/freeipa/issues/6176>`__
 
 
 
@@ -297,13 +297,13 @@ Michal Reznik (3)
 
 -  test_caless: add replica ca-less to ca-full test (master caless)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4c9b751e2cd0cd9862ed6897341906b246d7c18>`__
-   `#7086 <https://pagure.io/freeipa/issue/7086>`__
+   `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__
 -  test_caless: add server_replica ca-less to ca-full test
    `commit <https://codeberg.org/freeipa/freeipa/commit/45db679fb5c8f387e16c36cef93bcfebf4aac9f7>`__
-   `#7086 <https://pagure.io/freeipa/issue/7086>`__
+   `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__
 -  tests: fix external_ca test suite failing due to missing SKI
    `commit <https://codeberg.org/freeipa/freeipa/commit/870f430efc5f483096dfb70e248e9a747891615e>`__
-   `#7099 <https://pagure.io/freeipa/issue/7099>`__
+   `#7099 <https://codeberg.org/freeipa/freeipa/issues/7099>`__
 
 
 
@@ -312,7 +312,7 @@ Nathaniel McCallum (1)
 
 -  ipa-otptoken-import: Make PBKDF2 refer to the pkcs5 namespace
    `commit <https://codeberg.org/freeipa/freeipa/commit/ade766abe5e60a90899e0df0d019fd9df0386864>`__
-   `#7035 <https://pagure.io/freeipa/issue/7035>`__
+   `#7035 <https://codeberg.org/freeipa/freeipa/issues/7035>`__
 
 
 
@@ -321,7 +321,7 @@ Petr Čech (1)
 
 -  ipatests: Fix on logs collection
    `commit <https://codeberg.org/freeipa/freeipa/commit/653ed4a00b90335153cea39378bf32685b1df8d2>`__
-   `#7214 <https://pagure.io/freeipa/issue/7214>`__
+   `#7214 <https://codeberg.org/freeipa/freeipa/issues/7214>`__
 
 
 
@@ -330,10 +330,10 @@ Petr Vobornik (2)
 
 -  log progress of wait_for_open_ports
    `commit <https://codeberg.org/freeipa/freeipa/commit/756734351410077ab7b102a9a7a5264a62bcb0e0>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 -  control logging of host_port_open from caller
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5970862a5b22c4272c00be1d31e1d50f3b7c14c>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 
 
 
@@ -342,30 +342,30 @@ Pavel Vomacka (9)
 
 -  WebUI: Fix calling undefined method during reset passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3615994c304c3157ddfb2a32bf0de3cc1a12598>`__
-   `#7175 <https://pagure.io/freeipa/issue/7175>`__
+   `#7175 <https://codeberg.org/freeipa/freeipa/issues/7175>`__
 -  WebUI: remove unused parameter from get_whoami_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/4be73033442276ea518d950e3df0531b418252d8>`__
-   `#7175 <https://pagure.io/freeipa/issue/7175>`__
+   `#7175 <https://codeberg.org/freeipa/freeipa/issues/7175>`__
 -  Adds whoami DS plugin in case that plugin is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/736a472222802dd0880063a3a4e288d1b40347b3>`__
-   `#7126 <https://pagure.io/freeipa/issue/7126>`__
+   `#7126 <https://codeberg.org/freeipa/freeipa/issues/7126>`__
 -  WebUI: remove creating js/libs symlink from makefile
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b0d696ba8d5dc430a6eadf14276bdb5163e05cf>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  WebUI: Remove plugins symlink as it is unused
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c246375d5ca517f76248d0a36499e03ae39da0d>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  Remove all old JSON files
    `commit <https://codeberg.org/freeipa/freeipa/commit/16e14f29e60c93e80a1f395e65423864df4ba634>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  Revert "Web UI: Remove offline version of Web UI"
    `commit <https://codeberg.org/freeipa/freeipa/commit/331ad1fe8ec39c93cd11c6def910a55a410bc466>`__
 -  WebUI: Add hyphenate versions of Host(Role) Based strings
    `commit <https://codeberg.org/freeipa/freeipa/commit/873cfe58f2445dc1af41ac0543811db0676bfd42>`__
-   `#6582 <https://pagure.io/freeipa/issue/6582>`__
+   `#6582 <https://codeberg.org/freeipa/freeipa/issues/6582>`__
 -  WebUI: fix incorrectly shown links in association tables
    `commit <https://codeberg.org/freeipa/freeipa/commit/705351c27092292d0ddc6c099bf060f68a3c8616>`__
-   `#7066 <https://pagure.io/freeipa/issue/7066>`__
+   `#7066 <https://codeberg.org/freeipa/freeipa/issues/7066>`__
 
 
 
@@ -374,7 +374,7 @@ Rob Crittenden (1)
 
 -  Collect group membership without a size limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/c27d015202be35b2ac04151a73a2179909127704>`__
-   `#7112 <https://pagure.io/freeipa/issue/7112>`__
+   `#7112 <https://codeberg.org/freeipa/freeipa/issues/7112>`__
 
 
 
@@ -383,7 +383,7 @@ Sumit Bose (1)
 
 -  ipa-kdb: reinit trusted domain data for enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e74685b1d6b465cd33aa5a8049db80da51de962>`__
-   `#7172 <https://pagure.io/freeipa/issue/7172>`__
+   `#7172 <https://codeberg.org/freeipa/freeipa/issues/7172>`__
 
 
 
@@ -396,7 +396,7 @@ Stanislav Laznicka (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7544e71fdf5a250dc161c1a5755c0854360fdb35>`__
 -  pkinit: don't fail when no pkinit servers found
    `commit <https://codeberg.org/freeipa/freeipa/commit/fee3adbdb56cdd8d5961e59d5f7600c6b6d0bda6>`__
-   `#7144 <https://pagure.io/freeipa/issue/7144>`__
+   `#7144 <https://codeberg.org/freeipa/freeipa/issues/7144>`__
 -  travis: temporary workaround for Travis CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f524ae5b5bc26ea33e5ae2abaa527f2384d09b5>`__
 
@@ -407,7 +407,7 @@ Thierry Bordaz (1)
 
 -  NULL LDAP context in call to ldap_search_ext_s during search
    `commit <https://codeberg.org/freeipa/freeipa/commit/1cb93edd5bbfbca51362ca8dd3bf7c40d2020218>`__
-   `#7017 <https://pagure.io/freeipa/issue/7017>`__
+   `#7017 <https://codeberg.org/freeipa/freeipa/issues/7017>`__
 
 
 
@@ -416,7 +416,7 @@ Tibor Dudlák (1)
 
 -  otptoken_yubikey.py: Removed traceback when package missing.
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b33cdad14d7d5978266bac07c68dbe66cd298ce>`__
-   `#6979 <https://pagure.io/freeipa/issue/6979>`__
+   `#6979 <https://codeberg.org/freeipa/freeipa/issues/6979>`__
 
 
 
@@ -433,17 +433,17 @@ Tomas Krizek (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3c217f3a50cfb6ad8a9925e996e3480c2b1595c>`__
 -  ipatests: collect log after ipa-ca-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/be0f4787b5e7fb0992fb6e9dee81fa8b670f6ea8>`__
-   `#7060 <https://pagure.io/freeipa/issue/7060>`__
+   `#7060 <https://codeberg.org/freeipa/freeipa/issues/7060>`__
 -  dnssec: fix localhsm.py utility script
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e6c38096faa69c8e2ff847464d10bb504a3f63b>`__
-   `#7116 <https://pagure.io/freeipa/issue/7116>`__
+   `#7116 <https://codeberg.org/freeipa/freeipa/issues/7116>`__
 -  prci: rename template to ci-ipa-4-5-f25
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe4b1547d700970ea27404aeff883b194f986f13>`__
 -  prci: add caless tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/af0dfc90cad34f548ec5a0e20687d52a6e320c0c>`__
 -  build: checkout \*.po files at the end of makerpms.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/f66360ebe01a23279b3e91e94634ce43aefea53f>`__
-   `#6605 <https://pagure.io/freeipa/issue/6605>`__
+   `#6605 <https://codeberg.org/freeipa/freeipa/issues/6605>`__
 -  freeipa-pr-ci: enable pull-request CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ca9b3de1b0ed8ae70c0fcc00e6f17091b1df088>`__
 -  4.5 set back to git snapshot

--- a/src/page/Releases/4.6.0.rst
+++ b/src/page/Releases/4.6.0.rst
@@ -49,121 +49,121 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7123 <https://pagure.io/freeipa/issue/7123>`__ External CA renewal
+-  `#7123 <https://codeberg.org/freeipa/freeipa/issues/7123>`__ External CA renewal
    fails when IPA CA subject DN does not match "CN=Certificate
    Authority, {subject-base}"
--  `#7116 <https://pagure.io/freeipa/issue/7116>`__ dnssec: fix
+-  `#7116 <https://codeberg.org/freeipa/freeipa/issues/7116>`__ dnssec: fix
    localhsm.py with openhsm >= 2.2.0
--  `#7108 <https://pagure.io/freeipa/issue/7108>`__ ipa-backup broken
+-  `#7108 <https://codeberg.org/freeipa/freeipa/issues/7108>`__ ipa-backup broken
    because of cyclic import
--  `#7086 <https://pagure.io/freeipa/issue/7086>`__ [ipatests] - add
+-  `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__ [ipatests] - add
    caless to cafull tests
--  `#7066 <https://pagure.io/freeipa/issue/7066>`__ WebUI: All columns
+-  `#7066 <https://codeberg.org/freeipa/freeipa/issues/7066>`__ WebUI: All columns
    of user in group table are clickable
--  `#7035 <https://pagure.io/freeipa/issue/7035>`__ ipa-otptoken-import
+-  `#7035 <https://codeberg.org/freeipa/freeipa/issues/7035>`__ ipa-otptoken-import
    - XML file is missing PBKDF2 parameters!
--  `#7017 <https://pagure.io/freeipa/issue/7017>`__ NULL LDAP context in
+-  `#7017 <https://codeberg.org/freeipa/freeipa/issues/7017>`__ NULL LDAP context in
    call to ldap_search_ext_s during search in
    cn=ad,cn=trusts,dc=example,dc=com
--  `#6605 <https://pagure.io/freeipa/issue/6605>`__ make lint + make
+-  `#6605 <https://codeberg.org/freeipa/freeipa/issues/6605>`__ make lint + make
    modifies PO files in place
--  `#6582 <https://pagure.io/freeipa/issue/6582>`__ Web UI: Change "Host
+-  `#6582 <https://codeberg.org/freeipa/freeipa/issues/6582>`__ Web UI: Change "Host
    Based" and "Role Based" to "Host-Based" and "Role-Based"
--  `#6447 <https://pagure.io/freeipa/issue/6447>`__ [WebUI] Remove
+-  `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__ [WebUI] Remove
    offline version of WebUI
--  `#6261 <https://pagure.io/freeipa/issue/6261>`__ Replace ERROR:
+-  `#6261 <https://codeberg.org/freeipa/freeipa/issues/6261>`__ Replace ERROR:
    cannot connect to 'http://localhost:8888/ipa/json': [Errno 111]
    Connection refused with 'IPA is not configured on this system'
--  `#6176 <https://pagure.io/freeipa/issue/6176>`__ Updating of dns
+-  `#6176 <https://codeberg.org/freeipa/freeipa/issues/6176>`__ Updating of dns
    system records rapidly slowdown uninstallation
--  `#7121 <https://pagure.io/freeipa/issue/7121>`__ ipa
+-  `#7121 <https://codeberg.org/freeipa/freeipa/issues/7121>`__ ipa
    otptoken-add-yubikey fails with python3
--  `#7118 <https://pagure.io/freeipa/issue/7118>`__ Fix CA-less
+-  `#7118 <https://codeberg.org/freeipa/freeipa/issues/7118>`__ Fix CA-less
    installation due to incorrect with statement
--  `#7110 <https://pagure.io/freeipa/issue/7110>`__ Missing requirement
+-  `#7110 <https://codeberg.org/freeipa/freeipa/issues/7110>`__ Missing requirement
    in freeipa 4.5.90.dev201708161122+git799551892-0
--  `#7100 <https://pagure.io/freeipa/issue/7100>`__ test_caless: add SAN
+-  `#7100 <https://codeberg.org/freeipa/freeipa/issues/7100>`__ test_caless: add SAN
    dNSName extensions for wildcard tests
--  `#7088 <https://pagure.io/freeipa/issue/7088>`__ Use X509v3 Basic
+-  `#7088 <https://codeberg.org/freeipa/freeipa/issues/7088>`__ Use X509v3 Basic
    Constraints "CA:TRUE" instead of "CA:FALSE" IPA CA CSR
--  `#7076 <https://pagure.io/freeipa/issue/7076>`__ Adjust to CURL
+-  `#7076 <https://codeberg.org/freeipa/freeipa/issues/7076>`__ Adjust to CURL
    whichs started to use OpenSSL - ipa-server-install fails to obtain RA
    certificate from CA (CA_UNREACHABLE)
--  `#7053 <https://pagure.io/freeipa/issue/7053>`__ Replica install
+-  `#7053 <https://codeberg.org/freeipa/freeipa/issues/7053>`__ Replica install
    fails to configure IPA-specific temporary files/directories
--  `#7052 <https://pagure.io/freeipa/issue/7052>`__ WebUI: search facet
+-  `#7052 <https://codeberg.org/freeipa/freeipa/issues/7052>`__ WebUI: search facet
    spec actions contains 'undefined' item
--  `#7051 <https://pagure.io/freeipa/issue/7051>`__ ipapython/graph.py
+-  `#7051 <https://codeberg.org/freeipa/freeipa/issues/7051>`__ ipapython/graph.py
    complexity optimization
--  `#7050 <https://pagure.io/freeipa/issue/7050>`__ Type error when
+-  `#7050 <https://codeberg.org/freeipa/freeipa/issues/7050>`__ Type error when
    running tests for whoami command.
--  `#7046 <https://pagure.io/freeipa/issue/7046>`__ missing default
+-  `#7046 <https://codeberg.org/freeipa/freeipa/issues/7046>`__ missing default
    basedn causes failure during initialization of multi host tests
--  `#7030 <https://pagure.io/freeipa/issue/7030>`__ tests: CA-less test
+-  `#7030 <https://codeberg.org/freeipa/freeipa/issues/7030>`__ tests: CA-less test
    suite broken due to missing subject key identifier extension
--  `#7011 <https://pagure.io/freeipa/issue/7011>`__ --force-join option
+-  `#7011 <https://codeberg.org/freeipa/freeipa/issues/7011>`__ --force-join option
    is not mentioned in ipa-replica-install man page
--  `#7010 <https://pagure.io/freeipa/issue/7010>`__ ipa-backup fails
+-  `#7010 <https://codeberg.org/freeipa/freeipa/issues/7010>`__ ipa-backup fails
    silently
--  `#7002 <https://pagure.io/freeipa/issue/7002>`__ adtrustinstance:
+-  `#7002 <https://codeberg.org/freeipa/freeipa/issues/7002>`__ adtrustinstance:
    broken ID range assessment
--  `#6987 <https://pagure.io/freeipa/issue/6987>`__ ca-add: invalid
+-  `#6987 <https://codeberg.org/freeipa/freeipa/issues/6987>`__ ca-add: invalid
    X.509 DN fails ungracefully
--  `#6986 <https://pagure.io/freeipa/issue/6986>`__ make pylint is not
+-  `#6986 <https://codeberg.org/freeipa/freeipa/issues/6986>`__ make pylint is not
    working on F26
--  `#6980 <https://pagure.io/freeipa/issue/6980>`__ Pagination Size
+-  `#6980 <https://codeberg.org/freeipa/freeipa/issues/6980>`__ Pagination Size
    under Customization in IPA WebUI accepts negative values
--  `#6976 <https://pagure.io/freeipa/issue/6976>`__ External CA: check
+-  `#6976 <https://codeberg.org/freeipa/freeipa/issues/6976>`__ External CA: check
    that IPA CA certificate contains Subject Key Identifier
--  `#6974 <https://pagure.io/freeipa/issue/6974>`__ WebUI: Fix unit
+-  `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__ WebUI: Fix unit
    webUI tests
--  `#6971 <https://pagure.io/freeipa/issue/6971>`__ ipatests: collect
+-  `#6971 <https://codeberg.org/freeipa/freeipa/issues/6971>`__ ipatests: collect
    systemd journal
--  `#6956 <https://pagure.io/freeipa/issue/6956>`__ Backup and restore
+-  `#6956 <https://codeberg.org/freeipa/freeipa/issues/6956>`__ Backup and restore
    tests faliling
--  `#6946 <https://pagure.io/freeipa/issue/6946>`__ ipa-replica-manage
+-  `#6946 <https://codeberg.org/freeipa/freeipa/issues/6946>`__ ipa-replica-manage
    del (dl 0) doesn't remove server from defaultServerList
--  `#6945 <https://pagure.io/freeipa/issue/6945>`__ Bring back error
+-  `#6945 <https://codeberg.org/freeipa/freeipa/issues/6945>`__ Bring back error
    messages from certificate validation
--  `#6943 <https://pagure.io/freeipa/issue/6943>`__ server-del doesn't
+-  `#6943 <https://codeberg.org/freeipa/freeipa/issues/6943>`__ server-del doesn't
    remove server from defaultServerList in cn=default,ou=profile,$BASE
--  `#6940 <https://pagure.io/freeipa/issue/6940>`__ installer should
+-  `#6940 <https://codeberg.org/freeipa/freeipa/issues/6940>`__ installer should
    indicate that it is waiting for keys
--  `#6939 <https://pagure.io/freeipa/issue/6939>`__
+-  `#6939 <https://codeberg.org/freeipa/freeipa/issues/6939>`__
    ipaserver.plugins.host.get_dn timeout due to unindexed search
--  `#6928 <https://pagure.io/freeipa/issue/6928>`__ ipa-managed-entries
+-  `#6928 <https://codeberg.org/freeipa/freeipa/issues/6928>`__ ipa-managed-entries
    incorrectly states server not installed
--  `#6865 <https://pagure.io/freeipa/issue/6865>`__ minor spelling
+-  `#6865 <https://codeberg.org/freeipa/freeipa/issues/6865>`__ minor spelling
    mistake in ipa-adtrust-install.1
--  `#6863 <https://pagure.io/freeipa/issue/6863>`__ minor spelling
+-  `#6863 <https://codeberg.org/freeipa/freeipa/issues/6863>`__ minor spelling
    mistake
--  `#6852 <https://pagure.io/freeipa/issue/6852>`__ [RFE] Create client
+-  `#6852 <https://codeberg.org/freeipa/freeipa/issues/6852>`__ [RFE] Create client
    enrollment role
--  `#6849 <https://pagure.io/freeipa/issue/6849>`__ Priority field
+-  `#6849 <https://codeberg.org/freeipa/freeipa/issues/6849>`__ Priority field
    missing in required field incicator - \*
--  `#6845 <https://pagure.io/freeipa/issue/6845>`__ ipa-otpd.socket.in
+-  `#6845 <https://codeberg.org/freeipa/freeipa/issues/6845>`__ ipa-otpd.socket.in
    has wrong kdc service name for Debian
--  `#6834 <https://pagure.io/freeipa/issue/6834>`__
+-  `#6834 <https://codeberg.org/freeipa/freeipa/issues/6834>`__
    ipa-kdc-proxy.conf.template hardcodes python module directory
--  `#6822 <https://pagure.io/freeipa/issue/6822>`__ git-commit-template:
+-  `#6822 <https://codeberg.org/freeipa/freeipa/issues/6822>`__ git-commit-template:
    update ticket URL to use pagure.io instead of fedorahosted.org
--  `#6818 <https://pagure.io/freeipa/issue/6818>`__ Update asn1c code in
+-  `#6818 <https://codeberg.org/freeipa/freeipa/issues/6818>`__ Update asn1c code in
    /asn1/asn1c
--  `#6809 <https://pagure.io/freeipa/issue/6809>`__ Failed to write
+-  `#6809 <https://codeberg.org/freeipa/freeipa/issues/6809>`__ Failed to write
    schema: b'sudo/1' is not JSON serializable
--  `#6745 <https://pagure.io/freeipa/issue/6745>`__ [test] ipa whoami
+-  `#6745 <https://codeberg.org/freeipa/freeipa/issues/6745>`__ [test] ipa whoami
    command
--  `#6725 <https://pagure.io/freeipa/issue/6725>`__ No page for
+-  `#6725 <https://codeberg.org/freeipa/freeipa/issues/6725>`__ No page for
    information on build from source
--  `#6642 <https://pagure.io/freeipa/issue/6642>`__ Py3:
+-  `#6642 <https://codeberg.org/freeipa/freeipa/issues/6642>`__ Py3:
    test_serverroles: use ldap2/ldapclient instead of MockLDAP
--  `#6591 <https://pagure.io/freeipa/issue/6591>`__ pytest 3.0: yield
+-  `#6591 <https://codeberg.org/freeipa/freeipa/issues/6591>`__ pytest 3.0: yield
    tests are deprecated
--  `#5990 <https://pagure.io/freeipa/issue/5990>`__ Py3:
+-  `#5990 <https://codeberg.org/freeipa/freeipa/issues/5990>`__ Py3:
    zonemgr_callback: expected unicode, got bytes
--  `#5919 <https://pagure.io/freeipa/issue/5919>`__ cert-request
+-  `#5919 <https://codeberg.org/freeipa/freeipa/issues/5919>`__ cert-request
    rfc822Name check compares whole email address case-sensitively
--  `#4985 <https://pagure.io/freeipa/issue/4985>`__ [RFE] Support Python
+-  `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__ [RFE] Support Python
    3
 
 
@@ -178,45 +178,45 @@ Alexander Bokovoy (13)
 
 -  csrgen: support openssl 1.0 and 1.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/79378c90512a1cdd5f3d5ec6482e434caea06e01>`__
-   `#7110 <https://pagure.io/freeipa/issue/7110>`__
+   `#7110 <https://codeberg.org/freeipa/freeipa/issues/7110>`__
 -  dcerpc: support Python 3
    `commit <https://codeberg.org/freeipa/freeipa/commit/928374ca7de5c0bec54e848a35b6bacda9f55343>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ipa-sam: use smbldap_set_bind_callback for Samba 4.7 or later
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ab6a68e91a4fad5af037a910fd4f6b6d8f7611f>`__
-   `#6877 <https://pagure.io/freeipa/issue/6877>`__
+   `#6877 <https://codeberg.org/freeipa/freeipa/issues/6877>`__
 -  ipa-sam: use own private structure, not ldapsam_privates
    `commit <https://codeberg.org/freeipa/freeipa/commit/11d43a16035d9ce7970ddf757f17025289ec4854>`__
-   `#6877 <https://pagure.io/freeipa/issue/6877>`__
+   `#6877 <https://codeberg.org/freeipa/freeipa/issues/6877>`__
 -  trust-mod: allow modifying list of UPNs of a trusted forest
    `commit <https://codeberg.org/freeipa/freeipa/commit/abb638487580af99882b4751b64939d0aff0d38b>`__
-   `#7015 <https://pagure.io/freeipa/issue/7015>`__
+   `#7015 <https://codeberg.org/freeipa/freeipa/issues/7015>`__
 -  ipa-kdb: add pkinit authentication indicator in case of a successful
    certauth
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8a7e2e38ad7cea2964305247430e964d2b785b1>`__
-   `#6736 <https://pagure.io/freeipa/issue/6736>`__
+   `#6736 <https://codeberg.org/freeipa/freeipa/issues/6736>`__
 -  Fix index definition for ipaAnchorUUID
    `commit <https://codeberg.org/freeipa/freeipa/commit/49ce395b90ea64eda3f9362b05936a3e4d43234a>`__
-   `#6975 <https://pagure.io/freeipa/issue/6975>`__
+   `#6975 <https://codeberg.org/freeipa/freeipa/issues/6975>`__
 -  krb5: make sure KDC certificate is readable
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c3fad9cef7785a65c795f1b4fc3f94e50af9db2>`__
-   `#6973 <https://pagure.io/freeipa/issue/6973>`__
+   `#6973 <https://codeberg.org/freeipa/freeipa/issues/6973>`__
 -  trust: always use oddjobd helper for fetching trust information
    `commit <https://codeberg.org/freeipa/freeipa/commit/e560899cce20ca7773a5ce46a1c29db1349e8ec7>`__
 -  ipaserver/dcerpc: unify error processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/aef77b3529540ad12939a2cc54996c341c5d49d3>`__
-   `#6859 <https://pagure.io/freeipa/issue/6859>`__
+   `#6859 <https://codeberg.org/freeipa/freeipa/issues/6859>`__
 -  adtrust: make sure that runtime hostname result is consistent with
    the configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d817ae63a4ad8ba7a29910a9342a78e15e89593>`__
-   `#6786 <https://pagure.io/freeipa/issue/6786>`__
+   `#6786 <https://codeberg.org/freeipa/freeipa/issues/6786>`__
 -  server: make sure we test for sss_nss_getlistbycert
    `commit <https://codeberg.org/freeipa/freeipa/commit/67e5244cad72bef76de1c4df47a0c77a672fa861>`__
-   `#6828 <https://pagure.io/freeipa/issue/6828>`__
+   `#6828 <https://codeberg.org/freeipa/freeipa/issues/6828>`__
 -  ldap2: use LDAP whoami operation to retrieve bind DN for current
    connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/7324451834ec03786fda947679f750fe2a72f29c>`__
-   `#6797 <https://pagure.io/freeipa/issue/6797>`__
+   `#6797 <https://codeberg.org/freeipa/freeipa/issues/6797>`__
 
 
 
@@ -225,17 +225,17 @@ Abhijeet Kasurde (6)
 
 -  Vault testcase improvement
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d3924dc98ba5a3873ae21c3c60de97510eebc88>`__
-   `#7098 <https://pagure.io/freeipa/issue/7098>`__
+   `#7098 <https://codeberg.org/freeipa/freeipa/issues/7098>`__
 -  Minor typo fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb869314729022d4c16339bb08b79c5c30fe29df>`__
-   `#6865 <https://pagure.io/freeipa/issue/6865>`__
+   `#6865 <https://codeberg.org/freeipa/freeipa/issues/6865>`__
 -  Minor typo in details.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f20eca3f58b59ed15a5acd69b3d763bf19f26f1>`__
-   `#6863 <https://pagure.io/freeipa/issue/6863>`__
+   `#6863 <https://codeberg.org/freeipa/freeipa/issues/6863>`__
 -  Hide request_type doc string in cert-request help
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1bb442054936113369a88b49483e914664712e7>`__
-   `#5734 <https://pagure.io/freeipa/issue/5734>`__,
-   `#6494 <https://pagure.io/freeipa/issue/6494>`__
+   `#5734 <https://codeberg.org/freeipa/freeipa/issues/5734>`__,
+   `#6494 <https://codeberg.org/freeipa/freeipa/issues/6494>`__
 -  Hide PKI Client database password in log file
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fddc1df573cb56949b1bc8ad83a041e97523df1>`__
 -  Use with statement for opening file
@@ -260,7 +260,7 @@ Aleksei Slaikovskii (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe913b9c9f8ce6e481f8f1f78bc082b55390fbea>`__
 -  ipapython/graph.py complexity optimization
    `commit <https://codeberg.org/freeipa/freeipa/commit/52a435978b367fb94834f7c02debd06327c5e930>`__
-   `#7051 <https://pagure.io/freeipa/issue/7051>`__
+   `#7051 <https://codeberg.org/freeipa/freeipa/issues/7051>`__
 
 
 
@@ -269,17 +269,17 @@ Ben Lipton (4)
 
 -  csrgen: Beginnings of NSS database support
    `commit <https://codeberg.org/freeipa/freeipa/commit/a53e17830c3d4fd59a62248d4447491675c6a80e>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Modify cert_get_requestdata to return a
    CertificationRequestInfo
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7588ab2dc73e7f66ebc6cdcfb99470540e37731>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Change to pure openssl config format (no script)
    `commit <https://codeberg.org/freeipa/freeipa/commit/136c6c3e2a4f77a27f435efd4a1cd95c9e089314>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 -  csrgen: Remove helper abstraction
    `commit <https://codeberg.org/freeipa/freeipa/commit/5420e9cfbe7803808b6e26d2dae64f2a6a50149a>`__
-   `#4899 <https://pagure.io/freeipa/issue/4899>`__
+   `#4899 <https://codeberg.org/freeipa/freeipa/issues/4899>`__
 
 
 
@@ -288,43 +288,43 @@ Christian Heimes (40)
 
 -  Misc Python 3 fixes for ipaserver.secrets
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f0332905132b7c8fa65d6ed16cd2c028e5a0ed5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Reimplement yield tests are parametrized tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/090eadbe4e4d0ab9fe387c1966b51cdf28ed9b17>`__
-   `#6591 <https://pagure.io/freeipa/issue/6591>`__
+   `#6591 <https://codeberg.org/freeipa/freeipa/issues/6591>`__
 -  Silence pytest.yield_fixture deprecation warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/af140b0bc15cf4c27c63cc88bc6eec792f29422a>`__
-   `#6591 <https://pagure.io/freeipa/issue/6591>`__
+   `#6591 <https://codeberg.org/freeipa/freeipa/issues/6591>`__
 -  Slim down dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd5a5012d24820b54cdca2955f5405b84de1178c>`__
 -  Vault: Explicitly default to 3DES CBC
    `commit <https://codeberg.org/freeipa/freeipa/commit/5197422ef65e7239fc56c562ab87d99388a38a8d>`__
-   `#6899 <https://pagure.io/freeipa/issue/6899>`__
+   `#6899 <https://codeberg.org/freeipa/freeipa/issues/6899>`__
 -  Band-aid for pip dependency bug
    `commit <https://codeberg.org/freeipa/freeipa/commit/994d24d288080e924e039ca0a7b0b0dfc2355ac1>`__
 -  Correct PyPI package dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/26ab51ddf47f421f3404709052db89f08c05adaa>`__
-   `#6875 <https://pagure.io/freeipa/issue/6875>`__
+   `#6875 <https://codeberg.org/freeipa/freeipa/issues/6875>`__
 -  tox: use pylint 1.6.x for now
    `commit <https://codeberg.org/freeipa/freeipa/commit/b64ec757883284a765745ef4fbd78fb55bf0e228>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Replace \_BSD_SOURCE with \_DEFAULT_SOURCE
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b443b908fe6fb9c11f9b76552bf4fef2c3b2be5>`__
-   `#6818 <https://pagure.io/freeipa/issue/6818>`__
+   `#6818 <https://codeberg.org/freeipa/freeipa/issues/6818>`__
 -  Regenerate ASN.1 code with asn1c 0.9.28
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad0843047779b55848425eaba0385034d6893446>`__
-   `#6818 <https://pagure.io/freeipa/issue/6818>`__
+   `#6818 <https://codeberg.org/freeipa/freeipa/issues/6818>`__
 -  tox testing support for client wheel packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a5b3be8b92a509d207d814c9fe294ee7b4e81c4>`__
 -  Stabilize make pypi_packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0c36b9c2eae1298604ec8ad4597e19e20365e11>`__
 -  Replace hard-coded kdcproxy path with WSGI script
    `commit <https://codeberg.org/freeipa/freeipa/commit/2cd6788c3f52a9b87f24b9b3e57d66a864397966>`__
-   `#6834 <https://pagure.io/freeipa/issue/6834>`__
+   `#6834 <https://codeberg.org/freeipa/freeipa/issues/6834>`__
 -  Use entry_points for ipa CLI
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf67974459f093487a1c5a49234769803780ecbe>`__
-   `#6653 <https://pagure.io/freeipa/issue/6653>`__,
-   `#6850 <https://pagure.io/freeipa/issue/6850>`__
+   `#6653 <https://codeberg.org/freeipa/freeipa/issues/6653>`__,
+   `#6850 <https://codeberg.org/freeipa/freeipa/issues/6850>`__
 -  Don't hard-code with_wheels
    `commit <https://codeberg.org/freeipa/freeipa/commit/40a60675f3feb118af70562582399afefe97214d>`__
 -  Add an option to build ipaserver wheels
@@ -337,7 +337,7 @@ Christian Heimes (40)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c092c24b2bfbba0a3f263d88f7a0dbf83f24869>`__
 -  Add make devcheck for developers
    `commit <https://codeberg.org/freeipa/freeipa/commit/e357133fd7b276ccabfe1896ee948f2bb3541d94>`__
-   `#6604 <https://pagure.io/freeipa/issue/6604>`__
+   `#6604 <https://codeberg.org/freeipa/freeipa/issues/6604>`__
 -  session storage parameters must be bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/d06315de6b1e951d6cce7d7d6495a32b44216274>`__
 -  Fix ipatests.util doc tests
@@ -346,47 +346,47 @@ Christian Heimes (40)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5bf5466eda0de2a211b4f2682e5c50b82577701>`__
 -  Simplify KRA transport cert cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/abefb64bea8ea1b8487ad87716e4a335555d19dc>`__
-   `#6787 <https://pagure.io/freeipa/issue/6787>`__
+   `#6787 <https://codeberg.org/freeipa/freeipa/issues/6787>`__
 -  pytest 3.x compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd6b72e418eba01cc9eb9a7305291bf141b9eadf>`__
 -  Constrain wheel package versions
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe17d187f9f2cbac28fe369cbcdd697d85105481>`__
-   `#6468 <https://pagure.io/freeipa/issue/6468>`__
+   `#6468 <https://codeberg.org/freeipa/freeipa/issues/6468>`__
 -  Move remaining util functions to tasks module
    `commit <https://codeberg.org/freeipa/freeipa/commit/24161a619049e0fb3b954592f64ee6d561320d2c>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Ship ipatests.pytest_plugins.integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/5587a37e2345de4e76813e00f4b2751d24c618fc>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move function run_repeatedly to tasks module
    `commit <https://codeberg.org/freeipa/freeipa/commit/8aadd55c93a627e88e007d2df864a5fb72fba0a2>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move hosts module to ipatests.pytest_plugins.integration.hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/8867412adc0ffd0cacf555a5c3693e04074fed5b>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move tasks module to ipatests.pytest_plugins.integration.tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/313ae46b573b4cac1075dc1b5bd7294424fabfdb>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move env_config module to
    ipatests.pytest_plugins.integration.env_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/1406dbc8c223ac0894088146bfe2a8ef0688097a>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move config module to ipatests.pytest_plugins.integration.config
    `commit <https://codeberg.org/freeipa/freeipa/commit/2895e3931d0b4a9e20e1b211ef5a76f79fc73c9d>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Move helper code for integration plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/dde71ec4a9669a155456a8e8912ed3a0503b8704>`__
-   `#6798 <https://pagure.io/freeipa/issue/6798>`__
+   `#6798 <https://codeberg.org/freeipa/freeipa/issues/6798>`__
 -  Increase Apache HTTPD's default keep alive timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f567286f6b89f3e981af02913e833d3e8ed5064>`__
 -  Add debug logging for keep-alive
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2bdd2e1a912573ae4a3e8e5f40831a800d972f7>`__
 -  Use connection keep-alive
    `commit <https://codeberg.org/freeipa/freeipa/commit/7beb6d1cad7e2200208cb14be6c823a89abf0dc3>`__
-   `#6641 <https://pagure.io/freeipa/issue/6641>`__
+   `#6641 <https://codeberg.org/freeipa/freeipa/issues/6641>`__
 -  Add options to run only ipaclient unittests
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd1b4f6ec9a349196d5df510008c4745f0b1fb84>`__
-   `#6517 <https://pagure.io/freeipa/issue/6517>`__
+   `#6517 <https://codeberg.org/freeipa/freeipa/issues/6517>`__
 -  Python 3: Fix session storage
    `commit <https://codeberg.org/freeipa/freeipa/commit/42bc778c0c1de91f0d8dc695dfee4e5aea4cc1f0>`__
 -  Fix Python 3 pylint errors
@@ -414,75 +414,75 @@ David Kupka (22)
 
 -  tests: certmap: Add test for user-{add,remove}-certmap
    `commit <https://codeberg.org/freeipa/freeipa/commit/bda3dd722b87aea3e852284775b15af67b15359d>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapdataMixin tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bce62d5d4a93bdce4cefd673289caeec1668093>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Add test for certmapconfig-{mod,show}
    `commit <https://codeberg.org/freeipa/freeipa/commit/e574f5d65e51a0a368f0efe3117d3c26d889bd2a>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapconfigTracker to tests certmapconfig-\*
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ccde4450198270ff191f1320f80d3c0e4b5d487>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Test permissions for certmap
    `commit <https://codeberg.org/freeipa/freeipa/commit/eabd3971548b313e1905f7025c40fac643786e1b>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: certmap: Add basic tests for certmaprule commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6a43ffcad5b3860cbb0587b4f823a4b6e9a607f>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add CertmapTracker for testing certmap-\* commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/aee200816e68d1eba1e635538dfb64dbb51e1fc4>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add ConfigurationTracker to test \*config-{mod,show}
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/3113bfb0cfdca14569303137beb2f2fb4f0c4099>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Add EnableTracker to test \*-{enable,disable}
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b015a2e761258039f0f2e9ff3c7daafecf97b3d>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  tests: tracker: Split Tracker into one-purpose Trackers
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac7712c93e2080d298e9e0a909aae40238dee305>`__
-   `#7105 <https://pagure.io/freeipa/issue/7105>`__
+   `#7105 <https://codeberg.org/freeipa/freeipa/issues/7105>`__
 -  install: replica: Show message about key synchronization
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6787eea4899af6bd7075a3311a45cb8eda571e5>`__
-   `#6940 <https://pagure.io/freeipa/issue/6940>`__
+   `#6940 <https://codeberg.org/freeipa/freeipa/issues/6940>`__
 -  kra: promote: Get ticket before calling custodia
    `commit <https://codeberg.org/freeipa/freeipa/commit/342f72140f9bd8b8db19f469ae4c56cac7492901>`__
-   `#7020 <https://pagure.io/freeipa/issue/7020>`__
+   `#7020 <https://codeberg.org/freeipa/freeipa/issues/7020>`__
 -  ipapython.ipautil.run: Add option to set umask before executing
    command
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9fd123d61fa7adda090c05216906ba0cf4779a9>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  otptoken-add-yubikey: When --digits not provided use default value
    `commit <https://codeberg.org/freeipa/freeipa/commit/e415da22f350fbda5b8b341bf2dc5f969cecb84a>`__
-   `#6900 <https://pagure.io/freeipa/issue/6900>`__
+   `#6900 <https://codeberg.org/freeipa/freeipa/issues/6900>`__
 -  Bump version of ipa.conf file
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d32e61ba548e7e940f165c0ec8df0b4bfd210bd>`__
-   `#6860 <https://pagure.io/freeipa/issue/6860>`__
+   `#6860 <https://codeberg.org/freeipa/freeipa/issues/6860>`__
 -  Create system users for FreeIPA services during package installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/a726e98f034347227765d7303a033a0538f5d8a1>`__
-   `#6743 <https://pagure.io/freeipa/issue/6743>`__
+   `#6743 <https://codeberg.org/freeipa/freeipa/issues/6743>`__
 -  WebUI: cert login: Configure name of parameter used to pass username
    `commit <https://codeberg.org/freeipa/freeipa/commit/157831a287c64106eed4da4ace5228d7e369ae2f>`__
-   `#6860 <https://pagure.io/freeipa/issue/6860>`__
+   `#6860 <https://codeberg.org/freeipa/freeipa/issues/6860>`__
 -  httpinstance.disable_system_trust: Don't fail if module 'Root Certs'
    is not available
    `commit <https://codeberg.org/freeipa/freeipa/commit/0128e805e591bc8ca5cea99739ad4cd7478df0b4>`__
-   `#6803 <https://pagure.io/freeipa/issue/6803>`__
+   `#6803 <https://codeberg.org/freeipa/freeipa/issues/6803>`__
 -  spec file: Bump requires to make Certificate Login in WebUI work
    `commit <https://codeberg.org/freeipa/freeipa/commit/27d13d90fe9b06618c88bc20b7d6540e6b4d367f>`__
-   `#6823 <https://pagure.io/freeipa/issue/6823>`__
+   `#6823 <https://codeberg.org/freeipa/freeipa/issues/6823>`__
 -  rpcserver.login_x509: Actually return reply from \__call_\_ method
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e1fdd2c5881893fd9540689045a11f9e88beef9>`__
-   `#6819 <https://pagure.io/freeipa/issue/6819>`__
+   `#6819 <https://codeberg.org/freeipa/freeipa/issues/6819>`__
 -  Create temporaty directories at the begining of uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dcd3426310ccacdb1564ad7fe83358110a044f6>`__
-   `#6715 <https://pagure.io/freeipa/issue/6715>`__
+   `#6715 <https://codeberg.org/freeipa/freeipa/issues/6715>`__
 -  ipapython.ipautil.nolog_replace: Do not replace empty value
    `commit <https://codeberg.org/freeipa/freeipa/commit/4297ad6db0d4f39d82fd155323163df92b2b7894>`__
-   `#6738 <https://pagure.io/freeipa/issue/6738>`__
+   `#6738 <https://codeberg.org/freeipa/freeipa/issues/6738>`__
 
 
 
@@ -491,7 +491,7 @@ felipe (1)
 
 -  Fixing replica install: fix ldap connection in domlvl 0
    `commit <https://codeberg.org/freeipa/freeipa/commit/772d4e3d4e9a2756e6a34e265a1219599688cde3>`__
-   `#6549 <https://pagure.io/freeipa/issue/6549>`__
+   `#6549 <https://codeberg.org/freeipa/freeipa/issues/6549>`__
 
 
 
@@ -500,14 +500,14 @@ Felipe Volpone (3)
 
 -  Removing part of circular dependency of ipalib in ipaplaform
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b7d9c5a7b271f0e8b296dac86525b9ce948084a>`__
-   `#7108 <https://pagure.io/freeipa/issue/7108>`__
+   `#7108 <https://codeberg.org/freeipa/freeipa/issues/7108>`__
 -  Changing how commands handles error when it can't connect to IPA
    server
    `commit <https://codeberg.org/freeipa/freeipa/commit/cac3475a0454b730d6e5b2093c2e63d395acd387>`__
-   `#6261 <https://pagure.io/freeipa/issue/6261>`__
+   `#6261 <https://codeberg.org/freeipa/freeipa/issues/6261>`__
 -  py3: fixing zonemgr_callback
    `commit <https://codeberg.org/freeipa/freeipa/commit/75d26e1f0121f875bdb017b0636c02a6f5660e8a>`__
-   `#5990 <https://pagure.io/freeipa/issue/5990>`__
+   `#5990 <https://codeberg.org/freeipa/freeipa/issues/5990>`__
 
 
 
@@ -516,21 +516,21 @@ Felipe Volpone (5)
 
 -  Adding section "Building FreeIPA from source" on README
    `commit <https://codeberg.org/freeipa/freeipa/commit/be2fba08ce3d89448d4a87f9d0dd15f605cf6dd1>`__
-   `#6725 <https://pagure.io/freeipa/issue/6725>`__
+   `#6725 <https://codeberg.org/freeipa/freeipa/issues/6725>`__
 -  Changing cert-find to go through the proxy instead of using the port
    8080
    `commit <https://codeberg.org/freeipa/freeipa/commit/36532031cfef893aa2f95d709efd807729de79f7>`__
-   `#6966 <https://pagure.io/freeipa/issue/6966>`__
+   `#6966 <https://codeberg.org/freeipa/freeipa/issues/6966>`__
 -  Changing cert-find to do not use only primary key to search in LDAP.
    `commit <https://codeberg.org/freeipa/freeipa/commit/44bd5e358b027f8956b730f250854efb5087f05e>`__
-   `#6948 <https://pagure.io/freeipa/issue/6948>`__
+   `#6948 <https://codeberg.org/freeipa/freeipa/issues/6948>`__
 -  Fixing adding authenticator indicators to host
    `commit <https://codeberg.org/freeipa/freeipa/commit/d51af28bdbef8386b6d3bde683be2fc5f73b904e>`__
-   `#6911 <https://pagure.io/freeipa/issue/6911>`__
+   `#6911 <https://codeberg.org/freeipa/freeipa/issues/6911>`__
 -  Fixing the cert-request comparing whole email address
    case-sensitively.
    `commit <https://codeberg.org/freeipa/freeipa/commit/d973168e89c7fb5e8c36919b3adb685371e1a3ab>`__
-   `#5919 <https://pagure.io/freeipa/issue/5919>`__
+   `#5919 <https://codeberg.org/freeipa/freeipa/issues/5919>`__
 
 
 
@@ -539,7 +539,7 @@ Fabiano Fidêncio (1)
 
 -  Allow erasing ipaDomainResolutionOrder attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/e03056cf34de5ba0100d62f008d76e8c851c3ba7>`__
-   `#6825 <https://pagure.io/freeipa/issue/6825>`__
+   `#6825 <https://codeberg.org/freeipa/freeipa/issues/6825>`__
 
 
 
@@ -548,73 +548,73 @@ Florence Blanc-Renaud (22)
 
 -  Fix Certificate renewal (with ext ca)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee5345ac05fd1e133243ffb61c25615840f7bd87>`__
-   `#7106 <https://pagure.io/freeipa/issue/7106>`__
+   `#7106 <https://codeberg.org/freeipa/freeipa/issues/7106>`__
 -  Fix ipa-server-upgrade: This entry already exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/69bda6b440d6b84f042ff74b9ce708d963616eda>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  ipa-replica-conncheck: handle ssh not installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/f960450820c13284b52b4c5f420f0f1191a45619>`__
-   `#6935 <https://pagure.io/freeipa/issue/6935>`__
+   `#6935 <https://codeberg.org/freeipa/freeipa/issues/6935>`__
 -  ipa-ca-install: append CA cert chain into /etc/ipa/ca.crt
    `commit <https://codeberg.org/freeipa/freeipa/commit/d93264247563937d6d8e3f030a2bffac10572612>`__
-   `#6925 <https://pagure.io/freeipa/issue/6925>`__
+   `#6925 <https://codeberg.org/freeipa/freeipa/issues/6925>`__
 -  ipa-replica-manage del (dl 0): remove server from defaultServerList
    `commit <https://codeberg.org/freeipa/freeipa/commit/319a079f6decc81c7f0912ee5aef239768db554b>`__
-   `#6946 <https://pagure.io/freeipa/issue/6946>`__
+   `#6946 <https://codeberg.org/freeipa/freeipa/issues/6946>`__
 -  server-del: update defaultServerList in cn=default,ou=profile,$BASE
    `commit <https://codeberg.org/freeipa/freeipa/commit/a02a0a95f24c07357147e44147194c296b16d24a>`__
-   `#6943 <https://pagure.io/freeipa/issue/6943>`__
+   `#6943 <https://codeberg.org/freeipa/freeipa/issues/6943>`__
 -  ipa-kra-install: fix pkispawn setting for
    pki_security_domain_hostname
    `commit <https://codeberg.org/freeipa/freeipa/commit/c26038d24cc11ab2dc1e6839a160fcf1bce48f69>`__
-   `#6895 <https://pagure.io/freeipa/issue/6895>`__
+   `#6895 <https://codeberg.org/freeipa/freeipa/issues/6895>`__
 -  ipa-server-install: fix uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9ed2573fd5b4dcdc8ea865f16d81325707e0f9d>`__
-   `#6950 <https://pagure.io/freeipa/issue/6950>`__
+   `#6950 <https://codeberg.org/freeipa/freeipa/issues/6950>`__
 -  ipa-kra-install manpage: document domain-level 1
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3e1efdcf5db5da2c3c42d3d58be172943f20bce>`__
-   `#6922 <https://pagure.io/freeipa/issue/6922>`__
+   `#6922 <https://codeberg.org/freeipa/freeipa/issues/6922>`__
 -  ipa-kra-install: fix check_host_keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/8983ce53e3fdee98926f81f3012146e33bb92d30>`__
-   `#6934 <https://pagure.io/freeipa/issue/6934>`__
+   `#6934 <https://codeberg.org/freeipa/freeipa/issues/6934>`__
 -  ipa-server-install with external CA: fix pkinit cert issuance
    `commit <https://codeberg.org/freeipa/freeipa/commit/a24923066dd95a88ded329f1a558d46fbb9d8f81>`__
-   `#6921 <https://pagure.io/freeipa/issue/6921>`__
+   `#6921 <https://codeberg.org/freeipa/freeipa/issues/6921>`__
 -  ipa-client-install: remove extra space in pkinit_anchors definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/26dbab1fd4384b8f3999b153c2d94220cf541ad2>`__
-   `#6916 <https://pagure.io/freeipa/issue/6916>`__
+   `#6916 <https://codeberg.org/freeipa/freeipa/issues/6916>`__
 -  vault: piped input for ipa vault-add fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5c41ed4ad370c7d74296a830993a5bd3fd32e5f>`__
-   `#6907 <https://pagure.io/freeipa/issue/6907>`__
+   `#6907 <https://codeberg.org/freeipa/freeipa/issues/6907>`__
 -  upgrade: adtrust update_tdo_gidnumber plugin must check if adtrust is
    installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/434d9e539d24fe0110c5d6bf4a4342daf40d15d5>`__
-   `#6881 <https://pagure.io/freeipa/issue/6881>`__
+   `#6881 <https://codeberg.org/freeipa/freeipa/issues/6881>`__
 -  tests: add non-reg for idrange-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/342dccea47f6cb14cda63f75789eab51070fb3f6>`__
-   `#6404 <https://pagure.io/freeipa/issue/6404>`__
+   `#6404 <https://codeberg.org/freeipa/freeipa/issues/6404>`__
 -  Upgrade: add gidnumber to trusted domain entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/5405de5bc15941d71137af10aa66a6cf922d9e6d>`__
-   `#6827 <https://pagure.io/freeipa/issue/6827>`__
+   `#6827 <https://codeberg.org/freeipa/freeipa/issues/6827>`__
 -  ipa-sam: create the gidNumber attribute in the trusted domain entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/e052c2dce04f5ce147dc2b6804f44705fa4d69df>`__
-   `#6827 <https://pagure.io/freeipa/issue/6827>`__
+   `#6827 <https://codeberg.org/freeipa/freeipa/issues/6827>`__
 -  idrange-add: properly handle empty --dom-name option
    `commit <https://codeberg.org/freeipa/freeipa/commit/70743c8c48db54309a09d510b3a5d8ae86c29e58>`__
-   `#6404 <https://pagure.io/freeipa/issue/6404>`__
+   `#6404 <https://codeberg.org/freeipa/freeipa/issues/6404>`__
 -  ipa-ca-install man page: Add domain level 1 help
    `commit <https://codeberg.org/freeipa/freeipa/commit/b96a942cdca09496be9f911499036bee60084aee>`__
-   `#5831 <https://pagure.io/freeipa/issue/5831>`__
+   `#5831 <https://codeberg.org/freeipa/freeipa/issues/5831>`__
 -  git-commit-template: update ticket url to use pagure.io instead of
    fedorahosted.org
    `commit <https://codeberg.org/freeipa/freeipa/commit/f17460a34ce452b46d431850aa565efd6c7b23ba>`__
-   `#6822 <https://pagure.io/freeipa/issue/6822>`__
+   `#6822 <https://codeberg.org/freeipa/freeipa/issues/6822>`__
 -  dogtag-ipa-ca-renew-agent-submit: fix the is_replicated() function
    `commit <https://codeberg.org/freeipa/freeipa/commit/e934da09d5e738c735f874931dd1b54d79b3150b>`__
-   `#6813 <https://pagure.io/freeipa/issue/6813>`__
+   `#6813 <https://codeberg.org/freeipa/freeipa/issues/6813>`__
 -  man ipa-cacert-manage install needs clarification
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ea2834b76a72c97186b01487e885800754c0fbc>`__
-   `#6795 <https://pagure.io/freeipa/issue/6795>`__
+   `#6795 <https://codeberg.org/freeipa/freeipa/issues/6795>`__
 
 
 
@@ -623,46 +623,46 @@ Fraser Tweedale (14)
 
 -  Fix external renewal for CA with non-default subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/504c303ec448d5adce2f12416c9ee1719ee1de3b>`__
-   `#7123 <https://pagure.io/freeipa/issue/7123>`__
+   `#7123 <https://codeberg.org/freeipa/freeipa/issues/7123>`__
 -  py3: handle bytes in schema response
    `commit <https://codeberg.org/freeipa/freeipa/commit/947ac4bc1f6f4016cf5baf2ecb4577e893bc3948>`__
-   `#6809 <https://pagure.io/freeipa/issue/6809>`__
+   `#6809 <https://codeberg.org/freeipa/freeipa/issues/6809>`__
 -  py3: fix vault public key decoding
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cead4da2ee4a1b1abbb60e28dee1a78cda83bf5>`__
-   `#7033 <https://pagure.io/freeipa/issue/7033>`__
+   `#7033 <https://codeberg.org/freeipa/freeipa/issues/7033>`__
 -  cert: fix application of 'str' to bytes when formatting otherName
    `commit <https://codeberg.org/freeipa/freeipa/commit/cac7357ebdd7c7218f1d847ca7374735d7e411cd>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: fix schema response for py2 server with py3 client
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1e1109679c0a95aadbd63ce2587561b58d7a050>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Fix incorrect 'with' statement in CA-less installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/477b3dca802349ac4e8d60cfcabc7fe31d0ab9ef>`__
-   `#7118 <https://pagure.io/freeipa/issue/7118>`__
+   `#7118 <https://codeberg.org/freeipa/freeipa/issues/7118>`__
 -  Restore old version of caIPAserviceCert for upgrade only
    `commit <https://codeberg.org/freeipa/freeipa/commit/79955189217fec328f2d561a4a1a23ddb29eac44>`__
-   `#7097 <https://pagure.io/freeipa/issue/7097>`__
+   `#7097 <https://codeberg.org/freeipa/freeipa/issues/7097>`__
 -  cert-request: simplify request processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/227cf8d4e98178212386eca0a1ac21459436e63f>`__
-   `#6531 <https://pagure.io/freeipa/issue/6531>`__
+   `#6531 <https://codeberg.org/freeipa/freeipa/issues/6531>`__
 -  Add CommonNameToSANDefault to default cert profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a35a2e213b46f3c5bb91d0f1b7fa05e8f051d4a>`__
-   `#7007 <https://pagure.io/freeipa/issue/7007>`__
+   `#7007 <https://codeberg.org/freeipa/freeipa/issues/7007>`__
 -  Add a README to certificate profile templates directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7e1ab8438b02db9250b0985be29ac3325c2d2dc>`__
-   `#7014 <https://pagure.io/freeipa/issue/7014>`__
+   `#7014 <https://codeberg.org/freeipa/freeipa/issues/7014>`__
 -  py3: fix regression in schemaupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/89eb162fcd60861ed4c628dab4e1aaf10c6160bb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ca-add: validate Subject DN name attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f0e13ce9c3d1ead02de61a148de973fc6787b96>`__
-   `#6987 <https://pagure.io/freeipa/issue/6987>`__
+   `#6987 <https://codeberg.org/freeipa/freeipa/issues/6987>`__
 -  Add Subject Key Identifier to CA cert validity check
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc6d4995144505c45a62320c71f503b54f68a962>`__
-   `#6976 <https://pagure.io/freeipa/issue/6976>`__
+   `#6976 <https://codeberg.org/freeipa/freeipa/issues/6976>`__
 -  Support 8192-bit RSA keys in default cert profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/1530758475c2e21dd732581ff6816e03ca74dede>`__
-   `#6319 <https://pagure.io/freeipa/issue/6319>`__
+   `#6319 <https://codeberg.org/freeipa/freeipa/issues/6319>`__
 
 
 
@@ -704,114 +704,114 @@ Jan Cholasta (61)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9cb74fd27f4015ad980781785d95bd4107b6f40>`__
 -  install: do not assume /etc/krb5.conf.d exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5fc0ddd874f6289c0fcf60a6a4147ca5b280700>`__
-   `#6589 <https://pagure.io/freeipa/issue/6589>`__
+   `#6589 <https://codeberg.org/freeipa/freeipa/issues/6589>`__
 -  server upgrade: do not enable PKINIT by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/0772ef20b39b11950fddc913a350534988294c89>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  pkinit manage: introduce ipa-pkinit-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/92276c1e8809f3ff6b59bd6124869f816627bac7>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  server certinstall: update KDC master entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/e131905f3e0fe9179c5f4a09da4e7a204012603a>`__
-   `#7000 <https://pagure.io/freeipa/issue/7000>`__
+   `#7000 <https://codeberg.org/freeipa/freeipa/issues/7000>`__
 -  httpinstance: wait until the service entry is replicated
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab71cd5a1693c221950bdfa9ffdfb99b9c317004>`__
-   `#6867 <https://pagure.io/freeipa/issue/6867>`__
+   `#6867 <https://codeberg.org/freeipa/freeipa/issues/6867>`__
 -  server certinstall: support PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/96ca62f81d3505b050eb9b9d71d4fc4c18e1535e>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  cacert manage: support PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ea764ecf5c3118df0917d94c4940b4ee38b3a31>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  replica install: respect --pkinit-cert-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3855704f479eaf122139189b762b943b2dcc0fc>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  server install: fix KDC certificate validation in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b5dbf7cdb4c03260057c8f7a2abd5c5712eca41>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__,
-   `#6869 <https://pagure.io/freeipa/issue/6869>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__,
+   `#6869 <https://codeberg.org/freeipa/freeipa/issues/6869>`__
 -  certs: do not export CA certs in install_pem_from_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc572378a69a7e4d18b7297b7fa54e2fe8e33b2f>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__,
-   `#6869 <https://pagure.io/freeipa/issue/6869>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__,
+   `#6869 <https://codeberg.org/freeipa/freeipa/issues/6869>`__
 -  certs: do not export keys world-readable in install_key_from_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c5b2c42bf52dc75ecf9d95036ca8517670877d6>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  server install: fix KDC PKINIT configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/f769045f0ae9c5fdc651e03c0c96af9cdec8f298>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  install: introduce generic Kerberos Augeas lens
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d36cbf6ad412822b8fb029f517f9228e2c8d4ee>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  client install: fix client PKINIT configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/11b8a3434655932fa73f05d4bd864bed0194035c>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  install: trust IPA CA for PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/01a7416d305ddb11d5b83c99afbacf8ba854c148>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb: use custom object for trust flags
    `commit <https://codeberg.org/freeipa/freeipa/commit/52730c786f6bb11aa7992b11fa0f5c94c90f9eb8>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb, certs: make trust flags argument mandatory
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0442a2d0ed54abe6567fce6d99fd31f7c6c7883>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  certdb: add named trust flag constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/235265a5f5436148dd8d7e63b7e3928689796560>`__
-   `#6831 <https://pagure.io/freeipa/issue/6831>`__
+   `#6831 <https://codeberg.org/freeipa/freeipa/issues/6831>`__
 -  ipa-cacert-manage: add --external-ca-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/b03ede87963bc5933691c9e3f88768e1bf92736f>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: get rid of virtual profiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/21f4cbf8da8091b898fc8032fff65e821223d042>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: always export CSR on IPA CA certificate renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/0bf41e804e89937fc72502cfbe1363dd7591675e>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: allow reusing existing certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/25aeeaf46dd92e06f14de83459ab9be8ab846922>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  cainstance: use correct profile for lightweight CA certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/09a49ad45846e3c2e76c5a035a27d0fa95b347b9>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  server upgrade: always fix certmonger tracking request
    `commit <https://codeberg.org/freeipa/freeipa/commit/5abd9bb99680df45b6cd87de3b08466d612344bb>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  renew agent: respect CA renewal master setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce9eefe53b398b73f956df420ea8694b90e24f76>`__
-   `#5799 <https://pagure.io/freeipa/issue/5799>`__
+   `#5799 <https://codeberg.org/freeipa/freeipa/issues/5799>`__
 -  spec file: bump krb5 Requires for certauth fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f42670afa935801c25bc66f733a8d1b90ea5a0b>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  spec file: bump python-netaddr Requires
    `commit <https://codeberg.org/freeipa/freeipa/commit/0784e53f7f8a323acafbbff26a9d1c0276a229b0>`__
-   `#6894 <https://pagure.io/freeipa/issue/6894>`__
+   `#6894 <https://codeberg.org/freeipa/freeipa/issues/6894>`__
 -  configure: fix AC_CHECK_LIB usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/4322b57e313105611df39e99097993ba4161ab42>`__
-   `#6846 <https://pagure.io/freeipa/issue/6846>`__
+   `#6846 <https://codeberg.org/freeipa/freeipa/issues/6846>`__
 -  cert: defer cert-find result post-processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb6d4c3037d0cc269a7924745f1cbd8f647e6e1a>`__
-   `#6808 <https://pagure.io/freeipa/issue/6808>`__
+   `#6808 <https://codeberg.org/freeipa/freeipa/issues/6808>`__
 -  renew agent, restart scripts: connect to LDAP after kinit
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6a89e24147d8542fd09cf64e04982599b79e3cc>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  renew agent: revert to host keytab authentication
    `commit <https://codeberg.org/freeipa/freeipa/commit/3884a671cb59c360fae67884755fa5779053107a>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  install: request service certs after host keytab is set up
    `commit <https://codeberg.org/freeipa/freeipa/commit/181cb94e744c380a823b94d0d5ca088ab3dcca1c>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  dsinstance, httpinstance: consolidate certificate request code
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec52332229672f35af8db5aaf1ed2827a8dd5467>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  httpinstance: avoid httpd restart during certificate request
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a8558637946d7dac1d85642baaf9ba7c1be98f8>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  dsinstance: reconnect ldap2 after DS is restarted by certmonger
    `commit <https://codeberg.org/freeipa/freeipa/commit/b189be12ecd1ba9efa35daf41e7e04a9362c6a5e>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  httpinstance: make sure NSS database is backed up
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f5a3b29dba7cc736ba334aefb55484baeefeb76>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  certdb: fix \`AttributeError\` in \`verify_ca_cert_validity\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/720034f1b440135671d03596368ed5e9e5a0f3c3>`__
 -  setup, pylint, spec file: drop python-nss dependency
@@ -820,25 +820,25 @@ Jan Cholasta (61)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9183cf2a7505624235b255b1406702cdaa65bb38>`__
 -  spec file: bump libsss_nss_idmap-devel BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/b18ee8b9dd3b1d0cfdc45373a7a56747e1f993a3>`__
-   `#6828 <https://pagure.io/freeipa/issue/6828>`__
+   `#6828 <https://codeberg.org/freeipa/freeipa/issues/6828>`__
 -  spec file: bump krb5-devel BuildRequires for certauth
    `commit <https://codeberg.org/freeipa/freeipa/commit/2dda1acf44dc96e660e81baadee9c3a54bf05eb0>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  cert: do not limit internal searches in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/6de507c2cad255975665eca6dd6ef7c8f2458d51>`__
-   `#6716 <https://pagure.io/freeipa/issue/6716>`__
+   `#6716 <https://codeberg.org/freeipa/freeipa/issues/6716>`__
 -  replica prepare: fix wrong IPA CA nickname in replica file
    `commit <https://codeberg.org/freeipa/freeipa/commit/9939aa53630a9c6a66e83140e64ec56539891c13>`__
-   `#6777 <https://pagure.io/freeipa/issue/6777>`__
+   `#6777 <https://codeberg.org/freeipa/freeipa/issues/6777>`__
 -  httpinstance: clean up /etc/httpd/alias on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/e263cb46cba604421d5ed2e1dbf5dd1d66ce0221>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  certs: do not implicitly create DS pin.txt
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbd18cf10f2e67e5205a3a3bee883272e89c0042>`__
-   `#4639 <https://pagure.io/freeipa/issue/4639>`__
+   `#4639 <https://codeberg.org/freeipa/freeipa/issues/4639>`__
 -  tasks: run \`systemctl daemon-reload\` after httpd.service.d updates
    `commit <https://codeberg.org/freeipa/freeipa/commit/3de09709cc33f1d26f2d605bac82110fe73dde03>`__
-   `#6773 <https://pagure.io/freeipa/issue/6773>`__
+   `#6773 <https://codeberg.org/freeipa/freeipa/issues/6773>`__
 
 
 
@@ -859,138 +859,138 @@ Martin Babinsky (45)
 
 -  Move tmpfiles.d configuration handling back to spec file
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2de6a17c56ab86b0f4f22f63406bfff131155cf>`__
-   `#7053 <https://pagure.io/freeipa/issue/7053>`__
+   `#7053 <https://codeberg.org/freeipa/freeipa/issues/7053>`__
 -  Do not remove the old masters when setting the attribute fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2e380e83be8bafd8cf23e0a395edf065b1ae961>`__
-   `#7029 <https://pagure.io/freeipa/issue/7029>`__
+   `#7029 <https://codeberg.org/freeipa/freeipa/issues/7029>`__
 -  \*config-show: Do not show empty roles/attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4d77533f5e0cb306da2aeb9548d891c5264c088>`__
-   `#7029 <https://pagure.io/freeipa/issue/7029>`__
+   `#7029 <https://codeberg.org/freeipa/freeipa/issues/7029>`__
 -  smart-card-advises: ensure that krb5-pkinit is installed on client
    `commit <https://codeberg.org/freeipa/freeipa/commit/53c5c0ad7bde137b1123504f6a52c2b22e2a3868>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart card advise: use password when changing trust flags on HTTP
    cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0cf7090f3869bc3d4673242f64d63011dc8d1a5>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart card advises: use a wrapper around Bash \`for\` loops
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d57aef7a50eeae04bbd117531808ac616c675eb>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Use the compound statement formatting API for configuring PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9fec090f7a50e6f53394cab1cc5929c18934ac0>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Fix indentation of statements in Smart card advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/85a79b5ccd29a532f7e3f0f17b9ba08153bf9717>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  delegate formatting of compound Bash statements to dedicated classes
    `commit <https://codeberg.org/freeipa/freeipa/commit/9808395c17388d69b51e562bc7f2b1d7d172a7fb>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  advise: add an infrastructure for formatting Bash compound statements
    `commit <https://codeberg.org/freeipa/freeipa/commit/dea4b4ca1bebf128a9a2e26dbbe9ffd3d6f360e1>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  delegate the indentation handling in advises to dedicated class
    `commit <https://codeberg.org/freeipa/freeipa/commit/0181334c4c8e4b73b9b1c634d9837857e5e388b8>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  add a class that tracks the indentation in the generated advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/36e0d2d65cf19033b1022737cd24a1120bc0f85f>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Allow to pass in multiple CA cert paths to the smart card advises
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0c2e0f26cc264dccc51295cdd595109b4e46392>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart-card advises: add steps to store smart card signing CA cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/584abe5b68b74d6a4721525328d5dfadd0e092c0>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  smart-card advises: configure systemwide NSS DB also on master
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ba5f942284d17f32650638965c21dcf907a579>`__
-   `#7036 <https://pagure.io/freeipa/issue/7036>`__
+   `#7036 <https://codeberg.org/freeipa/freeipa/issues/7036>`__
 -  Prepare advise plugin for smart card auth configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/e418e9a4ca747886c53d05ae80597834f1d3d021>`__
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  Extend the advice printing code by some useful abstractions
    `commit <https://codeberg.org/freeipa/freeipa/commit/0569c02f17f853d97280f52f4a7fefecc72cf45d>`__
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  fix incorrect suffix handling in topology checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ef4888af77f8e6fd8324297d26287b575b18163>`__
-   `#6965 <https://pagure.io/freeipa/issue/6965>`__
+   `#6965 <https://codeberg.org/freeipa/freeipa/issues/6965>`__
 -  Do not delete DS and PKI users during backup/restore tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e5f55e791ac3665d4db0f6d14995491f11ef887>`__
-   `#6956 <https://pagure.io/freeipa/issue/6956>`__
+   `#6956 <https://codeberg.org/freeipa/freeipa/issues/6956>`__
 -  test_backup_restore: do not fail on missing KrbLastSuccessfulAuth
    `commit <https://codeberg.org/freeipa/freeipa/commit/2624cf2e4cc4b4b560fe64688ee55160f9d8fb80>`__
-   `#6956 <https://pagure.io/freeipa/issue/6956>`__
+   `#6956 <https://codeberg.org/freeipa/freeipa/issues/6956>`__
 -  only stop/disable simple service if it is installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b6f8ed7d47542b9bd8b7453a8a0e202ed1db97d>`__
-   `#6977 <https://pagure.io/freeipa/issue/6977>`__
+   `#6977 <https://codeberg.org/freeipa/freeipa/issues/6977>`__
 -  test_serverroles: Get rid of MockLDAP and use ldap2 instead
    `commit <https://codeberg.org/freeipa/freeipa/commit/58fd229a1dbb3f00a591de9417f36197141e26d7>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add \`pkinit-status\` command
    `commit <https://codeberg.org/freeipa/freeipa/commit/99352731b4b4bdcedfe6668ce71c1d67720ac4af>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add the list of PKINIT servers as a virtual attribute to global
    config
    `commit <https://codeberg.org/freeipa/freeipa/commit/f80553208e8d9f3df422f5be8e1cafa511e1b2c4>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Add an attribute reporting client PKINIT-capable servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8bb23ac389929f28c584602e592b821e4c6ef9a>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Refactor the role/attribute member reporting code
    `commit <https://codeberg.org/freeipa/freeipa/commit/cac7e49daa04e838650548cc9162b8f117dc55b3>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Allow for multivalued server attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/bddb90f38a3505a2768862d2f814c5e749a7dcde>`__
-   `#6937 <https://pagure.io/freeipa/issue/6937>`__
+   `#6937 <https://codeberg.org/freeipa/freeipa/issues/6937>`__
 -  Travis CI: Add the server uninstaller as a last step of tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/89a5bb2c6becae8d3463731f39234d54ced7bbca>`__
-   `#6950 <https://pagure.io/freeipa/issue/6950>`__
+   `#6950 <https://codeberg.org/freeipa/freeipa/issues/6950>`__
 -  Travis CI: explicitly update pip before running the builds
    `commit <https://codeberg.org/freeipa/freeipa/commit/afe85c37981d2846c26010f22f652c60d9cd0941>`__
 -  Do not test anonymous PKINIT after install/upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/960e361f68a3d7acd9bcf16ec6fe8f6d5376c4ae>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Upgrade: configure local/full PKINIT depending on the master status
    `commit <https://codeberg.org/freeipa/freeipa/commit/a194055c92c7ca4eba29323f990ec3b92026221b>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Use local anchor when armoring password requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/2374b648d0dfd08ec4cfbcc35f7987fa8b8a6ffa>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Stop requesting anonymous keytab and purge all references of it
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c6a4d4e1340ce01bdc7ec5dd394604a3da7688>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Use only anonymous PKINIT to fetch armor ccache
    `commit <https://codeberg.org/freeipa/freeipa/commit/3adb9ca875f8eb99e99a29e17a471a2b6f408a4a>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  API for retrieval of master's PKINIT status and publishing it in LDAP
    `commit <https://codeberg.org/freeipa/freeipa/commit/86972299d937960bcb713fc73b447cddb4ea44bd>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Allow for configuration of all three PKINIT variants when deploying
    KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb52f7a1f328b126626525179d5250692daca2cd>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  separate function to set ipaConfigString values on service entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1a1e104391c84cb9af7b0a7c8748c8652442ddb>`__
-   `#6830 <https://pagure.io/freeipa/issue/6830>`__
+   `#6830 <https://codeberg.org/freeipa/freeipa/issues/6830>`__
 -  Revert "Store GSSAPI session key in /var/run/ipa"
    `commit <https://codeberg.org/freeipa/freeipa/commit/50f6883662e258b0335c8b3cb69946d6dcbf206c>`__
-   `#6880 <https://pagure.io/freeipa/issue/6880>`__
+   `#6880 <https://codeberg.org/freeipa/freeipa/issues/6880>`__
 -  Remove duplicate functionality in upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/2eabb0dab7b4dab1c45395f3e02d43676d91f4a2>`__
-   `#6799 <https://pagure.io/freeipa/issue/6799>`__
+   `#6799 <https://codeberg.org/freeipa/freeipa/issues/6799>`__
 -  Always check and create anonymous principal during KDC install
    `commit <https://codeberg.org/freeipa/freeipa/commit/191668e85be0b53020a56df409731812e528d101>`__
-   `#6799 <https://pagure.io/freeipa/issue/6799>`__
+   `#6799 <https://codeberg.org/freeipa/freeipa/issues/6799>`__
 -  Ensure KDC is propery configured after upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c22f905d48d3d8dd50e394290e1feb8f6dedcaa>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Split out anonymous PKINIT test to a separate method
    `commit <https://codeberg.org/freeipa/freeipa/commit/17aa51ef0291b9c6174509f52913076ae599357f>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Remove unused variable from failed anonymous PKINIT handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fc48cd0af3b19272fcfe25235e55eae249bb6c9>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Upgrade: configure PKINIT after adding anonymous principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2d95d3962d525017732618e66b39b099235d43e>`__
-   `#6792 <https://pagure.io/freeipa/issue/6792>`__
+   `#6792 <https://codeberg.org/freeipa/freeipa/issues/6792>`__
 -  Travis CI: invoke integration test helper scripts before test
    execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6624594bedce75849248469305ae964ce5ea2ef>`__
@@ -1002,63 +1002,63 @@ Martin Basti (63)
 
 -  DNS update: reduce timeout for CA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/dffddbd2c0dae7d646bdb2be23ac5ebe46f19d7a>`__
-   `#6176 <https://pagure.io/freeipa/issue/6176>`__
+   `#6176 <https://codeberg.org/freeipa/freeipa/issues/6176>`__
 -  baseldap: fix format string
    `commit <https://codeberg.org/freeipa/freeipa/commit/041982f07392f117c5acf252cc5faacf0e127712>`__
 -  IPAOptionParser: fix dict comprehension
    `commit <https://codeberg.org/freeipa/freeipa/commit/f18ce013556c5bafe7e9c35e361deb149eef37a4>`__
 -  py3: run already ported scripts under py3 by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa1c0cf3e8f2a77e27d548f73694d99aa0497459>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: temporary set dependencies to both py2 and py3 packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/17103e53cbbf6d4cfb42d727d3f2edb7b56c8e9c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: test_otptoken_import: fix bytes usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/902f736a2b288fac5d080b7f146f6a8b16f882f1>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipa_otptoken_import: fix hex decoding
    `commit <https://codeberg.org/freeipa/freeipa/commit/637d259361306bcbc4af86bbedf17a7ff6875716>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipa_otptoken_import: fix calling unicode on bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/e53674e741fa8a2268e4a663c3ffbc00d891123c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipa_otptoken_import: fix lamba code inspection
    `commit <https://codeberg.org/freeipa/freeipa/commit/24eadd3a39f472669585355c5db00fc430acac1b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: Remove comparison >=2 of debnug log level
    `commit <https://codeberg.org/freeipa/freeipa/commit/8416d5772d5e14829df58dabb24b30721c302c07>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: vault: data must be bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f59721c5548a62ec63a72bad0c08021e0dd536e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: test_location_plugin: fix iteration over changed dict
    `commit <https://codeberg.org/freeipa/freeipa/commit/10d4fb7ea859cb07240b09acdb805f23782b3dc9>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: test_kerberos_principal_aliases: fix code scope
    `commit <https://codeberg.org/freeipa/freeipa/commit/8116a7b450581cc2bc6e0e9a58b511f43addde42>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: dogtag.py: fix bytes warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/c422206cc7e5de9cd94c30811489e78817290c59>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: travis: enable tests for plugins that are aleready working
    `commit <https://codeberg.org/freeipa/freeipa/commit/b35db9152c12f8029086fc5c3720b63c4b2b58d7>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: secrets: remove iteritems usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0e51688417ee422196006b700499ef7b8bb5737>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Travis: check for BytesWarnings in httpd error_log
    `commit <https://codeberg.org/freeipa/freeipa/commit/b43dab83880b8ed99ffab3ed8b4b69e5da80177c>`__
 -  py3: ipaldap: fix encoding of datetime objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/0487f993fdba5487bd622ffcc9c64e516077e745>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: LDAPClient: remove \__del_\_ method
    `commit <https://codeberg.org/freeipa/freeipa/commit/db01767acf4cb002995a3609061a45ca90cde573>`__
 -  LDAPEntry: rename \_orig to \_orig_raw
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c163c90b8445fe441612f6857174b5fd5d505f4>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  python-netifaces: update to reflect upstream changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/52b43c7168d02e84865e31faa478d8a93be7a913>`__
-   `#7021 <https://pagure.io/freeipa/issue/7021>`__
+   `#7021 <https://codeberg.org/freeipa/freeipa/issues/7021>`__
 -  Travis: enable temporary Py3 testing
    `commit <https://codeberg.org/freeipa/freeipa/commit/172a2e7456fe3f702dd6d4da51a92ad030824294>`__
 -  Travis: build only py2 packages for py2 testing
@@ -1067,116 +1067,116 @@ Martin Basti (63)
    `commit <https://codeberg.org/freeipa/freeipa/commit/4eec2f5e572a9ec77b4eb3ef66470f0f9813bfbb>`__
 -  Remove network and broadcast address warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3537297bee2890c6b839750bb7a0a2cf904cdf9>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  replica install: add missing check for non-local IP address
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b8dc1131c9ca7218efb8fe16dcce97f9f960be9>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Remove ip_netmask from option parser
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9cba7d161f788c32336b66ff7c641f4a1ed2754>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  CheckedIPAddress: remove match_local param
    `commit <https://codeberg.org/freeipa/freeipa/commit/6024165101677c844dc3bbb337e290df2e66eaf1>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  refactor CheckedIPAddress class
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b69e44f16fbba6ab7ddef5a3e55bdabcfd6a8a6>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  ipa-dns-install: remove check for local ip address
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb48a49c80f4a11d2d16511e0f1366867320f153>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Fix local IP address validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/82ad586f6cbf6e707add3c866ed4e37ade69b045>`__
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  Explicitly ask for py2 dependencies in py2 packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2147de6e2eb217163d6f106d3220c7b1e7570b5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Only warn when specified server IP addresses don't match intf
    `commit <https://codeberg.org/freeipa/freeipa/commit/6637980af6069623d944d9d592cbadba20b610a2>`__
-   `#2715 <https://pagure.io/freeipa/issue/2715>`__,
-   `#4317 <https://pagure.io/freeipa/issue/4317>`__
+   `#2715 <https://codeberg.org/freeipa/freeipa/issues/2715>`__,
+   `#4317 <https://codeberg.org/freeipa/freeipa/issues/4317>`__
 -  pylint: explicitly depends on python2-pylint
    `commit <https://codeberg.org/freeipa/freeipa/commit/be1415b6cc8f5dadc1ac3766305a33f370fdf9bb>`__
-   `#6986 <https://pagure.io/freeipa/issue/6986>`__
+   `#6986 <https://codeberg.org/freeipa/freeipa/issues/6986>`__
 -  py3: update_mod_nss_cipher_suite: ordering doesn't work with None
    `commit <https://codeberg.org/freeipa/freeipa/commit/99771ceb9ffcf21d0364bf57994716322b24551e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: urlfetch: use "file://" prefix with filenames
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6a57d8091aeefb6067711189ee0ce11411dee57>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: cainstance: fix BytesWarning
    `commit <https://codeberg.org/freeipa/freeipa/commit/b09a941f34507cfce682d8c5a3acf6dfe7fa624e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: schemaupdate: fix BytesWarning
    `commit <https://codeberg.org/freeipa/freeipa/commit/d89de4219d0e8ee33e81d6b6d1bc6c22ac9ffbaa>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: LDAP updates: use only bytes/raw values
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc9addac30d69d88f5040e194be1e32a881cfba9>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: softhsm key_id must be bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7a9e81fbd7a339dddd41a8c5ae9f29252522944>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ipaldap: encode Boolean as bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/27f8f9f03d69276f9ee410169b76574da2461794>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: ConfigParser: replace deprecated readfd with read
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e7071d6add24e8923d705d35a362761f356d56d>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: use ConfigParser instead of SafeConfigParser
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e63ec42d0f879f2d129c4f81f88a1712ce86b8c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Add remote_plugins subdirectories to RPM
    `commit <https://codeberg.org/freeipa/freeipa/commit/71adc8cd3ff6d6e54f332e94bfda3ed59396de90>`__
-   `#6927 <https://pagure.io/freeipa/issue/6927>`__
+   `#6927 <https://codeberg.org/freeipa/freeipa/issues/6927>`__
 -  custodia dep: require explictly python2 version
    `commit <https://codeberg.org/freeipa/freeipa/commit/a90a113b66fca620b04635442b135a5136ece7ba>`__
-   `#6962 <https://pagure.io/freeipa/issue/6962>`__
+   `#6962 <https://codeberg.org/freeipa/freeipa/issues/6962>`__
 -  pylint: ignore new checks added in 1.7
    `commit <https://codeberg.org/freeipa/freeipa/commit/7eb02a49ed86c0640266af47d11c9efa91bc54cb>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Pylint: fix ipa_forbidden_import checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f640de76e57272d7b7707e710bbee19a8eda79a>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  travis: fix pylint execution with py3
    `commit <https://codeberg.org/freeipa/freeipa/commit/cba678d846056606e8d1c2d29177baaa345fdbdb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: add missing py3 pylint depedencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e679783561eaa755691f6d193481e998efb7617>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__,
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__,
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  adtrust: move SELinux settings to constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/663f227a5cd8ee4eb2b365d2765b330a9aa60685>`__
 -  httpd: move SELinux settings to constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a6de32c9e74493ca677353a0c7f14aa45977b6b>`__
 -  ipasetup: fix dependencies handling based on python version
    `commit <https://codeberg.org/freeipa/freeipa/commit/bea7236b9c5a82db5d945a88103c0524a793a8a2>`__
-   `#6875 <https://pagure.io/freeipa/issue/6875>`__
+   `#6875 <https://codeberg.org/freeipa/freeipa/issues/6875>`__
 -  ipaclient: fix missing RPM ownership
    `commit <https://codeberg.org/freeipa/freeipa/commit/374a58fa49adc715d50996571631af37ae16bd64>`__
-   `#6927 <https://pagure.io/freeipa/issue/6927>`__
+   `#6927 <https://codeberg.org/freeipa/freeipa/issues/6927>`__
 -  tests: add missing dependency iptables
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c061b6836c13bf63553c6143b19e89658937e7e>`__
 -  ca_status: add HTTP timeout 30 seconds
    `commit <https://codeberg.org/freeipa/freeipa/commit/05984f171b0b41681254c95380a0598e4208a201>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  http_request: add timeout option
    `commit <https://codeberg.org/freeipa/freeipa/commit/20f7689079328aeef42b62a359b303f531db5666>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Use proper SELinux context with http.keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f4c2fbd975d09c01e6898a4eb70d7dfea1171b4>`__
-   `#6924 <https://pagure.io/freeipa/issue/6924>`__
+   `#6924 <https://codeberg.org/freeipa/freeipa/issues/6924>`__
 -  Store GSSAPI session key in /var/run/ipa
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bab2d4963daa99742875f3633a99966bc56f5a3>`__
-   `#6880 <https://pagure.io/freeipa/issue/6880>`__
+   `#6880 <https://codeberg.org/freeipa/freeipa/issues/6880>`__
 -  Fix PKCS11 helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8f2a415b3dcba30b0c39cd542acd6b459f46957>`__
-   `#6692 <https://pagure.io/freeipa/issue/6692>`__
+   `#6692 <https://codeberg.org/freeipa/freeipa/issues/6692>`__
 -  Remove surplus 'the' in output of ipa-adtrust-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/bad0f608c4f44cb36556f305f1290020d37439c6>`__
-   `#6864 <https://pagure.io/freeipa/issue/6864>`__
+   `#6864 <https://codeberg.org/freeipa/freeipa/issues/6864>`__
 -  collect audit.log for easier selinux investigation
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd597f83aed53bf3281ce9ec6b94f601868cfc75>`__
 -  Set "KDC:Disable Last Success" by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/eeaf428b1befc37489ed5ee14ae193b46cbd1db7>`__
-   `#5313 <https://pagure.io/freeipa/issue/5313>`__
+   `#5313 <https://codeberg.org/freeipa/freeipa/issues/5313>`__
 -  Set development version to 4.5.90
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ac62bec44b642838cbb175d94efd90acb417ecc>`__
 
@@ -1195,29 +1195,29 @@ Michal Reznik (9)
 
 -  test_caless: add SAN dNSName extensions for wildcard tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c99367bfe1071073cd93237660d783459b25e2>`__
-   `#7100 <https://pagure.io/freeipa/issue/7100>`__
+   `#7100 <https://codeberg.org/freeipa/freeipa/issues/7100>`__
 -  test_caless: add replica ca-less to ca-full test (master caless)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ff356241c890e7021e64530a6e4a8c17ca99bdb>`__
-   `#6226 <https://pagure.io/freeipa/issue/6226>`__,
-   `#7086 <https://pagure.io/freeipa/issue/7086>`__
+   `#6226 <https://codeberg.org/freeipa/freeipa/issues/6226>`__,
+   `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__
 -  test_caless: add server_replica ca-less to ca-full test
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a5b1cc1402d739a9804eebe1a9d2be13bf454ec>`__
-   `#7086 <https://pagure.io/freeipa/issue/7086>`__
+   `#7086 <https://codeberg.org/freeipa/freeipa/issues/7086>`__
 -  tests: fix external_ca test suite failing due to missing SKI
    `commit <https://codeberg.org/freeipa/freeipa/commit/4caabb140e31218c72846877da0c985c6a178d7a>`__
-   `#7099 <https://pagure.io/freeipa/issue/7099>`__
+   `#7099 <https://codeberg.org/freeipa/freeipa/issues/7099>`__
 -  test_caless: remove xfail in wildcard certificate tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/284658e08ef88ae2796ace0a4f172e7b8464a5e9>`__
-   `#5603 <https://pagure.io/freeipa/issue/5603>`__
+   `#5603 <https://codeberg.org/freeipa/freeipa/issues/5603>`__
 -  test_caless: introduce new python makepki + fix SKI extension issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/64375ba65bfc56694a425b1e39bd2081e604f777>`__
-   `#7030 <https://pagure.io/freeipa/issue/7030>`__
+   `#7030 <https://codeberg.org/freeipa/freeipa/issues/7030>`__
 -  test_caless: mark TestCertinstall intermediate CA tests as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5e84d70650a8b3430c11583876e5f604560c74e>`__
-   `#6959 <https://pagure.io/freeipa/issue/6959>`__
+   `#6959 <https://codeberg.org/freeipa/freeipa/issues/6959>`__
 -  test_caless: add pkinit option and test it
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7c4039e415af2db51ae132ec15456f57eed161a>`__
-   `#6854 <https://pagure.io/freeipa/issue/6854>`__
+   `#6854 <https://codeberg.org/freeipa/freeipa/issues/6854>`__
 -  added krb5kdc.log to pytest logging
    `commit <https://codeberg.org/freeipa/freeipa/commit/2493f812048f191225eefc07abd91090dee47653>`__
 
@@ -1228,7 +1228,7 @@ Nathaniel McCallum (1)
 
 -  ipa-otptoken-import: Make PBKDF2 refer to the pkcs5 namespace
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc05ab992226febb54e47e3963b694fe96ca4167>`__
-   `#7035 <https://pagure.io/freeipa/issue/7035>`__
+   `#7035 <https://codeberg.org/freeipa/freeipa/issues/7035>`__
 
 
 
@@ -1254,20 +1254,20 @@ Petr Vobornik (5)
 
 -  log progress of wait_for_open_ports
    `commit <https://codeberg.org/freeipa/freeipa/commit/038d1920657c6fd349f8414ed173a9c97681a602>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 -  control logging of host_port_open from caller
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc72db67e2eaede577c3129d572b85e9c2ba593c>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 -  kerberos session: use CA cert with full cert chain for obtaining
    cookie
    `commit <https://codeberg.org/freeipa/freeipa/commit/c19196a0d3fc0a38c4c83cb8a7fde56e6bc310af>`__
-   `#6876 <https://pagure.io/freeipa/issue/6876>`__
+   `#6876 <https://codeberg.org/freeipa/freeipa/issues/6876>`__
 -  restore: restart/reload gssproxy after restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a4c8e39c3e38ec651cfcbb3cac59e0e92e04fe0>`__
-   `#6902 <https://pagure.io/freeipa/issue/6902>`__
+   `#6902 <https://codeberg.org/freeipa/freeipa/issues/6902>`__
 -  automount install: fix checking of SSSD functionality on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4e447fa6fc7d659ae6a3b6285d4ddda0baa0be4>`__
-   `#6861 <https://pagure.io/freeipa/issue/6861>`__
+   `#6861 <https://codeberg.org/freeipa/freeipa/issues/6861>`__
 
 
 
@@ -1276,75 +1276,75 @@ Pavel Vomacka (34)
 
 -  Fixes bug in actions creating for search facet
    `commit <https://codeberg.org/freeipa/freeipa/commit/76f217b2893b0604ed0adf372422c685c2febbe8>`__
-   `#7052 <https://pagure.io/freeipa/issue/7052>`__
+   `#7052 <https://codeberg.org/freeipa/freeipa/issues/7052>`__
 -  WebUI: fix showing required asterisk '*'
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5ef1a7fd0863b52d91fc44f0e9dbdb9d76a7bb1>`__
-   `#6849 <https://pagure.io/freeipa/issue/6849>`__
+   `#6849 <https://codeberg.org/freeipa/freeipa/issues/6849>`__
 -  WebUI: Update unit test README
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c2dbece59b9ff1ee8d247e940e2e776a660fec8>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Fixes details_test.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b70b91de4d241b999d62cc56051c8af364d3630>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Fixes for widget_tests.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb5582d52bc7ce80e6cfc691cc4bb10a9beb307b>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Fixes for aci_tests.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/63f7575cb38982575342a6856b7d322c14fc83f6>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Fixes for entity_tests.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/11e19cd5d5e475350d6de29d9cb2920c3ab99110>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Fixes for ipa_test.js
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fb52371f27f4013a8e30c09ccaed75da5a08404>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Add up to date JSON files
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e0db0759abe35d786f6570234afb04d353ae6df>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  Add loader.js into requirements of all HTML unit test files
    `commit <https://codeberg.org/freeipa/freeipa/commit/46fba2128fb42c5c2cbea60ff288f3180d729042>`__
-   `#6974 <https://pagure.io/freeipa/issue/6974>`__
+   `#6974 <https://codeberg.org/freeipa/freeipa/issues/6974>`__
 -  WebUI: remove creating js/libs symlink from makefile
    `commit <https://codeberg.org/freeipa/freeipa/commit/4eb37d7436bcb90991f56cd7e1cf75fa2d34fa22>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  WebUI: Remove plugins symlink as it is unused
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ee7db75e45573a8f16a3776c3e0d862b685c15c>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  Remove all old JSON files
    `commit <https://codeberg.org/freeipa/freeipa/commit/41a18bbbc8793335daa0583bddb2f8c775d2b6a2>`__
-   `#6447 <https://pagure.io/freeipa/issue/6447>`__
+   `#6447 <https://codeberg.org/freeipa/freeipa/issues/6447>`__
 -  Revert "Web UI: Remove offline version of Web UI"
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ad92d3a4f0a4e9af0124fe457d2a3c646f15710>`__
 -  WebUI: Add hyphenate versions of Host(Role) Based strings
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a73b5d7399e21b2ea074ddcb915a74adb4f0f48>`__
-   `#6582 <https://pagure.io/freeipa/issue/6582>`__
+   `#6582 <https://codeberg.org/freeipa/freeipa/issues/6582>`__
 -  WebUI: fix incorrectly shown links in association tables
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed7de96648daf95868f34107890700124836b69d>`__
-   `#7066 <https://pagure.io/freeipa/issue/7066>`__
+   `#7066 <https://codeberg.org/freeipa/freeipa/issues/7066>`__
 -  WebUI: fix jslint error
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b8d46019172e83bdbacf7200759de640c19a2d4>`__
 -  WebUI: change validator of page size settings
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfa157c1e554e0cd113a6fb9fd3af9fbad4529ef>`__
-   `#6980 <https://pagure.io/freeipa/issue/6980>`__
+   `#6980 <https://codeberg.org/freeipa/freeipa/issues/6980>`__
 -  WebUI: Add positive number validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cac851498ab85e6b0abf74bc3ff4eea2f960983>`__
-   `#6980 <https://pagure.io/freeipa/issue/6980>`__
+   `#6980 <https://codeberg.org/freeipa/freeipa/issues/6980>`__
 -  WebUI: add support for changing trust UPN suffixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/b25412f9889f3523974e7aeb43920d4e2347fcfa>`__
-   `#7015 <https://pagure.io/freeipa/issue/7015>`__
+   `#7015 <https://codeberg.org/freeipa/freeipa/issues/7015>`__
 -  Bump version of python-gssapi
    `commit <https://codeberg.org/freeipa/freeipa/commit/2485c3377abe7628c5f657233e65b1df6b3ce290>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  Turn off OCSP check
    `commit <https://codeberg.org/freeipa/freeipa/commit/566361e63d4a670460df3dbb28b9d19f38eaea2d>`__
-   `#6981 <https://pagure.io/freeipa/issue/6981>`__,
-   `#6982 <https://pagure.io/freeipa/issue/6982>`__
+   `#6981 <https://codeberg.org/freeipa/freeipa/issues/6981>`__,
+   `#6982 <https://codeberg.org/freeipa/freeipa/issues/6982>`__
 -  Change python-cryptography to python2-cryptography
    `commit <https://codeberg.org/freeipa/freeipa/commit/9149f2d9c6e90f6dd974ea4317f71d17db3c869c>`__
-   `#6749 <https://pagure.io/freeipa/issue/6749>`__
+   `#6749 <https://codeberg.org/freeipa/freeipa/issues/6749>`__
 -  Turn on NSSOCSP check in mod_nss conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0b32dac5462164869ab19c3d56c36e80cde4b7b>`__
-   `#6370 <https://pagure.io/freeipa/issue/6370>`__
+   `#6370 <https://codeberg.org/freeipa/freeipa/issues/6370>`__
 -  WebUI - Coverity: fix identical branches of if statement
    `commit <https://codeberg.org/freeipa/freeipa/commit/01516e58c8fc71985c538136b2286198765da296>`__
 -  WebUI - Coverity: fixed null pointer exception
@@ -1353,25 +1353,25 @@ Pavel Vomacka (34)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b54ceae9616b733c35ce7928309b8ab93527110b>`__
 -  WebUI: Allow to add certs to certmapping with CERT LINES around
    `commit <https://codeberg.org/freeipa/freeipa/commit/84b38b6793cbc45d36c39abf79893e22e90baac6>`__
-   `#6772 <https://pagure.io/freeipa/issue/6772>`__
+   `#6772 <https://codeberg.org/freeipa/freeipa/issues/6772>`__
 -  WebUI: Fix showing vault in selfservice view
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab6d7ac50a93efa6a9e3566dbe07b34a23c41cce>`__
-   `#6812 <https://pagure.io/freeipa/issue/6812>`__
+   `#6812 <https://codeberg.org/freeipa/freeipa/issues/6812>`__
 -  WebUI: suppress truncation warning in select widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9e6ad1967ba24c7ebe5181da1ebe32d30e7b28f>`__
-   `#6618 <https://pagure.io/freeipa/issue/6618>`__
+   `#6618 <https://codeberg.org/freeipa/freeipa/issues/6618>`__
 -  WebUI: Add support for suppressing warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b3a10da7001d7ee394cd891d926def66d0f2546>`__
-   `#6618 <https://pagure.io/freeipa/issue/6618>`__
+   `#6618 <https://codeberg.org/freeipa/freeipa/issues/6618>`__
 -  WebUI: Add support for login for AD users
    `commit <https://codeberg.org/freeipa/freeipa/commit/ceedc3f7ecb1300ed5bfaf5db8ef1b1450c6288e>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 -  WebUI: add method for disabling item in user dropdown menu
    `commit <https://codeberg.org/freeipa/freeipa/commit/2992e3c5d480567cfdc71b38365d5d74f009b4d2>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 -  WebUI: check principals in lowercase
    `commit <https://codeberg.org/freeipa/freeipa/commit/1dcdcd12f4336c98e7507fe0e7f0c0da2bc69eba>`__
-   `#3242 <https://pagure.io/freeipa/issue/3242>`__
+   `#3242 <https://codeberg.org/freeipa/freeipa/issues/3242>`__
 
 
 
@@ -1380,10 +1380,10 @@ Rob Crittenden (2)
 
 -  Include the CA basic constraint in CSRs when renewing a CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/a37e90530fd205604d30213c3410bd5cb9e063cf>`__
-   `#7088 <https://pagure.io/freeipa/issue/7088>`__
+   `#7088 <https://codeberg.org/freeipa/freeipa/issues/7088>`__
 -  Pass ipa-ca-agent credentials as PEM files
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c1ab3ca5015317091f40ac8c352823a75849cef>`__
-   `#7076 <https://pagure.io/freeipa/issue/7076>`__
+   `#7076 <https://codeberg.org/freeipa/freeipa/issues/7076>`__
 
 
 
@@ -1393,7 +1393,7 @@ Gabe (2)
 -  Update get_attr_filter in LDAPSearch to handle nsaccountlock user
    searches
    `commit <https://codeberg.org/freeipa/freeipa/commit/38276d3473ecf2a4cc5b5e2a107347f046625626>`__
-   `#6896 <https://pagure.io/freeipa/issue/6896>`__
+   `#6896 <https://codeberg.org/freeipa/freeipa/issues/6896>`__
 -  Add --password-expiration to allow admin to force user password
    expiration
    `commit <https://codeberg.org/freeipa/freeipa/commit/274b0bcf5ff2408739d94ba1b1b4bca69f310dfc>`__
@@ -1405,36 +1405,36 @@ Sumit Bose (11)
 
 -  ipa_pwd_extop: do not generate NT hashes in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f0ca6aafd966e086692007a0df76e3c3276915f>`__
-   `#7026 <https://pagure.io/freeipa/issue/7026>`__
+   `#7026 <https://codeberg.org/freeipa/freeipa/issues/7026>`__
 -  ipa-sam: replace encode_nt_key() with E_md4hash()
    `commit <https://codeberg.org/freeipa/freeipa/commit/f169481b558bd7ec9102e02e40eb38df7867a694>`__
-   `#7026 <https://pagure.io/freeipa/issue/7026>`__
+   `#7026 <https://codeberg.org/freeipa/freeipa/issues/7026>`__
 -  ipa-kdb: use canonical principal in certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/117d6e9be0c386f134bd27eee3377e70df77f0f0>`__
-   `#6993 <https://pagure.io/freeipa/issue/6993>`__
+   `#6993 <https://codeberg.org/freeipa/freeipa/issues/6993>`__
 -  ipa-kdb: reload certificate mapping rules periodically
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8aed2524846f1cff3d09d676675f3b426178f60>`__
-   `#6963 <https://pagure.io/freeipa/issue/6963>`__
+   `#6963 <https://codeberg.org/freeipa/freeipa/issues/6963>`__
 -  IPA-KDB: use relative path in ipa-certmap config snippet
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c2772dde52c84024d32533b29e6cbd04c69924a>`__
-   `#6833 <https://pagure.io/freeipa/issue/6833>`__
+   `#6833 <https://codeberg.org/freeipa/freeipa/issues/6833>`__
 -  extdom: improve cert request
    `commit <https://codeberg.org/freeipa/freeipa/commit/8960398a57f69c124ec3105289dc355baa0d5b09>`__
-   `#6826 <https://pagure.io/freeipa/issue/6826>`__
+   `#6826 <https://codeberg.org/freeipa/freeipa/issues/6826>`__
 -  extdom: do reverse search for domain separator
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee455f163d756a6b71db8e999365139cad46c6ad>`__
 -  ipa-kdb: do not depend on certauth_plugin.h
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ba0c0781367d8e2d4affca29e3cf5ab93c4c33a>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  configure: fix --disable-server with certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/054f1bd78b04a79f765f524f829b34c0ee252a1b>`__
-   `#6816 <https://pagure.io/freeipa/issue/6816>`__
+   `#6816 <https://codeberg.org/freeipa/freeipa/issues/6816>`__
 -  IPA certauth plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4156041feb9c48598427ad59e43313b9c7327bb>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 -  ipa-kdb: add ipadb_fetch_principals_with_extra_filter()
    `commit <https://codeberg.org/freeipa/freeipa/commit/da880decfedc66f9d0d2734dcb86c23a8866f603>`__
-   `#4905 <https://pagure.io/freeipa/issue/4905>`__
+   `#4905 <https://codeberg.org/freeipa/freeipa/issues/4905>`__
 
 
 
@@ -1447,33 +1447,33 @@ Simo Sorce (12)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0537ab07bad852381357df3b93d5ca7d30b1b5ec>`__
 -  Revert setting sessionMaxAge for old clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/c52ca92cdabf07da5b3b27344b8eaa8b161ea49b>`__
-   `#7001 <https://pagure.io/freeipa/issue/7001>`__
+   `#7001 <https://codeberg.org/freeipa/freeipa/issues/7001>`__
 -  Add code to be able to set default kinit lifetime
    `commit <https://codeberg.org/freeipa/freeipa/commit/77db574cca900eb03d8e0ab577568c2058ae4a86>`__
-   `#7001 <https://pagure.io/freeipa/issue/7001>`__
+   `#7001 <https://codeberg.org/freeipa/freeipa/issues/7001>`__
 -  Fix rare race condition with missing ccache file
    `commit <https://codeberg.org/freeipa/freeipa/commit/83619e804b53f2bfb8b0d94882c01abed23c4a9f>`__
 -  Make sure remote hosts have our keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f9f84a66d6cf9391b91ee4a13ac0f1119212578>`__
-   `#6838 <https://pagure.io/freeipa/issue/6838>`__
+   `#6838 <https://codeberg.org/freeipa/freeipa/issues/6838>`__
 -  Fix s4u2self with adtrust
    `commit <https://codeberg.org/freeipa/freeipa/commit/e88d5e815ea440bcef4acdc5f8fcb3a29e6eaec9>`__
-   `#6862 <https://pagure.io/freeipa/issue/6862>`__
+   `#6862 <https://codeberg.org/freeipa/freeipa/issues/6862>`__
 -  Prevent churn on ccaches
    `commit <https://codeberg.org/freeipa/freeipa/commit/d63326632b796a5ec9c6468c5ffe0c5a846501e1>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Work around issues fetching session data
    `commit <https://codeberg.org/freeipa/freeipa/commit/e07aefb886096a7d419a4f1a2dec287e5ecd1626>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Handle failed authentication via cookie
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbbeb132bf37f8a03ef2f2184adb11796ab13d8b>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Avoid growing FILE ccaches unnecessarily
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a6ac74eb4421b9ffa831dc6fed067d2ddc0618e>`__
-   `#6775 <https://pagure.io/freeipa/issue/6775>`__
+   `#6775 <https://codeberg.org/freeipa/freeipa/issues/6775>`__
 -  Add options to allow ticket caching
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ee7e4ee6d6500d8b8935c9033388adc4cdbe672>`__
-   `#6771 <https://pagure.io/freeipa/issue/6771>`__
+   `#6771 <https://codeberg.org/freeipa/freeipa/issues/6771>`__
 
 
 
@@ -1482,291 +1482,291 @@ Stanislav Laznicka (97)
 
 -  spec: remove strict options from shebangs
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa969da461a2bbdfc2fc2de49c3f21b6de23e9e1>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  spec: have the scripts depend on py3 packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/263217ff46f7ec260629c2ace5640bd281be9914>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  spec: remove python3 workaround
    `commit <https://codeberg.org/freeipa/freeipa/commit/3aff58c804145716a34b38a0d7009df62be17d0d>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Remove unused variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/c14aa6cdac5795bd2a05606c51e4b9d9f26755a4>`__
 -  certmonger: remove temporary workaround
    `commit <https://codeberg.org/freeipa/freeipa/commit/170f7a778bf62d11c0ba910f1e6d7924614b68c5>`__
 -  cert: fix wrong assumption of cert-show result type
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b78f79283e633abc5dd901ca4db99cea36aca1a>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  rpc: don't encode bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/e09b6c260288b955c1f7d63209ff6b932f363ad1>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: Fix searching for yubikeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/0be9a1721133ad512a7420f6508249d4e8453d90>`__
-   `#7121 <https://pagure.io/freeipa/issue/7121>`__
+   `#7121 <https://codeberg.org/freeipa/freeipa/issues/7121>`__
 -  py3: remove relative import
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bc5b7f044435921b9fa1d5728731a843919102e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__,
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__,
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  py3: remove Exception.message appearances
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6a9de8a2ea453843e71ff717bee7dd74383db64>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__,
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__,
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Fix cert file creation during CA-less installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a86ff5d9bf5d9bf0f5970298addcd5b0f21d728>`__
-   `#7118 <https://pagure.io/freeipa/issue/7118>`__
+   `#7118 <https://codeberg.org/freeipa/freeipa/issues/7118>`__
 -  Uninstall: fix BytesWarning exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ca8787cc7f4865cfce20241440f17d3a41bef78>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Unify storing certificates in LDAP
    `commit <https://codeberg.org/freeipa/freeipa/commit/31142ead830b441c81ee1439e81210426792cac5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: fix caless to CA promotion on replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/2151ab02c19d0a74d90d3784a1ac1b14877a7b96>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  cacert_manage: fix CA cert renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fc7a96e11b3f5de88f971478dc9365bf91c069e>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  python3: port certmonger requests script
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ef6de931bf2dda4be022c912012974d9e494fac>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  crtmgr: fix bug if CERTMONGER_CERTIFICATE not set
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c11b01afa4d0f33a507c03bfdd4299fdf987dc>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  certmonger: finish refactoring for request script
    `commit <https://codeberg.org/freeipa/freeipa/commit/0412625a2bfc20b9f9b85ba6cb4b1e087e4630e9>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  certmonger: fix storing retrieved certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/32be3ef62210d77dc07f94837be739c82be17661>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Make the IPA server run under Python 3 by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/9869d52bab70bb144d51835dc4e70a61a5788ffa>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Turn IPA scripts to python3 -bb for testing
    `commit <https://codeberg.org/freeipa/freeipa/commit/5965e27b304dd21482228e4b9134549bdc9dd1ab>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  py3: Depend on newer pyldap for server-upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bf6eb7e19ecdb24be185ab2a4d0a549029b9cf0>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ipautil: port host_port_open() to python 3
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1fbdbefdb201fc036e41e84a25e3e0725d8e3d2>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  conncheck: fix progression on failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/31a5cf588e1171bcfd58d6a08a76867552dfe811>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  kerberos: fix sorting Principal objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbeb41efd6ad2067f24a099f27c02cab88a8d84b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  host, service: fix adding host/svc with a cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d217c8c9b6f9703b46a42ecbd55b4ca32868795>`__
-   `#7077 <https://pagure.io/freeipa/issue/7077>`__
+   `#7077 <https://codeberg.org/freeipa/freeipa/issues/7077>`__
 -  server plugin: pass bytes to ldap.modify_s
    `commit <https://codeberg.org/freeipa/freeipa/commit/d147948fccd7fda1909a809a691f86722cb6de6b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  replica: fix SetuptoolsVersion comparison
    `commit <https://codeberg.org/freeipa/freeipa/commit/76904ba84dce182ea003d0f88e66fc09778f51eb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  replica-prepare: run the script in py3 by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/1124eee2ffc8fed933c2f061f4c65a0a17b519cb>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  certs: write and read bytes as such
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fc2cab972c3506b96d49b8d341259360b486eb1>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  client: make ipa-client-install py3 compatible
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f8d90d97a5f3751252f2ab99f13a5d012247f22>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  cainstance: read cert file as bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/c95617e71495fff4bf2352fdeb5089e3e02bd79b>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ca: TypeError fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c848b791df7368a32434b3ac87a45728abc2d0f>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  krainstance: fix writing str to file
    `commit <https://codeberg.org/freeipa/freeipa/commit/276bef101b9fa0f83e5de353bc733270d958ee41>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  replica-conncheck: log when failed to RPC connect
    `commit <https://codeberg.org/freeipa/freeipa/commit/06fbf4b312777751085f3dcfeff456b037ee2737>`__
 -  Fixup of not-so-good PEM certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1f88c844e704246e4a948dc74489513f66633d5>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  x509,certdb: handle certificates as bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1521296297d99ea9f6e8f67b30d8e11c6bd56426>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Create a Certificate parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a44ca638310913ab6b0c239374f4b0ddeeedeb3>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  parameters: relax type checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ff1de84909dd65c44b9aa48000b9e73a7a93716>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  tests: fix failing HTTPS connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf4dae70e0d163f4d485771d7d163169748fa6b3>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Introduce load_unknown_x509_certificate()
    `commit <https://codeberg.org/freeipa/freeipa/commit/43c74d33337d4c65947816ba31de5eaa53e001ff>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  x509: Make certificates represented as objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5732efda6d27f588adbc3f41259bc4511716f43>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  Split x509.load_certificate() into PEM/DER functions
    `commit <https://codeberg.org/freeipa/freeipa/commit/4375ef860fdd8221baeff23e88f9217b0cddc5ac>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  README: Fix trailing whitespace
    `commit <https://codeberg.org/freeipa/freeipa/commit/62f19fc082a7d7d41fb732e9fcb726f6b4591f57>`__
 -  Ensure network is online prior to an upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/a36f2aed637dad5bac6f2063c05a5ed64eb922ce>`__
-   `#7039 <https://pagure.io/freeipa/issue/7039>`__
+   `#7039 <https://codeberg.org/freeipa/freeipa/issues/7039>`__
 -  rpcserver: remove addition of str and bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/d308abac2e6758014ebb39bcbd0fc3bd61a57db2>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  wsgi plugins: mod_wsgi expects bytes as an output
    `commit <https://codeberg.org/freeipa/freeipa/commit/db4d0998fdd37422ed9dcb0d88ea5adf6ac98412>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  adtrustinstance: write the conf as a string
    `commit <https://codeberg.org/freeipa/freeipa/commit/8311069d1890d6b742b5aac17dfaaf79a6e1bf62>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  adtrustinstance: pep8 fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/a83b2583ab9eaeffc1b37ceb9009bdc7d5de084c>`__
 -  More verbose error message on kdc cert validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/bee3c1eccd44f7671a1455d12235bcbb910494b3>`__
-   `#6945 <https://pagure.io/freeipa/issue/6945>`__
+   `#6945 <https://codeberg.org/freeipa/freeipa/issues/6945>`__
 -  cert-validate: keep all messages in cert validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/f827fe0f19596d29f9354368077fb43be2e16e8e>`__
-   `#6945 <https://pagure.io/freeipa/issue/6945>`__
+   `#6945 <https://codeberg.org/freeipa/freeipa/issues/6945>`__
 -  adtrustinstance: fix ID range comparison
    `commit <https://codeberg.org/freeipa/freeipa/commit/440c61dc40353833cad3a5fc509821ce1f23757f>`__
-   `#7002 <https://pagure.io/freeipa/issue/7002>`__
+   `#7002 <https://codeberg.org/freeipa/freeipa/issues/7002>`__
 -  Docstring+refactor of IPADiscovery.ipadnssearchkrbrealm()
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8cc62564b09959c451522b1d7eb122566594867>`__
 -  ipadiscovery: Return realm as a string
    `commit <https://codeberg.org/freeipa/freeipa/commit/1cab1e980c7cad65943e2984158a458a6472c9d2>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  session_storage: Correctly handle string/byte types
    `commit <https://codeberg.org/freeipa/freeipa/commit/d665224a85610cccbe7d291e9ed41d2ce7e5b61c>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  rpc: avoid possible recursion in create_connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1f8684e858b4ae47b54acd0d76a844bc20ce443>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  rpc: preparations for recursion fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/79d1752577e8fcb568b701509fe5b52f949d5e4b>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  Avoid possible endless recursion in RPC call
    `commit <https://codeberg.org/freeipa/freeipa/commit/81a808caeb5676427610e113b5a259511c2835d6>`__
-   `#6796 <https://pagure.io/freeipa/issue/6796>`__
+   `#6796 <https://codeberg.org/freeipa/freeipa/issues/6796>`__
 -  kdc.key should not be visible to all
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b6892783ee6ed6dac9c4f328cc89ae030ce10a7>`__
-   `#6973 <https://pagure.io/freeipa/issue/6973>`__
+   `#6973 <https://codeberg.org/freeipa/freeipa/issues/6973>`__
 -  Change ConfigParser to RawConfigParser
    `commit <https://codeberg.org/freeipa/freeipa/commit/35675ca2bbe9c044f115764a2daac45f7468be00>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ca/cert-show: check certificate_out in options
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ed1717e9956ba5a3baa9d0992e14fd2d4a2dd6a>`__
-   `#6885 <https://pagure.io/freeipa/issue/6885>`__
+   `#6885 <https://codeberg.org/freeipa/freeipa/issues/6885>`__
 -  Remove pkinit-anonymous command
    `commit <https://codeberg.org/freeipa/freeipa/commit/24099d0f806103d8ec57d69fc97e9b4ae061bfdd>`__
-   `#6936 <https://pagure.io/freeipa/issue/6936>`__
+   `#6936 <https://codeberg.org/freeipa/freeipa/issues/6936>`__
 -  Make a doctext more clear
    `commit <https://codeberg.org/freeipa/freeipa/commit/df8205b55c67cfbe2abfe0f68e8747c0d09a44b8>`__
 -  Provide useful messages during cert validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d969d7bad06e4f9527c88106806c28b68bfcc20>`__
-   `#6945 <https://pagure.io/freeipa/issue/6945>`__
+   `#6945 <https://codeberg.org/freeipa/freeipa/issues/6945>`__
 -  cert-show: writable files does not mean dirs
    `commit <https://codeberg.org/freeipa/freeipa/commit/33b3d7ad7ada45edbd178fe99f1257c40f39dcaa>`__
-   `#6883 <https://pagure.io/freeipa/issue/6883>`__
+   `#6883 <https://codeberg.org/freeipa/freeipa/issues/6883>`__
 -  fix managed-entries printing IPA not installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/6522c4a8378a22ffe82e8e845698ab104f611888>`__
-   `#6928 <https://pagure.io/freeipa/issue/6928>`__
+   `#6928 <https://codeberg.org/freeipa/freeipa/issues/6928>`__
 -  Fix wrong message on Dogtag instances stop
    `commit <https://codeberg.org/freeipa/freeipa/commit/aba384ddb535e81f81a518fa468a8ed095250ca1>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Make CA/KRA fail when they don't start
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a7a1f955e327bf1a06faa53c517bdbffff22eba>`__
-   `#6766 <https://pagure.io/freeipa/issue/6766>`__
+   `#6766 <https://codeberg.org/freeipa/freeipa/issues/6766>`__
 -  Remove the cachedproperty class
    `commit <https://codeberg.org/freeipa/freeipa/commit/92313c9e9d37733feb79d1b1c825178f48d6c69c>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  Refresh Dogtag RestClient.ca_host property
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d406fcb784924bfe685729f3156efb8c902b947>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  compat plugin: Update link to slapi-nis project
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c8ddf1871efe7ef78ce153573d522aefecfdfa>`__
 -  compat: ignore cn=topology,cn=ipa,cn=etc subtree
    `commit <https://codeberg.org/freeipa/freeipa/commit/645615958d4b0f9e6dd8a5ff2541952abb588d55>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  Move the compat plugin setup at the end of install
    `commit <https://codeberg.org/freeipa/freeipa/commit/ddbbb1c58e8a4fec8129e7d1e941c54660af6a69>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  compat-manage: behave the same for all users
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c0af8cf7adf61ef03ba1240ecbdecef7fa15275>`__
-   `#6821 <https://pagure.io/freeipa/issue/6821>`__
+   `#6821 <https://codeberg.org/freeipa/freeipa/issues/6821>`__
 -  Fix CAInstance.import_ra_cert for empty passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/b38750eaa82025aad56f8eca849f47775b2cbc75>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  Fix RA cert import during DL0 replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f0a622d83ee22ce712a380d1701cb1f383689e4>`__
-   `#6878 <https://pagure.io/freeipa/issue/6878>`__
+   `#6878 <https://codeberg.org/freeipa/freeipa/issues/6878>`__
 -  ext. CA: correctly write the cert chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b8503173b253860c1059bd40858f2fdffb4ae33>`__
-   `#6872 <https://pagure.io/freeipa/issue/6872>`__
+   `#6872 <https://codeberg.org/freeipa/freeipa/issues/6872>`__
 -  server-install: No double Kerberos install
    `commit <https://codeberg.org/freeipa/freeipa/commit/25a33ce8b1c77b0d957772143affd7085757bccb>`__
-   `#6757 <https://pagure.io/freeipa/issue/6757>`__
+   `#6757 <https://codeberg.org/freeipa/freeipa/issues/6757>`__
 -  Fix CA-less to CA-full upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ac56e47d78582fbc2911f67a7344bcce321842f>`__
-   `#6853 <https://pagure.io/freeipa/issue/6853>`__
+   `#6853 <https://codeberg.org/freeipa/freeipa/issues/6853>`__
 -  replicainstall: better client install exception handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/db84516d23d3a6e53e95881828d494fb80647602>`__
-   `#6183 <https://pagure.io/freeipa/issue/6183>`__
+   `#6183 <https://codeberg.org/freeipa/freeipa/issues/6183>`__
 -  Add the force-join option to replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/87051f51c695afa3e9ba072da7005cf1a4194668>`__
-   `#6183 <https://pagure.io/freeipa/issue/6183>`__
+   `#6183 <https://codeberg.org/freeipa/freeipa/issues/6183>`__
 -  server-install: remove broken no-pkinit check
    `commit <https://codeberg.org/freeipa/freeipa/commit/1160dc5d8bacea42a7ada45a10bf1019a3af5aca>`__
-   `#6807 <https://pagure.io/freeipa/issue/6807>`__
+   `#6807 <https://codeberg.org/freeipa/freeipa/issues/6807>`__
 -  Add pki_pin only when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/1aa77fe389e957a652c530ec0456ee05467754b3>`__
-   `#6839 <https://pagure.io/freeipa/issue/6839>`__
+   `#6839 <https://codeberg.org/freeipa/freeipa/issues/6839>`__
 -  Remove publish_ca_cert() method from NSSDatabase
    `commit <https://codeberg.org/freeipa/freeipa/commit/aae9a918b68dc4f9a7b4fb9abf1bb4d26673109d>`__
-   `#6806 <https://pagure.io/freeipa/issue/6806>`__
+   `#6806 <https://codeberg.org/freeipa/freeipa/issues/6806>`__
 -  Get correct CA cert nickname in CA-less
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c87014e199b3dbe885c69d40a01d2723f813c3e>`__
-   `#6806 <https://pagure.io/freeipa/issue/6806>`__
+   `#6806 <https://codeberg.org/freeipa/freeipa/issues/6806>`__
 -  Remove redundant option check for cert files
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe7cf1e854b7dc28861455011091df3cbe45abe9>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  replica-prepare man: remove pkinit option refs
    `commit <https://codeberg.org/freeipa/freeipa/commit/8af884d0489d5d57895959d27ca6eb8815c6c922>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Don't allow setting pkinit-related options on DL0
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e3ae785ac9b62b8e0809a4aa56363c458316135>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Fix the order of cert-files check
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cda1509a68d7a21578280d381a6b9e994fd4f49>`__
-   `#6801 <https://pagure.io/freeipa/issue/6801>`__
+   `#6801 <https://codeberg.org/freeipa/freeipa/issues/6801>`__
 -  Generate PIN for PKI to help Dogtag in FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/e204d030fc4154800acb0b2b312188e72dd80f80>`__
-   `#6824 <https://pagure.io/freeipa/issue/6824>`__
+   `#6824 <https://codeberg.org/freeipa/freeipa/issues/6824>`__
 -  Backup CA cert from kerberos folder
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc13703e75997e0c9539b326acb13458dae00202>`__
-   `#6748 <https://pagure.io/freeipa/issue/6748>`__
+   `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__
 -  Allow renaming of the sudorule objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c1409155e9a9a978d3d763045a84d1eac585dfd>`__
-   `#2466 <https://pagure.io/freeipa/issue/2466>`__
+   `#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__
 -  Allow renaming of the HBAC rule objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/55424c8677ba7de464c820afd31260aa4a7678d0>`__
-   `#6784 <https://pagure.io/freeipa/issue/6784>`__
+   `#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__
 -  Reworked the renaming mechanism
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e4408e6784f929b4c3d861f0dd509335238e951>`__
-   `#2466 <https://pagure.io/freeipa/issue/2466>`__,
-   `#6784 <https://pagure.io/freeipa/issue/6784>`__
+   `#2466 <https://codeberg.org/freeipa/freeipa/issues/2466>`__,
+   `#6784 <https://codeberg.org/freeipa/freeipa/issues/6784>`__
 -  Bump samba version for FIPS and priv. separation
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7ae3363fd5bb1bf3b3175395d5bd3d26c9b48f0>`__
-   `#6671 <https://pagure.io/freeipa/issue/6671>`__,
-   `#6697 <https://pagure.io/freeipa/issue/6697>`__
+   `#6671 <https://codeberg.org/freeipa/freeipa/issues/6671>`__,
+   `#6697 <https://codeberg.org/freeipa/freeipa/issues/6697>`__
 -  Backup ipa-specific httpd unit-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/2612c092dd797c9c8f772c785aae1f152f06847d>`__
-   `#6748 <https://pagure.io/freeipa/issue/6748>`__
+   `#6748 <https://codeberg.org/freeipa/freeipa/issues/6748>`__
 -  Add debug log in case cookie retrieval went wrong
    `commit <https://codeberg.org/freeipa/freeipa/commit/0bb858ea770e081817dc243579d08ad1f113e825>`__
-   `#6774 <https://pagure.io/freeipa/issue/6774>`__
+   `#6774 <https://codeberg.org/freeipa/freeipa/issues/6774>`__
 
 
 
@@ -1775,7 +1775,7 @@ Thierry Bordaz (1)
 
 -  NULL LDAP context in call to ldap_search_ext_s during search
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f0423cf531d5fab73516323750af6b5106ba070>`__
-   `#7017 <https://pagure.io/freeipa/issue/7017>`__
+   `#7017 <https://codeberg.org/freeipa/freeipa/issues/7017>`__
 
 
 
@@ -1784,37 +1784,37 @@ Tibor Dudlák (11)
 
 -  otptoken_yubikey.py: Removed traceback when package missing.
    `commit <https://codeberg.org/freeipa/freeipa/commit/76357283ec522aef8aaf3d3b8eea7155263e3517>`__
-   `#6979 <https://pagure.io/freeipa/issue/6979>`__
+   `#6979 <https://codeberg.org/freeipa/freeipa/issues/6979>`__
 -  topology.py: Removes error message from dictionary.
    `commit <https://codeberg.org/freeipa/freeipa/commit/69d05b86b76461880bc316120b95fbf6fcf35159>`__
-   `#6533 <https://pagure.io/freeipa/issue/6533>`__
+   `#6533 <https://codeberg.org/freeipa/freeipa/issues/6533>`__
 -  Add test: test_xmlrpc/test_whoami_plugin.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/19f3eda7900207a4a0c77b1781a9cdb3483ea234>`__
-   `#6745 <https://pagure.io/freeipa/issue/6745>`__
+   `#6745 <https://codeberg.org/freeipa/freeipa/issues/6745>`__
 -  whoami.py: Type error when running tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17f03a7952ff444a36c40dd6aaf5c27ef087d41d>`__
-   `#7050 <https://pagure.io/freeipa/issue/7050>`__
+   `#7050 <https://codeberg.org/freeipa/freeipa/issues/7050>`__
 -  Create indexes for 'serverhostname' attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/22b0ae440a34dc8f18475f79c656f67584d4ad3b>`__
-   `#6939 <https://pagure.io/freeipa/issue/6939>`__
+   `#6939 <https://codeberg.org/freeipa/freeipa/issues/6939>`__
 -  Add --force-join into ipa-replica-install manpage
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fd2102a78f2e008f2cd5fe68e9be58ead914b35>`__
-   `#7011 <https://pagure.io/freeipa/issue/7011>`__
+   `#7011 <https://codeberg.org/freeipa/freeipa/issues/7011>`__
 -  dnsserver.py: dnsserver-find no longer returns internal server error
    `commit <https://codeberg.org/freeipa/freeipa/commit/74d36a8af69a2946007ebd4d57c7bf0891d561db>`__
-   `#6571 <https://pagure.io/freeipa/issue/6571>`__
+   `#6571 <https://codeberg.org/freeipa/freeipa/issues/6571>`__
 -  Add Role 'Enrollment Administrator'
    `commit <https://codeberg.org/freeipa/freeipa/commit/468eb3c712140399ed2ec346ff4356bffd590e09>`__
-   `#6852 <https://pagure.io/freeipa/issue/6852>`__
+   `#6852 <https://codeberg.org/freeipa/freeipa/issues/6852>`__
 -  server.py: Removes dns-server configuration from ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/063211d665d02fc343952f5b158fd8d89223fbc9>`__
-   `#6572 <https://pagure.io/freeipa/issue/6572>`__
+   `#6572 <https://codeberg.org/freeipa/freeipa/issues/6572>`__
 -  sssd.py: Deprecating no-sssd option.
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfc271fdf4514481c11c342fabda135feeb44de6>`__
-   `#5860 <https://pagure.io/freeipa/issue/5860>`__
+   `#5860 <https://codeberg.org/freeipa/freeipa/issues/5860>`__
 -  client.py: Replace hardcoded 'admin' with options.principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/eae8714026339e1e7926d01412916ad08be737b9>`__
-   `#5406 <https://pagure.io/freeipa/issue/5406>`__
+   `#5406 <https://codeberg.org/freeipa/freeipa/issues/5406>`__
 
 
 
@@ -1823,7 +1823,7 @@ Tibor Dudlák (2)
 
 -  user.py: replace user_mod with ldap.update_entry()
    `commit <https://codeberg.org/freeipa/freeipa/commit/d73ec06cb3c8042f90d1520485aa9b0f2e7c8fbe>`__
-   `#5788 <https://pagure.io/freeipa/issue/5788>`__
+   `#5788 <https://codeberg.org/freeipa/freeipa/issues/5788>`__
 -  Add 'TIP' to enable copr repo.
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2f4a94925b24cc22aa3c3e046935671750daa2f>`__
 
@@ -1835,7 +1835,7 @@ Timo Aaltonen (2)
 -  ipa-otpd.socket.in: Use a platform specific value for KDC service
    file
    `commit <https://codeberg.org/freeipa/freeipa/commit/076eb409a032cbd689f1d5e298c1009e80168e34>`__
-   `#6845 <https://pagure.io/freeipa/issue/6845>`__
+   `#6845 <https://codeberg.org/freeipa/freeipa/issues/6845>`__
 -  configure: Use ODS_USER and NAMED_GROUP in
    daemons/dnssec/\*.service.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/44a3e0fe1d168ad87182654976a26e352287b1e0>`__
@@ -1855,21 +1855,21 @@ Tomas Krizek (25)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ca68e42680a3f130f694ab8e337e8c0898c983e>`__
 -  dnssec: keep dnssec daemons in Python2
    `commit <https://codeberg.org/freeipa/freeipa/commit/5dcb0e6fc772f459a29693867f9b73f1ac811b9a>`__
-   `#4985 <https://pagure.io/freeipa/issue/4985>`__
+   `#4985 <https://codeberg.org/freeipa/freeipa/issues/4985>`__
 -  ipatests: collect log after ipa-ca-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/4028f1aebb460eb4f81eabd31e7621b026c4aa9d>`__
-   `#7060 <https://pagure.io/freeipa/issue/7060>`__
+   `#7060 <https://codeberg.org/freeipa/freeipa/issues/7060>`__
 -  dnssec: fix localhsm.py utility script
    `commit <https://codeberg.org/freeipa/freeipa/commit/661e611d14ac744154c9b493876d373826e6b24a>`__
-   `#7116 <https://pagure.io/freeipa/issue/7116>`__
+   `#7116 <https://codeberg.org/freeipa/freeipa/issues/7116>`__
 -  prci: add caless tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3091938c0b2df192fb0fddf24ec885e6e20cf697>`__
 -  makerpms.sh: make git checkout optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7d1a10f22548fb2c1eba99a3001c6da49605edd>`__
-   `#6605 <https://pagure.io/freeipa/issue/6605>`__
+   `#6605 <https://codeberg.org/freeipa/freeipa/issues/6605>`__
 -  build: checkout \*.po files at the end of makerpms.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/f32784f4cb0c89ceae95f5bbc7c7224ed139aeb0>`__
-   `#6605 <https://pagure.io/freeipa/issue/6605>`__
+   `#6605 <https://codeberg.org/freeipa/freeipa/issues/6605>`__
 -  freeipa-pr-ci: enable pull-request CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f92a9bdc16129d506d4c46388f16c9d12ec3b65>`__
 -  ipactl: log check_version exception
@@ -1878,39 +1878,39 @@ Tomas Krizek (25)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba5f7afedca282e79fdfde0dd359028fc4111f90>`__
 -  ipatests: do not finalize api when IPA is not configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f8d79f637825c61922aba8952acb5eccf6956bb>`__
-   `#7046 <https://pagure.io/freeipa/issue/7046>`__
+   `#7046 <https://codeberg.org/freeipa/freeipa/issues/7046>`__
 -  ipatests: do not collect systemd journal when logfile_dir is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/44e3496bd1a3004bc7a6497cbd212bba7910b2e3>`__
-   `#6971 <https://pagure.io/freeipa/issue/6971>`__
+   `#6971 <https://codeberg.org/freeipa/freeipa/issues/6971>`__
 -  ipatests: add systemd journal collection for multihost tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/48b7e83511b80b3a1e0416134496ac37244f1073>`__
-   `#6971 <https://pagure.io/freeipa/issue/6971>`__
+   `#6971 <https://codeberg.org/freeipa/freeipa/issues/6971>`__
 -  ipatests: change logdir naming pattern for multihost tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/906c4c94590455c41603e5eca869b64c8d86d4f5>`__
-   `#6971 <https://pagure.io/freeipa/issue/6971>`__
+   `#6971 <https://codeberg.org/freeipa/freeipa/issues/6971>`__
 -  named.conf template: add modification warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/a924efe847e725d6a4dde209f57521a9a899ef23>`__
 -  ca, kra install: validate DM password
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b1bace75095cf7a26a56156ff537479ef4b9619>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  installutils: add DM password validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a4a368c5387569f6802b5b3ca0686ea20f1de7e>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  ca install: merge duplicated code for DM password
    `commit <https://codeberg.org/freeipa/freeipa/commit/80d61c2e01bdce0ab805037bfc1ce8e9543d2b10>`__
-   `#6892 <https://pagure.io/freeipa/issue/6892>`__
+   `#6892 <https://codeberg.org/freeipa/freeipa/issues/6892>`__
 -  upgrade: add missing suffix to http instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebefb281775d5bd5f32459ac597af78781d7dbf5>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  installer service: fix typo in service entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b8ab77dd4800bd9c6b822502462ee649c88c663>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  python2-ipalib: add missing python dependency
    `commit <https://codeberg.org/freeipa/freeipa/commit/999706fcdfa7fd4206a2399aa578fb00753d9978>`__
-   `#6920 <https://pagure.io/freeipa/issue/6920>`__
+   `#6920 <https://codeberg.org/freeipa/freeipa/issues/6920>`__
 -  kra install: update installation failure message
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa6c4d96ef2a55f853eedf3fb89433863e29ddf>`__
-   `#6923 <https://pagure.io/freeipa/issue/6923>`__
+   `#6923 <https://codeberg.org/freeipa/freeipa/issues/6923>`__
 
 
 
@@ -1919,6 +1919,6 @@ Thorsten Scherf (2)
 
 -  Changed ownership of ldiffile to DS_USER
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8358eaea9ccf05c5c5ac0bf5c970663c611e333>`__
-   `#7010 <https://pagure.io/freeipa/issue/7010>`__
+   `#7010 <https://codeberg.org/freeipa/freeipa/issues/7010>`__
 -  Fixed typo in ipa-client-install output
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3f849d541e8d054b0932d8ec1bd4c836e53c6f0>`__

--- a/src/page/Releases/4.6.1.rst
+++ b/src/page/Releases/4.6.1.rst
@@ -15,7 +15,7 @@ Known Issues
 ----------------------------------------------------------------------------------------------
 
 PyPI packages are broken since 4.6.0
-`#7132 <https://pagure.io/freeipa/issue/7132>`__
+`#7132 <https://codeberg.org/freeipa/freeipa/issues/7132>`__
 
 
 Bug fixes
@@ -43,35 +43,35 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7157 <https://pagure.io/freeipa/issue/7157>`__ [tracker] pyasn1
+-  `#7157 <https://codeberg.org/freeipa/freeipa/issues/7157>`__ [tracker] pyasn1
    fails to parse kerberos principal name
--  `#7150 <https://pagure.io/freeipa/issue/7150>`__ Ipa-server-install
+-  `#7150 <https://codeberg.org/freeipa/freeipa/issues/7150>`__ Ipa-server-install
    update dse.ldif with wrong SELinux context
--  `#7143 <https://pagure.io/freeipa/issue/7143>`__ "unknown command
+-  `#7143 <https://codeberg.org/freeipa/freeipa/issues/7143>`__ "unknown command
    'undefined'" error when changing user's password via the web UI
--  `#7135 <https://pagure.io/freeipa/issue/7135>`__ Server deployment
+-  `#7135 <https://codeberg.org/freeipa/freeipa/issues/7135>`__ Server deployment
    still sets up Firefox extension, this is no longer necessary and
    broken on F27+
--  `#7129 <https://pagure.io/freeipa/issue/7129>`__
+-  `#7129 <https://codeberg.org/freeipa/freeipa/issues/7129>`__
    ipa-server/replica-install fails with: "exception: BytesWarning:
    Comparison between bytes and string" when using
    '--dirsrv-config-file' parameter
--  `#7119 <https://pagure.io/freeipa/issue/7119>`__ kdc_proxy: kinit
+-  `#7119 <https://codeberg.org/freeipa/freeipa/issues/7119>`__ kdc_proxy: kinit
    admin fails with "Cannot contact any KDC for realm 'IPA.TEST' while
    getting initial credentials"
--  `#7115 <https://pagure.io/freeipa/issue/7115>`__
+-  `#7115 <https://codeberg.org/freeipa/freeipa/issues/7115>`__
    ipa-pki-retrieve-key: failure results in crash report
--  `#7081 <https://pagure.io/freeipa/issue/7081>`__ [ipatests] -
+-  `#7081 <https://codeberg.org/freeipa/freeipa/issues/7081>`__ [ipatests] -
    installutils.is_ipa_configured() - users other then root cannot check
    if IPA is configured
--  `#7027 <https://pagure.io/freeipa/issue/7027>`__ Use TLS for
+-  `#7027 <https://codeberg.org/freeipa/freeipa/issues/7027>`__ Use TLS for
    cert-find
--  `#6874 <https://pagure.io/freeipa/issue/6874>`__ pylint 1.7.1 fails
--  `#6848 <https://pagure.io/freeipa/issue/6848>`__ Test IPA with
+-  `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__ pylint 1.7.1 fails
+-  `#6848 <https://codeberg.org/freeipa/freeipa/issues/6848>`__ Test IPA with
    OpenSSL-base libcurl for Fedora 27
--  `#6566 <https://pagure.io/freeipa/issue/6566>`__ [py3] session cookie
+-  `#6566 <https://codeberg.org/freeipa/freeipa/issues/6566>`__ [py3] session cookie
    not found with py3
--  `#5121 <https://pagure.io/freeipa/issue/5121>`__ [py3] Remove
+-  `#5121 <https://codeberg.org/freeipa/freeipa/issues/5121>`__ [py3] Remove
    unnecessary calls to dict.keys()
 
 
@@ -86,13 +86,13 @@ Alexander Bokovoy (3)
 
 -  Make sure upgrade also checks for IPv6 stack
    `commit <https://codeberg.org/freeipa/freeipa/commit/f05afa4813f425e9fc9960f63100431a78310638>`__
-   `#7083 <https://pagure.io/freeipa/issue/7083>`__
+   `#7083 <https://codeberg.org/freeipa/freeipa/issues/7083>`__
 -  OTP import: support hash names with HMAC- prefix
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c079d9d55ae63f318c8ead1e17d4966bfe4378>`__
-   `#7146 <https://pagure.io/freeipa/issue/7146>`__
+   `#7146 <https://codeberg.org/freeipa/freeipa/issues/7146>`__
 -  dsinstance: Restore context after changing dse.ldif
    `commit <https://codeberg.org/freeipa/freeipa/commit/715e78654158fbebce7da5f0f35bca7807502162>`__
-   `#7150 <https://pagure.io/freeipa/issue/7150>`__
+   `#7150 <https://codeberg.org/freeipa/freeipa/issues/7150>`__
 
 
 
@@ -101,10 +101,10 @@ Felipe Volpone (2)
 
 -  Changing idoverrideuser-\* to treat objectClass case insensitively
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5e8f52801f5f6c59ac9bfcf2a14b002584c560a>`__
-   `#7074 <https://pagure.io/freeipa/issue/7074>`__
+   `#7074 <https://codeberg.org/freeipa/freeipa/issues/7074>`__
 -  Fixing how sssd.conf is updated when promoting a client to replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc6ae8f2d868cdf846c017b8307dd12bab1b3768>`__
-   `#7127 <https://pagure.io/freeipa/issue/7127>`__
+   `#7127 <https://codeberg.org/freeipa/freeipa/issues/7127>`__
 
 
 
@@ -113,13 +113,13 @@ Florence Blanc-Renaud (3)
 
 -  Fix ipa-server-upgrade with server cert tracking
    `commit <https://codeberg.org/freeipa/freeipa/commit/726a8b269c8843e495168deea3a4951c61de0e72>`__
-   `#7141 <https://pagure.io/freeipa/issue/7141>`__
+   `#7141 <https://codeberg.org/freeipa/freeipa/issues/7141>`__
 -  Python3: Fix winsync replication agreement
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dea5b5d960674e5fb13ac60bb704495ba39b374>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  Fix ipa config-mod --ca-renewal-master
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f79504d3dc29891802c6d7eeaa465c298b7e417>`__
-   `#7120 <https://pagure.io/freeipa/issue/7120>`__
+   `#7120 <https://codeberg.org/freeipa/freeipa/issues/7120>`__
 
 
 
@@ -128,10 +128,10 @@ Fraser Tweedale (2)
 
 -  ipa-pki-retrieve-key: ensure we do not crash
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9074dcc9c025594d6961dcbb03805b9a20bb220>`__
-   `#7115 <https://pagure.io/freeipa/issue/7115>`__
+   `#7115 <https://codeberg.org/freeipa/freeipa/issues/7115>`__
 -  issue_server_cert: avoid application of str to bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5a1bb1b93094e192ced394b7a51c3e50c0f04ef>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 
 
 
@@ -140,7 +140,7 @@ Martin Basti (1)
 
 -  py3: set samba dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b4fb990a5cdbf1b9a550005e3051a9ec51595d1>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 
 
 
@@ -149,7 +149,7 @@ Petr Vobornik (1)
 
 -  browser config: cleanup after removal of Firefox extension
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e8e94aa69dff9ac14490ae07dda61fccf1544b0>`__
-   `#7135 <https://pagure.io/freeipa/issue/7135>`__
+   `#7135 <https://codeberg.org/freeipa/freeipa/issues/7135>`__
 
 
 
@@ -158,13 +158,13 @@ Pavel Vomacka (3)
 
 -  WebUI: Fix calling undefined method during reset passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/44b012cc01cd6a543ba460cdc723eb469f22ffd4>`__
-   `#7143 <https://pagure.io/freeipa/issue/7143>`__
+   `#7143 <https://codeberg.org/freeipa/freeipa/issues/7143>`__
 -  WebUI: remove unused parameter from get_whoami_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/47c7a192a6a96e89bd714854ed35466e48299cfe>`__
-   `#7143 <https://pagure.io/freeipa/issue/7143>`__
+   `#7143 <https://codeberg.org/freeipa/freeipa/issues/7143>`__
 -  Adds whoami DS plugin in case that plugin is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/59ef33d2a20bb6ea1b19a40f049490a14fffd3c8>`__
-   `#7126 <https://pagure.io/freeipa/issue/7126>`__
+   `#7126 <https://codeberg.org/freeipa/freeipa/issues/7126>`__
 
 
 
@@ -173,10 +173,10 @@ Rob Crittenden (2)
 
 -  Add exec to /var/lib/ipa/sysrestore for install status inquiries
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b642245b96ed4afc26ac9e499bf1c87c02524c0>`__
-   `#7081 <https://pagure.io/freeipa/issue/7081>`__
+   `#7081 <https://codeberg.org/freeipa/freeipa/issues/7081>`__
 -  Use TLS for the cert-find operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/52a18de613458f8cabc81742ddf2e1311d772eb9>`__
-   `#7027 <https://pagure.io/freeipa/issue/7027>`__
+   `#7027 <https://codeberg.org/freeipa/freeipa/issues/7027>`__
 
 
 
@@ -185,81 +185,81 @@ Stanislav Laznicka (28)
 
 -  Don't write p11-kit EKU extension object if no EKU
    `commit <https://codeberg.org/freeipa/freeipa/commit/7da5187987799210b596fe638e98ed26a8563b11>`__
-   `#7119 <https://pagure.io/freeipa/issue/7119>`__
+   `#7119 <https://codeberg.org/freeipa/freeipa/issues/7119>`__
 -  pylint: fix missing module
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ff94501cc8bd6af302997eaafe706de91d78271>`__
 -  travis: run the same tests in python2/3
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3d07e5c42937bf55f7abdef828b9384168bfac5>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  certmap testing: fix wrong cert construction
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c21a8d01d3041382df94145524879a7d6d96a7c>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  ldap2: don't use decode() on str instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b255b22fd4473d191179c40f066a181e427d1ac>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  client: fix retrieving certs from HTTP
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba4386599331cf81d222687d658f5ce54e923478>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  uninstall: remove deprecation warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/f57ab91d1e7af3cd1d0b358895036722d62ae834>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  ldif: handle attribute names as strings
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bb28b8a0f9b5d5c7c54964d8d93a81e3defb907>`__
-   `#7129 <https://pagure.io/freeipa/issue/7129>`__
+   `#7129 <https://codeberg.org/freeipa/freeipa/issues/7129>`__
 -  pkinit: fix sorting dictionaries
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecee99c4c13f1fa5b57dff0162c258bcc227b77c>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  pkinit: don't fail when no pkinit servers found
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0bbe68c133a18c61443d60aae1d2b9261fd0662>`__
-   `#7144 <https://pagure.io/freeipa/issue/7144>`__
+   `#7144 <https://codeberg.org/freeipa/freeipa/issues/7144>`__
 -  travis: remove "fast" from "makecache fast"
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f4b0ef61b9c9beb5d07db3e89a40d391fbaeaa3>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Change Travis CI container to FreeIPA-owned
    `commit <https://codeberg.org/freeipa/freeipa/commit/79d9bdcec388b5b21b46fcb5a35d93d5b246ace2>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Change the requirements for pylint in wheel
    `commit <https://codeberg.org/freeipa/freeipa/commit/0449a4c8113719004297db3466fd189f22544875>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  rpcserver: don't call xmlserver.Command
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfeadfed2c6fe1540933c46b540c657344a6a264>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  secrets: disable relative-imports for custodia
    `commit <https://codeberg.org/freeipa/freeipa/commit/388bc9459216183deda2336220ca1f5d6f9d0698>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  pylint: disable \__hash_\_ for some classes
    `commit <https://codeberg.org/freeipa/freeipa/commit/2952af4dc450363ae6c6a466812ae4ef32d087f4>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  install.util: disable no-value-for-parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/e67cdb01c40f9eaec4518b327bd72fdd3100253c>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  pylint: make unsupported-assignment-operation check local
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cf1f1d4cbe38730dff7f35476fd1a5ad09ca605>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  sudocmd: fix unsupported assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/568926fd74f395be5c3b6a2d3bc811732c470fcc>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  pylint: Iterate through dictionaries
    `commit <https://codeberg.org/freeipa/freeipa/commit/06f3aad5cf26b36e40abd0dd5fc547690c5c5b3d>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  parameters: convert Decimal.precision to int
    `commit <https://codeberg.org/freeipa/freeipa/commit/25d8229bf9843b857b1918026dc45da92771fa7c>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  dcerpc: disable unbalanced-tuple-unpacking
    `commit <https://codeberg.org/freeipa/freeipa/commit/f80af622810afc05675eaf7d0b91217ca41a05ab>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  dcerpc: refactor assess_dcerpc_exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b8207df865b28288519a1b6bcfea52f3c693096>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  pylint: fix no-member in schema plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c64aca2d08fdc40901f4b5bf04a9d093944086a>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  csrgen: fix incorrect codec for pyasn BitString
    `commit <https://codeberg.org/freeipa/freeipa/commit/47352fb19df83675863167601d57a6d28c278eb2>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  pylint: fix not-context-manager false positives
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce148ed700b354b4324e65fe5a6097b80bdfc442>`__
-   `#6874 <https://pagure.io/freeipa/issue/6874>`__
+   `#6874 <https://codeberg.org/freeipa/freeipa/issues/6874>`__
 -  Travis: archive logs of py3 jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/0565600635777b71a96e63ed421820e0a0891ae5>`__
 -  travis: temporary workaround for Travis CI
@@ -278,7 +278,7 @@ Tomas Krizek (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/65cc71c2f35114e676a80aea99b310a42c2471f1>`__
 -  spec: bump python-pyasn1 to 0.3.2-2
    `commit <https://codeberg.org/freeipa/freeipa/commit/f982a8aa93c5cf41090889273d00c3b9769a2c76>`__
-   `#7157 <https://pagure.io/freeipa/issue/7157>`__
+   `#7157 <https://codeberg.org/freeipa/freeipa/issues/7157>`__
 -  prci: use f26 template for master
    `commit <https://codeberg.org/freeipa/freeipa/commit/659f9d111de6dcfd084aab41940d69b050b27251>`__
 -  VERSION: set back to git snapshot

--- a/src/page/Releases/4.6.2.rst
+++ b/src/page/Releases/4.6.2.rst
@@ -44,61 +44,61 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7275 <https://pagure.io/freeipa/issue/7275>`__ Viewing DNS Records
+-  `#7275 <https://codeberg.org/freeipa/freeipa/issues/7275>`__ Viewing DNS Records
    with WebUI fails
--  `#7254 <https://pagure.io/freeipa/issue/7254>`__ test_caless: fix
+-  `#7254 <https://codeberg.org/freeipa/freeipa/issues/7254>`__ test_caless: fix
    http.p12 is not valid and provide domain_level for replica tests
--  `#7226 <https://pagure.io/freeipa/issue/7226>`__ Remove remaining
+-  `#7226 <https://codeberg.org/freeipa/freeipa/issues/7226>`__ Remove remaining
    references to Firefox configuration extension
--  `#7213 <https://pagure.io/freeipa/issue/7213>`__ Increase dbus client
+-  `#7213 <https://codeberg.org/freeipa/freeipa/issues/7213>`__ Increase dbus client
    timeouts during CA install
--  `#7210 <https://pagure.io/freeipa/issue/7210>`__ Firefox reports
+-  `#7210 <https://codeberg.org/freeipa/freeipa/issues/7210>`__ Firefox reports
    insecure TLS configuration when visiting FreeIPA web UI after
    standard server deployment
--  `#7208 <https://pagure.io/freeipa/issue/7208>`__ freeipa: binary RPMs
+-  `#7208 <https://codeberg.org/freeipa/freeipa/issues/7208>`__ freeipa: binary RPMs
    require both Python 2 and Python 3
--  `#7190 <https://pagure.io/freeipa/issue/7190>`__ Wrong info message
+-  `#7190 <https://codeberg.org/freeipa/freeipa/issues/7190>`__ Wrong info message
    from tasks.py
--  `#7189 <https://pagure.io/freeipa/issue/7189>`__ make check is failed
--  `#7187 <https://pagure.io/freeipa/issue/7187>`__ ipa-replica-manage
+-  `#7189 <https://codeberg.org/freeipa/freeipa/issues/7189>`__ make check is failed
+-  `#7187 <https://codeberg.org/freeipa/freeipa/issues/7187>`__ ipa-replica-manage
    should provide a debug option
--  `#7186 <https://pagure.io/freeipa/issue/7186>`__ testing: get back
+-  `#7186 <https://codeberg.org/freeipa/freeipa/issues/7186>`__ testing: get back
    command outputs when running tests
--  `#7155 <https://pagure.io/freeipa/issue/7155>`__ test_caless: add
+-  `#7155 <https://codeberg.org/freeipa/freeipa/issues/7155>`__ test_caless: add
    caless to external CA test
--  `#7154 <https://pagure.io/freeipa/issue/7154>`__ test_external_ca:
+-  `#7154 <https://codeberg.org/freeipa/freeipa/issues/7154>`__ test_external_ca:
    switch to python-cryptography
--  `#7153 <https://pagure.io/freeipa/issue/7153>`__ Switch
+-  `#7153 <https://codeberg.org/freeipa/freeipa/issues/7153>`__ Switch
    "ipa-run-tests" symlink to "ipa-run-tests-3.6"
--  `#7151 <https://pagure.io/freeipa/issue/7151>`__ ipa-server-upgrade
+-  `#7151 <https://codeberg.org/freeipa/freeipa/issues/7151>`__ ipa-server-upgrade
    performs unneeded steps to stop tracking/start tracking certs
--  `#7148 <https://pagure.io/freeipa/issue/7148>`__ py3: ipa
+-  `#7148 <https://codeberg.org/freeipa/freeipa/issues/7148>`__ py3: ipa
    cert-request --principal --database fails with BytesWarning: str() on
    a bytes instance
--  `#7142 <https://pagure.io/freeipa/issue/7142>`__ py3: ipa ca-add
+-  `#7142 <https://codeberg.org/freeipa/freeipa/issues/7142>`__ py3: ipa ca-add
    fails with 'an internal error has occurred'
--  `#7134 <https://pagure.io/freeipa/issue/7134>`__ ipa param-find:
+-  `#7134 <https://codeberg.org/freeipa/freeipa/issues/7134>`__ ipa param-find:
    command displays internal error
--  `#7133 <https://pagure.io/freeipa/issue/7133>`__ tox -e pylint3 fails
+-  `#7133 <https://codeberg.org/freeipa/freeipa/issues/7133>`__ tox -e pylint3 fails
    under Python 3.6
--  `#7132 <https://pagure.io/freeipa/issue/7132>`__ [4.6] PyPI packages
+-  `#7132 <https://codeberg.org/freeipa/freeipa/issues/7132>`__ [4.6] PyPI packages
    are broken
--  `#7124 <https://pagure.io/freeipa/issue/7124>`__ [ipatests] -
+-  `#7124 <https://codeberg.org/freeipa/freeipa/issues/7124>`__ [ipatests] -
    forced_client_reenrollment-domlevel-1 test suite fails due to missing
    dns records
--  `#7033 <https://pagure.io/freeipa/issue/7033>`__ vault: TypeError:
+-  `#7033 <https://codeberg.org/freeipa/freeipa/issues/7033>`__ vault: TypeError:
    ... is not JSON serializable
--  `#6994 <https://pagure.io/freeipa/issue/6994>`__ RFE: Remove 389-ds
+-  `#6994 <https://codeberg.org/freeipa/freeipa/issues/6994>`__ RFE: Remove 389-ds
    tuning step
--  `#6858 <https://pagure.io/freeipa/issue/6858>`__ RFE - Option to add
+-  `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__ RFE - Option to add
    custom OID or display name in IPA Cert
--  `#6844 <https://pagure.io/freeipa/issue/6844>`__ ipa-restore fails
+-  `#6844 <https://codeberg.org/freeipa/freeipa/issues/6844>`__ ipa-restore fails
    when umask is set to 0027
--  `#6702 <https://pagure.io/freeipa/issue/6702>`__ Update Dogtag to
+-  `#6702 <https://codeberg.org/freeipa/freeipa/issues/6702>`__ Update Dogtag to
    10.4
--  `#5887 <https://pagure.io/freeipa/issue/5887>`__ IDNA domains does
+-  `#5887 <https://codeberg.org/freeipa/freeipa/issues/5887>`__ IDNA domains does
    not work under py3
--  `#5442 <https://pagure.io/freeipa/issue/5442>`__ [tracker] SELinux
+-  `#5442 <https://codeberg.org/freeipa/freeipa/issues/5442>`__ [tracker] SELinux
    'execmem' denials
 
 
@@ -116,12 +116,12 @@ Alexander Bokovoy (10)
 -  trust: detect and error out when non-AD trust with IPA domain name
    exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/c34c1da3291b722e21fec0875e0bf9c771423f96>`__
-   `#7264 <https://pagure.io/freeipa/issue/7264>`__
+   `#7264 <https://codeberg.org/freeipa/freeipa/issues/7264>`__
 -  ipaserver/plugins/trust.py; fix some indenting issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ea2e7e314cbabb155cb130051945e67a638bc24>`__
 -  ipa-extdom-extop: refactor nsswitch operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1dd79423ecf664f3a3bb7b9fa919f56d0bd32e5>`__
-   `#5464 <https://pagure.io/freeipa/issue/5464>`__
+   `#5464 <https://codeberg.org/freeipa/freeipa/issues/5464>`__
 -  test_dns_plugin: cope with missing IPv6 in Travis
    `commit <https://codeberg.org/freeipa/freeipa/commit/c380e42a307c6e63762b79d1f0a51e73d10998cd>`__
 -  travis-ci: collect logs from cmocka tests
@@ -130,13 +130,13 @@ Alexander Bokovoy (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/abcbb4501e79906f766b16ac9c3555ee88755a93>`__
 -  adtrust: filter out subdomains when defining our topology to AD
    `commit <https://codeberg.org/freeipa/freeipa/commit/1490e9c8277bd5bd996a532c498430485d423050>`__
-   `#6666 <https://pagure.io/freeipa/issue/6666>`__
+   `#6666 <https://codeberg.org/freeipa/freeipa/issues/6666>`__
 -  ipa-replica-manage: implicitly ignore initial time skew in force-sync
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3b0af387f8e3c67f1b223869d3f540989eb2f43>`__
-   `#7211 <https://pagure.io/freeipa/issue/7211>`__
+   `#7211 <https://codeberg.org/freeipa/freeipa/issues/7211>`__
 -  ds: ignore time skew during initial replication step
    `commit <https://codeberg.org/freeipa/freeipa/commit/eaacfed3d9ae82b92897ddeb298d1baa295bed8e>`__
-   `#7211 <https://pagure.io/freeipa/issue/7211>`__
+   `#7211 <https://codeberg.org/freeipa/freeipa/issues/7211>`__
 
 
 
@@ -147,10 +147,10 @@ Abhijeet Kasurde (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/62ada1290e07f292b207f9afcc1bec1a137f93fe>`__
 -  ipatests: Fix interactive prompt in ca_less tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/467c065deee1613b3be82b4d2b2365eb9976e602>`__
-   `#7182 <https://pagure.io/freeipa/issue/7182>`__
+   `#7182 <https://codeberg.org/freeipa/freeipa/issues/7182>`__
 -  tests: correct usage of hostname in logger in tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/4116812a3ec9934fa9172f4e997467f10fbb807a>`__
-   `#7190 <https://pagure.io/freeipa/issue/7190>`__
+   `#7190 <https://codeberg.org/freeipa/freeipa/issues/7190>`__
 
 
 
@@ -159,7 +159,7 @@ Alexander Koksharov (1)
 
 -  kra-install: better warning message
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca09c180a0d751e0e995b83434062bd164021267>`__
-   `#6952 <https://pagure.io/freeipa/issue/6952>`__
+   `#6952 <https://codeberg.org/freeipa/freeipa/issues/6952>`__
 
 
 
@@ -168,22 +168,22 @@ Aleksei Slaikovskii (6)
 
 -  ipa-restore: Set umask to 0022 while restoring
    `commit <https://codeberg.org/freeipa/freeipa/commit/74fcdefd22bbe47d9e5dd19fab829beb28c77743>`__
-   `#6844 <https://pagure.io/freeipa/issue/6844>`__
+   `#6844 <https://codeberg.org/freeipa/freeipa/issues/6844>`__
 -  View plugin/command help in pager
    `commit <https://codeberg.org/freeipa/freeipa/commit/36ccc8facea3150e4c96ce789d1fb115685c50cf>`__
-   `#7225 <https://pagure.io/freeipa/issue/7225>`__
+   `#7225 <https://codeberg.org/freeipa/freeipa/issues/7225>`__
 -  Add a notice to restart ipa services after certs are installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/9175b9c12d9e488c38281f91a961db4083565281>`__
-   `#7016 <https://pagure.io/freeipa/issue/7016>`__
+   `#7016 <https://codeberg.org/freeipa/freeipa/issues/7016>`__
 -  Fix TypeError while ipa-restore is restoring a backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fc40ae5ee741b8df94a74c67752bd323dc68e07>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  ipaclient.plugins.dns: Cast DNS name to unicode
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dc4ddf9cd05b50d25abdd1b11406f48ce58e3d5>`__
-   `#7185 <https://pagure.io/freeipa/issue/7185>`__
+   `#7185 <https://codeberg.org/freeipa/freeipa/issues/7185>`__
 -  Less confusing message for PKINIT configuration during install
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8e6c997b54564533250e536fbe250f460035235>`__
-   `#7179 <https://pagure.io/freeipa/issue/7179>`__
+   `#7179 <https://codeberg.org/freeipa/freeipa/issues/7179>`__
 
 
 
@@ -198,10 +198,10 @@ Christian Heimes (23)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc389e9fe69f9f145d7b36837168a7886a44b501>`__
 -  Add python_requires to Python package metadata
    `commit <https://codeberg.org/freeipa/freeipa/commit/e88e2b0cde4a5d81aad84a4b76a8bb0dc7079d21>`__
-   `#7294 <https://pagure.io/freeipa/issue/7294>`__
+   `#7294 <https://codeberg.org/freeipa/freeipa/issues/7294>`__
 -  Remove Custodia keys on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/fef419bc6562c83ca84cf2b477e1cd81da0e789f>`__
-   `#7253 <https://pagure.io/freeipa/issue/7253>`__
+   `#7253 <https://codeberg.org/freeipa/freeipa/issues/7253>`__
 -  Update to python-ldap 3.0.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8536f5084cbaf6712c98287bd0d0bb20740b91e>`__
 -  Update builddep command to install Python 3 and tox deps
@@ -210,44 +210,44 @@ Christian Heimes (23)
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c92b6dabc40d886560bf178790fb9e738ac5060>`__
 -  Fix dict iteration bug in dnsrecord_show
    `commit <https://codeberg.org/freeipa/freeipa/commit/a090225cb5e7ab8f0dccc4804182294bde386290>`__
-   `#7275 <https://pagure.io/freeipa/issue/7275>`__
+   `#7275 <https://codeberg.org/freeipa/freeipa/issues/7275>`__
 -  Reproducer for bug in structured dnsrecord_show
    `commit <https://codeberg.org/freeipa/freeipa/commit/4de5bf3789bda5c808cf0fbfd03ef5f2a4c1f565>`__
-   `#7275 <https://pagure.io/freeipa/issue/7275>`__
+   `#7275 <https://codeberg.org/freeipa/freeipa/issues/7275>`__
 -  Use Python 3 on Travis
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcb1f9d48ca282eacddebf6a69ed360f6462d1d1>`__
 -  Prevent installation of Py2 and Py3 mod_wsgi
    `commit <https://codeberg.org/freeipa/freeipa/commit/66e38e917f6517a86cd08839018e14d03aad4a5b>`__
-   `#7161 <https://pagure.io/freeipa/issue/7161>`__
+   `#7161 <https://codeberg.org/freeipa/freeipa/issues/7161>`__
 -  libotp: add libraries after objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/40c98383aa374eee6598972c2fa40edebbc77f39>`__
-   `#7189 <https://pagure.io/freeipa/issue/7189>`__
+   `#7189 <https://codeberg.org/freeipa/freeipa/issues/7189>`__
 -  Require UTF-8 fs encoding
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ea1fdd7421bcf288ed82939e84352af3cd6a6b4>`__
-   `#5887 <https://pagure.io/freeipa/issue/5887>`__
+   `#5887 <https://codeberg.org/freeipa/freeipa/issues/5887>`__
 -  Run tox tests for PyPI packages on Travis
    `commit <https://codeberg.org/freeipa/freeipa/commit/29d0c211b8051b2b91f9b610a9c04d9afd17818b>`__
 -  Py3: Fix vault tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b446f03a26e42165b0d855acd1e2044304d9423>`__
-   `#7033 <https://pagure.io/freeipa/issue/7033>`__
+   `#7033 <https://codeberg.org/freeipa/freeipa/issues/7033>`__
 -  Use namespace-aware meta importer for ipaplatform
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbc9c01d055f16bb513258a6e49f632a144d856f>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__
 -  Test script for ipa-custodia
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ffe4847e94561814263ad8a5130b292fda54077>`__
 -  Remove ignore_import_errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb5b8b1e4af3768f105f76cf01a041c8b31ffe25>`__
 -  Backup ipa-custodia conf and keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/a926a002d65d5980df8b6f6f5fe6a4aa811ec41e>`__
-   `#7247 <https://pagure.io/freeipa/issue/7247>`__
+   `#7247 <https://codeberg.org/freeipa/freeipa/issues/7247>`__
 -  Py3: fix fetching of tar files
    `commit <https://codeberg.org/freeipa/freeipa/commit/5de813b4e4da0953d78183eaf4252da39e33466c>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  Use os.path.isfile() and isdir()
    `commit <https://codeberg.org/freeipa/freeipa/commit/f044643fa6a83f47ac06de444dca39da69946ee0>`__
 -  Block PyOpenSSL to prevent SELinux execmem in wsgi
    `commit <https://codeberg.org/freeipa/freeipa/commit/52dd5e138b7ebec68c7280122b1284648bd4117b>`__
-   `#5442 <https://pagure.io/freeipa/issue/5442>`__
+   `#5442 <https://codeberg.org/freeipa/freeipa/issues/5442>`__
 
 
 
@@ -259,7 +259,7 @@ David Kupka (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/41de9cc381e8227225e6628109b80e065be18ad8>`__
 -  tests: Add LDAP URI to ldappasswd explicitly
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0f38d5563fd460369238b564f875ee645d6090b>`__
-   `#6622 <https://pagure.io/freeipa/issue/6622>`__
+   `#6622 <https://codeberg.org/freeipa/freeipa/issues/6622>`__
 
 
 
@@ -268,22 +268,22 @@ Felipe Barreto (6)
 
 -  Warning the user when using a loopback IP as forwarder
    `commit <https://codeberg.org/freeipa/freeipa/commit/29e1f264740d9f0eee47441f1a9b61f2a6abfb7a>`__
-   `#5801 <https://pagure.io/freeipa/issue/5801>`__
+   `#5801 <https://codeberg.org/freeipa/freeipa/issues/5801>`__
 -  Removing replica-s4u2proxy.ldif since it's not used anymore
    `commit <https://codeberg.org/freeipa/freeipa/commit/bff8cb6e8db67790539936360d139ec7d0e52823>`__
-   `#7174 <https://pagure.io/freeipa/issue/7174>`__
+   `#7174 <https://codeberg.org/freeipa/freeipa/issues/7174>`__
 -  Fix log capture when running pytests_multihosts commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9737c0fe49711e148cc5c417d293d2dcdaf3c7c>`__
-   `#7186 <https://pagure.io/freeipa/issue/7186>`__
+   `#7186 <https://codeberg.org/freeipa/freeipa/issues/7186>`__
 -  Checks if replica-s4u2proxy.ldif should be applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3dfc13f36de365b78bfbf6ac0fda2549d134739>`__
-   `#7174 <https://pagure.io/freeipa/issue/7174>`__
+   `#7174 <https://codeberg.org/freeipa/freeipa/issues/7174>`__
 -  Fixing tox and pylint errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/90aa4d6b9379ec02873c7cfa20364eb64721f5af>`__
-   `#7132 <https://pagure.io/freeipa/issue/7132>`__
+   `#7132 <https://codeberg.org/freeipa/freeipa/issues/7132>`__
 -  Fixing param-{find,show} and output-{find,show} commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/68178a45523ecdfb11216261cd62f7a68ee87426>`__
-   `#7134 <https://pagure.io/freeipa/issue/7134>`__
+   `#7134 <https://codeberg.org/freeipa/freeipa/issues/7134>`__
 
 
 
@@ -292,34 +292,34 @@ Florence Blanc-Renaud (10)
 
 -  Improve help message for ipa trust-add --range-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/131ac7c8900ecf29499893869316759a3142412c>`__
-   `#7308 <https://pagure.io/freeipa/issue/7308>`__
+   `#7308 <https://codeberg.org/freeipa/freeipa/issues/7308>`__
 -  Fix ca less IPA install on fips mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba25408d997ec064038ee815e970b4b39a633f16>`__
-   `#7280 <https://pagure.io/freeipa/issue/7280>`__
+   `#7280 <https://codeberg.org/freeipa/freeipa/issues/7280>`__
 -  Fix ipa-restore (python2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/71c54ef03cabd598ff1c0032529793dbbcd59a9e>`__
-   `#7231 <https://pagure.io/freeipa/issue/7231>`__
+   `#7231 <https://codeberg.org/freeipa/freeipa/issues/7231>`__
 -  ipa-getkeytab man page: add more details about the -r option
    `commit <https://codeberg.org/freeipa/freeipa/commit/e76ab3e8b08a4b4d08f05208117be38e383fa0a6>`__
-   `#7237 <https://pagure.io/freeipa/issue/7237>`__
+   `#7237 <https://codeberg.org/freeipa/freeipa/issues/7237>`__
 -  Py3: fix ipa-replica-conncheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/50fb9b6272dbedd64d8f200ab72f70648e78b380>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  Fix ipa-replica-conncheck when called with --principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd09db2042a38cc4026dfd5591e38275ca602d93>`__
-   `#7221 <https://pagure.io/freeipa/issue/7221>`__
+   `#7221 <https://codeberg.org/freeipa/freeipa/issues/7221>`__
 -  py3: fix ipa cert-request --database ...
    `commit <https://codeberg.org/freeipa/freeipa/commit/d00a2c75413d392c60e47e89652ea18fab5ccd02>`__
-   `#7148 <https://pagure.io/freeipa/issue/7148>`__
+   `#7148 <https://codeberg.org/freeipa/freeipa/issues/7148>`__
 -  ipa-cacert-manage renew: switch from ext-signed CA to self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1eee1155ddcfe86cb1651e2e476ce49ef854e11>`__
-   `#7173 <https://pagure.io/freeipa/issue/7173>`__
+   `#7173 <https://codeberg.org/freeipa/freeipa/issues/7173>`__
 -  ipa-server-upgrade: do not add untracked certs to the request list
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef6aa6759bfc7e0a46e1dafefb3a1b9d15b5f553>`__
-   `#7151 <https://pagure.io/freeipa/issue/7151>`__
+   `#7151 <https://codeberg.org/freeipa/freeipa/issues/7151>`__
 -  ipa-server-upgrade: fix the logic for tracking certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/b70e1f59c54d68e8e318db396b777efd0e340e8d>`__
-   `#7151 <https://pagure.io/freeipa/issue/7151>`__
+   `#7151 <https://codeberg.org/freeipa/freeipa/issues/7151>`__
 
 
 
@@ -328,70 +328,70 @@ Fraser Tweedale (22)
 
 -  ipa_certupdate: avoid classmethod and staticmethod
    `commit <https://codeberg.org/freeipa/freeipa/commit/5eab20e3e8c9a9e9a2fe1d91de65045705637ccd>`__
-   `#6577 <https://pagure.io/freeipa/issue/6577>`__
+   `#6577 <https://codeberg.org/freeipa/freeipa/issues/6577>`__
 -  Run certupdate after promoting to CA-ful deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd4d9cc46d7d4b3bb9ed7a69976b0986b083abfa>`__
-   `#7230 <https://pagure.io/freeipa/issue/7230>`__
+   `#7230 <https://codeberg.org/freeipa/freeipa/issues/7230>`__
 -  ipa-ca-install: run certupdate as initial step
    `commit <https://codeberg.org/freeipa/freeipa/commit/75a3ede7107c07521a668bcfeb268a5024132731>`__
-   `#6577 <https://pagure.io/freeipa/issue/6577>`__
+   `#6577 <https://codeberg.org/freeipa/freeipa/issues/6577>`__
 -  CertUpdate: make it easy to invoke from other programs
    `commit <https://codeberg.org/freeipa/freeipa/commit/75e4cf1d2a4de9323b95437b6097059014d21ac3>`__
-   `#6577 <https://pagure.io/freeipa/issue/6577>`__
+   `#6577 <https://codeberg.org/freeipa/freeipa/issues/6577>`__
 -  renew_ra_cert: fix update of IPA RA user entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d5e3d199d8a05102805f8550f6fc649f29a985c>`__
-   `#7282 <https://pagure.io/freeipa/issue/7282>`__
+   `#7282 <https://codeberg.org/freeipa/freeipa/issues/7282>`__
 -  Use correct version of Python in RPM scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/74ec1f934ecfb01f2c2dff3146cca28d67b4e2a6>`__
-   `#7299 <https://pagure.io/freeipa/issue/7299>`__
+   `#7299 <https://codeberg.org/freeipa/freeipa/issues/7299>`__
 -  Re-enable some KRA installation tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17b4fa7832517879baa8964500451b8e83319a13>`__
-   `#7220 <https://pagure.io/freeipa/issue/7220>`__
+   `#7220 <https://codeberg.org/freeipa/freeipa/issues/7220>`__
 -  Remove caJarSigningCert profile and related code
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea116544db19554efd7389ef436bf8c97a2518b6>`__
-   `#7226 <https://pagure.io/freeipa/issue/7226>`__
+   `#7226 <https://codeberg.org/freeipa/freeipa/issues/7226>`__
 -  CertDB: remove unused method issue_signing_cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/6441185b789cd693cfdc22020e647ceecdc4e2af>`__
-   `#7226 <https://pagure.io/freeipa/issue/7226>`__
+   `#7226 <https://codeberg.org/freeipa/freeipa/issues/7226>`__
 -  Remove XPI and JAR MIME types from httpd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e62dd1686b66557e158a12dff923c88ecadbd6f>`__
-   `#7226 <https://pagure.io/freeipa/issue/7226>`__
+   `#7226 <https://codeberg.org/freeipa/freeipa/issues/7226>`__
 -  Remove mention of firefox plugin after CA-less install
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9b168665901615e2fd89ad6f4957b008b7534eb>`__
-   `#7226 <https://pagure.io/freeipa/issue/7226>`__
+   `#7226 <https://codeberg.org/freeipa/freeipa/issues/7226>`__
 -  ipa-cacert-manage: avoid some duplicate string definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/78d0122c938cc31d288116370ec1a14d5bddd7f8>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  ipa-cacert-manage: handle alternative tracking request CA name
    `commit <https://codeberg.org/freeipa/freeipa/commit/d07563b744060a4c4d02cb44de20d5589800f38e>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  Add tests for external CA profile specifiers
    `commit <https://codeberg.org/freeipa/freeipa/commit/05be8398572fc517e4adc48b2454a68bc402ce26>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  ipa-cacert-manage: support MS V2 template extension
    `commit <https://codeberg.org/freeipa/freeipa/commit/562f114aad4dc674f87f6264ff123b9f0cf403f9>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  certmonger: add support for MS V2 template
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d8c2fcf2407487a2273e980ef78268369b39cbd>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  certmonger: refactor 'resubmit_request' and 'modify'
    `commit <https://codeberg.org/freeipa/freeipa/commit/9774af3dc7c1ddf0b8f4386ce599c64dbcf38120>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  ipa-ca-install: add --external-ca-profile option
    `commit <https://codeberg.org/freeipa/freeipa/commit/0054cfb7ebd41fb39a92d71e623cf2cbf8365de3>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  install: allow specifying external CA template
    `commit <https://codeberg.org/freeipa/freeipa/commit/f612678ad6af006bd3bb949db119d126c0ba1822>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  Remove duplicate references to external CA type
    `commit <https://codeberg.org/freeipa/freeipa/commit/6de5432d25723b5ae4af88bf126fb48862abc8ce>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  cli: simplify parsing of arbitrary types
    `commit <https://codeberg.org/freeipa/freeipa/commit/61303c73a20f45499c70add171478c96eb24305e>`__
-   `#6858 <https://pagure.io/freeipa/issue/6858>`__
+   `#6858 <https://codeberg.org/freeipa/freeipa/issues/6858>`__
 -  py3: fix pkcs7 file processing
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f21e70786a3ed352b51265c67a27a4e49859d5b>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 
 
 
@@ -408,40 +408,40 @@ Michal Reznik (12)
 
 -  test_batch_plugin: fix py2/3 failing assertion
    `commit <https://codeberg.org/freeipa/freeipa/commit/72ff10b230b8d3fc9d921c8b4c8ab4cad51b89c5>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  test_vault: increase WAIT_AFTER_ARCHIVE
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b8f6121090cda022db160b40f618699ef604ae5>`__
-   `#7265 <https://pagure.io/freeipa/issue/7265>`__
+   `#7265 <https://codeberg.org/freeipa/freeipa/issues/7265>`__
 -  test_caless: fix http.p12 is not valid
    `commit <https://codeberg.org/freeipa/freeipa/commit/d94ffdb795e150d39302d0f6d361257350a5aaad>`__
-   `#7254 <https://pagure.io/freeipa/issue/7254>`__
+   `#7254 <https://codeberg.org/freeipa/freeipa/issues/7254>`__
 -  test_caless: fix TypeError on domain_level compare
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cd3f224096bfcb571b55693b3a3ecfa69931095>`__
-   `#7254 <https://pagure.io/freeipa/issue/7254>`__
+   `#7254 <https://codeberg.org/freeipa/freeipa/issues/7254>`__
 -  manpage: ipa-replica-conncheck - fix minor typo
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec153949d703ec36444af3594433261fd82127f6>`__
-   `#7250 <https://pagure.io/freeipa/issue/7250>`__
+   `#7250 <https://codeberg.org/freeipa/freeipa/issues/7250>`__
 -  test_forced_client: decode get_file_contents() result
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cdf5ffa6fe62002c242893b4d50b1fb505d4947>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  test_external_dns: add missing test cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/c11395685bf667810dee07a71554bc9ec31be371>`__
-   `#6091 <https://pagure.io/freeipa/issue/6091>`__
+   `#6091 <https://codeberg.org/freeipa/freeipa/issues/6091>`__
 -  test_caless: open CA cert in binary mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2a1766cacf0ecdce0b408131c88d0b50f435786>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  tests: add host zone with overlap
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6bedd7e8fe512db60a03f963d6c844f37030cc9>`__
-   `#7124 <https://pagure.io/freeipa/issue/7124>`__
+   `#7124 <https://codeberg.org/freeipa/freeipa/issues/7124>`__
 -  tests_py3: decode get_file_contents() result
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bee023caf908ee1256c2c12722de9e44e84a582>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  test_caless: add caless to external CA test
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d954986166b51a7ed5895fd5d5c686b1f3dfe4f>`__
-   `#7155 <https://pagure.io/freeipa/issue/7155>`__
+   `#7155 <https://codeberg.org/freeipa/freeipa/issues/7155>`__
 -  test_external_ca: switch to python-cryptography
    `commit <https://codeberg.org/freeipa/freeipa/commit/353a4910897976471630639fc445a7c66f71b1a5>`__
-   `#7154 <https://pagure.io/freeipa/issue/7154>`__
+   `#7154 <https://codeberg.org/freeipa/freeipa/issues/7154>`__
 
 
 
@@ -450,8 +450,8 @@ Mohammad Rizwan Yusuf (1)
 
 -  ipatest: replica install with existing entry on master
    `commit <https://codeberg.org/freeipa/freeipa/commit/05acc9c1f5b39c2fae27f53a2b1d1e3dca72b29b>`__
-   `#7174 <https://pagure.io/freeipa/issue/7174>`__,
-   `#7276 <https://pagure.io/freeipa/issue/7276>`__
+   `#7174 <https://codeberg.org/freeipa/freeipa/issues/7174>`__,
+   `#7276 <https://codeberg.org/freeipa/freeipa/issues/7276>`__
 
 
 
@@ -460,11 +460,11 @@ Petr Čech (2)
 
 -  tests: Mark failing tests as failing
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8a3c0e768ae2b46912d7b501f21d45072a15b6f>`__
-   `#7008 <https://pagure.io/freeipa/issue/7008>`__,
-   `#7220 <https://pagure.io/freeipa/issue/7220>`__
+   `#7008 <https://codeberg.org/freeipa/freeipa/issues/7008>`__,
+   `#7220 <https://codeberg.org/freeipa/freeipa/issues/7220>`__
 -  ipatests: Fix on logs collection
    `commit <https://codeberg.org/freeipa/freeipa/commit/085ec3ee21351d83a3e00041c475a58dd6f44d86>`__
-   `#7214 <https://pagure.io/freeipa/issue/7214>`__
+   `#7214 <https://codeberg.org/freeipa/freeipa/issues/7214>`__
 
 
 
@@ -473,7 +473,7 @@ Pavel Vomacka (1)
 
 -  WebUI: make Domain Resolution Order writable
    `commit <https://codeberg.org/freeipa/freeipa/commit/94a645939628666d57537ce24f85b07ce80db2a4>`__
-   `#7169 <https://pagure.io/freeipa/issue/7169>`__
+   `#7169 <https://codeberg.org/freeipa/freeipa/issues/7169>`__
 
 
 
@@ -482,24 +482,24 @@ Rob Crittenden (7)
 
 -  Run server upgrade in ipactl start/restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2d3b568ce2e1163e67dc633ea84c418baa0b553>`__
-   `#6968 <https://pagure.io/freeipa/issue/6968>`__
+   `#6968 <https://codeberg.org/freeipa/freeipa/issues/6968>`__
 -  If the cafile is not present or readable then raise an exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/6273ec612b1318fbab2208b39d5855909c38e983>`__
-   `#7145 <https://pagure.io/freeipa/issue/7145>`__
+   `#7145 <https://codeberg.org/freeipa/freeipa/issues/7145>`__
 -  Add test to ensure that properties are being set in rpcclient
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd0066a5de7bb58e0169917ec4eeb6d4b96055cf>`__
 -  Use the CA chain file from the RPC context
    `commit <https://codeberg.org/freeipa/freeipa/commit/806b76b650da1d2b7c2fe135dfe3691355e1e849>`__
-   `#7145 <https://pagure.io/freeipa/issue/7145>`__
+   `#7145 <https://codeberg.org/freeipa/freeipa/issues/7145>`__
 -  Fix cert-find for CA-less installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbb781a73aed67efe2f7c25f9f95f57acfaef7f7>`__
-   `#7202 <https://pagure.io/freeipa/issue/7202>`__
+   `#7202 <https://codeberg.org/freeipa/freeipa/issues/7202>`__
 -  Use 389-ds provided method for file limits tuning
    `commit <https://codeberg.org/freeipa/freeipa/commit/669e84b85c16fd47a0a832de89062611ddf8fad2>`__
-   `#6994 <https://pagure.io/freeipa/issue/6994>`__
+   `#6994 <https://codeberg.org/freeipa/freeipa/issues/6994>`__
 -  Collect group membership without a size limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/b516ad8af484a12a0a88375cef7da12569d6ae01>`__
-   `#7112 <https://pagure.io/freeipa/issue/7112>`__
+   `#7112 <https://codeberg.org/freeipa/freeipa/issues/7112>`__
 
 
 
@@ -508,7 +508,7 @@ Rishabh Dave (1)
 
 -  ipa-ca-install: mention REPLICA_FILE as optional in help
    `commit <https://codeberg.org/freeipa/freeipa/commit/411f5bebd84ada977ed554cc72bf0288401ba7f2>`__
-   `#7223 <https://pagure.io/freeipa/issue/7223>`__
+   `#7223 <https://codeberg.org/freeipa/freeipa/issues/7223>`__
 
 
 
@@ -517,7 +517,7 @@ Sumit Bose (1)
 
 -  ipa-kdb: reinit trusted domain data for enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7da70183d0d15e4ee5f8f1023bf5b1697f2d67f>`__
-   `#7172 <https://pagure.io/freeipa/issue/7172>`__
+   `#7172 <https://codeberg.org/freeipa/freeipa/issues/7172>`__
 
 
 
@@ -526,63 +526,63 @@ Stanislav Laznicka (22)
 
 -  Don't allow OTP or RADIUS in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/61e7c41bb8e87a9304f422343a1453974e528ce9>`__
-   `#7168 <https://pagure.io/freeipa/issue/7168>`__
+   `#7168 <https://codeberg.org/freeipa/freeipa/issues/7168>`__
 -  caless tests: decode cert bytes in debug log
    `commit <https://codeberg.org/freeipa/freeipa/commit/59a5b245ca55f1abfd169ae9b9422c94d3f780b3>`__
 -  caless tests: make debug log of certificates sensible
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa23cdc70feba90ca595d37dec28002b4633afc9>`__
 -  Add indexing to improve host-find performance
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5735dd3d62f30507cc5d7348edb325cedcf6122>`__
-   `#6371 <https://pagure.io/freeipa/issue/6371>`__
+   `#6371 <https://codeberg.org/freeipa/freeipa/issues/6371>`__
 -  Add the sub operation for fqdn index config
    `commit <https://codeberg.org/freeipa/freeipa/commit/47f426a2d31ae3224e355af4de573e4f8c8ccd03>`__
-   `#6371 <https://pagure.io/freeipa/issue/6371>`__
+   `#6371 <https://codeberg.org/freeipa/freeipa/issues/6371>`__
 -  x509: remove subject_base() function
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2bcf42bba0aa3ccc81ce5659ba4eb99c1072c1c>`__
 -  x509: remove the strip_header() function
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffc162468e5ddaa9c0e4b8fced1a7d3ef15beb64>`__
 -  py3: pass raw entries to LDIFWriter
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a2b42839bc130078a4058c5065df9ebda059508>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  ipatests: use python3 if built with python3
    `commit <https://codeberg.org/freeipa/freeipa/commit/9baa3f6101cb81cf1bb0dd02749024e40f762c61>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  PRCI: use a new template for py3 testing
    `commit <https://codeberg.org/freeipa/freeipa/commit/c16679222f213015b5345e6ff5717dd95892cac7>`__
 -  csrgen_ffi: cast the DN value to unsigned char \*
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ea9a0d9fe0ab982230878764d0f9abc71dae475>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  Remove pkcs10 module contents
    `commit <https://codeberg.org/freeipa/freeipa/commit/c73a1800263e17b61d4bd2f114c7d876cac04bcd>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  Add tests for CertificateSigningRequest
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb657e0b63eedd9eebebcc02acb202edf7884f1f>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  parameters: introduce CertificateSigningRequest
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fe53145c9bc6fadbedbf81e8fa734b7354ea910>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  parameters: relax type checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/db19ecc9696ea0de2632cd1ae7d204d0b3e228ef>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  csrgen: update docstring for py3
    `commit <https://codeberg.org/freeipa/freeipa/commit/72536fdd33b57a60974422acabe5b83003993786>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  csrgen: accept public key info as Bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/8495683d99692c893a5cdcc5133dec33d6733925>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  csrgen_ffi: pass bytes where "char \*" is required
    `commit <https://codeberg.org/freeipa/freeipa/commit/f860d0f50ec295da998c406bd967f35a1b42f979>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  travis: pep8 changes to pycodestyle
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba1064ee3e1d9ab50596a4451f3ad69b3f9e5fdd>`__
 -  p11-kit: add serial number in DER format
    `commit <https://codeberg.org/freeipa/freeipa/commit/07630799b65721f2d3543d33a8ede4cf9064be71>`__
-   `#7210 <https://pagure.io/freeipa/issue/7210>`__
+   `#7210 <https://codeberg.org/freeipa/freeipa/issues/7210>`__
 -  travis: make tests fail if pep8 does not pass
    `commit <https://codeberg.org/freeipa/freeipa/commit/39239fea14af08293c7e0f3b503dd218b3b590d8>`__
 -  Remove the \`message\` attribute from exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b34869271dc0e5518a2f25903f2d3875cff9492>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 
 
 
@@ -591,7 +591,7 @@ Thierry Bordaz (1)
 
 -  389-ds-base crashed as part of ipa-server-intall in ipa-uuid
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb6ac16fcd58f0ca18bba93ef5714d6efdc98abf>`__
-   `#7227 <https://pagure.io/freeipa/issue/7227>`__
+   `#7227 <https://codeberg.org/freeipa/freeipa/issues/7227>`__
 
 
 
@@ -616,13 +616,13 @@ Tomas Krizek (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed460f1bfe58e6153fcd54861eb99e6f2a78ed25>`__
 -  py3 spec: remove python2 dependencies from server-trust-ad
    `commit <https://codeberg.org/freeipa/freeipa/commit/aaf2621e84243ab8978054cad14164ae50b539b8>`__
-   `#7208 <https://pagure.io/freeipa/issue/7208>`__
+   `#7208 <https://codeberg.org/freeipa/freeipa/issues/7208>`__
 -  py3 spec: remove python2 dependencies from freeipa-server
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4f47d17f1077f3c839c325fd3d86b363772434b>`__
-   `#7208 <https://pagure.io/freeipa/issue/7208>`__
+   `#7208 <https://codeberg.org/freeipa/freeipa/issues/7208>`__
 -  py3 spec: use proper python2 package names
    `commit <https://codeberg.org/freeipa/freeipa/commit/b03d51555e22cf138fc93c85584493eb64aba0cd>`__
-   `#7131 <https://pagure.io/freeipa/issue/7131>`__
+   `#7131 <https://codeberg.org/freeipa/freeipa/issues/7131>`__
 -  ipatests: fix circular import for collect_logs
    `commit <https://codeberg.org/freeipa/freeipa/commit/768e18b419dc23c15329a1b212f33f1de0a4df86>`__
 -  ipatests: collect logs for external_ca test suite
@@ -631,12 +631,12 @@ Tomas Krizek (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/efcbe1b415e6be413d27448f6714bb345e48df8f>`__
 -  ldap: limit the retro changelog to dns subtree
    `commit <https://codeberg.org/freeipa/freeipa/commit/68a7e478d4b44a96a6b2684e60203f622e719dd9>`__
-   `#6515 <https://pagure.io/freeipa/issue/6515>`__
+   `#6515 <https://codeberg.org/freeipa/freeipa/issues/6515>`__
 -  spec: bump 389-ds-base to 1.3.7.6-1
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb131796300b5ccc511c3176888fc01ee846b981>`__
 -  ipatests: set default 389-ds log level to 0
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9d058f9afa69f8f89bbd67316070bd01e28ac2c>`__
-   `#7162 <https://pagure.io/freeipa/issue/7162>`__
+   `#7162 <https://codeberg.org/freeipa/freeipa/issues/7162>`__
 -  prci: update F26 template
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7d952dba01d30d5c681056627d0e25561df6254>`__
 -  4.6 set back to git snapshot
@@ -650,4 +650,4 @@ Thorsten Scherf (1)
 -  Add debug option to ipa-replica-manage and remove references to
    api_env var.
    `commit <https://codeberg.org/freeipa/freeipa/commit/40fc14769128b0bad80257676f6295917020fe75>`__
-   `#7187 <https://pagure.io/freeipa/issue/7187>`__
+   `#7187 <https://codeberg.org/freeipa/freeipa/issues/7187>`__

--- a/src/page/Releases/4.6.8.rst
+++ b/src/page/Releases/4.6.8.rst
@@ -89,165 +89,165 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#4972 <https://pagure.io/freeipa/issue/4972>`__
+-  `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
    (`rhbz#1206690 <https://bugzilla.redhat.com/show_bug.cgi?id=1206690>`__)
    check for existence of private group is done even if UPG definition
    is disabled
--  `#5662 <https://pagure.io/freeipa/issue/5662>`__
+-  `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
    (`rhbz#1404770 <https://bugzilla.redhat.com/show_bug.cgi?id=1404770>`__)
    ID Views: do not allow custom Views for the masters
--  `#6210 <https://pagure.io/freeipa/issue/6210>`__
+-  `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
    (`rhbz#1364139 <https://bugzilla.redhat.com/show_bug.cgi?id=1364139>`__,
    `rhbz#1751951 <https://bugzilla.redhat.com/show_bug.cgi?id=1751951>`__)
    When master's IP address does not resolve to its name,
    ipa-replica-install fails
--  `#6783 <https://pagure.io/freeipa/issue/6783>`__
+-  `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
    (`rhbz#1430365 <https://bugzilla.redhat.com/show_bug.cgi?id=1430365>`__)
    [RFE] Host-group names command rename
--  `#6951 <https://pagure.io/freeipa/issue/6951>`__
+-  `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
    (`rhbz#1449133 <https://bugzilla.redhat.com/show_bug.cgi?id=1449133>`__)
    Update samba config file and use sss idmap module
--  `#7181 <https://pagure.io/freeipa/issue/7181>`__
+-  `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
    (`rhbz#1545755 <https://bugzilla.redhat.com/show_bug.cgi?id=1545755>`__)
    ipa-replica-prepare fails for 2nd replica when passwordHistory is
    enabled
--  `#7307 <https://pagure.io/freeipa/issue/7307>`__
+-  `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
    (`rhbz#1518939 <https://bugzilla.redhat.com/show_bug.cgi?id=1518939>`__)
    RFE: Extend IPA to support unadvertised replicas
--  `#7470 <https://pagure.io/freeipa/issue/7470>`__
+-  `#7470 <https://codeberg.org/freeipa/freeipa/issues/7470>`__
    TestBasicADTrust.test_ipauser_authentication is failing with error
    "Confidentiality required"
--  `#7566 <https://pagure.io/freeipa/issue/7566>`__
+-  `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
    (`rhbz#1591824 <https://bugzilla.redhat.com/show_bug.cgi?id=1591824>`__)
    Installation of replica against a specific master
--  `#7597 <https://pagure.io/freeipa/issue/7597>`__
+-  `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
    (`rhbz#1583950 <https://bugzilla.redhat.com/show_bug.cgi?id=1583950>`__)
    IPA: IDM drops all custom attributes when moving account from
    preserved to stage
--  `#7600 <https://pagure.io/freeipa/issue/7600>`__
+-  `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
    (`rhbz#1585020 <https://bugzilla.redhat.com/show_bug.cgi?id=1585020>`__)
    Enable compat tree to provide information about AD users and groups
    on trust agents
--  `#7725 <https://pagure.io/freeipa/issue/7725>`__
+-  `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
    (`rhbz#1636765 <https://bugzilla.redhat.com/show_bug.cgi?id=1636765>`__)
    ipa-restore set wrong file permissions and ownership for
    /var/log/dirsrv/slapd- directory
--  `#7795 <https://pagure.io/freeipa/issue/7795>`__
+-  `#7795 <https://codeberg.org/freeipa/freeipa/issues/7795>`__
    (`rhbz#1795890 <https://bugzilla.redhat.com/show_bug.cgi?id=1795890>`__)
    ipa-pkinit-manage enable fails on replica if it doesn't host the CA
--  `#7804 <https://pagure.io/freeipa/issue/7804>`__
+-  `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
    (`rhbz#1777811 <https://bugzilla.redhat.com/show_bug.cgi?id=1777811>`__)
    \`ipa otptoken-sync\` fails with stack trace
--  `#7807 <https://pagure.io/freeipa/issue/7807>`__
+-  `#7807 <https://codeberg.org/freeipa/freeipa/issues/7807>`__
    (`rhbz#1752005 <https://bugzilla.redhat.com/show_bug.cgi?id=1752005>`__)
    Detect container installation to avoid Kernel keyring
--  `#7870 <https://pagure.io/freeipa/issue/7870>`__
+-  `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
    (`rhbz#1680039 <https://bugzilla.redhat.com/show_bug.cgi?id=1680039>`__)
    [certmonger][upgrade] "Failed to get request: bus, object_path and
    dbus_interface must not be None."
--  `#7893 <https://pagure.io/freeipa/issue/7893>`__ ipasam needs changes
+-  `#7893 <https://codeberg.org/freeipa/freeipa/issues/7893>`__ ipasam needs changes
    for Samba 4.10
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
    (`rhbz#1686302 <https://bugzilla.redhat.com/show_bug.cgi?id=1686302>`__)
    ipa trust fetch-domains, server parameter ignored
--  `#7964 <https://pagure.io/freeipa/issue/7964>`__ GSSAPI failure
+-  `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__ GSSAPI failure
    causing LWCA key replication failure on f30
--  `#7995 <https://pagure.io/freeipa/issue/7995>`__
+-  `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
    (`rhbz#1711172 <https://bugzilla.redhat.com/show_bug.cgi?id=1711172>`__)
    Removing TLSv1.0, TLSv1.1 from nss.conf
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8017 <https://pagure.io/freeipa/issue/8017>`__
+-  `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
    (`rhbz#1817927 <https://bugzilla.redhat.com/show_bug.cgi?id=1817927>`__)
    host-add --password logs cleartext userpassword to Apache error log
--  `#8026 <https://pagure.io/freeipa/issue/8026>`__ Update pr-ci
+-  `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__ Update pr-ci
    definitions with master_3client topology
--  `#8029 <https://pagure.io/freeipa/issue/8029>`__
+-  `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
    (`rhbz#1749788 <https://bugzilla.redhat.com/show_bug.cgi?id=1749788>`__)
    ipa host-find --pkey-only includes SSH keys in output
--  `#8044 <https://pagure.io/freeipa/issue/8044>`__
+-  `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
    (`rhbz#1717008 <https://bugzilla.redhat.com/show_bug.cgi?id=1717008>`__)
    Extdom plugin should not return LDAP_NO_SUCH_OBJECT if there are
    timeout or other errors
--  `#8058 <https://pagure.io/freeipa/issue/8058>`__
+-  `#8058 <https://codeberg.org/freeipa/freeipa/issues/8058>`__
    (`rhbz#1745108 <https://bugzilla.redhat.com/show_bug.cgi?id=1745108>`__)
    ipa-4-6: ipa-client-install should not refuse single-label domains
--  `#8067 <https://pagure.io/freeipa/issue/8067>`__
+-  `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
    (`rhbz#1750700 <https://bugzilla.redhat.com/show_bug.cgi?id=1750700>`__)
    add default access control configuration to trusted domain objects
--  `#8070 <https://pagure.io/freeipa/issue/8070>`__ Test failure in
+-  `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__ Test failure in
    test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::()::test_hidden_replica_install
--  `#8077 <https://pagure.io/freeipa/issue/8077>`__ New pylint 2.4.0
+-  `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__ New pylint 2.4.0
    errors
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
    (`rhbz#1756432 <https://bugzilla.redhat.com/show_bug.cgi?id=1756432>`__)
    Default client configuration breaks ssh in FIPS mode.
--  `#8084 <https://pagure.io/freeipa/issue/8084>`__
+-  `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
    (`rhbz#1758406 <https://bugzilla.redhat.com/show_bug.cgi?id=1758406>`__)
    KRA authentication fails when IPA CA has custom Subject DN
--  `#8086 <https://pagure.io/freeipa/issue/8086>`__
+-  `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
    (`rhbz#1756568 <https://bugzilla.redhat.com/show_bug.cgi?id=1756568>`__)
    ipa-server-certinstall man page does not match built-in help.
--  `#8099 <https://pagure.io/freeipa/issue/8099>`__
+-  `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
    (`rhbz#1762317 <https://bugzilla.redhat.com/show_bug.cgi?id=1762317>`__)
    ipa-backup command is failing on rhel-7.8
--  `#8102 <https://pagure.io/freeipa/issue/8102>`__ Pylint 2.4.3 +
+-  `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__ Pylint 2.4.3 +
    Astroid 2.3.2 errors
--  `#8113 <https://pagure.io/freeipa/issue/8113>`__
+-  `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
    (`rhbz#1755535 <https://bugzilla.redhat.com/show_bug.cgi?id=1755535>`__)
    ipa-advise on a RHEL7 IdM server is not able to generate a
    configuration script for a RHEL8 IdM client
--  `#8115 <https://pagure.io/freeipa/issue/8115>`__ Nightly test failure
+-  `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__ Nightly test failure
    in fedora-30/test_smb and fedora-29/test_smb
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
    (`rhbz#1769791 <https://bugzilla.redhat.com/show_bug.cgi?id=1769791>`__)
    Invisible part of notification area in Web UI intercepts clicks of
    some page elements
--  `#8126 <https://pagure.io/freeipa/issue/8126>`__ Nightly test failure
+-  `#8126 <https://codeberg.org/freeipa/freeipa/issues/8126>`__ Nightly test failure
    in fedora-27/test_ca_custom_sdn
--  `#8131 <https://pagure.io/freeipa/issue/8131>`__
+-  `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
    (`rhbz#1777920 <https://bugzilla.redhat.com/show_bug.cgi?id=1777920>`__)
    covscan memory leaks report
--  `#8138 <https://pagure.io/freeipa/issue/8138>`__
+-  `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
    (`rhbz#1780548 <https://bugzilla.redhat.com/show_bug.cgi?id=1780548>`__)
    Man page ipa-cacert-manage does not display correctly on RHEL
--  `#8148 <https://pagure.io/freeipa/issue/8148>`__
+-  `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
    (`rhbz#1782587 <https://bugzilla.redhat.com/show_bug.cgi?id=1782587>`__)
    add "systemctl restart sssd" to warning message when adding trust
    agents to replicas
--  `#8152 <https://pagure.io/freeipa/issue/8152>`__ ipatests: Enhance
+-  `#8152 <https://codeberg.org/freeipa/freeipa/issues/8152>`__ ipatests: Enhance
    install_replica() method with promote option for ipa-4-6
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
    (`rhbz#1788907 <https://bugzilla.redhat.com/show_bug.cgi?id=1788907>`__)
    Renewed certs are not picked up by IPA CAs
--  `#8170 <https://pagure.io/freeipa/issue/8170>`__ Nightly test failure
+-  `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__ Nightly test failure
    in
    fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNS
--  `#8176 <https://pagure.io/freeipa/issue/8176>`__ External CA is
+-  `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__ External CA is
    tracked for renewals and replaced with a self-signed certificate
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
    (`rhbz#1801791 <https://bugzilla.redhat.com/show_bug.cgi?id=1801791>`__)
    Re-order 50-externalmembers.update to be after
    80-schema_compat.update
--  `#8213 <https://pagure.io/freeipa/issue/8213>`__ Test failure in
+-  `#8213 <https://codeberg.org/freeipa/freeipa/issues/8213>`__ Test failure in
    Travis CI: missing IPv6 loopback interface
--  `#8219 <https://pagure.io/freeipa/issue/8219>`__ ipatests: unify
+-  `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__ ipatests: unify
    editing of sssd.conf
--  `#8220 <https://pagure.io/freeipa/issue/8220>`__ Pylint for python2
+-  `#8220 <https://codeberg.org/freeipa/freeipa/issues/8220>`__ Pylint for python2
    complains about import from ipaplatform
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
    (`rhbz#1812169 <https://bugzilla.redhat.com/show_bug.cgi?id=1812169>`__)
    Secure AJP connector between Dogtag and Apache proxy
--  `#8236 <https://pagure.io/freeipa/issue/8236>`__
+-  `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
    (`rhbz#1809835 <https://bugzilla.redhat.com/show_bug.cgi?id=1809835>`__)
    Enforce a check to prevent adding objects from IPA as external
    members of external groups
--  `#8238 <https://pagure.io/freeipa/issue/8238>`__ Nightly test failure
+-  `#8238 <https://codeberg.org/freeipa/freeipa/issues/8238>`__ Nightly test failure
    in fedora-27/test_sssd
--  `#8239 <https://pagure.io/freeipa/issue/8239>`__ Actualize Bootstrap
+-  `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__ Actualize Bootstrap
    version
--  `#8242 <https://pagure.io/freeipa/issue/8242>`__
+-  `#8242 <https://codeberg.org/freeipa/freeipa/issues/8242>`__
    (`rhbz#1788718 <https://bugzilla.redhat.com/show_bug.cgi?id=1788718>`__)
    ipa-server-install incorrectly setting slew mode (-x) when setting up
    ntpd
@@ -264,7 +264,7 @@ Armando Neto (2)
 
 -  Travis: Enable IPv6 support for Docker
    `commit <https://codeberg.org/freeipa/freeipa/commit/423a052700889d075d5dba3711679375e8990437>`__
-   `#8213 <https://pagure.io/freeipa/issue/8213>`__
+   `#8213 <https://codeberg.org/freeipa/freeipa/issues/8213>`__
 -  prci: Update box used in branch ipa-4-6
    `commit <https://codeberg.org/freeipa/freeipa/commit/b93258d004ccd5da8b526ea554031315d756b57b>`__
 
@@ -281,63 +281,63 @@ Alexander Bokovoy (24)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c0749a3c12c3799fd772da17dd864896fc6f908>`__
 -  Allow rename of a host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c0a2a113d707166cca8cba857937fd624426745>`__
-   `#6783 <https://pagure.io/freeipa/issue/6783>`__
+   `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
 -  Add 'api' and 'aci' targets to make
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ce5e79dae8cae2790717f68adacd039dc913ab4>`__
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d41453138c0d730a94acd8c22ef345d910a4e42>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/d038fc70f8e904a492c5ec0874e0fd0be254ead6>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/41fc40a6b18d26d92869f278b2b8436378653b38>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4f3cd0f26efda56db44bf55aa0bb65d8470b160>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  Fix indentation levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/aaa79c872aad2a5458acefdc16203b9efd62c6c9>`__
 -  Prevent adding IPA objects as external members of external groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/c14e385141ea05f2709364b6f0fca844578a7652>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/901d0eca7d462c74c1664aae9b3415ede7ba3dfc>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Tighten permissions on PKI proxy configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/af2dca13d0cc24e0cf32bc23e4edb86fbbf60d03>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  install/updates: move external members past schema compat update
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5a201fc008b19841f98bb70d44ede7d04ef1126>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
    `commit <https://codeberg.org/freeipa/freeipa/commit/830466c0489466d385a333cb829fe8cd5e59644c>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  covscan: free encryption types in case there is an error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8983f69ce1788144b2b348a65f709412c68e47e>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  Become FreeIPA 4.6.7
    `commit <https://codeberg.org/freeipa/freeipa/commit/71c4dd1f0ba5bd4ddee841d69821398bec35cef8>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa23f5a13a326b4cedf6705be7d14da8bc813763>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  adtrust: add default read_keys permission for TDO objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/b764b386f66fdf813f3914362985b4944c13090f>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  add default access control when migrating trust objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/5741e031318267b28f5812154fa34ff2ff6c3483>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  ipasam: use SID formatting calls to libsss_idmap
    `commit <https://codeberg.org/freeipa/freeipa/commit/95c91b5709d0c7fec20eef5ef69a084a74868c2d>`__
-   `#7893 <https://pagure.io/freeipa/issue/7893>`__
+   `#7893 <https://codeberg.org/freeipa/freeipa/issues/7893>`__
 -  Use unicode strings for Python 2 version
    `commit <https://codeberg.org/freeipa/freeipa/commit/37fa917fa2630dd90dd3a12bab213aeb6adfe182>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
    `commit <https://codeberg.org/freeipa/freeipa/commit/387ed98e59ba4df8d3fd435cfc84f055970c064e>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 -  Revert back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca00a83c79677c22aed5ff77044cb09c59182448>`__
 
@@ -374,7 +374,7 @@ Anuja More (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c452369f753116496f3a170d1bb7fde4cdfb12f>`__
 -  Extdom plugin should not return error (32)/'No such object'
    `commit <https://codeberg.org/freeipa/freeipa/commit/17536af58b5a2d1ae1adf7e741dade7b3f84179a>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -383,20 +383,20 @@ Christian Heimes (7)
 
 -  Add test case for OTP login
    `commit <https://codeberg.org/freeipa/freeipa/commit/cabb7abfc07b093a9912b20ee712baaa40d16d19>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Cherry-picked only ldapmodify_dm()
    `commit <https://codeberg.org/freeipa/freeipa/commit/48ecb92afdbd577fbb4fe05ea15cfaf44e504f89>`__
 -  Use default ssh host key algorithms
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cd1d565ac2b240eda697dbebb043a1a2885d23a>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 -  Log stderr in run_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5ff32870d22f7c42edec63c686a730d7bcf21cc>`__
 -  Fix CustodiaClient ccache handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/436214aea7fd5893525292cb03b3c28cdbc249f2>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 -  Don't configure KEYRING ccache in containers
    `commit <https://codeberg.org/freeipa/freeipa/commit/91e54057f130f0c2d9da8506e34c3cadc9cd9c6e>`__
-   `#7807 <https://pagure.io/freeipa/issue/7807>`__
+   `#7807 <https://codeberg.org/freeipa/freeipa/issues/7807>`__
 -  Remove ZERO_STRUCT() call
    `commit <https://codeberg.org/freeipa/freeipa/commit/910e56333d4631244053b5c506ba2bec905d1c27>`__
 
@@ -407,10 +407,10 @@ François Cami (2)
 
 -  adtrust.py: mention restarting sssd when adding trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bc4218bf8716d28339a3f30d1be8471d04cb4b4>`__
-   `#8148 <https://pagure.io/freeipa/issue/8148>`__
+   `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
 -  prci_definitions: add master_3client topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/663163cbcf0bb12236a675b60784fdf36f917343>`__
-   `#8026 <https://pagure.io/freeipa/issue/8026>`__
+   `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__
 
 
 
@@ -419,87 +419,87 @@ Florence Blanc-Renaud (28)
 
 -  ipatests: fix group-add-member in test_sssd
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b9cdfb2556bd290d5f18b0680a1cf907b4dff0c>`__
-   `#8238 <https://pagure.io/freeipa/issue/8238>`__
+   `#8238 <https://codeberg.org/freeipa/freeipa/issues/8238>`__
 -  ipatests: fix KeyError in test_sssd
    `commit <https://codeberg.org/freeipa/freeipa/commit/bce50976ca5363e2097171b36a0d9a5df652a988>`__
-   `#8238 <https://pagure.io/freeipa/issue/8238>`__
+   `#8238 <https://codeberg.org/freeipa/freeipa/issues/8238>`__
 -  xmlrpc tests: add a test for idview-apply on a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/e946b879750d0b316b25902f15b7f5a0a078012e>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  idviews: prevent applying to a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d62f3de06520282c9656e13ca07e503f1d48c59>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/79f9ba5557d14e74ab29b85407c5de5622d7ea35>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/796c86ac701d23d1dd281d0d5c5331b9a66c2888>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9fcd2c7fb7823becb3a6b68da4b0bf2c1db229f>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
    `commit <https://codeberg.org/freeipa/freeipa/commit/d051d2d47a36c79fd2c20733437fda95f443f053>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed71305be9e236d8f49e3298516c6f6bfadb958c>`__
 -  ipatests: fix modify_sssd_conf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/f605f21cc092300640a27dfc4652c2748407664f>`__
 -  test: add non-reg test checking pkinit after server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/18ed56acc58bb379d5187fbcaafc6d7f16178cdb>`__
-   `#7795 <https://pagure.io/freeipa/issue/7795>`__
+   `#7795 <https://codeberg.org/freeipa/freeipa/issues/7795>`__
 -  pkinit setup: fix regression on master install
    `commit <https://codeberg.org/freeipa/freeipa/commit/50e8c5d652bc2b6c937a3def52621f0c60e085f1>`__
-   `#7795 <https://pagure.io/freeipa/issue/7795>`__
+   `#7795 <https://codeberg.org/freeipa/freeipa/issues/7795>`__
 -  ipatests: add integration test for pkinit enable on replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/95cbf7003ff7b391311a1da6f1065aa1d2c6addf>`__
-   `#7795 <https://pagure.io/freeipa/issue/7795>`__
+   `#7795 <https://codeberg.org/freeipa/freeipa/issues/7795>`__
 -  pkinit enable: use local dogtag only if host has CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7c47341c217312b4b4265fcbea80088bc06381f>`__
-   `#7795 <https://pagure.io/freeipa/issue/7795>`__
+   `#7795 <https://codeberg.org/freeipa/freeipa/issues/7795>`__
 -  ipatests: fix backup and restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/4bd5da1417f12e9f1f22d20b09ed58dcbcfca5cc>`__
-   `#8170 <https://pagure.io/freeipa/issue/8170>`__
+   `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__
 -  ipa-cacert-manage man page: fix indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d8b16b9457a3a4d7eceb326b3c53be13bb6543c>`__
-   `#8138 <https://pagure.io/freeipa/issue/8138>`__
+   `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
 -  trust upgrade: ensure that host is member of adtrust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb4ec6fcb4547bc624cde93e16a9201dfa8d4426>`__
 -  ipatests: fix test_ca_custom_sdn
    `commit <https://codeberg.org/freeipa/freeipa/commit/526c184a8729c36a54a81eeff73bac3428ed6e5a>`__
-   `#8126 <https://pagure.io/freeipa/issue/8126>`__
+   `#8126 <https://codeberg.org/freeipa/freeipa/issues/8126>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a19c0d730ae3d16a9763f4769a37bf19680622a>`__
-   `#8113 <https://pagure.io/freeipa/issue/8113>`__
+   `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/11921266df6e2600afc207b3a721f00bc7e63e99>`__
-   `#8099 <https://pagure.io/freeipa/issue/8099>`__
+   `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
 -  ipa-server-certinstall manpage: add missing options
    `commit <https://codeberg.org/freeipa/freeipa/commit/ddc00468b74b170721c1769029f771e163621c70>`__
-   `#8086 <https://pagure.io/freeipa/issue/8086>`__
+   `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5228a7fb94fdcb16ec4571677af5b5ec33979d2>`__
-   `#8070 <https://pagure.io/freeipa/issue/8070>`__
+   `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/317c111b830fbeb4cd907a6812ce35b7fbf1c174>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b574c130a1d28a6c7d085f795a9fdd3ef91f016>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  replica install: enforce --server arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/22e4eef6cb54c74fc9907db1385549db670094fa>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  check for single-label domains only during server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ae6c1af1e6ef25fdfbbf7e72265372366e6b106>`__
-   `#8058 <https://pagure.io/freeipa/issue/8058>`__
+   `#8058 <https://codeberg.org/freeipa/freeipa/issues/8058>`__
 -  xmlrpc test: add test for preserved > stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ab31a9c3b16536b02416c6b996aec2c1f3ba962>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a9f1c802bb28fde8e1d9f38673e554ef23e5620>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 
 
 
@@ -508,27 +508,27 @@ Fraser Tweedale (8)
 
 -  Do not renew externally-signed CA as self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/c30af44b8a55ebf85f4657ee13eb1554e3b2a2ad>`__
-   `#8176 <https://pagure.io/freeipa/issue/8176>`__
+   `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__
 -  test_integration: add tests for custom CA subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a0e802bd47188fe31d6bf02b28ef0ea51567194>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fa8c6903405294f0e11e373db321172663d6cfd>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/946d96f6c3fd5766d60222da940c27d5d4e41158>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  Bump krb5 min version
    `commit <https://codeberg.org/freeipa/freeipa/commit/e686949dcdc46486061d23d5e18f21e2a2038f58>`__
 -  CustodiaClient: fix IPASecStore config on ipa-4-7
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9d0ba0c355c433ae883cafa3c1e99fea1a85220>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 -  CustodiaClient: use ldapi when ldap_uri not specified
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f455867f82407c0dfab0b9f123c75ca0d1a0090>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 -  Handle missing LWCA certificate or chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/82a9fe7e655115befbdde10907a5aa7669c35fde>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 
 
 
@@ -545,7 +545,7 @@ Ganna Kaihorodova (1)
 
 -  TestBasicADTrust.test_ipauser_authentication
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b6638becbfbae746cef35176890ae3f4a8b01a6>`__
-   `#7470 <https://pagure.io/freeipa/issue/7470>`__
+   `#7470 <https://codeberg.org/freeipa/freeipa/issues/7470>`__
 
 
 
@@ -572,24 +572,24 @@ Mohammad Rizwan Yusuf (7)
 
 -  ipatests: Test if slew mode is not set while configuring ntpd
    `commit <https://codeberg.org/freeipa/freeipa/commit/81b859795c72f6c96b27137cc24d6df327ca8471>`__
-   `#8242 <https://pagure.io/freeipa/issue/8242>`__
+   `#8242 <https://codeberg.org/freeipa/freeipa/issues/8242>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/b739bc2089774cea0437347283c821ac86f8251d>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6960b7af2e8d8e4746245d8ba82a46225174529>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Add promote option to install_replica() method
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d91a78ee409e66f96e7b2555ca33fb2128fdfa3>`__
-   `#8152 <https://pagure.io/freeipa/issue/8152>`__
+   `#8152 <https://codeberg.org/freeipa/freeipa/issues/8152>`__
 -  Add test to nightly.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b3855ec486990ecd08a9f3a0ca408425ee7fbf7>`__
 -  Installation of replica against a specific server
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4dc0ee169689974020a4a77b8bb58b26f360369>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  Check file ownership and permission for dirsrv log instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/de0afeaf5e07028af8ec7247ce37efc789add2ae>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 
 
 
@@ -598,7 +598,7 @@ ndehadra (1)
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad3ddbb80d9f1dd3556afdc9cf506f3bae7f6783>`__
-   `#7307 <https://pagure.io/freeipa/issue/7307>`__
+   `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
 
 
 
@@ -607,7 +607,7 @@ Rob Crittenden (11)
 
 -  Don't configure ntpd with -x
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c1495460fcb0d58d27579bfbd6aba63b91bf985>`__
-   `#8242 <https://pagure.io/freeipa/issue/8242>`__
+   `#8242 <https://codeberg.org/freeipa/freeipa/issues/8242>`__
 -  Test that pwpolicy only applied on Kerberos entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a98670e4abfac2b7de2f604f8fe19fbea988b16>`__
 -  Add ability to change a user password as the Directory Manager
@@ -616,24 +616,24 @@ Rob Crittenden (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc833948006fac6920581e56ec69763bde3f1d4a>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
    `commit <https://codeberg.org/freeipa/freeipa/commit/73d415b72da8a57a2369a55b1533b45f36daf544>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
    `commit <https://codeberg.org/freeipa/freeipa/commit/5913826a4654a115cd5ff2dbf4a2b3ad38a93081>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cd2052c3cb6d8a2569903593762d64669303ff6>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 -  Report if a certmonger CA is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/9eb7763b76c7f4f3d78c76fa324560a8af9342ae>`__
-   `#7870 <https://pagure.io/freeipa/issue/7870>`__
+   `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
 -  Don't log host passwords when they are set/modified
    `commit <https://codeberg.org/freeipa/freeipa/commit/86529f5e21a5b09f026b9787178426a8b8b96bb4>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  Disable deprecated-lambda check in adtrust upgrade code
    `commit <https://codeberg.org/freeipa/freeipa/commit/582e7a35121e0f5ff331699d29a485408f5e17ff>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/643a1d6747e523ac456aefc4707772aebde5573a>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 
 
 
@@ -656,7 +656,7 @@ Sumit Bose (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa0b273874760503c7f57f279721e97aaf007ca5>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
    `commit <https://codeberg.org/freeipa/freeipa/commit/574a615e61ca74b08e2bd7e1e820757f88150418>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -665,10 +665,10 @@ Stanislav Levin (2)
 
 -  Fix errors found by Pylint-2.4.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0f839326c8c0de83cb875a473b3fb5d4a014296>`__
-   `#8102 <https://pagure.io/freeipa/issue/8102>`__
+   `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__
 -  Fixed errors newly exposed by pylint 2.4.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/700a6c9313188a0448e46cca17a08146deb21c2a>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 
 
 
@@ -685,27 +685,27 @@ Sergey Orlov (24)
    `commit <https://codeberg.org/freeipa/freeipa/commit/941c231b692216f3dc4b66944dd170b5380fe981>`__
 -  ipatests: provide AD admin password when trying to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/795a973c00c2fe862b1eff8bd851d8eafe9d970a>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  ipatests: remove workaround for pylint error no-name-in-module
    `commit <https://codeberg.org/freeipa/freeipa/commit/46b9139ac9ecbbd89495239e380982514db3a5f4>`__
-   `#8220 <https://pagure.io/freeipa/issue/8220>`__
+   `#8220 <https://codeberg.org/freeipa/freeipa/issues/8220>`__
 -  ipatests: temporary disable pylint check no-name-in-module
    `commit <https://codeberg.org/freeipa/freeipa/commit/044748b5724f408643fe9f95c3a63d29ca646002>`__
-   `#8220 <https://pagure.io/freeipa/issue/8220>`__
+   `#8220 <https://codeberg.org/freeipa/freeipa/issues/8220>`__
 -  ipatests: remove invalid parameter from sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/551dabe5f933475e4609b6b23eb1200dec90945b>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/aff397b9ef09b1f2dc6c02a6bb85b96fb16b9ded>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: replace utility for editing sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f18f08ca607fdf3b730a6b5e66dc97535007259>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
    `commit <https://codeberg.org/freeipa/freeipa/commit/e25b10ef3a4da973300cd7d888f1506291fa882d>`__
 -  ipatests: refactor FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/714b61f3605f53ecde73dd7e3d23ae92d219f926>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: fix collection of tests from test_trust suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/d12e4bdeef92415c081b99c5b3235997bb086529>`__
 -  Add convenient template for temp commits
@@ -721,10 +721,10 @@ Sergey Orlov (24)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee3d998599bf96c4f0ddb1ab0abf049e3e0e892c>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8fbbb1d3528952685d7b3259329313cc112080e>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
    `commit <https://codeberg.org/freeipa/freeipa/commit/4487fc43d036481a315574bfe719b10a57c54a64>`__
-   `#7995 <https://pagure.io/freeipa/issue/7995>`__
+   `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
 -  ipatests: modify run_command to allow specify successful return codes
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa0ecc93ff0faad6663add73d5e013775ce4a68f>`__
 -  ipatests: in DNS zone file add A record for name server
@@ -743,7 +743,7 @@ Sumedh Sidhaye (2)
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
    `commit <https://codeberg.org/freeipa/freeipa/commit/189fc03a52c80dc675ea1015d97a4e4c357549b5>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d8936c44aaf1531a8f6de1ec747cd28db266fc6>`__
@@ -763,10 +763,10 @@ Serhii Tsymbaliuk (2)
 
 -  WebUI: Fix notification area layout
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e6223419de9a50f1357fc7478a95cf623bf5a10>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/927e339cae309226b654997871c9f8b5cdf32b0b>`__
-   `#8239 <https://pagure.io/freeipa/issue/8239>`__
+   `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__
 
 
 
@@ -775,7 +775,7 @@ Tibor Dudlák (1)
 
 -  Add container environment check to replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/a016ed75ecbe7e2698530036043ef19df1bd718f>`__
-   `#6210 <https://pagure.io/freeipa/issue/6210>`__
+   `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
 
 
 

--- a/src/page/Releases/4.6.9.rst
+++ b/src/page/Releases/4.6.9.rst
@@ -93,7 +93,7 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#8326 <https://pagure.io/freeipa/issue/8326>`__ CVE-2020-10747
+-  `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__ CVE-2020-10747
 
 
 
@@ -115,4 +115,4 @@ Christian Heimes (1)
 
 -  Prevent local account takeover
    `commit <https://codeberg.org/freeipa/freeipa/commit/316ac7cd62ac130f88b374c1f9f47b41806187c1>`__
-   `#8326 <https://pagure.io/freeipa/issue/8326>`__
+   `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__

--- a/src/page/Releases/4.7.2.rst
+++ b/src/page/Releases/4.7.2.rst
@@ -195,7 +195,7 @@ Varun Mylaraiah (1)
 ----------------------------------------------------------------------------------------------
 
 -  Added test for ipa-client-install with a non-standard ldap.conf file
-   Ticket: https://pagure.io/freeipa/issue/7418
+   Ticket: https://codeberg.org/freeipa/freeipa/issues/7418
 
 
 

--- a/src/page/Releases/4.7.5.rst
+++ b/src/page/Releases/4.7.5.rst
@@ -99,132 +99,132 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#2018 <https://pagure.io/freeipa/issue/2018>`__ Change hostname
+-  `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__ Change hostname
    length limit to 64
--  `#4972 <https://pagure.io/freeipa/issue/4972>`__ check for existence
+-  `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__ check for existence
    of private group is done even if UPG definition is disabled
--  `#5062 <https://pagure.io/freeipa/issue/5062>`__ [WebUI] Unlock
+-  `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__ [WebUI] Unlock
    option is enabled for all user.
--  `#5662 <https://pagure.io/freeipa/issue/5662>`__ ID Views: do not
+-  `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__ ID Views: do not
    allow custom Views for the masters
--  `#6210 <https://pagure.io/freeipa/issue/6210>`__ When master's IP
+-  `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__ When master's IP
    address does not resolve to its name, ipa-replica-install fails
--  `#6843 <https://pagure.io/freeipa/issue/6843>`__ ipa-backup does not
+-  `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__ ipa-backup does not
    create log file at /var/log/
--  `#6951 <https://pagure.io/freeipa/issue/6951>`__ Update samba config
+-  `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__ Update samba config
    file and use sss idmap module
--  `#7181 <https://pagure.io/freeipa/issue/7181>`__ ipa-replica-prepare
+-  `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__ ipa-replica-prepare
    fails for 2nd replica when passwordHistory is enabled
--  `#7307 <https://pagure.io/freeipa/issue/7307>`__ RFE: Extend IPA to
+-  `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__ RFE: Extend IPA to
    support unadvertised replicas
--  `#7566 <https://pagure.io/freeipa/issue/7566>`__ Installation of
+-  `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__ Installation of
    replica against a specific master
--  `#7600 <https://pagure.io/freeipa/issue/7600>`__ Enable compat tree
+-  `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__ Enable compat tree
    to provide information about AD users and groups on trust agents
--  `#7725 <https://pagure.io/freeipa/issue/7725>`__ ipa-restore set
+-  `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__ ipa-restore set
    wrong file permissions and ownership for /var/log/dirsrv/slapd-
    directory
--  `#7804 <https://pagure.io/freeipa/issue/7804>`__ \`ipa
+-  `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__ \`ipa
    otptoken-sync\` fails with stack trace
--  `#7810 <https://pagure.io/freeipa/issue/7810>`__ [F28] Require NSS
+-  `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__ [F28] Require NSS
    with fix for p11-kit issue.
--  `#7834 <https://pagure.io/freeipa/issue/7834>`__ Fix certificate
+-  `#7834 <https://codeberg.org/freeipa/freeipa/issues/7834>`__ Fix certificate
    revocation tests for Web UI
--  `#7870 <https://pagure.io/freeipa/issue/7870>`__
+-  `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
    [certmonger][upgrade] "Failed to get request: bus, object_path and
    dbus_interface must not be None."
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__ ipa trust
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__ ipa trust
    fetch-domains, server parameter ignored
--  `#7908 <https://pagure.io/freeipa/issue/7908>`__ Write tests for
+-  `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__ Write tests for
    interactive prompt for NTP options.
--  `#7917 <https://pagure.io/freeipa/issue/7917>`__ Occasional
+-  `#7917 <https://codeberg.org/freeipa/freeipa/issues/7917>`__ Occasional
    'whoami.data is undefined' error in FreeIPA web UI
--  `#7949 <https://pagure.io/freeipa/issue/7949>`__
+-  `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
    test_integration/test_nfs.py fails at cleanup
--  `#7995 <https://pagure.io/freeipa/issue/7995>`__ Removing TLSv1.0,
+-  `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__ Removing TLSv1.0,
    TLSv1.1 from nss.conf
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8017 <https://pagure.io/freeipa/issue/8017>`__ host-add --password
+-  `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__ host-add --password
    logs cleartext userpassword to Apache error log
--  `#8026 <https://pagure.io/freeipa/issue/8026>`__ Update pr-ci
+-  `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__ Update pr-ci
    definitions with master_3client topology
--  `#8027 <https://pagure.io/freeipa/issue/8027>`__ test_nfs.py: migrate
+-  `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__ test_nfs.py: migrate
    to master_3client
--  `#8029 <https://pagure.io/freeipa/issue/8029>`__ ipa host-find
+-  `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__ ipa host-find
    --pkey-only includes SSH keys in output
--  `#8034 <https://pagure.io/freeipa/issue/8034>`__ Existing p11-kit
+-  `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__ Existing p11-kit
    config file is not restored on uninstall
--  `#8044 <https://pagure.io/freeipa/issue/8044>`__ Extdom plugin should
+-  `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__ Extdom plugin should
    not return LDAP_NO_SUCH_OBJECT if there are timeout or other errors
--  `#8055 <https://pagure.io/freeipa/issue/8055>`__ Test for PG6843:
+-  `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__ Test for PG6843:
    ipa-backup does not create log file at /var/log is failing
--  `#8067 <https://pagure.io/freeipa/issue/8067>`__ add default access
+-  `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__ add default access
    control configuration to trusted domain objects
--  `#8070 <https://pagure.io/freeipa/issue/8070>`__ Test failure in
+-  `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__ Test failure in
    test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::()::test_hidden_replica_install
--  `#8073 <https://pagure.io/freeipa/issue/8073>`__ Backup/restore does
+-  `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__ Backup/restore does
    not restore /etc/pkcs11/modules/softhsm2.module
--  `#8077 <https://pagure.io/freeipa/issue/8077>`__ New pylint 2.4.0
+-  `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__ New pylint 2.4.0
    errors
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__ Default client
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__ Default client
    configuration breaks ssh in FIPS mode.
--  `#8084 <https://pagure.io/freeipa/issue/8084>`__ KRA authentication
+-  `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__ KRA authentication
    fails when IPA CA has custom Subject DN
--  `#8086 <https://pagure.io/freeipa/issue/8086>`__
+-  `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
    ipa-server-certinstall man page does not match built-in help.
--  `#8099 <https://pagure.io/freeipa/issue/8099>`__ ipa-backup command
+-  `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__ ipa-backup command
    is failing on rhel-7.8
--  `#8102 <https://pagure.io/freeipa/issue/8102>`__ Pylint 2.4.3 +
+-  `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__ Pylint 2.4.3 +
    Astroid 2.3.2 errors
--  `#8113 <https://pagure.io/freeipa/issue/8113>`__ ipa-advise on a
+-  `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__ ipa-advise on a
    RHEL7 IdM server is not able to generate a configuration script for a
    RHEL8 IdM client
--  `#8115 <https://pagure.io/freeipa/issue/8115>`__ Nightly test failure
+-  `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__ Nightly test failure
    in fedora-30/test_smb and fedora-29/test_smb
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__ Invisible part of
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__ Invisible part of
    notification area in Web UI intercepts clicks of some page elements
--  `#8131 <https://pagure.io/freeipa/issue/8131>`__ covscan memory leaks
+-  `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__ covscan memory leaks
    report
--  `#8138 <https://pagure.io/freeipa/issue/8138>`__ Man page
+-  `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__ Man page
    ipa-cacert-manage does not display correctly on RHEL
--  `#8148 <https://pagure.io/freeipa/issue/8148>`__ add "systemctl
+-  `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__ add "systemctl
    restart sssd" to warning message when adding trust agents to replicas
--  `#8151 <https://pagure.io/freeipa/issue/8151>`__ test_commands
+-  `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__ test_commands
    timing-out
--  `#8157 <https://pagure.io/freeipa/issue/8157>`__ NIghtly test failure
+-  `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__ NIghtly test failure
    in fedora-rawhide/test_webui_network
--  `#8163 <https://pagure.io/freeipa/issue/8163>`__ "Internal Server
+-  `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__ "Internal Server
    Error" reported for minor issues implies IPA is broken
    [IdmHackfest2019]
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__ Renewed certs are
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__ Renewed certs are
    not picked up by IPA CAs
--  `#8169 <https://pagure.io/freeipa/issue/8169>`__ NIghtly test failure
+-  `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__ NIghtly test failure
    in fedora-rawhide/test_webui_policy
--  `#8170 <https://pagure.io/freeipa/issue/8170>`__ Nightly test failure
+-  `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__ Nightly test failure
    in
    fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNS
--  `#8176 <https://pagure.io/freeipa/issue/8176>`__ External CA is
+-  `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__ External CA is
    tracked for renewals and replaced with a self-signed certificate
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__ Re-order
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__ Re-order
    50-externalmembers.update to be after 80-schema_compat.update
--  `#8213 <https://pagure.io/freeipa/issue/8213>`__ Test failure in
+-  `#8213 <https://codeberg.org/freeipa/freeipa/issues/8213>`__ Test failure in
    Travis CI: missing IPv6 loopback interface
--  `#8219 <https://pagure.io/freeipa/issue/8219>`__ ipatests: unify
+-  `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__ ipatests: unify
    editing of sssd.conf
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__ Secure AJP connector
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__ Secure AJP connector
    between Dogtag and Apache proxy
--  `#8226 <https://pagure.io/freeipa/issue/8226>`__ ipa-restore does not
+-  `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__ ipa-restore does not
    restart httpd
--  `#8228 <https://pagure.io/freeipa/issue/8228>`__ Nightly failure in
+-  `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__ Nightly failure in
    backup/restore while calling 'id admin'
--  `#8233 <https://pagure.io/freeipa/issue/8233>`__ 4.8.5 master
+-  `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__ 4.8.5 master
    Installation error
--  `#8236 <https://pagure.io/freeipa/issue/8236>`__ Enforce a check to
+-  `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__ Enforce a check to
    prevent adding objects from IPA as external members of external
    groups
--  `#8239 <https://pagure.io/freeipa/issue/8239>`__ Actualize Bootstrap
+-  `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__ Actualize Bootstrap
    version
 
 
@@ -239,12 +239,12 @@ Armando Neto (6)
 
 -  Travis: Enable IPv6 support for Docker
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cddbfd8cc7b46b78cb8e27200a12941a3781e3e>`__
-   `#8213 <https://pagure.io/freeipa/issue/8213>`__
+   `#8213 <https://codeberg.org/freeipa/freeipa/issues/8213>`__
 -  prci: Bump template version
    `commit <https://codeberg.org/freeipa/freeipa/commit/529d571d505e83e764596496db5d2dfc9a43960f>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
    `commit <https://codeberg.org/freeipa/freeipa/commit/54b14f4cb3e65571be54b94ab5f42d471b92a23d>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  prci: bump template version
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fec68611059069205086b88829d9dddbd7f78c7>`__
 -  prci: increase timeout argument for test_sssd.py
@@ -260,60 +260,60 @@ Alexander Bokovoy (20)
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/eaec7584195ce173a6de5101d745be35b7c4cb5f>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/79fab655ceca9d1ea0791d3a0fb584ea51a9849d>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/74c5a96b8441f0d6b5a64ede2e9de95b4f3fcc4b>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/d91c4d638c6db3183bd0c5e3f18f25ed229a1f3f>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  Fix indentation levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/57e30f88242d926c9487e7ca26dc5ded40700192>`__
 -  ipatests: always skip additional input for group-add-member
    --external
    `commit <https://codeberg.org/freeipa/freeipa/commit/935c356dace23a60be8a0fba4ac482eeccb95948>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  Prevent adding IPA objects as external members of external groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a2f27fe036d61415a128b650d6750e2c2048b4b>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc82b966c054b8a6a98441f08d9ccf2f5737e623>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Tighten permissions on PKI proxy configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4ad2c24df2477a5b4ced14a592d99547a0c029e>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  install/updates: move external members past schema compat update
    `commit <https://codeberg.org/freeipa/freeipa/commit/9db61a51f4cfcaae5e51d10c9ce2ed751cce4c49>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
    `commit <https://codeberg.org/freeipa/freeipa/commit/c37081576d2f282e702b42652c04e053886c47cf>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  covscan: free encryption types in case there is an error
    `commit <https://codeberg.org/freeipa/freeipa/commit/212e86eee15e883bffd01f969219ce644c3e45c6>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  Become FreeIPA 4.7.4
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5e60ffe9e0b909075071511ffa041390a9a87b6>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f8f257d9a9c076bf1a2d28aee06fbac0532aa72>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  adtrust: add default read_keys permission for TDO objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/df19bf51730e1762f3c1e8a1fe196ec5c5381b98>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  add default access control when migrating trust objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf23e732f521f6b6dca8a3b7043cabb161dcbca9>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
    `commit <https://codeberg.org/freeipa/freeipa/commit/f87ee14da5c734e6c6d2455da6272712c567c091>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 -  Update sudo test as SSSD 2.2.0 is available in the test image
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce2dcd7b6188416c5c7024786e258a524eb98288>`__
 -  Restore SELinux context for p11-kit config overrides
    `commit <https://codeberg.org/freeipa/freeipa/commit/e16099a6097ed73d647e5a20d969bd15b5f4df0f>`__
-   `#7810 <https://pagure.io/freeipa/issue/7810>`__
+   `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__
 -  Back to git builds
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4c55e144e7e73a3ed5f2875f5bddc271d4cbb38>`__
 
@@ -346,7 +346,7 @@ Anuja More (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/480ac797439e24609f7154a168b2ddcfa32575a4>`__
 -  Extdom plugin should not return error (32)/'No such object'
    `commit <https://codeberg.org/freeipa/freeipa/commit/83e3f5d105a8d52328fbd966bf82404760c51668>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -355,14 +355,14 @@ Christian Heimes (4)
 
 -  Add test case for OTP login
    `commit <https://codeberg.org/freeipa/freeipa/commit/85b595aefacd8a52ca9cadf53bdd74184aeb2ba8>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Cherry-picked only ldapmodify_dm()
    `commit <https://codeberg.org/freeipa/freeipa/commit/f66df362c31f1bed322d891568d888b2e2e48bfa>`__
 -  Print LDAP diagnostic messages on error
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ffe826caa0283b2b2a15e341e178bac7a748fe5>`__
 -  Use default ssh host key algorithms
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb313d83adf04bc52f047c9167ade9be4c28e946>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 
 
 
@@ -371,22 +371,22 @@ François Cami (6)
 
 -  ipa-restore: restart services at the end
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7fcffcc7209428f2775c97f76db3ecff8499689>`__
-   `#8226 <https://pagure.io/freeipa/issue/8226>`__
+   `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/14de3644ea1e8ce3954b1da6a0e99f6e27d4db03>`__
-   `#8148 <https://pagure.io/freeipa/issue/8148>`__
+   `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
 -  test_nfs.py: switch to master_3repl
    `commit <https://codeberg.org/freeipa/freeipa/commit/98d3b63ca95aafbba3075b5d38fb0bc0ee6d559e>`__
-   `#8027 <https://pagure.io/freeipa/issue/8027>`__
+   `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/912c38a661874274206948f8bc1befa827b2d959>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b79f8d8d38860097bfad98bd29a60a7511f02a4b>`__
-   `#7949 <https://pagure.io/freeipa/issue/7949>`__
+   `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
 -  prci_definitions: add master_3client topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5b11567488ac2c6a6abd242ef3bf37eb8781234>`__
-   `#8026 <https://pagure.io/freeipa/issue/8026>`__
+   `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__
 
 
 
@@ -395,70 +395,70 @@ Florence Blanc-Renaud (22)
 
 -  ipatests: wait for SSSD to become online in backup/restore tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcdab7b8f8f82077943b5842368e5797a141dbb3>`__
-   `#8228 <https://pagure.io/freeipa/issue/8228>`__
+   `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/454168fadd19e0b613e76266ca62157bf2befe67>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  idviews: prevent applying to a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9bf4edbee28ea28d9d0a0ead834773c46861c4c>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fccdd00d53bc71e87ab5a4b1c68ab6e3efcce8c>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/59b09f154b9d85d937da64d6fe271d09c5b61bc1>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a880ff64d44156fa274ef13ea726fe78cd37f2e>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b5c409c3031696a358d57def4dc2e98142ef643>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/15ab3a21dcfca6d11de0179455a09f3816f30bf3>`__
 -  ipatests: fix modify_sssd_conf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b25791f791e716f566dc945b58f241c71312cb6>`__
 -  ipatests: fix backup and restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa0bcb1380198fee4028eeb327c6541828779391>`__
-   `#8170 <https://pagure.io/freeipa/issue/8170>`__
+   `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__
 -  AD user without override receive InternalServerError with API
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9f822ac10c0a5fffca906d5f5412c8d35adcc18>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 -  ipa-cacert-manage man page: fix indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/a281a42ed89c1e901c7f4676423998c6764ec765>`__
-   `#8138 <https://pagure.io/freeipa/issue/8138>`__
+   `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
 -  trust upgrade: ensure that host is member of adtrust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/206e1f94efda11dd773860c9bbf9609d797688d4>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/134c6bd1243329ec41f7a6648e78af57955bc6a6>`__
-   `#8113 <https://pagure.io/freeipa/issue/8113>`__
+   `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a399e1dfa4d64ad1a1030f86dbdb13486aa69f7>`__
-   `#8099 <https://pagure.io/freeipa/issue/8099>`__
+   `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
 -  ipa-server-certinstall manpage: add missing options
    `commit <https://codeberg.org/freeipa/freeipa/commit/5448797ee8a0d1e83599a58bb1b0b8257a9ff35a>`__
-   `#8086 <https://pagure.io/freeipa/issue/8086>`__
+   `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/548b697fbdc9a851ce22745a477f938c5816bf43>`__
-   `#8070 <https://pagure.io/freeipa/issue/8070>`__
+   `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f512b00ee4b5cce9e5b8a658cb7388e2aa3a52a>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee0b0f66c15b4062c214f6993bc0b1e0da9a8a6d>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  replica install: enforce --server arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c5e72aee4dffb353b79b99324858bf2a1ec7314>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7168658210c85e746c6bb2d1a0be9b546702677>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bf6a39ceab02e0dca0626a556eadfe6a853a61a>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 
 
 
@@ -467,16 +467,16 @@ Fraser Tweedale (4)
 
 -  Do not renew externally-signed CA as self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/3afd13a0b45de7349e2cb27cb45e7b3a02edf1c6>`__
-   `#8176 <https://pagure.io/freeipa/issue/8176>`__
+   `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__
 -  test_integration: add tests for custom CA subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/4767add057353280274b884b1bd15f7f63408970>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/4aad2c9b5ed7c7f4b6cba1e0328cf2ff88175d1c>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/1071eb2c64ef94fde13ba7a146d75635b4d56244>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 
 
 
@@ -504,15 +504,15 @@ Michal Polovka (3)
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
    `commit <https://codeberg.org/freeipa/freeipa/commit/353062abc635d6fd310680461618d1cc32d5e07a>`__
-   `#2018 <https://pagure.io/freeipa/issue/2018>`__
+   `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/465706ac98cd7608916090610418a15943e791e0>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__,
-   `#8055 <https://pagure.io/freeipa/issue/8055>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__,
+   `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/b384b297f44e3fb96b1509affabcd9f0011592a7>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__
 
 
 
@@ -521,18 +521,18 @@ Mohammad Rizwan Yusuf (5)
 
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/651d97a47d1f60875648ae72c2c0e6fe6ffabe04>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/405363baa62c7a2e875aae516abc8080031094f2>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  add test to nightly yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/16c794d8a3d7d690883da5b29c5c04a203a2b8db>`__
 -  Installation of replica against a specific server
    `commit <https://codeberg.org/freeipa/freeipa/commit/e12fa0b88371962e3684c6b932980c3ac0ab8e1d>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  Check file ownership and permission for dirsrv log instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/140111cd53803194a6c41a576cab9b3c282ed54f>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 
 
 
@@ -541,7 +541,7 @@ ndehadra (1)
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/90c22dbc46910739b1ed43c5a1e94afdc464fe75>`__
-   `#7307 <https://pagure.io/freeipa/issue/7307>`__
+   `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
 
 
 
@@ -556,25 +556,25 @@ Rob Crittenden (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/82585849cfbad0c7cf2225d2766cb0aed0dce898>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5983600bfc0f143c3a6732be6532e48d9faaf15>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8ed8b0b242e3c8e4107090f56a4771b53b777e5>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/05b173c1a7fb0b18b371771bafe01c0083547c79>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 -  Report if a certmonger CA is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/eda9a51110a645de2ffe459a5101631af4d7772b>`__
-   `#7870 <https://pagure.io/freeipa/issue/7870>`__
+   `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
    `commit <https://codeberg.org/freeipa/freeipa/commit/a62e3c011992ca8d4d9dbd0a8d97b036820a5cd2>`__
-   `#8034 <https://pagure.io/freeipa/issue/8034>`__
+   `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__
 -  Don't log host passwords when they are set/modified
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d58e3bcaa8732f448e01e75448092fe53fd6d13>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdbc918724275e19c81e2e8fa6edfa1972e63f95>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 
 
 
@@ -595,7 +595,7 @@ Sumit Bose (1)
 
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0a16df8a9a171c6508a04970ba3b5321d43ddfa>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -604,13 +604,13 @@ Stanislav Levin (3)
 
 -  pki-proxy: Don't rely on running apache until it's configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/0db996906bbc0fcfd02c81dd468276aae67f0e53>`__
-   `#8233 <https://pagure.io/freeipa/issue/8233>`__
+   `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__
 -  Fix errors found by Pylint-2.4.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/20548ef82f470e11c11722b549f4aac21e8ca5a7>`__
-   `#8102 <https://pagure.io/freeipa/issue/8102>`__
+   `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__
 -  Fixed errors newly exposed by pylint 2.4.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/1248050e19fef3aa39a95fecd2257f841ef6392e>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 
 
 
@@ -619,18 +619,18 @@ Sergey Orlov (19)
 
 -  ipatests: provide AD admin password when trying to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/db1b9fc428d8932f4fa9da79501ff2be8e4e7cc2>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  ipatests: remove test_ordering
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca8cd6ad722590eec545bfb2a68208a0ba8557f0>`__
 -  ipatests: remove invalid parameter from sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c89dbf2440ef0da37b1f766f7a424408b3202966>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/90d88634ef0b05fdfe6879e03c7c44cd2246668d>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: replace utility for editing sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a4d30717e1d4a65e0e9277e6a52e369df3989bf>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa722083cea3d3d238d80699de21201242888116>`__
 -  ipatests: add test_trust suite to nightly runs
@@ -641,17 +641,17 @@ Sergey Orlov (19)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a60c057310db5ad11f4358890fc9e3784681e663>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2a7e73f86d66740f8e6c8e64929bcad6793b6f6>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 -  ipatests: refactor FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/f92c28da7bbc03c2ef47f0617e8dabbdfd0bf65e>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: in DNS zone file add A record for name server
    `commit <https://codeberg.org/freeipa/freeipa/commit/13fbe2c8642906711c660ab7edc1b7b883b295a7>`__
 -  ipatests: strip newline character when getting name of temp file
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b59ceeb37f4c94fe2903fdd7ff81149147f7bd9>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9566100a512656b98b72baf708becc7870750c4>`__
-   `#7995 <https://pagure.io/freeipa/issue/7995>`__
+   `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/180259f20c4170b96b3a0433d4db0950eda6cd20>`__
@@ -673,7 +673,7 @@ Sumedh Sidhaye (2)
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4fdfaac3bea3b1301222f6362275f34b1b710e9>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c421ec4d5dbfa63027c8c41b8b699a2b938e3de>`__
@@ -693,26 +693,26 @@ Serhii Tsymbaliuk (7)
 
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e122aa20594e8f34ffa175401d6ada4c05bbb5e>`__
-   `#8239 <https://pagure.io/freeipa/issue/8239>`__
+   `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
    `commit <https://codeberg.org/freeipa/freeipa/commit/a45679047f82a3fbb98422a023a782766df0ca25>`__
-   `#8157 <https://pagure.io/freeipa/issue/8157>`__
+   `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/220aba3119c2243e890540a95404f14cfffc6ca5>`__
-   `#8169 <https://pagure.io/freeipa/issue/8169>`__
+   `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__
 -  Fix occasional 'whoami.data is undefined' error in FreeIPA web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/74e66ba3aac2fcf751f58a89879e2031078c7960>`__
-   `#7917 <https://pagure.io/freeipa/issue/7917>`__
+   `#7917 <https://codeberg.org/freeipa/freeipa/issues/7917>`__
 -  Fix certificate revocation tests for Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/e054f681a301bdde2ed92334957fe906229b3bcf>`__
-   `#7834 <https://pagure.io/freeipa/issue/7834>`__
+   `#7834 <https://codeberg.org/freeipa/freeipa/issues/7834>`__
 -  WebUI: Fix notification area layout
    `commit <https://codeberg.org/freeipa/freeipa/commit/128a8bcf7b18a7e295ac8cb811021cf462282877>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad006f7008cf6d97c0ff435b5bcb6d17a450a94b>`__
-   `#5062 <https://pagure.io/freeipa/issue/5062>`__
+   `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
 
 
 
@@ -721,17 +721,17 @@ Tibor Dudlák (5)
 
 -  Add container environment check to replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/82351f1e09e9d592e3b0bef521c2c94b0d222cce>`__
-   `#6210 <https://pagure.io/freeipa/issue/6210>`__
+   `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
 -  Increase ntp_options test timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f40193c6301174f54865fd867ad279456fe3ddd>`__
 -  ipatests: refactor TestNTPoptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a046c525d61f5962c02a7ede808080089420604>`__
 -  ipatests: Add tests for interactive chronyd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2c79ecbc1e47e36cbc7e65a575a398bd005f95c>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 -  ipatests: Update test tasks for client to be interactive
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e08b90bb785416582f4e993206b9342b1f0dbf9>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 
 
 

--- a/src/page/Releases/4.7.90.pre1.rst
+++ b/src/page/Releases/4.7.90.pre1.rst
@@ -1006,7 +1006,7 @@ Varun Mylaraiah (4)
 -  ipatests: add tests for NTP options usage on server, replica, and
    client
 -  Added test for ipa-client-install with a non-standard ldap.conf file
-   Ticket: https://pagure.io/freeipa/issue/7418
+   Ticket: https://codeberg.org/freeipa/freeipa/issues/7418
 
 
 

--- a/src/page/Releases/4.8.0.rst
+++ b/src/page/Releases/4.8.0.rst
@@ -298,122 +298,122 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#2018 <https://pagure.io/freeipa/issue/2018>`__ Change hostname
+-  `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__ Change hostname
    length limit to 64
--  `#3999 <https://pagure.io/freeipa/issue/3999>`__ [RFE] Fix and
+-  `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__ [RFE] Fix and
    Document how to set up Samba File Server with IPA
--  `#4812 <https://pagure.io/freeipa/issue/4812>`__ Switch
+-  `#4812 <https://codeberg.org/freeipa/freeipa/issues/4812>`__ Switch
    nsslapd-unhashed-pw-switch to nolog
--  `#5062 <https://pagure.io/freeipa/issue/5062>`__ [WebUI] Unlock
+-  `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__ [WebUI] Unlock
    option is enabled for all user.
--  `#6077 <https://pagure.io/freeipa/issue/6077>`__ [RFE] Support
+-  `#6077 <https://codeberg.org/freeipa/freeipa/issues/6077>`__ [RFE] Support
    One-Way Trust authenticated by trust secret
--  `#6627 <https://pagure.io/freeipa/issue/6627>`__ WebUI: Enable
+-  `#6627 <https://codeberg.org/freeipa/freeipa/issues/6627>`__ WebUI: Enable
    pagination
--  `#7139 <https://pagure.io/freeipa/issue/7139>`__ Traceback is seen
+-  `#7139 <https://codeberg.org/freeipa/freeipa/issues/7139>`__ Traceback is seen
    when modification is done for user from ID Views - Default Trust View
    Tab.
--  `#7647 <https://pagure.io/freeipa/issue/7647>`__ Error message should
+-  `#7647 <https://codeberg.org/freeipa/freeipa/issues/7647>`__ Error message should
    be more useful while ipa-backup fails for insufficient space
--  `#7667 <https://pagure.io/freeipa/issue/7667>`__ When setting up
+-  `#7667 <https://codeberg.org/freeipa/freeipa/issues/7667>`__ When setting up
    mod_ssl, define range of the TLS protocols within the system-wide
    crypto policy
--  `#7716 <https://pagure.io/freeipa/issue/7716>`__ [RFE] remove "last
+-  `#7716 <https://codeberg.org/freeipa/freeipa/issues/7716>`__ [RFE] remove "last
    init status" from ipa-replica-manage list if it's None.
--  `#7761 <https://pagure.io/freeipa/issue/7761>`__ External CA renewal
+-  `#7761 <https://codeberg.org/freeipa/freeipa/issues/7761>`__ External CA renewal
    accepts issuer key < 2048-bit
--  `#7836 <https://pagure.io/freeipa/issue/7836>`__ print appropriate
+-  `#7836 <https://codeberg.org/freeipa/freeipa/issues/7836>`__ print appropriate
    message when uninstalling non-existent IPA client
--  `#7885 <https://pagure.io/freeipa/issue/7885>`__ RFE: wrapper for
+-  `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__ RFE: wrapper for
    Dogtag cert-fix command
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__ ipa trust
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__ ipa trust
    fetch-domains, server parameter ignored
--  `#7917 <https://pagure.io/freeipa/issue/7917>`__ Occasional
+-  `#7917 <https://codeberg.org/freeipa/freeipa/issues/7917>`__ Occasional
    'whoami.data is undefined' error in FreeIPA web UI
--  `#7918 <https://pagure.io/freeipa/issue/7918>`__ ipa-client-automount
+-  `#7918 <https://codeberg.org/freeipa/freeipa/issues/7918>`__ ipa-client-automount
    needs option to specify domain
--  `#7926 <https://pagure.io/freeipa/issue/7926>`__ cert renewal is
+-  `#7926 <https://codeberg.org/freeipa/freeipa/issues/7926>`__ cert renewal is
    failing when ipa ca cert is renewed from self-signed > external ca >
    self-sign
--  `#7927 <https://pagure.io/freeipa/issue/7927>`__ Wrong logic in
+-  `#7927 <https://codeberg.org/freeipa/freeipa/issues/7927>`__ Wrong logic in
    ipactl restart leads to start instead of restart pki-tomcatd
--  `#7928 <https://pagure.io/freeipa/issue/7928>`__ cn=cacert could show
+-  `#7928 <https://codeberg.org/freeipa/freeipa/issues/7928>`__ cn=cacert could show
    expired certificate
--  `#7930 <https://pagure.io/freeipa/issue/7930>`__ Interactive promt
+-  `#7930 <https://codeberg.org/freeipa/freeipa/issues/7930>`__ Interactive promt
    for NTP options after install check.
--  `#7934 <https://pagure.io/freeipa/issue/7934>`__ ipa-server-common
+-  `#7934 <https://codeberg.org/freeipa/freeipa/issues/7934>`__ ipa-server-common
    expected file permissions in package don't match runtime permissions
--  `#7937 <https://pagure.io/freeipa/issue/7937>`__
+-  `#7937 <https://codeberg.org/freeipa/freeipa/issues/7937>`__
    \`build_requestinfo\` crashes in OpenSSL1.1.0+ enviroments
--  `#7939 <https://pagure.io/freeipa/issue/7939>`__ Upgrade failure when
+-  `#7939 <https://codeberg.org/freeipa/freeipa/issues/7939>`__ Upgrade failure when
    ipa-server-upgrade is being run on a system with no trust established
    but trust configured
--  `#7940 <https://pagure.io/freeipa/issue/7940>`__
+-  `#7940 <https://codeberg.org/freeipa/freeipa/issues/7940>`__
    ipatests.test_integration.test_legacy_clients failure
--  `#7941 <https://pagure.io/freeipa/issue/7941>`__
+-  `#7941 <https://codeberg.org/freeipa/freeipa/issues/7941>`__
    ipapython/dn_ctypes.py: libldap_r shared library missing
--  `#7942 <https://pagure.io/freeipa/issue/7942>`__ WebUI test for
+-  `#7942 <https://codeberg.org/freeipa/freeipa/issues/7942>`__ WebUI test for
    automount is broken
--  `#7943 <https://pagure.io/freeipa/issue/7943>`__ [FIPS] Use PKCS#8
+-  `#7943 <https://codeberg.org/freeipa/freeipa/issues/7943>`__ [FIPS] Use PKCS#8
    instead of weaker traditional OpenSSL private key format
--  `#7948 <https://pagure.io/freeipa/issue/7948>`__ [FIPS] Use 3DES for
+-  `#7948 <https://codeberg.org/freeipa/freeipa/issues/7948>`__ [FIPS] Use 3DES for
    certificate encryption when creating a PKCS#12
--  `#7951 <https://pagure.io/freeipa/issue/7951>`__ IPA i18n_messages
+-  `#7951 <https://codeberg.org/freeipa/freeipa/issues/7951>`__ IPA i18n_messages
    call does not obey translations requests
--  `#7952 <https://pagure.io/freeipa/issue/7952>`__ ipa-backup file
+-  `#7952 <https://codeberg.org/freeipa/freeipa/issues/7952>`__ ipa-backup file
    logging does not work
--  `#7953 <https://pagure.io/freeipa/issue/7953>`__ ipa-pwd-extop: do
+-  `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__ ipa-pwd-extop: do
    not remove MagicRegen mod, replace it
--  `#7956 <https://pagure.io/freeipa/issue/7956>`__ Ipatests don't honor
+-  `#7956 <https://codeberg.org/freeipa/freeipa/issues/7956>`__ Ipatests don't honor
    TMPDIR, TEMP or TMP environment variables
--  `#7959 <https://pagure.io/freeipa/issue/7959>`__ ipa-client-install
+-  `#7959 <https://codeberg.org/freeipa/freeipa/issues/7959>`__ ipa-client-install
    fails to add SSH public keys that are missing a whitespace as the
    last character
--  `#7960 <https://pagure.io/freeipa/issue/7960>`__ tests are failing to
+-  `#7960 <https://codeberg.org/freeipa/freeipa/issues/7960>`__ tests are failing to
    create secure LDAP connection in some test configurations
--  `#7962 <https://pagure.io/freeipa/issue/7962>`__ Different
+-  `#7962 <https://codeberg.org/freeipa/freeipa/issues/7962>`__ Different
    pycodestyle results: Travis vs Azure
--  `#7963 <https://pagure.io/freeipa/issue/7963>`__ x509.Name ->
+-  `#7963 <https://codeberg.org/freeipa/freeipa/issues/7963>`__ x509.Name ->
    ipapython.dn.DN does not handle multi-valued RDNs
--  `#7964 <https://pagure.io/freeipa/issue/7964>`__ GSSAPI failure
+-  `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__ GSSAPI failure
    causing LWCA key replication failure on f30
--  `#7965 <https://pagure.io/freeipa/issue/7965>`__ Stop using 389-ds
+-  `#7965 <https://codeberg.org/freeipa/freeipa/issues/7965>`__ Stop using 389-ds
    legacy tools for backup and restore
--  `#7969 <https://pagure.io/freeipa/issue/7969>`__ test failure in
+-  `#7969 <https://codeberg.org/freeipa/freeipa/issues/7969>`__ test failure in
    test_caless.py::TestServerInstall
--  `#7970 <https://pagure.io/freeipa/issue/7970>`__ test failure in
+-  `#7970 <https://codeberg.org/freeipa/freeipa/issues/7970>`__ test failure in
    test_backup_and_restore.py::TestBackupAndRestore
--  `#7972 <https://pagure.io/freeipa/issue/7972>`__ automember rebuild
+-  `#7972 <https://codeberg.org/freeipa/freeipa/issues/7972>`__ automember rebuild
    sometimes appears to return before the rebuild is complete
--  `#7974 <https://pagure.io/freeipa/issue/7974>`__ Nightly test failure
+-  `#7974 <https://codeberg.org/freeipa/freeipa/issues/7974>`__ Nightly test failure
    in
    ipatests.test_integration.test_user_permissions.TestUserPermissions
--  `#7977 <https://pagure.io/freeipa/issue/7977>`__ tox 3.8.0+ fails on
+-  `#7977 <https://codeberg.org/freeipa/freeipa/issues/7977>`__ tox 3.8.0+ fails on
    \`make wheel_bundle\`
--  `#7978 <https://pagure.io/freeipa/issue/7978>`__ Missing
+-  `#7978 <https://codeberg.org/freeipa/freeipa/issues/7978>`__ Missing
    configuration point for the default shell of user/admin
--  `#7981 <https://pagure.io/freeipa/issue/7981>`__ Pytest4.x warnings
--  `#7982 <https://pagure.io/freeipa/issue/7982>`__ Cannot modify TTL
+-  `#7981 <https://codeberg.org/freeipa/freeipa/issues/7981>`__ Pytest4.x warnings
+-  `#7982 <https://codeberg.org/freeipa/freeipa/issues/7982>`__ Cannot modify TTL
    with ipa dnsrecord-mod --ttl alone on command line
--  `#7983 <https://pagure.io/freeipa/issue/7983>`__ Staged user is not
+-  `#7983 <https://codeberg.org/freeipa/freeipa/issues/7983>`__ Staged user is not
    being recognized if the user entry doesn't have an objectClass
    "posixaccount"
--  `#7984 <https://pagure.io/freeipa/issue/7984>`__ make sure 'make
+-  `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__ make sure 'make
    fastlint' processes Python .in files
--  `#7986 <https://pagure.io/freeipa/issue/7986>`__ Increase debugging
+-  `#7986 <https://codeberg.org/freeipa/freeipa/issues/7986>`__ Increase debugging
    level of certmonger
--  `#7988 <https://pagure.io/freeipa/issue/7988>`__ test_nfs.py: errors
+-  `#7988 <https://codeberg.org/freeipa/freeipa/issues/7988>`__ test_nfs.py: errors
    when running ipa-client-automount
--  `#7990 <https://pagure.io/freeipa/issue/7990>`__ Assumptions about
+-  `#7990 <https://codeberg.org/freeipa/freeipa/issues/7990>`__ Assumptions about
    systemd name of \`named\`
--  `#7992 <https://pagure.io/freeipa/issue/7992>`__ ipa upgrade fails
+-  `#7992 <https://codeberg.org/freeipa/freeipa/issues/7992>`__ ipa upgrade fails
    with trust entry already exists
--  `#7996 <https://pagure.io/freeipa/issue/7996>`__
+-  `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__
    \`test_selinuxusermap_plugin\` fails against not default SELinux
    settings
--  `#7998 <https://pagure.io/freeipa/issue/7998>`__ Use system-wide
+-  `#7998 <https://codeberg.org/freeipa/freeipa/issues/7998>`__ Use system-wide
    crypto policy in TLS client
--  `#7999 <https://pagure.io/freeipa/issue/7999>`__ download errors in
+-  `#7999 <https://codeberg.org/freeipa/freeipa/issues/7999>`__ download errors in
    dnf in Azure pipelines
 
 
@@ -434,70 +434,70 @@ Alexander Bokovoy (35)
    `commit <https://codeberg.org/freeipa/freeipa/commit/58fe6fac619200873c299b158c639d88f9b9b7ce>`__
 -  prci: add test_integration/test_smb to the gating set
    `commit <https://codeberg.org/freeipa/freeipa/commit/e25392e976bcbc34e53fafa5eb68014ff3ceb5e5>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipa-client-samba: a tool to configure Samba domain member on IPA
    client
    `commit <https://codeberg.org/freeipa/freeipa/commit/814592cf2218956893baa2272101fffa93abb465>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipaserver.plugins.service: add service-add-smb to set up an SMB
    service
    `commit <https://codeberg.org/freeipa/freeipa/commit/afb8305ada944293f978a20f3829d0ab93180c2d>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  adtrust: update Samba domain controller keytab with host keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/d631e008ccec6827ca0c4b8d442469b0f0c994a8>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  kdb: support SMB services on IPA domain members
    `commit <https://codeberg.org/freeipa/freeipa/commit/653f72079ee27cfdfb880afb20905b7099748c14>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipasam: add handling of machine accounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/91abd1f67ad86ecdaf3100e282b045a6be7de591>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipasam: add lookup of an account by SID
    `commit <https://codeberg.org/freeipa/freeipa/commit/a42352628df6ac4a9a174bee89032c356fac4801>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipapython.ipautil.run: allow skipping stdout/stderr logging
    `commit <https://codeberg.org/freeipa/freeipa/commit/d85e0550cab58d64e65610314906d32bd21a9e39>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipaserver.install.installutils: move commonly used utils to
    ipapython.ipautil
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdb94e0ff2c7bc03b2f0064b77fedabfa0ae8121>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  adtrust: add design document for Samba domain member on IPA client
    `commit <https://codeberg.org/freeipa/freeipa/commit/84201e1daff7e2cd80352654dc7c81530b51dc74>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  trust-fetch-domains: make sure we use right KDC when --server is
    specified
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c9fcccfbcbb78b49b65c12bf05b2647f1522609>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  adtrust upgrade: fix wrong primary principal name, part 2
    `commit <https://codeberg.org/freeipa/freeipa/commit/7af4c7d4720227b5bff037a128061bf616e27096>`__
-   `#7992 <https://pagure.io/freeipa/issue/7992>`__
+   `#7992 <https://codeberg.org/freeipa/freeipa/issues/7992>`__
 -  adtrust upgrade: fix wrong primary principal name
    `commit <https://codeberg.org/freeipa/freeipa/commit/34bfffd1bed4ecd11fbcfe54904e0ac7e3f609e7>`__
-   `#7992 <https://pagure.io/freeipa/issue/7992>`__
+   `#7992 <https://codeberg.org/freeipa/freeipa/issues/7992>`__
 -  azure tests: make sure /etc/docker folder exists
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f4ca3957c84e3f9339bcfb7c511f80553c58e00>`__
 -  ipa-pwd-extop: do not remove MagicRegen mod, replace it
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9bcf531a69b8a39ee2df86b4eb783023b33928e>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  test_ipagetkeytab: test retrieval of explicit encryption types
    `commit <https://codeberg.org/freeipa/freeipa/commit/46234f0cb91ad892b7420eb061e758e26c64e3c7>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  Keytab retrieval: allow requesting arcfour-hmac for SMB services
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5fbbd1957873207afc2542a9d32246bccca0556>`__
 -  test_ipagetkeytab: factor out DM password reader
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f891c6a3fef7b75cb4b0a125e26e6e80b0bdcf3>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  test_ipagetkeytab: allow testing LDAP connection beyond bind
    operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/6163cbc16658930f49794ebecd5a6ac14ba8cfd4>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  ldap2.can_read: fix py3 compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef67dece522335fd26fcdddc822beb4bcc8e6b17>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  LDAPCreate: allow callers to override objectclasses
    `commit <https://codeberg.org/freeipa/freeipa/commit/53a0fa9130493d383d2542622ccdbdd483650bad>`__
-   `#7953 <https://pagure.io/freeipa/issue/7953>`__
+   `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__
 -  Azure Pipelines: run fast linter in case of a pull request build
    `commit <https://codeberg.org/freeipa/freeipa/commit/5230e2a12ddbed0e27b107d7174d08e038f3bc1f>`__
 -  Azure Pipelines: simplify test job definitions
@@ -506,20 +506,20 @@ Alexander Bokovoy (35)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a2c356da0c603f209f2310c013ef085e0c11eda>`__
 -  i18n_messages: get back a locale needed for testing
    `commit <https://codeberg.org/freeipa/freeipa/commit/74f3ca5db054d333a0a8d65abee90edba32a202a>`__
-   `#7951 <https://pagure.io/freeipa/issue/7951>`__
+   `#7951 <https://codeberg.org/freeipa/freeipa/issues/7951>`__
 -  test_legacy_clients: fix class inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/245a8bcdfe32f665a0a1902e54d49e4ba2cd4ce4>`__
-   `#7940 <https://pagure.io/freeipa/issue/7940>`__
+   `#7940 <https://codeberg.org/freeipa/freeipa/issues/7940>`__
 -  fix selenium imports in automount web UI test
    `commit <https://codeberg.org/freeipa/freeipa/commit/c41b3ae98f0782d05318dd2c36c88f66aa25909b>`__
-   `#7942 <https://pagure.io/freeipa/issue/7942>`__
+   `#7942 <https://codeberg.org/freeipa/freeipa/issues/7942>`__
 -  azure-run-tests: handle single unexpanded parameter too
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cb6817b3064da5a85d415b6b29dbfd9429d6d8d>`__
 -  Use nodejs 1.10 to avoid current issues with nodejs 1.11 in Fedora 30
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7533d9c5fd66441699a764df3b225a3a62d6fab>`__
 -  upgrade: adtrust - catch empty result when retrieving list of trusts
    `commit <https://codeberg.org/freeipa/freeipa/commit/98b4c710d90f289322ebda457fdb84c2dd34aace>`__
-   `#7939 <https://pagure.io/freeipa/issue/7939>`__
+   `#7939 <https://codeberg.org/freeipa/freeipa/issues/7939>`__
 -  Revert "Require a minimum SASL security factor of 56"
    `commit <https://codeberg.org/freeipa/freeipa/commit/294aa3a33375dc246b2a733fce3cbd09a39071a0>`__
 -  Turn master branch back after pre-release tagging
@@ -562,19 +562,19 @@ Christian Heimes (14)
 
 -  Use system-wide crypto policy for TLS ciphers
    `commit <https://codeberg.org/freeipa/freeipa/commit/b55344888478e2b05dc01200bed87e551aa7d00a>`__
-   `#7998 <https://pagure.io/freeipa/issue/7998>`__
+   `#7998 <https://codeberg.org/freeipa/freeipa/issues/7998>`__
 -  Use only TLS 1.2 by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/b57c818fab3bb9627a8c287766cdb5bd8071c837>`__
-   `#7667 <https://pagure.io/freeipa/issue/7667>`__
+   `#7667 <https://codeberg.org/freeipa/freeipa/issues/7667>`__
 -  Increase default debug level of certmonger
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac86707de3b424aa76d72b55139e5aecdebc81b8>`__
-   `#7986 <https://pagure.io/freeipa/issue/7986>`__
+   `#7986 <https://codeberg.org/freeipa/freeipa/issues/7986>`__
 -  Replace PYTHONSHEBANG with valid shebang
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d02eddd3ef7f65c1a922125371fcbb83e35d7f8>`__
-   `#7984 <https://pagure.io/freeipa/issue/7984>`__
+   `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__
 -  Fix CustodiaClient ccache handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/c027b9334b8c3fbb1f31674d7b46c9edb5445208>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 -  Bump release number to 4.7.91
    `commit <https://codeberg.org/freeipa/freeipa/commit/02d6fc74749f4c8aacb6e5963c952fb65d0516f1>`__
 -  Forbid imports of ipaserver and install packages
@@ -589,10 +589,10 @@ Christian Heimes (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/289f9c7e254180b6c28a724f0e840f89756c11de>`__
 -  Use PKCS#8 instead of traditional privkey format
    `commit <https://codeberg.org/freeipa/freeipa/commit/2042b5a0d2236d27ce36a139b4e9e89a055f28b5>`__
-   `#7943 <https://pagure.io/freeipa/issue/7943>`__
+   `#7943 <https://codeberg.org/freeipa/freeipa/issues/7943>`__
 -  Load libldap_r-\*.so.2
    `commit <https://codeberg.org/freeipa/freeipa/commit/64dc92ccb4f057ec49070b323f3b827d8642cece>`__
-   `#7941 <https://pagure.io/freeipa/issue/7941>`__
+   `#7941 <https://codeberg.org/freeipa/freeipa/issues/7941>`__
 -  Import urllib submodules
    `commit <https://codeberg.org/freeipa/freeipa/commit/e73fdcf8baf5c18ce2c3de011268aea9c81c1e1b>`__
 
@@ -603,19 +603,19 @@ François Cami (14)
 
 -  Make dnf more robust and faster
    `commit <https://codeberg.org/freeipa/freeipa/commit/7027f7914e32bcf0942931f8915fe602e27dd7aa>`__
-   `#7999 <https://pagure.io/freeipa/issue/7999>`__
+   `#7999 <https://codeberg.org/freeipa/freeipa/issues/7999>`__
 -  Makefile.am: add .in files to fastlint target
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b2efdfae5302427543ef42686c35db737da6261>`__
-   `#7984 <https://pagure.io/freeipa/issue/7984>`__
+   `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__
 -  Introduce minimal ipa-client-automount.in and ipactl.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/37ab150cc70be21ca57ca253d2a337533131457a>`__
-   `#7984 <https://pagure.io/freeipa/issue/7984>`__
+   `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__
 -  ipa_client_automount.py and ipactl.py: fix codestyle
    `commit <https://codeberg.org/freeipa/freeipa/commit/b49c627aa688e0eb1e9b34ff626f2a19aa4f6c3e>`__
-   `#7984 <https://pagure.io/freeipa/issue/7984>`__
+   `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__
 -  Move ipa-client-automount.in and ipactl into modules
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0cf65c4f78bdb410a472f63b98870321fd751e1>`__
-   `#7984 <https://pagure.io/freeipa/issue/7984>`__
+   `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__
 -  test_nfs.py: change pr-ci configuration to run on
    master_2repl_1client
    `commit <https://codeberg.org/freeipa/freeipa/commit/54836bce6e38221e6799f253d1c0b4920158e6da>`__
@@ -623,7 +623,7 @@ François Cami (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/694c3667c7226d893617358a4161f6d754bb5db9>`__
 -  ipa-client-automount: fix '--idmap-domain DNS' logic
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc348b990e607cb574d6eb70b6a9e35f14e8700c>`__
-   `#7988 <https://pagure.io/freeipa/issue/7988>`__
+   `#7988 <https://codeberg.org/freeipa/freeipa/issues/7988>`__
 -  nfs.py: fix user creation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a233a907afbb134eb9310242f5a307ee5b6bd5c>`__
 -  Hidden replica documentation: fix typo
@@ -632,15 +632,15 @@ François Cami (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5331510eabf81d0a93f0b1d547564e4d9379a108>`__
 -  ipa-backup: better error message if ENOSPC
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6415ec3210cda0808867642cb19f0df1ddd3c45>`__
-   `#7647 <https://pagure.io/freeipa/issue/7647>`__
+   `#7647 <https://codeberg.org/freeipa/freeipa/issues/7647>`__
 -  ipatests: add tests for the new NFSv4 domain option of
    ipa-client-automount
    `commit <https://codeberg.org/freeipa/freeipa/commit/d76737e4c6131ae6b4f550b2b7c1a19304f1e3a8>`__
-   `#7918 <https://pagure.io/freeipa/issue/7918>`__
+   `#7918 <https://codeberg.org/freeipa/freeipa/issues/7918>`__
 -  ipa-client-automount: add knob to configure NFSv4 Domain
    (idmapd.conf)
    `commit <https://codeberg.org/freeipa/freeipa/commit/660c4984c6281055752d74dc276fc39a07da324a>`__
-   `#7918 <https://pagure.io/freeipa/issue/7918>`__
+   `#7918 <https://codeberg.org/freeipa/freeipa/issues/7918>`__
 
 
 
@@ -649,46 +649,46 @@ Florence Blanc-Renaud (14)
 
 -  ipatests: fix ipatests/test_xmlrpc/test_dns_plugin.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/71884176478917aa75a4277e580ed785f818b57d>`__
-   `#7982 <https://pagure.io/freeipa/issue/7982>`__
+   `#7982 <https://codeberg.org/freeipa/freeipa/issues/7982>`__
 -  XMLRPC tests: add new test for ipa dsnrecord-mod $ZONE $RECORD --ttl
    `commit <https://codeberg.org/freeipa/freeipa/commit/f25a7c2e962e3165e54a01479067ca9a900db6a2>`__
-   `#7982 <https://pagure.io/freeipa/issue/7982>`__
+   `#7982 <https://codeberg.org/freeipa/freeipa/issues/7982>`__
 -  dnsrecord-mod: allow to modify ttl without passing the record
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb91fcabee352fcaa71c8e66998a25e01cfaf9f7>`__
-   `#7982 <https://pagure.io/freeipa/issue/7982>`__
+   `#7982 <https://codeberg.org/freeipa/freeipa/issues/7982>`__
 -  ipatests: add a test for stageuser-find with non-posix account
    `commit <https://codeberg.org/freeipa/freeipa/commit/0294ad213388a208079ad29ef4f6ce1c47d8866d>`__
-   `#7983 <https://pagure.io/freeipa/issue/7983>`__
+   `#7983 <https://codeberg.org/freeipa/freeipa/issues/7983>`__
 -  stageuser-find: fix search with non-posix user
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9c4dcdb8532297f4247b930f74a8d2e00db43d9>`__
-   `#7983 <https://pagure.io/freeipa/issue/7983>`__
+   `#7983 <https://codeberg.org/freeipa/freeipa/issues/7983>`__
 -  ipatests: fix TestUserPermissions::test_selinux_user_optimized
    `commit <https://codeberg.org/freeipa/freeipa/commit/910ff25badbea39c5b0381c7fa0d26131e77e1df>`__
-   `#7974 <https://pagure.io/freeipa/issue/7974>`__
+   `#7974 <https://codeberg.org/freeipa/freeipa/issues/7974>`__
 -  ipatests: fix test_backup_and_restore.py::TestBackupAndRestore
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ec3c84c0ca3f43d09272ffa6d656c1ed72067cb>`__
-   `#7970 <https://pagure.io/freeipa/issue/7970>`__
+   `#7970 <https://codeberg.org/freeipa/freeipa/issues/7970>`__
 -  ipatests: fix test_caless.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/07f7e3eaecf781b45c972c4348a9db5794e3fcaf>`__
-   `#7969 <https://pagure.io/freeipa/issue/7969>`__
+   `#7969 <https://codeberg.org/freeipa/freeipa/issues/7969>`__
 -  ipatests: add integration test for ipa-replica-manage list
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b21e2ab9f6f0cc08067d8b5a98efbe4de763904>`__
-   `#7716 <https://pagure.io/freeipa/issue/7716>`__
+   `#7716 <https://codeberg.org/freeipa/freeipa/issues/7716>`__
 -  NSSDatabase: fix get_trust_chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/64d187e56e02f3a400b2e6044e6ad670521160c8>`__
-   `#7926 <https://pagure.io/freeipa/issue/7926>`__
+   `#7926 <https://codeberg.org/freeipa/freeipa/issues/7926>`__
 -  ipatests: CA renewal must refresh cn=CAcert
    `commit <https://codeberg.org/freeipa/freeipa/commit/4804103315617bf1fab1db84a3ed4737418b4908>`__
-   `#7928 <https://pagure.io/freeipa/issue/7928>`__
+   `#7928 <https://codeberg.org/freeipa/freeipa/issues/7928>`__
 -  CA: set ipaconfigstring:compatCA in cn=DOMAIN IPA CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cd88587e45c4a588b4cbd9ce1eb31d4a0c711b0>`__
-   `#7928 <https://pagure.io/freeipa/issue/7928>`__
+   `#7928 <https://codeberg.org/freeipa/freeipa/issues/7928>`__
 -  ipatests: add integration test checking the files mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fe10d9903878d25987c44a8def72b6f056f3dd1>`__
-   `#7934 <https://pagure.io/freeipa/issue/7934>`__
+   `#7934 <https://codeberg.org/freeipa/freeipa/issues/7934>`__
 -  Fix expected file permissions for ghost files
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4254489147eaa0d2e6b7810182f1f3ed35b6324>`__
-   `#7934 <https://pagure.io/freeipa/issue/7934>`__
+   `#7934 <https://codeberg.org/freeipa/freeipa/issues/7934>`__
 
 
 
@@ -697,48 +697,48 @@ Fraser Tweedale (15)
 
 -  Handle missing LWCA certificate or chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/854d3053e294e775fac0e4e394ca3b7b71d04c7d>`__
-   `#7964 <https://pagure.io/freeipa/issue/7964>`__
+   `#7964 <https://codeberg.org/freeipa/freeipa/issues/7964>`__
 -  dn: sort AVAs when converting from x509.Name
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad7472970305f7be2d3afc65fda1e86296d118dd>`__
-   `#7963 <https://pagure.io/freeipa/issue/7963>`__
+   `#7963 <https://codeberg.org/freeipa/freeipa/issues/7963>`__
 -  .gitignore: add ipa-cert-fix program
    `commit <https://codeberg.org/freeipa/freeipa/commit/df99680eadcce43582d925711acab04f521e4aad>`__
 -  avoid realm_to_serverid deprecation warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/f30f040dca1c262541933ebefbc08b6356e42530>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  ipa-cert-fix: fix spurious renewal master change
    `commit <https://codeberg.org/freeipa/freeipa/commit/162dce1c70f8585931e3b748790bc313d6fcd1fe>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  ipa-cert-fix: handle 'pki-server cert-fix' failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/582cc7da1dde44618b57d4073a8513e92ecd4783>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  require Dogtag 10.7.0-1
    `commit <https://codeberg.org/freeipa/freeipa/commit/72027226821f9dfc92b6ece0fefbccab1430c95c>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  ipa-cert-fix: use customary exit statuses
    `commit <https://codeberg.org/freeipa/freeipa/commit/e41b7457f3acd3bf6c1db17c5d14c23f81c0ad4b>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  ipa-cert-fix: add man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f09fee56645120d2e202e5707dc017f8d3d3f3>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  Add ipa-cert-fix tool
    `commit <https://codeberg.org/freeipa/freeipa/commit/09aa3d1f769ac532069e2c39c2ff1eaf8ba0331f>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  constants: add ca_renewal container
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3becc76dd22b3f26442261f163824264e7b8425>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  cainstance: add function to determine ca_renewal nickname
    `commit <https://codeberg.org/freeipa/freeipa/commit/c28a42e27e1cff115aca1066bf3c943ff46ccc48>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  Extract ca_renewal cert update subroutine
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2a006c74667155e5e4c4a1bb0bd9c12da9b4aed>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  add test for external CA key size sanity check
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9b22283dd2160ec073e93df9b52ef6b47d6c335>`__
-   `#7761 <https://pagure.io/freeipa/issue/7761>`__
+   `#7761 <https://codeberg.org/freeipa/freeipa/issues/7761>`__
 -  dn: handle multi-valued RDNs in Name conversion
    `commit <https://codeberg.org/freeipa/freeipa/commit/891d54e46f9c237493f7985d4d8ea19d4d051d09>`__
-   `#7963 <https://pagure.io/freeipa/issue/7963>`__
+   `#7963 <https://codeberg.org/freeipa/freeipa/issues/7963>`__
 
 
 
@@ -747,7 +747,7 @@ German Parente (1)
 
 -  ipa-replica-manage: remove "last init status" if it's None.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef324a7f13887c581d74d4c09c8436af8523c635>`__
-   `#7716 <https://pagure.io/freeipa/issue/7716>`__
+   `#7716 <https://codeberg.org/freeipa/freeipa/issues/7716>`__
 
 
 
@@ -766,7 +766,7 @@ Mohammad Rizwan Yusuf (1)
 
 -  Test if ipactl restart restarts the pki-tomcatd
    `commit <https://codeberg.org/freeipa/freeipa/commit/581b7148f4560cd0595b2c771b6eef2fac5dc93b>`__
-   `#7927 <https://pagure.io/freeipa/issue/7927>`__
+   `#7927 <https://codeberg.org/freeipa/freeipa/issues/7927>`__
 
 
 
@@ -781,36 +781,36 @@ Rob Crittenden (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a43100badc43a2b22efd472ff4108b9821631311>`__
 -  For Fedora and RHEL use system-wide crypto policy for mod_ssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/c484d79ecfa1cc284b47b88377a4c2da23b9db2f>`__
-   `#7667 <https://pagure.io/freeipa/issue/7667>`__
+   `#7667 <https://codeberg.org/freeipa/freeipa/issues/7667>`__
 -  Log the raised message when DNS check_zone_overlap fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/0184e967e58fb7663219eacffeae894031794af0>`__
 -  admintool: don't display log file on errors unless logging is setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/10b721d118a295b62a4c1df52ae47d8b106464a2>`__
-   `#7952 <https://pagure.io/freeipa/issue/7952>`__
+   `#7952 <https://codeberg.org/freeipa/freeipa/issues/7952>`__
 -  tests: Wait for automember rebuild --no-wait tasks to finish
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ec0976cce61f829cb53dc96581dea2c569706d4>`__
-   `#7972 <https://pagure.io/freeipa/issue/7972>`__
+   `#7972 <https://codeberg.org/freeipa/freeipa/issues/7972>`__
 -  Fix expected return code in tests when server is uninstalled
    `commit <https://codeberg.org/freeipa/freeipa/commit/cef4edd384baeda913e309ebcc9a9dd8753dc744>`__
-   `#7836 <https://pagure.io/freeipa/issue/7836>`__
+   `#7836 <https://codeberg.org/freeipa/freeipa/issues/7836>`__
 -  Return 0 on uninstall when on_master for case of not installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1c50650a7f359aa9fd77d4348c31169ca878003>`__
-   `#7836 <https://pagure.io/freeipa/issue/7836>`__
+   `#7836 <https://codeberg.org/freeipa/freeipa/issues/7836>`__
 -  Drop list of return values to be ignored in AdminTool
    `commit <https://codeberg.org/freeipa/freeipa/commit/1284bf1588877d3549ddc98e4762038b8740c72e>`__
-   `#7836 <https://pagure.io/freeipa/issue/7836>`__
+   `#7836 <https://codeberg.org/freeipa/freeipa/issues/7836>`__
 -  When reading SSH pub key don't assume last character is newline
    `commit <https://codeberg.org/freeipa/freeipa/commit/21777e4ba04594c09a2a20ae92ab8fe2cd908fad>`__
-   `#7959 <https://pagure.io/freeipa/issue/7959>`__
+   `#7959 <https://codeberg.org/freeipa/freeipa/issues/7959>`__
 -  Stop using 389-ds legacy backup and restoration utilities
    `commit <https://codeberg.org/freeipa/freeipa/commit/f606d82024d3a74df2aeb5448944aa015e96cce2>`__
-   `#7965 <https://pagure.io/freeipa/issue/7965>`__
+   `#7965 <https://codeberg.org/freeipa/freeipa/issues/7965>`__
 -  Add knob to limit hostname length
    `commit <https://codeberg.org/freeipa/freeipa/commit/6662e99e173a16059271528e1fa58e37a3028924>`__
-   `#2018 <https://pagure.io/freeipa/issue/2018>`__
+   `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
 -  Use AES-128-CBC for PKCS#12 encryption when creating files (FIPS)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecc08e3983c6579850a436f04f579f29a35620ee>`__
-   `#7948 <https://pagure.io/freeipa/issue/7948>`__
+   `#7948 <https://codeberg.org/freeipa/freeipa/issues/7948>`__
 
 
 
@@ -819,39 +819,39 @@ Stanislav Levin (12)
 
 -  Make use of single configuration point for SELinux
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2acd65013348c0f5d91582f240714b0f3357678>`__
-   `#7996 <https://pagure.io/freeipa/issue/7996>`__
+   `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__
 -  Fix a typo in \`replace\` rule of 50-ipaconfig.update
    `commit <https://codeberg.org/freeipa/freeipa/commit/215e8f768c47261d78043dcea23add3da12f364e>`__
-   `#7996 <https://pagure.io/freeipa/issue/7996>`__
+   `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__
 -  Exit on fail in azure multiline script
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5bb436e9fece23f76b35055eddf638f7b8251fe>`__
 -  Make use of \`named\` well-known service
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f7d33356503794463611eb48317c9998187eddb>`__
-   `#7990 <https://pagure.io/freeipa/issue/7990>`__
+   `#7990 <https://codeberg.org/freeipa/freeipa/issues/7990>`__
 -  Make use of the single configuration point for the default shells
    `commit <https://codeberg.org/freeipa/freeipa/commit/d86b57c05764f771b1568409efd31c9e7b302919>`__
-   `#7978 <https://pagure.io/freeipa/issue/7978>`__
+   `#7978 <https://codeberg.org/freeipa/freeipa/issues/7978>`__
 -  Fix Pytest4.x warning about \`message\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/9836511a2b6d7cf48b1a54cb3158e5eac674081a>`__
-   `#7981 <https://pagure.io/freeipa/issue/7981>`__
+   `#7981 <https://codeberg.org/freeipa/freeipa/issues/7981>`__
 -  Fix Pytest4.1+ warnings about pytest.config
    `commit <https://codeberg.org/freeipa/freeipa/commit/d16dd2fd6258520d83eb6350b8aebc9bfdbb11f3>`__
-   `#7981 <https://pagure.io/freeipa/issue/7981>`__
+   `#7981 <https://codeberg.org/freeipa/freeipa/issues/7981>`__
 -  Resolve tox substitutions to absolute paths
    `commit <https://codeberg.org/freeipa/freeipa/commit/77bfd5f9b695e022f84dedf57b58368716090594>`__
-   `#7977 <https://pagure.io/freeipa/issue/7977>`__
+   `#7977 <https://codeberg.org/freeipa/freeipa/issues/7977>`__
 -  Make \`pycodestyle\` results identical
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f33ac88bd213f7626930b7769f5548ead77cecc>`__
-   `#7962 <https://pagure.io/freeipa/issue/7962>`__
+   `#7962 <https://codeberg.org/freeipa/freeipa/issues/7962>`__
 -  Respect TMPDIR, TEMP or TMP environment variables during testing
    `commit <https://codeberg.org/freeipa/freeipa/commit/5263c36c1b3a0e1cbc8f3f368c81706a46a75687>`__
-   `#7956 <https://pagure.io/freeipa/issue/7956>`__
+   `#7956 <https://codeberg.org/freeipa/freeipa/issues/7956>`__
 -  Fix \`build_requestinfo\` in LibreSSL environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b8a2af2197381058ca532d1ae206defb16fac88>`__
-   `#7937 <https://pagure.io/freeipa/issue/7937>`__
+   `#7937 <https://codeberg.org/freeipa/freeipa/issues/7937>`__
 -  Fix \`build_requestinfo\` in OpenSSL1.1.0+ environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac6568dcf58ec8d06df5493d14a28aa41845d4ef>`__
-   `#7937 <https://pagure.io/freeipa/issue/7937>`__
+   `#7937 <https://codeberg.org/freeipa/freeipa/issues/7937>`__
 
 
 
@@ -861,11 +861,11 @@ Sergey Orlov (2)
 -  ipatests: allow to relax security of LDAP connection from controller
    to IPA host
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd2b2443c5ba2f4885e3d85f98332b2fa8b30432>`__
-   `#7960 <https://pagure.io/freeipa/issue/7960>`__
+   `#7960 <https://codeberg.org/freeipa/freeipa/issues/7960>`__
 -  ipatests: new tests for establishing one-way AD trust with shared
    secret
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f02fc945e6306e8fb656db680d5a553683fabc4>`__
-   `#6077 <https://pagure.io/freeipa/issue/6077>`__
+   `#6077 <https://codeberg.org/freeipa/freeipa/issues/6077>`__
 
 
 
@@ -874,17 +874,17 @@ Serhii Tsymbaliuk (4)
 
 -  WebUI: Fix automount maps pagination
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd7198acec797342a6ef0bed6573d8963164a77b>`__
-   `#6627 <https://pagure.io/freeipa/issue/6627>`__
+   `#6627 <https://codeberg.org/freeipa/freeipa/issues/6627>`__
 -  WebUI: Disable 'Unlock' action for users with no password
    `commit <https://codeberg.org/freeipa/freeipa/commit/93dc2d569dad23a2d04523b2281af347ab93799c>`__
-   `#5062 <https://pagure.io/freeipa/issue/5062>`__
+   `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
 -  WebUI: Fix 'user not found' traceback on user ID override details
    page
    `commit <https://codeberg.org/freeipa/freeipa/commit/881ec5a31775a5643ca3c6a37b651fd2104d25b9>`__
-   `#7139 <https://pagure.io/freeipa/issue/7139>`__
+   `#7139 <https://codeberg.org/freeipa/freeipa/issues/7139>`__
 -  Fix occasional 'whoami.data is undefined' error in FreeIPA web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a9c20a87c2ae3eaa941120073cad34c328cb7df>`__
-   `#7917 <https://pagure.io/freeipa/issue/7917>`__
+   `#7917 <https://codeberg.org/freeipa/freeipa/issues/7917>`__
 
 
 
@@ -893,7 +893,7 @@ Thierry Bordaz (1)
 
 -  Switch nsslapd-unhashed-pw-switch to nolog
    `commit <https://codeberg.org/freeipa/freeipa/commit/67490acb045697302cc16d34cac3a81bc1f909ba>`__
-   `#4812 <https://pagure.io/freeipa/issue/4812>`__
+   `#4812 <https://codeberg.org/freeipa/freeipa/issues/4812>`__
 
 
 
@@ -902,12 +902,12 @@ Tibor Dudlák (4)
 
 -  Add SMB attributes for users
    `commit <https://codeberg.org/freeipa/freeipa/commit/c18ee9b641ddc1e6b52d0413caa1fb98ac13785d>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  Remove unreachable code
    `commit <https://codeberg.org/freeipa/freeipa/commit/339771b0d87e787a496c7d193edf5c9c4a50195d>`__
 -  ipatests: Add Unattended option to external ca task
    `commit <https://codeberg.org/freeipa/freeipa/commit/be39d3a99bfd676cd1661af7e8b2553337b4e1c8>`__
-   `#7930 <https://pagure.io/freeipa/issue/7930>`__
+   `#7930 <https://codeberg.org/freeipa/freeipa/issues/7930>`__
 -  Moving prompt for NTP options to install_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3f35843dc33fa6a3fb3071c5c89ecde9db1ce5e>`__
-   `#7930 <https://pagure.io/freeipa/issue/7930>`__
+   `#7930 <https://codeberg.org/freeipa/freeipa/issues/7930>`__

--- a/src/page/Releases/4.8.10.rst
+++ b/src/page/Releases/4.8.10.rst
@@ -90,77 +90,77 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#5914 <https://pagure.io/freeipa/issue/5914>`__
+-  `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__
    (`rhbz#1298288 <https://bugzilla.redhat.com/show_bug.cgi?id=1298288>`__)
    invalid setting of DS lock table size
--  `#6115 <https://pagure.io/freeipa/issue/6115>`__
+-  `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
    (`rhbz#1357495 <https://bugzilla.redhat.com/show_bug.cgi?id=1357495>`__)
    ipa command provides stack trace when provided with single hypen
    commands
--  `#7125 <https://pagure.io/freeipa/issue/7125>`__
+-  `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
    (`rhbz#1480102 <https://bugzilla.redhat.com/show_bug.cgi?id=1480102>`__)
    ipa-server-upgrade failes with "This entry already exists"
--  `#8204 <https://pagure.io/freeipa/issue/8204>`__
+-  `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
    (`rhbz#1810148 <https://bugzilla.redhat.com/show_bug.cgi?id=1810148>`__)
    ipa-server-certinstall -> certmonger add_subject template-subject
    dbus 'unable to set arguments' a{sv}
--  `#8248 <https://pagure.io/freeipa/issue/8248>`__ httpd ccaches
+-  `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__ httpd ccaches
    created during server upgrade aren't cleaned up on uninstall/install
--  `#8275 <https://pagure.io/freeipa/issue/8275>`__
+-  `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
    (`rhbz#1880628 <https://bugzilla.redhat.com/show_bug.cgi?id=1880628>`__)
    Support systemd-resolved
--  `#8344 <https://pagure.io/freeipa/issue/8344>`__ Nightly test failure
+-  `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8383 <https://pagure.io/freeipa/issue/8383>`__ Test with dnspython
+-  `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__ Test with dnspython
    2.0
--  `#8404 <https://pagure.io/freeipa/issue/8404>`__ Detect and fail if
+-  `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__ Detect and fail if
    not enough memory is available for installation
--  `#8443 <https://pagure.io/freeipa/issue/8443>`__ ipa delegation-add
+-  `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__ ipa delegation-add
    can add permissions and attributes several times
--  `#8446 <https://pagure.io/freeipa/issue/8446>`__ ipa dnszone-add
+-  `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__ ipa dnszone-add
    ignores --name-from-ip option if name is given
--  `#8458 <https://pagure.io/freeipa/issue/8458>`__ auto-upgrade will
+-  `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__ auto-upgrade will
    never happen for existing installations
--  `#8468 <https://pagure.io/freeipa/issue/8468>`__ [pylint] new
+-  `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__ [pylint] new
    warnings on dev branch
--  `#8472 <https://pagure.io/freeipa/issue/8472>`__ [tracker] Nightly
+-  `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__ [tracker] Nightly
    test failure in
    test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
--  `#8473 <https://pagure.io/freeipa/issue/8473>`__ Nightly test failure
+-  `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__ Nightly test failure
    in all webui tests: Invalid or corrupt jarfile /opt/selenium.jar
--  `#8474 <https://pagure.io/freeipa/issue/8474>`__ Mozilla's NSS
+-  `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__ Mozilla's NSS
    without DBM
--  `#8475 <https://pagure.io/freeipa/issue/8475>`__ Azure: tox task and
+-  `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__ Azure: tox task and
    virtualenv 20+
--  `#8481 <https://pagure.io/freeipa/issue/8481>`__ Nightly test failure
+-  `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__ Nightly test failure
    in rawhide in tasks.configure_dns_for_trust
--  `#8488 <https://pagure.io/freeipa/issue/8488>`__
+-  `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux blocks custodia key replication / retrieval for sub-CAs
--  `#8490 <https://pagure.io/freeipa/issue/8490>`__
+-  `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
    (`rhbz#1875001 <https://bugzilla.redhat.com/show_bug.cgi?id=1875001>`__)
    It is not possible to edit KDC database when the FreeIPA server is
    running
--  `#8491 <https://pagure.io/freeipa/issue/8491>`__ Unindexed searches
+-  `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__ Unindexed searches
    in FreeIPA git master
--  `#8494 <https://pagure.io/freeipa/issue/8494>`__ Azure Pipelines are
+-  `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__ Azure Pipelines are
    broken due to docker compose tool upgrade
--  `#8503 <https://pagure.io/freeipa/issue/8503>`__
+-  `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
    (`rhbz#1879604 <https://bugzilla.redhat.com/show_bug.cgi?id=1879604>`__)
    pkispawn logs files are empty
--  `#8505 <https://pagure.io/freeipa/issue/8505>`__ Nightly failure
+-  `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__ Nightly failure
    (fedora31) in
    test_integration/test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8507 <https://pagure.io/freeipa/issue/8507>`__ [WebUI] Backport
+-  `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__ [WebUI] Backport
    jQuery patches from newer versions of the library (e.g. 3.5.0)
--  `#8511 <https://pagure.io/freeipa/issue/8511>`__ The selinux
+-  `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__ The selinux
    subpackage does not have a requirement to match the server install
--  `#8512 <https://pagure.io/freeipa/issue/8512>`__ Import of psutil can
+-  `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__ Import of psutil can
    trigger SELinux violation
--  `#8513 <https://pagure.io/freeipa/issue/8513>`__
+-  `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux module fails to load: Re-declaration of type node_t
--  `#8515 <https://pagure.io/freeipa/issue/8515>`__
+-  `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
    (`rhbz#1882340 <https://bugzilla.redhat.com/show_bug.cgi?id=1882340>`__)
    nsslapd-db-locks patching no longer works
 
@@ -178,7 +178,7 @@ Armando Neto (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/02698275bc2b0a39058329f9cb7060a35d896eb3>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe9f4a86ca27c56ec9f4db85f9aea0dae8880638>`__
-   `#8473 <https://pagure.io/freeipa/issue/8473>`__
+   `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/57ea534c39232f65e8a4f0dc9917bd55331c8436>`__
 
@@ -191,17 +191,17 @@ Alexander Bokovoy (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a44bb2e0682e0a1e061bdd6673d04f511807fb34>`__
 -  Specify memory limits as strings for docker compose
    `commit <https://codeberg.org/freeipa/freeipa/commit/93fff042f4bf78541e69371eeaef05c49e8f9463>`__
-   `#8494 <https://pagure.io/freeipa/issue/8494>`__
+   `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
    `commit <https://codeberg.org/freeipa/freeipa/commit/f316d0118b8b00207e8d005f20d5de837c46a220>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec8a560392c89da96a805e9779eaa2041dd992c1>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc9840d83e2cd329281c1d42d75e4dbc4d4c0145>`__
-   `#8344 <https://pagure.io/freeipa/issue/8344>`__
+   `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__
 -  Return to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/e058c4d47ce9bb66ad93421b73f85fd5954e95d0>`__
 
@@ -212,36 +212,36 @@ Christian Heimes (11)
 
 -  Fix nsslapd-db-lock tuning of BDB backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/87e5c0500b76b7cbeecedc0c28d44095c7063186>`__
-   `#5914 <https://pagure.io/freeipa/issue/5914>`__,
-   `#8515 <https://pagure.io/freeipa/issue/8515>`__
+   `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__,
+   `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
 -  Create systemd-resolved configuration on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b3cb99dc15d826b825701fd04b00d74617e526e>`__
 -  Configure systemd-resolved to use IPA's BIND
    `commit <https://codeberg.org/freeipa/freeipa/commit/c67aba230fafd1ad9aded64fdac25081b4cd532d>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Use new API for auto-forwarders
    `commit <https://codeberg.org/freeipa/freeipa/commit/6dc5566c7b1edfd40722a5740e9bf9f33d74a609>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Configure NetworkManager to use systemd-resolved
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6827f52b629d2a6afdd1b60ad190efae0d55a3e>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Add helpers for resolve1 and nameservers
    `commit <https://codeberg.org/freeipa/freeipa/commit/489ddc6d872b00fe5cddd1e9234fbb3e26f4aa0f>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Delay import of psutil to avoid AVC
    `commit <https://codeberg.org/freeipa/freeipa/commit/202d7da8df37b9e5fb58d4546ef996825021137a>`__
-   `#8512 <https://pagure.io/freeipa/issue/8512>`__
+   `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__
 -  Make git a build requirement
    `commit <https://codeberg.org/freeipa/freeipa/commit/439170633f1e577561af289ec99d7426699adf95>`__
 -  Duplicate CA CRT: ignore expected cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7f39287dac7ada64719330ac3da66c8cbbef757>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Add krbPrincipalName pres index correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/672fe14dfa49b8a15fb3c0353415425302924e07>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  Only restart DS when duplicate cacrt was found
    `commit <https://codeberg.org/freeipa/freeipa/commit/be7efc4dfbe16cb8d700ec16bbc1177b4fcbe3df>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 
 
 
@@ -250,41 +250,41 @@ François Cami (12)
 
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/58c3343a67a3922dcc84d3d4b1deca515c48a6f8>`__
-   `#8513 <https://pagure.io/freeipa/issue/8513>`__
+   `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a31605c1d249416ed7627755bca23a1cc45a581>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ad04841245668e3126cb1718ef7ec1b744526e8>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
    `commit <https://codeberg.org/freeipa/freeipa/commit/25cf7af0d41bbd34621f37c95802675b42baeae9>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/0518c63768b50973f3d3129547f5b4b95335f4a8>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/310dbd6eec337f0747d73fa87363083a742fc5dc>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/c126610ea6605a1ff36cecf2e2f5b2cb97130831>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a5962426d8174212f0b7efef1a9e53aaecb5901>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/52929cbadf0252fcac1019b74663a2808061ea1b>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
    `commit <https://codeberg.org/freeipa/freeipa/commit/97c6d2d2c2359b8ff5585afa0d2e5f5599cd5048>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  ipatests: check that pkispawn log is not empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1c860e59b5237178066ed963cc2fa50d99cd690>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  SELinux Policy: let custodia replicate keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/438285470610dee4aa6a56523df22307840ede87>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 
 
 
@@ -293,15 +293,15 @@ Florence Blanc-Renaud (4)
 
 -  test_smb: skip test_smb_service_s4u2self for fed31
    `commit <https://codeberg.org/freeipa/freeipa/commit/707823a3703c4777dba5a260c391dc5887ae69d3>`__
-   `#8505 <https://pagure.io/freeipa/issue/8505>`__
+   `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/fefaeb4bf9f8ca0c64dd8ccb242ac7727ae4b70f>`__
-   `#8481 <https://pagure.io/freeipa/issue/8481>`__
+   `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab6811a131190d89c5ef8c55a2edb8b73499280a>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ce880e900423cedbf7c7a9dd422585e8e1522b1>`__
-   `#8472 <https://pagure.io/freeipa/issue/8472>`__
+   `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__
 
 
 
@@ -322,61 +322,61 @@ Rob Crittenden (19)
 
 -  Test that ccaches are cleaned up during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cfd03db48060c61e6a7fecbb72d9995a7de2511>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
    `commit <https://codeberg.org/freeipa/freeipa/commit/ade428f51909b79a7ec0ced8f9810ce459aba1d3>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
    `commit <https://codeberg.org/freeipa/freeipa/commit/8255bc7b92db44d375819857fed12faa85609c3a>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Require a matching server package for the selinux subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/80f66b751fda25cc48f3cf4727c2b55f6aa39a33>`__
-   `#8511 <https://pagure.io/freeipa/issue/8511>`__
+   `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__
 -  Add index for more trust-related attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/53a952f0cb55c8bd9cc0cd13adf24303d036bafd>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
    `commit <https://codeberg.org/freeipa/freeipa/commit/a572df9616c1da69611ed5a172fd638011ba161f>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  Use ACI class set_permissions() method to set permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/939a72f47c4f9ddd55fd703fbe26dad847ab8d1e>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  De-duplicate ACI attributes and permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e5ba24bcf99daa4764b43093ff6a6dbcde52485>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  ipatests: Add tests for checking available memory
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fa534c92c31488d7dbf7fb84ec0ed934e0376a8>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fd4440a2d49118c9be4f6a6bb9d90ca3abd7c53>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f19411a2e166120b53155e9ae85896990750d2e>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a0c00c3c7bfa7b4270eb7a8b91fac2e8155140d>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Set the certmonger subject with a string, not an object
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a5a2a0bf3e99ab8aa11235c3d01fbac51e33176>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/099ab6c7156202cb1bd0fb6b27dc389dc56c82f7>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  ipatests: Add test for is_ipa_configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/2057b330f8c3d89078ce2008660a799721ab3c57>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Use is_ipa_configured from ipalib.facts
    `commit <https://codeberg.org/freeipa/freeipa/commit/774bbb1703cb37b5b0623a987738efd5207d65d6>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Fall back to old server installation detection when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe783b632a0649f1894416dbd74a2a074c64b5ba>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  cli: When parsing options require name/value pairs
    `commit <https://codeberg.org/freeipa/freeipa/commit/dce5b1c854382058c62cb7c7155edf715088ca0a>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f4f7c616628a6200f7d3b56969d6e6204d3aea5>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 
 
 
@@ -388,17 +388,17 @@ Stanislav Levin (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/656aa91215d2c9142755fc0962dc13668e6f8f3c>`__
 -  dnspython: Add compatibility shim
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae8b723c1e0f5d66b0fa5e618b7274d872e918d3>`__
-   `#8383 <https://pagure.io/freeipa/issue/8383>`__
+   `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__
 -  tox: Don't expand symlinks
    `commit <https://codeberg.org/freeipa/freeipa/commit/76502144dd71c957954ac44002d034e691713cb3>`__
-   `#8475 <https://pagure.io/freeipa/issue/8475>`__
+   `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__
 -  Azure: Increase verbosity for Tox task
    `commit <https://codeberg.org/freeipa/freeipa/commit/428373f127f69b4fee45b356c765e7a227c8788b>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee661dc7223bf107d30dda39184c402964f2982f>`__
 -  nss: Raise exception earlier on unsupported DB type
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a8997ff0be5b3ce67172da9b123a461be83f1e6>`__
-   `#8474 <https://pagure.io/freeipa/issue/8474>`__
+   `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__
 -  Azure: base: Collect both install and uninstall logs
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ff6b6ee55bfb633b1aee7948c885dfa3f711168>`__
 -  Azure: Drop dependency on UsePythonVersion task
@@ -407,16 +407,16 @@ Stanislav Levin (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d13ef9bfe52442af7d8d39113a8b0a01f5f0bff>`__
 -  pylint: Ignore \`raise-missing-from\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffbbc30146e3f0f9e995a99031860e6130847a4c>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/31e16f7216a5e66f372a1759c39a6a254a94a210>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a283196b3da8aaa537fd506c50edbddb0ff2f045>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Teach pylint about more RRs types
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c7414a51ea1895292dccf203f8c5e0aa1c00d2c>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 
 
 
@@ -444,7 +444,7 @@ Serhii Tsymbaliuk (1)
 
 -  WebUI: Fix jQuery DOM manipulation issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/090a222879e5beb6a913821a903d49190401b847>`__
-   `#8507 <https://pagure.io/freeipa/issue/8507>`__
+   `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__
 
 
 
@@ -461,4 +461,4 @@ Zdenek Pytela (1)
 
 -  Add ipa_pki_retrieve_key_exec() interface
    `commit <https://codeberg.org/freeipa/freeipa/commit/c029eb7e732ee8b631c12ae17a154605ef2575e5>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__

--- a/src/page/Releases/4.8.4.rst
+++ b/src/page/Releases/4.8.4.rst
@@ -54,53 +54,53 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#6951 <https://pagure.io/freeipa/issue/6951>`__ Update samba config
+-  `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__ Update samba config
    file and use sss idmap module
--  `#7323 <https://pagure.io/freeipa/issue/7323>`__ IPv6 hack for Travis
+-  `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__ IPv6 hack for Travis
    CI
--  `#7804 <https://pagure.io/freeipa/issue/7804>`__ \`ipa
+-  `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__ \`ipa
    otptoken-sync\` fails with stack trace
--  `#7958 <https://pagure.io/freeipa/issue/7958>`__ traceback in idview
--  `#7985 <https://pagure.io/freeipa/issue/7985>`__ test failure in
+-  `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__ traceback in idview
+-  `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__ test failure in
    test_dnssec.py::TestInstallDNSSECLast::()::test_disable_reenable_signing_replica::teardown
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__ Default client
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__ Default client
    configuration breaks ssh in FIPS mode.
--  `#8104 <https://pagure.io/freeipa/issue/8104>`__ RFE: Disable
+-  `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__ RFE: Disable
    Stale/Inactive Users - Upstream Design Document
--  `#8118 <https://pagure.io/freeipa/issue/8118>`__ Run smoke tests in
+-  `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__ Run smoke tests in
    FIPS mode
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__ Invisible part of
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__ Invisible part of
    notification area in Web UI intercepts clicks of some page elements
--  `#8122 <https://pagure.io/freeipa/issue/8122>`__
+-  `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
    group-add-member-manager does not report errors
--  `#8123 <https://pagure.io/freeipa/issue/8123>`__ [WebUI] Finish group
+-  `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__ [WebUI] Finish group
    membership management UI
--  `#8125 <https://pagure.io/freeipa/issue/8125>`__ Use default crypto
+-  `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__ Use default crypto
    policy for TLS and enable TLS 1.3 support
--  `#8129 <https://pagure.io/freeipa/issue/8129>`__ Tests: Replace
+-  `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__ Tests: Replace
    paramiko with OpenSSH
--  `#8131 <https://pagure.io/freeipa/issue/8131>`__ covscan memory leaks
+-  `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__ covscan memory leaks
    report
--  `#8133 <https://pagure.io/freeipa/issue/8133>`__
+-  `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
    check_client_configuration() no longer works with IPA_CONFDIR
--  `#8134 <https://pagure.io/freeipa/issue/8134>`__ ipa user-add is
+-  `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__ ipa user-add is
    inefficient
--  `#8137 <https://pagure.io/freeipa/issue/8137>`__ reinstall failed in
+-  `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__ reinstall failed in
    adding delegation layout
--  `#8138 <https://pagure.io/freeipa/issue/8138>`__ Man page
+-  `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__ Man page
    ipa-cacert-manage does not display correctly on RHEL
--  `#8142 <https://pagure.io/freeipa/issue/8142>`__ check Not Before /
+-  `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__ check Not Before /
    Not After in externally signed CA sanity check
--  `#8143 <https://pagure.io/freeipa/issue/8143>`__
+-  `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
    service.ldap_disable() does not remove "enabledService"
--  `#8144 <https://pagure.io/freeipa/issue/8144>`__ test_nfs.py:
+-  `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__ test_nfs.py:
    umount.nfs4: /home: device is busy
--  `#8148 <https://pagure.io/freeipa/issue/8148>`__ add "systemctl
+-  `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__ add "systemctl
    restart sssd" to warning message when adding trust agents to replicas
--  `#8149 <https://pagure.io/freeipa/issue/8149>`__ SIDs of AD domains
+-  `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__ SIDs of AD domains
    do not display in ipa-client-samba installer
 
 
@@ -115,7 +115,7 @@ Armando Neto (1)
 
 -  travis: Remove CI integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/6486b1aa4c52f765ed0f10a4d055be7eff479f1c>`__
-   `#7323 <https://pagure.io/freeipa/issue/7323>`__
+   `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__
 
 
 
@@ -124,27 +124,27 @@ Alexander Bokovoy (8)
 
 -  ipa-client-samba: map domain sid of trust domain properly for display
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1d11aa6b1b03b57adf8deba681aa0fa25861c5e>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cf01e72ad2ab67229a7122aee24f6c4ebd40604>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
    `commit <https://codeberg.org/freeipa/freeipa/commit/eebabb5c5fe7478b391770a857fb9be4f0d60a9c>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  covscan: free encryption types in case there is an error
    `commit <https://codeberg.org/freeipa/freeipa/commit/84592e32c5b59b7b654a0a74b5cc8c1350af6451>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  Become FreeIPA 4.8.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/11be139069d1c4312858cddccb6c3f578f256109>`__
 -  Add Authentication Indicator Kerberos ticket policy options
    `commit <https://codeberg.org/freeipa/freeipa/commit/14ff82f3b86ceeb0836b0354b7edb965db72b494>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Allow presence of LDAP attribute options
    `commit <https://codeberg.org/freeipa/freeipa/commit/4dbd689e301a20d38a40e827ba58bc5c667ff0d8>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/18540386230e295087296e58761ced2b781ae4e3>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -161,55 +161,55 @@ Christian Heimes (18)
 
 -  Fix get_trusted_domain_object_from_sid()
    `commit <https://codeberg.org/freeipa/freeipa/commit/9462e4c4b6e37fd1178f96d6d901db8d115c4cfb>`__
-   `#7958 <https://pagure.io/freeipa/issue/7958>`__
+   `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__
 -  Fix service ldap_disable()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b39ee3e1721b6d8234dd209343a8b01dbeaf3d3a>`__
-   `#8143 <https://pagure.io/freeipa/issue/8143>`__
+   `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
 -  Require idstart to be larger than UID_MAX
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a953733f577f4e065a3bd2fa7c5597950d39f6f>`__
-   `#8137 <https://pagure.io/freeipa/issue/8137>`__
+   `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__
 -  Check valid before/after of external certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fc5990a73007bfc1273228efa09755b1db2983f>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix lite-server to work with GSS_NAME
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f726a20d947b7d4a87a6f96a6967cfc85fbc2de>`__
 -  Fix logic of check_client_configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d847cfb1d3779524e28d186c260db438bdf1369>`__
-   `#8133 <https://pagure.io/freeipa/issue/8133>`__
+   `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
    `commit <https://codeberg.org/freeipa/freeipa/commit/0785a032dfec0537aa90616fa0853abfe5ec058a>`__
-   `#8134 <https://pagure.io/freeipa/issue/8134>`__
+   `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__
 -  Don't hard-code client's TLS versions and ciphers
    `commit <https://codeberg.org/freeipa/freeipa/commit/b655586225c8587fc9e4522d1e25458f10c63f86>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae9e41baddbf30ab2002455b06886be9e12ae453>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Enable TLS 1.3 support on the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7de64c38b11d8fb22d313853b6113da1df449be>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Skip paramiko tests in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/82a4faefd2c719a1e269733280f4141241d89b68>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  FIPS: server key has different name in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/9091290a3e813f491f99626db3d07cbfe99a1d99>`__
 -  Remove FIPS noise from SSHd
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ce6b53de376ff6338df318d37330d531725e1be>`__
 -  Add test case for OTP login
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfa356e3d60468fab9eb873adfa0b08a7f8fd842>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Fix otptoken_sync plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/90f2866163b6fb4ec7f533e8d4820089b804d707>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Show group-add/remove-member-manager failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c98d76042ca37c499b4751e305d86b4a85d9286>`__
-   `#8122 <https://pagure.io/freeipa/issue/8122>`__
+   `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
 -  Test installation with (fake) userspace FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cd2f4ee337595c7e39e00cfef5e99f5d87768c9>`__
-   `#8118 <https://pagure.io/freeipa/issue/8118>`__
+   `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__
 -  Use default ssh host key algorithms
    `commit <https://codeberg.org/freeipa/freeipa/commit/2422970c34849192b15d1798eae9b11a400e7119>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 
 
 
@@ -228,13 +228,13 @@ François Cami (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7a2c71742c62ce87d04b78542314b51247ba54c>`__
 -  ipatests/test_nfs.py: wait before umount
    `commit <https://codeberg.org/freeipa/freeipa/commit/c00ec940db5ec759e152a646a7ee10f73f31bdfb>`__
-   `#8144 <https://pagure.io/freeipa/issue/8144>`__
+   `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/62f0bd0bb8194b0998fca0e582725a6f63bc9154>`__
-   `#8148 <https://pagure.io/freeipa/issue/8148>`__
+   `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
 -  DSU: add Design for Disable Stale Users
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5be38a5bb4263a6e67552b5dd9b606aceec3d41>`__
-   `#8104 <https://pagure.io/freeipa/issue/8104>`__
+   `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__
 
 
 
@@ -243,10 +243,10 @@ Florence Blanc-Renaud (7)
 
 -  ipa-cacert-manage man page: fix indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/668a6410373c39508e5e4c95f11c9e62efa0135c>`__
-   `#8138 <https://pagure.io/freeipa/issue/8138>`__
+   `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb8da7d388b1ff4077a443c04dbbf440d8f76b06>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/b21128c2d7575c6eba6a52fa4448a9a2c7b56913>`__
 -  ipatests: fix test_crlgen_manage
@@ -255,10 +255,10 @@ Florence Blanc-Renaud (7)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab67e0ed35a7a9f23e1b61f61ec6503a3a97231d>`__
 -  ipatests: generic uninstall should call ipa server-del
    `commit <https://codeberg.org/freeipa/freeipa/commit/c77b06265bfb08d85bb4bd875cdb104ce239356d>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  Nightly definition: use right template for krbtpolicy
    `commit <https://codeberg.org/freeipa/freeipa/commit/04cfaa1861d4c88eab6b3d29fbb68e2ae2223214>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -279,7 +279,7 @@ Rob Crittenden (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7db2000e12b217126febb6bcaf11acfe52388926>`__
 -  Add integration test for Kerberos ticket policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc007eca9361709f65bb9da0a8cc101a0b978ef1>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -288,7 +288,7 @@ Sumit Bose (1)
 
 -  ipa-kdb: Remove keys if password auth is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/aaf8fccbb65e82d33c6e3675f3195163feb8af34>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -297,7 +297,7 @@ Sergey Orlov (1)
 
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cbf47ae668c1cdff64b91bb0cda272b1c93b99e>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 
 
 
@@ -314,10 +314,10 @@ Serhii Tsymbaliuk (2)
 
 -  WebUI: Fix notification area layout
    `commit <https://codeberg.org/freeipa/freeipa/commit/d26429ea285857b55a4c78b63eea436618a861f5>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/444df81a3de320ebfabfa90c3e6c7a17d986f1b1>`__
-   `#8123 <https://pagure.io/freeipa/issue/8123>`__
+   `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__
 
 
 

--- a/src/page/Releases/4.8.5.rst
+++ b/src/page/Releases/4.8.5.rst
@@ -8,10 +8,10 @@ for Fedora 30-32 versions will be available soon.
 Highlights in 4.8.5
 -------------------
 
--  `#8214 <https://pagure.io/freeipa/issue/8214>`__ openDNSSEC 2.1
+-  `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__ openDNSSEC 2.1
    support
 
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__ AJP connector
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__ AJP connector
    protection for Dogtag/FreeIPA communication for CVE-2020-1938
    mitigation. Fedora and RHEL do not force encrypted AJP connector by
    default with 9.0.31 but FreeIPA 4.8.5 will convert to encrypted AJP
@@ -22,7 +22,7 @@ Highlights in 4.8.5
    workshop,
    https://github.com/freeipa/freeipa-workshop/blob/master/11-kerberos-ticket-policy.rst
 
--  `#6891 <https://pagure.io/freeipa/issue/6891>`__ FreeIPA SELinux
+-  `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__ FreeIPA SELinux
    policy is now part of the upstream packaging and replaces
    distribution-wide policies.
 
@@ -30,7 +30,7 @@ Highlights in 4.8.5
    ipa-adtrust-install, to allow configuring schema compatibility plugin
    on remote replicas.
 
--  `#8124 <https://pagure.io/freeipa/issue/8124>`__ New
+-  `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__ New
    "ipa-cacert-manage delete" command to allow pruning a CA certificate
    from LDAP store
 
@@ -89,126 +89,126 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#6891 <https://pagure.io/freeipa/issue/6891>`__ Move FreeIPA SELinux
+-  `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__ Move FreeIPA SELinux
    policy from system policy to project policy
--  `#7522 <https://pagure.io/freeipa/issue/7522>`__ Disable cert
+-  `#7522 <https://codeberg.org/freeipa/freeipa/issues/7522>`__ Disable cert
    publishing in dogtag
--  `#7537 <https://pagure.io/freeipa/issue/7537>`__ PR-CI: external_ca
+-  `#7537 <https://codeberg.org/freeipa/freeipa/issues/7537>`__ PR-CI: external_ca
    tests are hitting timeout
--  `#7600 <https://pagure.io/freeipa/issue/7600>`__ Enable compat tree
+-  `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__ Enable compat tree
    to provide information about AD users and groups on trust agents
--  `#7630 <https://pagure.io/freeipa/issue/7630>`__ ipa-restore should
+-  `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__ ipa-restore should
    check that optional feature packages are installed before restoring a
    backup using a feature
--  `#7744 <https://pagure.io/freeipa/issue/7744>`__ ipa-replica-install
+-  `#7744 <https://codeberg.org/freeipa/freeipa/issues/7744>`__ ipa-replica-install
    picks wrong replica for CA initial replication
--  `#7830 <https://pagure.io/freeipa/issue/7830>`__ FreeIPA installation
+-  `#7830 <https://codeberg.org/freeipa/freeipa/issues/7830>`__ FreeIPA installation
    fails with 389-DS 1.4.0.20-1
--  `#7856 <https://pagure.io/freeipa/issue/7856>`__ Nightly test failure
+-  `#7856 <https://codeberg.org/freeipa/freeipa/issues/7856>`__ Nightly test failure
    in
    test_uninstallation.py::TestUninstallBase::()::test_failed_uninstall
--  `#7861 <https://pagure.io/freeipa/issue/7861>`__ Make IPADiscovery
+-  `#7861 <https://codeberg.org/freeipa/freeipa/issues/7861>`__ Make IPADiscovery
    available in PyPI packages
--  `#7909 <https://pagure.io/freeipa/issue/7909>`__ Wrong evaluation of
+-  `#7909 <https://codeberg.org/freeipa/freeipa/issues/7909>`__ Wrong evaluation of
    replication update status
--  `#7917 <https://pagure.io/freeipa/issue/7917>`__ Occasional
+-  `#7917 <https://codeberg.org/freeipa/freeipa/issues/7917>`__ Occasional
    'whoami.data is undefined' error in FreeIPA web UI
--  `#7938 <https://pagure.io/freeipa/issue/7938>`__ 'ipa
+-  `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__ 'ipa
    dnszone-show/find' should display "Dynamic Update" and "Bind update
    policy" by default
--  `#7941 <https://pagure.io/freeipa/issue/7941>`__
+-  `#7941 <https://codeberg.org/freeipa/freeipa/issues/7941>`__
    ipapython/dn_ctypes.py: libldap_r shared library missing
--  `#7942 <https://pagure.io/freeipa/issue/7942>`__ WebUI test for
+-  `#7942 <https://codeberg.org/freeipa/freeipa/issues/7942>`__ WebUI test for
    automount is broken
--  `#7948 <https://pagure.io/freeipa/issue/7948>`__ [FIPS] Use 3DES for
+-  `#7948 <https://codeberg.org/freeipa/freeipa/issues/7948>`__ [FIPS] Use 3DES for
    certificate encryption when creating a PKCS#12
--  `#7953 <https://pagure.io/freeipa/issue/7953>`__ ipa-pwd-extop: do
+-  `#7953 <https://codeberg.org/freeipa/freeipa/issues/7953>`__ ipa-pwd-extop: do
    not remove MagicRegen mod, replace it
--  `#7965 <https://pagure.io/freeipa/issue/7965>`__ Stop using 389-ds
+-  `#7965 <https://codeberg.org/freeipa/freeipa/issues/7965>`__ Stop using 389-ds
    legacy tools for backup and restore
--  `#7974 <https://pagure.io/freeipa/issue/7974>`__ Nightly test failure
+-  `#7974 <https://codeberg.org/freeipa/freeipa/issues/7974>`__ Nightly test failure
    in
    ipatests.test_integration.test_user_permissions.TestUserPermissions
--  `#7984 <https://pagure.io/freeipa/issue/7984>`__ make sure 'make
+-  `#7984 <https://codeberg.org/freeipa/freeipa/issues/7984>`__ make sure 'make
    fastlint' processes Python .in files
--  `#7987 <https://pagure.io/freeipa/issue/7987>`__ Python shebang: Use
+-  `#7987 <https://codeberg.org/freeipa/freeipa/issues/7987>`__ Python shebang: Use
    isolated mode
--  `#7989 <https://pagure.io/freeipa/issue/7989>`__ Pytest4.2+ errors
--  `#7990 <https://pagure.io/freeipa/issue/7990>`__ Assumptions about
+-  `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__ Pytest4.2+ errors
+-  `#7990 <https://codeberg.org/freeipa/freeipa/issues/7990>`__ Assumptions about
    systemd name of \`named\`
--  `#7998 <https://pagure.io/freeipa/issue/7998>`__ Use system-wide
+-  `#7998 <https://codeberg.org/freeipa/freeipa/issues/7998>`__ Use system-wide
    crypto policy in TLS client
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8004 <https://pagure.io/freeipa/issue/8004>`__ RHEL 8 uses
+-  `#8004 <https://codeberg.org/freeipa/freeipa/issues/8004>`__ RHEL 8 uses
    nis-domainname instead of rhel-domainname
--  `#8029 <https://pagure.io/freeipa/issue/8029>`__ ipa host-find
+-  `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__ ipa host-find
    --pkey-only includes SSH keys in output
--  `#8079 <https://pagure.io/freeipa/issue/8079>`__ [Security] By
+-  `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__ [Security] By
    default, DNS recursion is open, breaking best practices
--  `#8098 <https://pagure.io/freeipa/issue/8098>`__ Host principals lack
+-  `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__ Host principals lack
    ACI to look up DNS objects in LDAP
--  `#8105 <https://pagure.io/freeipa/issue/8105>`__ getcert with -F
+-  `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__ getcert with -F
    option returns before cacert file is created
--  `#8110 <https://pagure.io/freeipa/issue/8110>`__ Enable AES SHA 256
+-  `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__ Enable AES SHA 256
    and 384 Kerberos enctypes
--  `#8116 <https://pagure.io/freeipa/issue/8116>`__ Pylint parallel
+-  `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__ Pylint parallel
    execution with custom plugin
--  `#8124 <https://pagure.io/freeipa/issue/8124>`__ Add option to
+-  `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__ Add option to
    ipa-cacert-manage to delete certificates
--  `#8135 <https://pagure.io/freeipa/issue/8135>`__ When Service weight
+-  `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__ When Service weight
    is set as 0 for server in IPA location "IPA Error 903: InternalError"
    is displayed
--  `#8142 <https://pagure.io/freeipa/issue/8142>`__ check Not Before /
+-  `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__ check Not Before /
    Not After in externally signed CA sanity check
--  `#8149 <https://pagure.io/freeipa/issue/8149>`__ SIDs of AD domains
+-  `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__ SIDs of AD domains
    do not display in ipa-client-samba installer
--  `#8150 <https://pagure.io/freeipa/issue/8150>`__ IPA Server install
+-  `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__ IPA Server install
    fail
--  `#8151 <https://pagure.io/freeipa/issue/8151>`__ test_commands
+-  `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__ test_commands
    timing-out
--  `#8153 <https://pagure.io/freeipa/issue/8153>`__ Kerberos ticket
+-  `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__ Kerberos ticket
    policy reset does not reset per-indicator policies
--  `#8157 <https://pagure.io/freeipa/issue/8157>`__ NIghtly test failure
+-  `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__ NIghtly test failure
    in fedora-rawhide/test_webui_network
--  `#8163 <https://pagure.io/freeipa/issue/8163>`__ "Internal Server
+-  `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__ "Internal Server
    Error" reported for minor issues implies IPA is broken
    [IdmHackfest2019]
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__ Renewed certs are
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__ Renewed certs are
    not picked up by IPA CAs
--  `#8169 <https://pagure.io/freeipa/issue/8169>`__ NIghtly test failure
+-  `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__ NIghtly test failure
    in fedora-rawhide/test_webui_policy
--  `#8170 <https://pagure.io/freeipa/issue/8170>`__ Nightly test failure
+-  `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__ Nightly test failure
    in
    fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNS
--  `#8173 <https://pagure.io/freeipa/issue/8173>`__ Broken -k argument
+-  `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__ Broken -k argument
    parsing in ipa-run-tests 4.8.4-1 package
--  `#8176 <https://pagure.io/freeipa/issue/8176>`__ External CA is
+-  `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__ External CA is
    tracked for renewals and replaced with a self-signed certificate
--  `#8179 <https://pagure.io/freeipa/issue/8179>`__ Tests broken with
+-  `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__ Tests broken with
    python version < 3.7 (module 're' has no attribute 'Pattern')
--  `#8190 <https://pagure.io/freeipa/issue/8190>`__ ipa-client-automount
+-  `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__ ipa-client-automount
    fails after repeated installation/uninstallation
--  `#8192 <https://pagure.io/freeipa/issue/8192>`__ ipa-adtrust-install
+-  `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__ ipa-adtrust-install
    does not list service records for manual addition to DNS zone
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__ Re-order
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__ Re-order
    50-externalmembers.update to be after 80-schema_compat.update
--  `#8196 <https://pagure.io/freeipa/issue/8196>`__ API: dnsrecord_del
+-  `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__ API: dnsrecord_del
    failure with empty list aaaarecord
--  `#8200 <https://pagure.io/freeipa/issue/8200>`__ ipa krb5kdc db:
+-  `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__ ipa krb5kdc db:
    krb5kdc coredump
--  `#8201 <https://pagure.io/freeipa/issue/8201>`__ update
+-  `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__ update
    ssbrowser.html
--  `#8202 <https://pagure.io/freeipa/issue/8202>`__ Azure: add support
+-  `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__ Azure: add support
    for multi-container tests
--  `#8214 <https://pagure.io/freeipa/issue/8214>`__ Support for
+-  `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__ Support for
    opendnssec 2.1.6
--  `#8219 <https://pagure.io/freeipa/issue/8219>`__ ipatests: unify
+-  `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__ ipatests: unify
    editing of sssd.conf
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__ Secure AJP connector
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__ Secure AJP connector
    between Dogtag and Apache proxy
--  `#8226 <https://pagure.io/freeipa/issue/8226>`__ ipa-restore does not
+-  `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__ ipa-restore does not
    restart httpd
 
 
@@ -227,7 +227,7 @@ Armando Neto (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/59593194d3eaf646ae757b88dc8a9231c21301c2>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
    `commit <https://codeberg.org/freeipa/freeipa/commit/011734279c37ca1e9a013694525563b4e77ace78>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: Improve test_commands reliability
    `commit <https://codeberg.org/freeipa/freeipa/commit/5431dd9706253ea7cd75f62f5cd387bbf25ac878>`__
 
@@ -244,27 +244,27 @@ Alexander Bokovoy (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b598982520891d2907070101c8953019613a4694>`__
 -  Secure AJP connector between Dogtag and Apache proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4d8b98c3588b212db6a26610e690cccb3af84ca>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Tighten permissions on PKI proxy configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/1deb1010b245df6c363c5655f9a548bdf4dbc040>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
    `commit <https://codeberg.org/freeipa/freeipa/commit/4eb48492b354ecc30ffe1dd9654dcc0e0e833d64>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
    `commit <https://codeberg.org/freeipa/freeipa/commit/30b8c8b9985a5eb41e700b80fd03f95548e45fba>`__
-   `#8200 <https://pagure.io/freeipa/issue/8200>`__
+   `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/936e27f75961c67e619ecfa641e256ce80662d68>`__
-   `#8192 <https://pagure.io/freeipa/issue/8192>`__
+   `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__
 -  Update Azure Pipelines to use Fedora 31
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4e2acd1333f0f3d88da81d3fda80e85c9c418c2>`__
 -  install/updates: move external members past schema compat update
    `commit <https://codeberg.org/freeipa/freeipa/commit/14dbf04148c6284b176eca34aa70df4bef09b857>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Reset per-indicator Kerberos policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8b52eaf3cf56c90e3d94fdef0b9e426052634ea>`__
-   `#8153 <https://pagure.io/freeipa/issue/8153>`__
+   `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__
 
 
 
@@ -294,7 +294,7 @@ Anuja More (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b19749a3769bbac5f11aa901bf6291b6240dddb>`__
 -  Add integration test for otp kerberos ticket policy.
    `commit <https://codeberg.org/freeipa/freeipa/commit/27a6920d50e5d63afbfc198e64885a2cd3fadc48>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  ipatests: filter_users should be applied correctly.
    `commit <https://codeberg.org/freeipa/freeipa/commit/71a4d574bd94eda3cb7490a2254ce764fe9bcdb1>`__
 
@@ -305,20 +305,20 @@ Christian Heimes (7)
 
 -  Allow hosts to read DNS records for IP SAN
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4a611aee8ca839c59798210b56e65f21a24e965>`__
-   `#8098 <https://pagure.io/freeipa/issue/8098>`__
+   `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__
 -  Cleanup SELinux policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/87e0d82dd4409cdecaacee1fa27d27033aa65f7a>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate SELinux policy into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/18ce2033c04aed2c4a34f61b9ee3642b01f53017>`__
 -  dnsrecord: Treat empty list arguments correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ade60ac63ff9a626ae1ec17196121fe694ee212>`__
-   `#8196 <https://pagure.io/freeipa/issue/8196>`__
+   `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__
 -  Remove dependency on custodia package
    `commit <https://codeberg.org/freeipa/freeipa/commit/b240b54bb4ff160851c7681914eb210934ae2abc>`__
 -  Make assert_error compatible with Python 3.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9ed8e78454f12fcfc3d0484dd36995cbef65961>`__
-   `#8179 <https://pagure.io/freeipa/issue/8179>`__
+   `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__
 -  Print LDAP diagnostic messages on error
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fe1f7701a616c17167f75e1e81f3a479a2ee50f>`__
 
@@ -337,21 +337,21 @@ François Cami (5)
 
 -  ipa-restore: restart services at the end
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d6a609d6e55dc11b4768ee54da46393228660f9>`__
-   `#8226 <https://pagure.io/freeipa/issue/8226>`__
+   `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ae804c726970ae467a7f76efa21bae40405551d>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipa-client-automount: call save_domain() for each change
    `commit <https://codeberg.org/freeipa/freeipa/commit/6332aed9ba67e2ee759a9d988ba92139486469d4>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/578bdce292c142b7fca6e237ccb3f5cec641e618>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3cff5d152fc36802f7ddfcd0730696e154d1b4c>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 
 
 
@@ -360,52 +360,52 @@ Florence Blanc-Renaud (16)
 
 -  opendnssec2.1 support: move all ods tasks to specific file
    `commit <https://codeberg.org/freeipa/freeipa/commit/799ebc8be681165e622778848a9b2989434a29dd>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
    `commit <https://codeberg.org/freeipa/freeipa/commit/598c55cc0dc884aa780ac2dc2f3adfd8299e6ea0>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc4ccfa5c3a7ecd7c9e5539595e0440965d62336>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  With opendnssec 2, read the zone list from file
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cb3b11a61d5b9b7df93130188c7feef83398090>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Remove the from opendnssec conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5716c3b78f43391d2ab7b4b1fd672135f3b55bdb>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support opendnssec 2.1.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/23993f58e1da98e537b03b9274d91308cbc63a6c>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/df0df14bf31dba5800747aa08824b24b8be41eab>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/21c923c4cf21f30f20ec4b21c488db6f6fa92b67>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/c444f7a35ada0dcb4f565557b7c71f3644fdd446>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/4afd6e5e07061dde6e30b5352668bdf23cd6dedd>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/5edc674e7262ce4506c40b8c066207f9e5f55c33>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
    `commit <https://codeberg.org/freeipa/freeipa/commit/66154f8bf79584b8fa6792e3d2ca534900dfa481>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a5bfaba83da700bed29fc82ef1d280bfabb8379>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  ipatests: fix modify_sssd_conf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e527507c0971ed1a8468e10246232491b1ef36c>`__
 -  ipatests: fix backup and restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b7cf51e292b917a18ec7959708cb62ceddd44b7>`__
-   `#8170 <https://pagure.io/freeipa/issue/8170>`__
+   `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__
 -  AD user without override receive InternalServerError with API
    `commit <https://codeberg.org/freeipa/freeipa/commit/4db18be5467c0b8f7633b281c724f469f907e573>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 
 
 
@@ -414,16 +414,16 @@ Fraser Tweedale (4)
 
 -  Do not renew externally-signed CA as self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b5513660cb73ee685e09c4f84634ac9d1fa792d>`__
-   `#8176 <https://pagure.io/freeipa/issue/8176>`__
+   `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
    `commit <https://codeberg.org/freeipa/freeipa/commit/25310105da0540eb84b6d0ee4c30649750583703>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix test regressions caused by certificate validation changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/d833b5ba607f79a495e0245722e8ccef7cefbd7a>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  ipatests: assert_error: allow regexp match
    `commit <https://codeberg.org/freeipa/freeipa/commit/44fca092ead0316084d68917032e28e5cbb20ad4>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 
 
 
@@ -462,7 +462,7 @@ Kaleemullah Siddiqui (1)
 
 -  Tests for backup-restore when pkg required is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ced5532576779ee7bb2e7f15ff4b5039ba4daba>`__
-   `#7630 <https://pagure.io/freeipa/issue/7630>`__
+   `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__
 
 
 
@@ -471,19 +471,19 @@ Mohammad Rizwan Yusuf (6)
 
 -  Test if getcert creates cacert file with -F option
    `commit <https://codeberg.org/freeipa/freeipa/commit/937fb1d9518c54bf9c05bc0b7d6f43b29971eb3c>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Move wait_for_request() method to tasks.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d8d9198ce1ddfd44eb7c0268c397359e6239fca>`__
 -  Test if server installer lock Bind9 recursion
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fbbd02b0e8bc5e4f196e8d26ecfa8c989dadabb>`__
-   `#8079 <https://pagure.io/freeipa/issue/8079>`__
+   `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
 -  Add certmonger wait_for_request that uses run_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/84ae778c8731b0934e011155b668acbb97d775c2>`__
 -  Test if certmonger reads the token in HSM
    `commit <https://codeberg.org/freeipa/freeipa/commit/eaf9e79c8000118317527caad4cf6aa521fd0028>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/61577c851e81beabc65e5b96603b88e9f7ec973b>`__
-   `#8110 <https://pagure.io/freeipa/issue/8110>`__
+   `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
 
 
 
@@ -494,22 +494,22 @@ Rob Crittenden (7)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f36b8697a1d7dcf0f698147b3791c8ed338863d7>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
    `commit <https://codeberg.org/freeipa/freeipa/commit/12d6864b6dc30155414e2483f7634684ccc9ee3e>`__
-   `#8135 <https://pagure.io/freeipa/issue/8135>`__
+   `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/f356d5734662d0a20f06702353b2f10f29b9f55d>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  Add tests for ipa-cacert-manage delete command
    `commit <https://codeberg.org/freeipa/freeipa/commit/78827db1aa561613d3fb40f39525f7e8fcae2b98>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d81a3458c266a1e0c4baa07717aac110c435e59>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/37f81cc566cc37a47b7d1b0d900a53273eae01ac>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d7d58d8214f3c899c0afd1a3a6a6678f38b7b39>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 
 
 
@@ -550,55 +550,55 @@ Stanislav Levin (24)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fbdb1357ca3e861bba14d21ceb6e2a6e753a14c>`__
 -  pylint: Run Pylint over Azure Python scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fff86757cfc7a78db33801e3c75e208b01660f7>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Add support for testing multi IPA environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/245a9dc93f086b685b09984ea4a3395b93fd5789>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
    `commit <https://codeberg.org/freeipa/freeipa/commit/685d902ca4cf10c8c440036016c2dd3e05d76222>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  yamllint: Lint all the YAML files
    `commit <https://codeberg.org/freeipa/freeipa/commit/2988f5f30c9379f8ac7cbfc56af382f2779479cf>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
    `commit <https://codeberg.org/freeipa/freeipa/commit/198cd506592c8dc078e7956a42d0d4e0342cf86d>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to run integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/d33b7d61fc8e012ecfd0354a6d3431301a66d768>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow SSH for Docker environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a6e3f2339c5773f051aaea08922f6853ef5942d>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to not provide tests to be ignored
    `commit <https://codeberg.org/freeipa/freeipa/commit/11d145300dcd1b9b986f259efa57eddcca9b2e32>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  ipatests: Allow zero-length arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/c35c066a6d7b7a493e22a4af3043d5d2a72133d4>`__
-   `#8173 <https://pagure.io/freeipa/issue/8173>`__
+   `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__
 -  lint: Make Pylint-2.4 happy again
    `commit <https://codeberg.org/freeipa/freeipa/commit/44a59ff39a3f481e90043e546c892c9108231d67>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Clean up comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f48848562f4e9ab9584154fd85e6ad1ac331ecd>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
    `commit <https://codeberg.org/freeipa/freeipa/commit/3460db4ee7c7ce6c9a639a644a39c4df09ce31ac>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Teach Pylint how to handle request.context
    `commit <https://codeberg.org/freeipa/freeipa/commit/5939c90752db9da1adaf8c0bfe6bec3d6c1e2ad6>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  ipatests: Properly kill gpg-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/294694ad69fa909e2f699cb2dad0f36b966a246f>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3659b46d6aeea06b4875860ec69a9215afcbdd91>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/356f907fc255ab3a9f93ff2808646b92a6652aec>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/87bc31464b6133af9befd412af54403665c22628>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 
 
 
@@ -611,20 +611,20 @@ Sergey Orlov (9)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d416a5a5ceaaf3fff9df423cea9114f1918aad2>`__
 -  ipatests: remove invalid parameter from sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1695722125674204b6e880b6ac652d78b783c88>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/32584ed34f466e8f474e22d778e3e964d0fcd2c4>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: replace utility for editing sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ff9b6e2a506c3ef1179655ae2d2e479005ec99e>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cb8984112ff31721b71dcdd4febcc23c2641691>`__
 -  ipatests: add test_trust suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ff0ab85a8b1d90fb94e09bdbb3e9eeeb11d191a>`__
 -  ipatests: add check for output contents of ipa-client-samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/577dd1e47a092cf7e4527707111d28297bb58f53>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/72e1b135b3862a16df4e8b5a1a7c2bbfcd5b08c9>`__
 
@@ -636,7 +636,7 @@ Sumedh Sidhaye (1)
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
    `commit <https://codeberg.org/freeipa/freeipa/commit/2cd67d5a9a22c009f050e493d4b3e2882dbfd81f>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 
 
 
@@ -646,10 +646,10 @@ Serhii Tsymbaliuk (2)
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e1d27c22a90d579a9019829f8ffd0bed51c2e5f>`__
-   `#8157 <https://pagure.io/freeipa/issue/8157>`__
+   `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/664eed7d0885791a3b16ad082d56f9a14682673e>`__
-   `#8169 <https://pagure.io/freeipa/issue/8169>`__
+   `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__
 
 
 
@@ -673,7 +673,7 @@ Thomas Woerner (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b5dc6a29e5e1893f9ec864bdde1f769ad6efc39>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c2cef7063315766d893b275185b422be3f3c019>`__
-   `#8150 <https://pagure.io/freeipa/issue/8150>`__
+   `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__
 
 
 

--- a/src/page/Releases/4.8.6.rst
+++ b/src/page/Releases/4.8.6.rst
@@ -110,30 +110,30 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#5662 <https://pagure.io/freeipa/issue/5662>`__ ID Views: do not
+-  `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__ ID Views: do not
    allow custom Views for the masters
--  `#6891 <https://pagure.io/freeipa/issue/6891>`__ Move FreeIPA SELinux
+-  `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__ Move FreeIPA SELinux
    policy from system policy to project policy
--  `#7181 <https://pagure.io/freeipa/issue/7181>`__ ipa-replica-prepare
+-  `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__ ipa-replica-prepare
    fails for 2nd replica when passwordHistory is enabled
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__ ipa trust
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__ ipa trust
    fetch-domains, server parameter ignored
--  `#8159 <https://pagure.io/freeipa/issue/8159>`__ please migrate to
+-  `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__ please migrate to
    the new Fedora translation platform
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__ Re-order
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__ Re-order
    50-externalmembers.update to be after 80-schema_compat.update
--  `#8228 <https://pagure.io/freeipa/issue/8228>`__ Nightly failure in
+-  `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__ Nightly failure in
    backup/restore while calling 'id admin'
--  `#8233 <https://pagure.io/freeipa/issue/8233>`__ 4.8.5 master
+-  `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__ 4.8.5 master
    Installation error
--  `#8236 <https://pagure.io/freeipa/issue/8236>`__ Enforce a check to
+-  `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__ Enforce a check to
    prevent adding objects from IPA as external members of external
    groups
--  `#8239 <https://pagure.io/freeipa/issue/8239>`__ Actualize Bootstrap
+-  `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__ Actualize Bootstrap
    version
--  `#8240 <https://pagure.io/freeipa/issue/8240>`__ KRA install fails if
+-  `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__ KRA install fails if
    all KRA members are Hidden Replicas
--  `#8241 <https://pagure.io/freeipa/issue/8241>`__ Build fails on
+-  `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__ Build fails on
    Fedora 30
 
 
@@ -151,23 +151,23 @@ Alexander Bokovoy (35)
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/bcbf64b1bf287d2b0b23bc7ac0cca9e8b789ba4a>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bae736bc81eaa1167ec64a69a32506dad2ca286>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/313542e8a125c4904750826ef9eabdead7d874bd>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4dc10b8caac44f5c2a8edbb4c647e6dcf71c3bd>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  Fix indentation levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/c62b9e7f6ab0dec54540dc6cd389fe58f8858275>`__
 -  ipatests: always skip additional input for group-add-member
    --external
    `commit <https://codeberg.org/freeipa/freeipa/commit/74f36e7c2f7f6d17b56e06b5f05205edb8a286d7>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  po: update Chinese (China) translation
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6adee04068ce946f8c9b8ad5db19721db13c602>`__
 -  po: update Ukrainian translation
@@ -220,13 +220,13 @@ Alexander Bokovoy (35)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e23ba779d3aefd871e348b91e7b0fa003d97c96e>`__
 -  Update translation infrastructure
    `commit <https://codeberg.org/freeipa/freeipa/commit/831f4dd320a93d01df6b06058c3ab618a98c9fd8>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Keep ipa.pot translation file in git for weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ff7b4a411d13ca148d2f53603dbcc812d92380a>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Prevent adding IPA objects as external members of external groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/127b8d9cf23bf65aa42e6ee9ed8d7f8628bbac19>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 
 
 
@@ -235,18 +235,18 @@ Christian Heimes (5)
 
 -  po: fix LINGUAS to use whitespace separation
    `commit <https://codeberg.org/freeipa/freeipa/commit/616ad399c99292542638e9e8f0995873e5c4f311>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  SELinux: apache_manage_pid_files for F30
    `commit <https://codeberg.org/freeipa/freeipa/commit/f08ced1b25e14f91526c82610a8219ae8ed898a3>`__
-   `#8241 <https://pagure.io/freeipa/issue/8241>`__
+   `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__
 -  Add pytest OpenSSH transport with password
    `commit <https://codeberg.org/freeipa/freeipa/commit/42aa86fadd7a7f2209e05291be9c76a8497998dd>`__
 -  Move freeipa-selinux dependency to freeipa-common
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d525ab4308060435808a311de55a76fb26a28c6>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate ipa_custodia policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/04cc0450125e3c9e989c3e769a25ba2f1f336060>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 
 
 
@@ -255,7 +255,7 @@ François Cami (1)
 
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/a692212e3bee36fbccba73ed21f7825381eeade4>`__
-   `#8240 <https://pagure.io/freeipa/issue/8240>`__
+   `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__
 
 
 
@@ -264,13 +264,13 @@ Florence Blanc-Renaud (3)
 
 -  ipatests: wait for SSSD to become online in backup/restore tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebb3c22ddb998997eb05e7bd4da2157e88b6c8f3>`__
-   `#8228 <https://pagure.io/freeipa/issue/8228>`__
+   `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/c37a84628601d369f83546085b7e29be8fe11a59>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  idviews: prevent applying to a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/7905891341197cb90faf635cf93ce63ae7a7a38b>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 
 
 
@@ -281,10 +281,10 @@ Mohammad Rizwan Yusuf (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/45507c1e86b634507fdc21dbb88ea9edd43e4166>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f3fa403a944035cf5531939fe3a2e338da99612>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/210619a98f0d8a042a181bab5891bdd595aa5351>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 
 
 
@@ -307,7 +307,7 @@ Stanislav Levin (1)
 
 -  pki-proxy: Don't rely on running apache until it's configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ea3c9f2df757b3d714044c16083716e377ca>`__
-   `#8233 <https://pagure.io/freeipa/issue/8233>`__
+   `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__
 
 
 
@@ -316,7 +316,7 @@ Sergey Orlov (2)
 
 -  ipatests: provide AD admin password when trying to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/814b47e85c87bc3c80c91ebd0aa9085ac06b521e>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  ipatests: remove test_ordering
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e9b020db201ff5797f0dabff05c3fc16a9bf79a>`__
 
@@ -327,7 +327,7 @@ Serhii Tsymbaliuk (1)
 
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1855dd51e1544a77f1b4a3d4c90f173c29fbed4>`__
-   `#8239 <https://pagure.io/freeipa/issue/8239>`__
+   `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__
 
 
 
@@ -345,4 +345,4 @@ Vit Mojzis (1)
 
 -  selinux: disable ipa_custodia when installing custom policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/f99cfa1443dfa33422eb4a7613d3dd9e921ccacd>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__

--- a/src/page/Releases/4.8.7.rst
+++ b/src/page/Releases/4.8.7.rst
@@ -243,178 +243,178 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#3687 <https://pagure.io/freeipa/issue/3687>`__
+-  `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
    (`rhbz#913799 <https://bugzilla.redhat.com/show_bug.cgi?id=913799>`__)
    [RFE] IPA user account expiry warning.
--  `#3827 <https://pagure.io/freeipa/issue/3827>`__ [RFE] Expose TTL in
+-  `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__ [RFE] Expose TTL in
    web UI
--  `#6474 <https://pagure.io/freeipa/issue/6474>`__ Remove ipaplatform
+-  `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__ Remove ipaplatform
    dependency from ipa modules
--  `#6783 <https://pagure.io/freeipa/issue/6783>`__
+-  `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
    (`rhbz#1430365 <https://bugzilla.redhat.com/show_bug.cgi?id=1430365>`__)
    [RFE] Host-group names command rename
--  `#6857 <https://pagure.io/freeipa/issue/6857>`__ ipa_pwd.c: Use
+-  `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__ ipa_pwd.c: Use
    OpenSSL instead of NSS for hashing
--  `#6884 <https://pagure.io/freeipa/issue/6884>`__
+-  `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
    (`rhbz#1441262 <https://bugzilla.redhat.com/show_bug.cgi?id=1441262>`__)
    ipa group-del gives ipa: ERROR: Insufficient access: but still
    deletes group
--  `#7255 <https://pagure.io/freeipa/issue/7255>`__
+-  `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
    baseidoverride.get_dn() does not default to a default ID view when
    resolving user IDs
--  `#7577 <https://pagure.io/freeipa/issue/7577>`__
+-  `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
    (`rhbz#1579296 <https://bugzilla.redhat.com/show_bug.cgi?id=1579296>`__)
    [RFE] DNS package check should be called earlier in installation
    routine
--  `#7695 <https://pagure.io/freeipa/issue/7695>`__
+-  `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
    (`rhbz#1623763 <https://bugzilla.redhat.com/show_bug.cgi?id=1623763>`__)
    ipa service-del should display principal name instead of Invalid
    'principal'.
--  `#8017 <https://pagure.io/freeipa/issue/8017>`__
+-  `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
    (`rhbz#1817927 <https://bugzilla.redhat.com/show_bug.cgi?id=1817927>`__)
    host-add --password logs cleartext userpassword to Apache error log
--  `#8064 <https://pagure.io/freeipa/issue/8064>`__ Request for IPA CI
+-  `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__ Request for IPA CI
    to enable DS audit/auditfail logging
--  `#8066 <https://pagure.io/freeipa/issue/8066>`__
+-  `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
    (`rhbz#1750242 <https://bugzilla.redhat.com/show_bug.cgi?id=1750242>`__)
    Don't use -t option to klist in adtrust code when timestamp is not
    needed
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
    (`rhbz#1756432 <https://bugzilla.redhat.com/show_bug.cgi?id=1756432>`__)
    Default client configuration breaks ssh in FIPS mode.
--  `#8101 <https://pagure.io/freeipa/issue/8101>`__ Wrong pytest
+-  `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__ Wrong pytest
    requirement in specfile
--  `#8106 <https://pagure.io/freeipa/issue/8106>`__ ca-certificate file
+-  `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__ ca-certificate file
    not being parsed correctly on Ubuntu with p11-kit-trust.so due to
    data inserted by FreeIPA Client install
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
    (`rhbz#1769791 <https://bugzilla.redhat.com/show_bug.cgi?id=1769791>`__)
    Invisible part of notification area in Web UI intercepts clicks of
    some page elements
--  `#8159 <https://pagure.io/freeipa/issue/8159>`__ please migrate to
+-  `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__ please migrate to
    the new Fedora translation platform
--  `#8163 <https://pagure.io/freeipa/issue/8163>`__
+-  `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
    (`rhbz#1782572 <https://bugzilla.redhat.com/show_bug.cgi?id=1782572>`__)
    "Internal Server Error" reported for minor issues implies IPA is
    broken [IdmHackfest2019]
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
    (`rhbz#1788907 <https://bugzilla.redhat.com/show_bug.cgi?id=1788907>`__)
    Renewed certs are not picked up by IPA CAs
--  `#8186 <https://pagure.io/freeipa/issue/8186>`__ Add ipa-ca.$DOMAIN
+-  `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__ Add ipa-ca.$DOMAIN
    alias to IPA server HTTP certificates
--  `#8217 <https://pagure.io/freeipa/issue/8217>`__
+-  `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
    (`rhbz#1810154 <https://bugzilla.redhat.com/show_bug.cgi?id=1810154>`__)
    RFE: ipa-backup should compare locally and globally installed server
    roles
--  `#8222 <https://pagure.io/freeipa/issue/8222>`__ Upgrade dojo.js
--  `#8247 <https://pagure.io/freeipa/issue/8247>`__ test_fips PR-CI
+-  `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__ Upgrade dojo.js
+-  `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__ test_fips PR-CI
    templates have a too-short timeout
--  `#8251 <https://pagure.io/freeipa/issue/8251>`__ [Azure] Catch
+-  `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__ [Azure] Catch
    coredumps
--  `#8254 <https://pagure.io/freeipa/issue/8254>`__ [Azure] 'Tox' task
+-  `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__ [Azure] 'Tox' task
    fails against Python3.8
--  `#8261 <https://pagure.io/freeipa/issue/8261>`__ [ipatests]
+-  `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__ [ipatests]
    Integration tests fail on non-firewalld distros
--  `#8262 <https://pagure.io/freeipa/issue/8262>`__ test_ipahealthcheck
+-  `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__ test_ipahealthcheck
    needs a higher timeout than 3600
--  `#8264 <https://pagure.io/freeipa/issue/8264>`__ Nightly test failure
+-  `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__ Nightly test failure
    in
    test_integration.test_commands.TestIPACommand.test_hbac_systemd_user
--  `#8265 <https://pagure.io/freeipa/issue/8265>`__ [ipatests]
+-  `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__ [ipatests]
    \`/var/log/ipaupgrade.log\` is not collected
--  `#8266 <https://pagure.io/freeipa/issue/8266>`__ test_webui_server
+-  `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__ test_webui_server
    requires a higher timeout than 3600
--  `#8268 <https://pagure.io/freeipa/issue/8268>`__ Prevent use of too
+-  `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__ Prevent use of too
    long passwords
--  `#8272 <https://pagure.io/freeipa/issue/8272>`__ Use /run instead of
+-  `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__ Use /run instead of
    /var/run
--  `#8273 <https://pagure.io/freeipa/issue/8273>`__
+-  `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
    (`rhbz#1834385 <https://bugzilla.redhat.com/show_bug.cgi?id=1834385>`__)
    Man page syntax issue detected by rpminspect
--  `#8276 <https://pagure.io/freeipa/issue/8276>`__ Add default password
+-  `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__ Add default password
    policy for sysaccounts
--  `#8283 <https://pagure.io/freeipa/issue/8283>`__ Failures and AVCs
+-  `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__ Failures and AVCs
    with OpenDNSSEC 2.1
--  `#8284 <https://pagure.io/freeipa/issue/8284>`__ Upgrade jQuery
+-  `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__ Upgrade jQuery
    version to actual one
--  `#8287 <https://pagure.io/freeipa/issue/8287>`__ named not starting
+-  `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__ named not starting
    after #8079, ipa-ext.conf breaks bind
--  `#8289 <https://pagure.io/freeipa/issue/8289>`__ ipa
+-  `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__ ipa
    servicedelegationtarget-add-member does not allow to add hosts as
    targets
--  `#8290 <https://pagure.io/freeipa/issue/8290>`__ API inconsistencies
--  `#8291 <https://pagure.io/freeipa/issue/8291>`__ krb5kdc crashes in
+-  `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__ API inconsistencies
+-  `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__ krb5kdc crashes in
    IPA plugin on use of IPA Windows principal alias
--  `#8297 <https://pagure.io/freeipa/issue/8297>`__ Fix new pylint 2.5.0
+-  `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__ Fix new pylint 2.5.0
    warnings and errors
--  `#8298 <https://pagure.io/freeipa/issue/8298>`__ [WebUI] Cover
+-  `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__ [WebUI] Cover
    membership management with UI tests
--  `#8300 <https://pagure.io/freeipa/issue/8300>`__ Replace uglify-js
+-  `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__ Replace uglify-js
    with python3-rjsmin
--  `#8301 <https://pagure.io/freeipa/issue/8301>`__ The value of the
+-  `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__ The value of the
    first character in target\* keywords is expected to be a double quote
--  `#8306 <https://pagure.io/freeipa/issue/8306>`__ Adopt Black code
+-  `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__ Adopt Black code
    style
--  `#8307 <https://pagure.io/freeipa/issue/8307>`__ make devcheck fails
+-  `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__ make devcheck fails
    for test_ipatests_plugins/test_ipa_run_tests.py
--  `#8308 <https://pagure.io/freeipa/issue/8308>`__
+-  `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
    (`rhbz#1829787 <https://bugzilla.redhat.com/show_bug.cgi?id=1829787>`__)
    ipa service-del deletes the required principal when specified in
    lower/upper case
--  `#8309 <https://pagure.io/freeipa/issue/8309>`__ Convert ipaplatform
+-  `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__ Convert ipaplatform
    from namespace package to regular package
--  `#8311 <https://pagure.io/freeipa/issue/8311>`__
+-  `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
    (`rhbz#1825829 <https://bugzilla.redhat.com/show_bug.cgi?id=1825829>`__)
    ipa-advise on a RHEL7 IdM server generate a configuration script for
    client having hardcoded python3
--  `#8312 <https://pagure.io/freeipa/issue/8312>`__ Fix api.env.in_tree
+-  `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__ Fix api.env.in_tree
    detection logic
--  `#8313 <https://pagure.io/freeipa/issue/8313>`__ Values of
+-  `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__ Values of
    api.env.mode are inconsistent
--  `#8315 <https://pagure.io/freeipa/issue/8315>`__
+-  `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
    (`rhbz#1833266 <https://bugzilla.redhat.com/show_bug.cgi?id=1833266>`__)
    [dirsrv] set 'nsslapd-enable-upgrade-hash: off' as this raises
    warnings
--  `#8316 <https://pagure.io/freeipa/issue/8316>`__ [Azure] Whitelist
+-  `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__ [Azure] Whitelist
    clock_adjtime syscall
--  `#8317 <https://pagure.io/freeipa/issue/8317>`__ XML-RCP and CLI
+-  `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__ XML-RCP and CLI
    tests depend on internal --force option
--  `#8319 <https://pagure.io/freeipa/issue/8319>`__ Support server
+-  `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__ Support server
    referrals for enterprise principals
--  `#8322 <https://pagure.io/freeipa/issue/8322>`__ [RFE] Changing
+-  `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__ [RFE] Changing
    default hostgroup is too easy
--  `#8323 <https://pagure.io/freeipa/issue/8323>`__ [Build failure]
+-  `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__ [Build failure]
    Race: make po fails on parallel build
--  `#8325 <https://pagure.io/freeipa/issue/8325>`__ [WebUI] Fix
+-  `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__ [WebUI] Fix
    htmlPrefilter issue in jQuery
--  `#8328 <https://pagure.io/freeipa/issue/8328>`__ krbtpolicy-mod
+-  `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__ krbtpolicy-mod
    cannot handle two auth ind options of the same type at the same time
--  `#8330 <https://pagure.io/freeipa/issue/8330>`__ [Azure] Build job
+-  `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__ [Azure] Build job
    fails on \`tests\` container preparation
--  `#8335 <https://pagure.io/freeipa/issue/8335>`__ [WebUI] manage IPA
+-  `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__ [WebUI] manage IPA
    resources as a user from a trusted Active Directory domain
--  `#8338 <https://pagure.io/freeipa/issue/8338>`__ [WebUI] Host detail
+-  `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__ [WebUI] Host detail
    with no assigned ID view makes invalid RPC call
--  `#8339 <https://pagure.io/freeipa/issue/8339>`__ [WebUI] User details
+-  `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__ [WebUI] User details
    tab headers don't show member count when on settings tab
--  `#8348 <https://pagure.io/freeipa/issue/8348>`__ Allow managed
+-  `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__ Allow managed
    permissions with ldap:///self bind rule
--  `#8349 <https://pagure.io/freeipa/issue/8349>`__ bind-9.16 and
+-  `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__ bind-9.16 and
    dnssec-enable
--  `#8350 <https://pagure.io/freeipa/issue/8350>`__ bind-9.16 and DLV
--  `#8352 <https://pagure.io/freeipa/issue/8352>`__ RPC API crashes when
+-  `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__ bind-9.16 and DLV
+-  `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__ RPC API crashes when
    a user is disabled while a session exists
--  `#8357 <https://pagure.io/freeipa/issue/8357>`__ Allow managing IPA
+-  `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__ Allow managing IPA
    resources as a user from a trusted Active Directory forest
--  `#8358 <https://pagure.io/freeipa/issue/8358>`__ TTL of DNS record
+-  `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__ TTL of DNS record
    can be set to negative value
--  `#8359 <https://pagure.io/freeipa/issue/8359>`__ [WebUI]
+-  `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__ [WebUI]
    dnsrecord_mod results in JS error
--  `#8362 <https://pagure.io/freeipa/issue/8362>`__
+-  `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
    (`rhbz#1826659 <https://bugzilla.redhat.com/show_bug.cgi?id=1826659>`__)
    IPA: Ldap authentication failure due to Kerberos principal expiration
    UTC timestamp
--  `#8363 <https://pagure.io/freeipa/issue/8363>`__ DNS config upgrade
+-  `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__ DNS config upgrade
    code fails
 
 
@@ -444,78 +444,78 @@ Alexander Bokovoy (35)
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca0a62eac36ecf6b55b0983eaa139a25ed2a1ca2>`__
-   `#8362 <https://pagure.io/freeipa/issue/8362>`__
+   `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b0f8f3617378da41ead8640e194e5b9415a38b1>`__
-   `#8357 <https://pagure.io/freeipa/issue/8357>`__
+   `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/99e613e478f7925d0f470a04d4de5a2f93385b7a>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 -  tests: account for ID overrides as members of groups and roles
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e8df37e4cca155bf58aa4e61b9fa3f28eddd526>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  Support adding user ID overrides as group and role members
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cce2bb31ab96f6ce6edba95f54575576f2b1a40>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ffb4fd18fceb509773951ce4f02aa0c5e2f851a>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  support using trust-related operations in the server console
    `commit <https://codeberg.org/freeipa/freeipa/commit/afe9191f99e034bcf52475b57996d81609de6837>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
    `commit <https://codeberg.org/freeipa/freeipa/commit/6abade3f8daed8dfa024936114209d19319c4f12>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  azure: do not run test_commands due to failures in low memory cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f292b2953460a7ae6b7784fd7dfb63d2994a28c>`__
 -  test_smb: test S4U2Self operation by IPA service
    `commit <https://codeberg.org/freeipa/freeipa/commit/eeb70047c9849fcc59686bdd3edd2923ee1be134>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/601151e7c6e99d67723af9e20e80252e71e9c49e>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
    `commit <https://codeberg.org/freeipa/freeipa/commit/68a0790b9da12ccb9f3a9f211f6d806ca604a861>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c844c704d4f7ca8837f0d034325a379ec9294af>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/741f64f4b5428ccfa8105c61a91de8e0fab37bc3>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add asserted identity SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/110812b43b202c83d4a90d01aab1cf7610b2de41>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/1990e3954b3c566a52697e38569ad472a62a7895>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca99bf2abc793d77e889c91d2a436c3de96eb36e>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a01e46aa0cd7e3cfd53b380b0ab3975ae1dc524>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
    `commit <https://codeberg.org/freeipa/freeipa/commit/4723100791663b8eb6053c6b9f17b8c34e362891>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
    `commit <https://codeberg.org/freeipa/freeipa/commit/363cb9fd7f3d8d57dcad91d92918bfb513164706>`__
-   `#8328 <https://pagure.io/freeipa/issue/8328>`__
+   `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__
 -  service delegation: allow to add and remove host principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8009e1caf141d57f68590bd60e1966d46090481>`__
-   `#8289 <https://pagure.io/freeipa/issue/8289>`__
+   `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
    `commit <https://codeberg.org/freeipa/freeipa/commit/831de842a7eca0df44367d8cb182cedc53680d77>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/77c2e425cc82bb34847ea8f1456e69f098a071c5>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c62fbd256798d6c9a0ec56bd12991e1c134ef3e>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
    `commit <https://codeberg.org/freeipa/freeipa/commit/4de1586ec3bb220f63a0889fbf8c09667ba87788>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  Azure Pipelines: switch to Fedora 32
    `commit <https://codeberg.org/freeipa/freeipa/commit/60ed4b09e1af597927ce471fc0d65b7809414292>`__
 -  Azure Pipelines: Override services known to not work in containers
@@ -524,10 +524,10 @@ Alexander Bokovoy (35)
    `commit <https://codeberg.org/freeipa/freeipa/commit/898891677f6eac36d0d566c5bc8f9d3ca1e27ec6>`__
 -  CVE-2020-1722: prevent use of too long passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/089a393581aa249ddec66ce1455fff4951cdb827>`__
-   `#8268 <https://pagure.io/freeipa/issue/8268>`__
+   `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__
 -  Allow rename of a host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4fdb83355e27c2e6f3d216cdc892f301391af6d>`__
-   `#6783 <https://pagure.io/freeipa/issue/6783>`__
+   `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
 -  Add 'api' and 'aci' targets to make
    `commit <https://codeberg.org/freeipa/freeipa/commit/38e026821cce2c6763a53ae6c675bbbaf68c8ff7>`__
 -  Remove Fedora repository fastmirror selection
@@ -540,33 +540,33 @@ Peter Keresztes Schmidt (10)
 
 -  Split named custom config to allow changes in options stanza
    `commit <https://codeberg.org/freeipa/freeipa/commit/539d46918f5c0e0c912965addd286ee31bcb93e1>`__
-   `#8287 <https://pagure.io/freeipa/issue/8287>`__
+   `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__
 -  util: replace NSS usage with OpenSSL
    `commit <https://codeberg.org/freeipa/freeipa/commit/41a20fef10382a3d2c7f3260a8e0fba8a29d809a>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  util: add unit test for pw hashing
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fe645efc16995f159db31dc514c8a8e0e13c706>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  po: remove zanata config since translation was moved to weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/a29eec33fa2bc4b5e57f3f63c67d212aeb5c5ff4>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Specify min and max values for TTL of a DNS record
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac47599ebf006d34d06d23654cb93f707cbd7d1f>`__
-   `#8358 <https://pagure.io/freeipa/issue/8358>`__
+   `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca4cc7abe1cad87cd1e80702aedaca43cb6660d1>`__
 -  WebUI: Expose TTL of DNS records
    `commit <https://codeberg.org/freeipa/freeipa/commit/df8bcc9637844c5058145eff5ed99097b6e9ca73>`__
-   `#3827 <https://pagure.io/freeipa/issue/3827>`__
+   `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/7dad4a5987fa001b1bc8f7740503e359ca0449e3>`__
-   `#8359 <https://pagure.io/freeipa/issue/8359>`__
+   `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
    `commit <https://codeberg.org/freeipa/freeipa/commit/2af2373c57c6828db922008ce1e3b7fd9b3e0da8>`__
-   `#8338 <https://pagure.io/freeipa/issue/8338>`__
+   `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__
 -  WebUI: Use data adapter to load facet header data
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e7d0d8397d466553268a52e3c4cf327f01a6957>`__
-   `#8339 <https://pagure.io/freeipa/issue/8339>`__
+   `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__
 
 
 
@@ -583,115 +583,115 @@ Christian Heimes (43)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ddaead3d70f0de8aa40a3eef313fa1ff24eb25c>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa2f93262f187b122cb3e3e0c755e21d98bb95d3>`__
-   `#8363 <https://pagure.io/freeipa/issue/8363>`__
+   `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__
 -  Auto-generated ipa-epn files to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fbd29d5d956646f2babf5166a8df43b3c8c44c2>`__
 -  libotp: Replace NSS with OpenSSL HMAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/47adde99c28d1f7da5180a29ebcd2d70158217b5>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  Include named config files in backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/782ee1162fbf82c6ab54cb7918d26aba8acbc665>`__
 -  Handle DatabaseError in RPC-Server connect()
    `commit <https://codeberg.org/freeipa/freeipa/commit/1062caaae6380fcf79ed11eb3ec5b015c0102e6a>`__
-   `#8352 <https://pagure.io/freeipa/issue/8352>`__
+   `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__
 -  Allow permissions with 'self' bindruletype
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2caafb58ec578002fdf88de9cca5a3f5eaa1b2e>`__
-   `#8348 <https://pagure.io/freeipa/issue/8348>`__
+   `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__
 -  make: serialize strip-po / strip-pot
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d759d3836aa36799978cd0333e1836ea2480f4b>`__
-   `#8323 <https://pagure.io/freeipa/issue/8323>`__
+   `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__
 -  Remove obsolete BIND named.conf options
    `commit <https://codeberg.org/freeipa/freeipa/commit/91f94612f3021a631dd8a97d08a6327c98f6e689>`__
-   `#8349 <https://pagure.io/freeipa/issue/8349>`__,
-   `#8350 <https://pagure.io/freeipa/issue/8350>`__
+   `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__,
+   `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__
 -  Add ipa-print-pac to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/5aa5f678828033e109112c45547b55553a377895>`__
 -  Allow dnsrecord-add --force on clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/c261a6eb768483f7ac45aab34994dcec01e819bd>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Check for freeipa-server-dns package early
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16a4b06b76412ac22763ca9e0a53d3560bfe4c1>`__
-   `#7577 <https://pagure.io/freeipa/issue/7577>`__
+   `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
 -  Hard-code in_tree=True for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/834b04b91dff670d3f0feb1b403705074a8f3d5b>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Fix detection logic for api.env.in_tree
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cd2d44707c69b6c83c0eaae3a94d6f64c6c1622>`__
-   `#8312 <https://pagure.io/freeipa/issue/8312>`__
+   `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__
 -  Make api.env.mode consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/3234892336f9bf1775127fb19504110c8dec70b1>`__
-   `#8313 <https://pagure.io/freeipa/issue/8313>`__
+   `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__
 -  Disable password schema update on LDAP bind
    `commit <https://codeberg.org/freeipa/freeipa/commit/27656669f7126ef92272530118d2d52122bb3008>`__
-   `#8315 <https://pagure.io/freeipa/issue/8315>`__
+   `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
 -  Use httpd 2.4 syntax for access control
    `commit <https://codeberg.org/freeipa/freeipa/commit/84d15da5b11e44db71bff5b487c57e1e32b97c7f>`__
 -  Fix make devcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2893b84967630be483e4321a22a5d7157470788>`__
-   `#8307 <https://pagure.io/freeipa/issue/8307>`__
+   `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__
 -  Make ipaplatform a regular top-level package
    `commit <https://codeberg.org/freeipa/freeipa/commit/07da5abd13a0691d5c9fc0c37609ebcb543c691e>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__,
-   `#8309 <https://pagure.io/freeipa/issue/8309>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__,
+   `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__
 -  Reconfigure pycodestyle
    `commit <https://codeberg.org/freeipa/freeipa/commit/d80b98b9daff3da019542117bd52d349a101eab8>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Manually reformat ipapython/version.py.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c3d00b17570104f4a1bc7a802496f515e810ae6>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Silence W601 .has_key() is deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/d44a392568bfbe058407f7ab3169a5778ec528b6>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E722 do not use bare 'except'
    `commit <https://codeberg.org/freeipa/freeipa/commit/45ddb4f17492bedfcf4e144c14ee0a5f03c1231c>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
    `commit <https://codeberg.org/freeipa/freeipa/commit/7be2ffea6a93e1d16e548bcb1d4870dccbe38c8c>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E714 test for object identity should be 'is not'
    `commit <https://codeberg.org/freeipa/freeipa/commit/70dc448280496edcc4971b60ece044cbbec10840>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E713 test for membership should be 'not in'
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef068bd30dddcc653726bd2602be288bef351385>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E712 comparison to True / False
    `commit <https://codeberg.org/freeipa/freeipa/commit/01c1cf67e5e88a4af7f149652af378d36f64a471>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E711 comparison to None
    `commit <https://codeberg.org/freeipa/freeipa/commit/c136aab0f87ac5b53db3193e0f1a4cd0cc5c832f>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E266 too many leading '#' for block comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/033f8dc626c0ad2e13594d964869b72cad228142>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Simplify pki proxy conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3f7d9befc0abdb4d5fb518a498b359675238828>`__
 -  Make check_required_principal() case-insensitive
    `commit <https://codeberg.org/freeipa/freeipa/commit/b590a674e7134333b14eeeef5bda077e7e831a62>`__
-   `#8308 <https://pagure.io/freeipa/issue/8308>`__
+   `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
 -  Address issues found by new pylint 2.5.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef2a74565d829ac47a1b2961b2966fcfa9e43aab>`__
-   `#8297 <https://pagure.io/freeipa/issue/8297>`__
+   `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__
 -  Add skip_if_platform marker
    `commit <https://codeberg.org/freeipa/freeipa/commit/c43f3a7139efda747744f2b58500bcae203125f9>`__
 -  Define default password policy for sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/e74cfcc96e0f7c43303b4121683c3d1b3594ce3a>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Use api.env.container_sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/7509f42516246a012a51a798859dbecbc708642d>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Fix exception escape warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/26a9241c37b349090f5adcf1567c845c70e1c33d>`__
 -  Fix APIVersion.__getnewargs_\_
    `commit <https://codeberg.org/freeipa/freeipa/commit/f812e2cdbcc514cee0fe70e21f57d57b50059504>`__
 -  servrole: takes_params must be a tuple
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d2ec1824845dda1af96d2f12cdfe976499572c4>`__
-   `#8290 <https://pagure.io/freeipa/issue/8290>`__
+   `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__
 -  Fix various OpenDNSSEC 2.1 issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3f97a9a080f1ca30d863640801eed920063b35c>`__
-   `#8283 <https://pagure.io/freeipa/issue/8283>`__
+   `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__
 -  Use /run and /run/lock instead of /var
    `commit <https://codeberg.org/freeipa/freeipa/commit/d22ce3d0ad09835d1a5ef94177752ff380cc6223>`__
-   `#8272 <https://pagure.io/freeipa/issue/8272>`__
+   `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__
 
 
 
@@ -700,10 +700,10 @@ François Cami (13)
 
 -  IPA-EPN: Test suite.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3552185c3ca740b538d1516955cae094dc29bebd>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: First version.
    `commit <https://codeberg.org/freeipa/freeipa/commit/98bb4e94fdc6e683bcc59bb58377c504d172800f>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/2032a619bb0a618b0d39fee0f61fbbc0a71ad77c>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
@@ -712,27 +712,27 @@ François Cami (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6681871084cb69477a48c93772f18d3103324593>`__
 -  ipatests: increase test_webui_server timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/589c7fd0f75fe1d83817df7e3b14bf0ecd63d643>`__
-   `#8266 <https://pagure.io/freeipa/issue/8266>`__
+   `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa395cec8910cb07b23367e24eed6db1c64f06c9>`__
-   `#8262 <https://pagure.io/freeipa/issue/8262>`__
+   `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__
 -  ipatests: move ipa_backup to tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/8691e5f8d33e7f023b1535d15637dedaee5bddec>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
    `commit <https://codeberg.org/freeipa/freeipa/commit/37a60b25a342d723bfe4b4b91373ad5003bd4d29>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  test_backup_and_restore: add server role verification steps
    `commit <https://codeberg.org/freeipa/freeipa/commit/69a2b6d71478094356ed78295b4c7177e200825c>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
    `commit <https://codeberg.org/freeipa/freeipa/commit/00e2a488726a353b7183d5d3b4c2084b9bf5dbc2>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  nightly_ipa-4-8_previous.yaml: fix typo
    `commit <https://codeberg.org/freeipa/freeipa/commit/48be293e470b6d9061c8e3e5836ed17e0eaf52d9>`__
 -  pr-ci templates: update test_fips timeouts
    `commit <https://codeberg.org/freeipa/freeipa/commit/d847f123244bb2aed23f901b9df17711219ad8b0>`__
-   `#8247 <https://pagure.io/freeipa/issue/8247>`__
+   `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__
 
 
 
@@ -742,17 +742,17 @@ Florence Blanc-Renaud (4)
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
    `commit <https://codeberg.org/freeipa/freeipa/commit/a457b79d1e5af3c1bd1d9517db07c5a85154c932>`__
-   `#6884 <https://pagure.io/freeipa/issue/6884>`__
+   `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
 -  ipatests: enable 389-ds audit log and collect audit file
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b39e5fbd8db10b5af3402e2c88194e351486614>`__
-   `#8064 <https://pagure.io/freeipa/issue/8064>`__
+   `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
    `commit <https://codeberg.org/freeipa/freeipa/commit/787ce4555a203bd3f31c1f6cc577855f779fe6cf>`__
-   `#8311 <https://pagure.io/freeipa/issue/8311>`__
+   `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
 -  Man pages: fix syntax issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/98045dc4a3b3be21c9badf75ce1b62df27fa5be0>`__
-   `#8273 <https://pagure.io/freeipa/issue/8273>`__
+   `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
 
 
 
@@ -769,34 +769,34 @@ Fraser Tweedale (10)
 
 -  upgrade: avoid stopping certmonger when fixing requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1564cd228068d54b949277f7bdc00203b5da81a>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/00dd80b77e115734e6f8942339cd2e0d3cc7fbdc>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e92190db866e7eb05aaaf41609b442f201d5c08>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/c445cefacf7713746f0bb0399d33b3f4008b71b4>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
    `commit <https://codeberg.org/freeipa/freeipa/commit/5275342b691b2f74b365cb3422459779544be16a>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b24129f9e1ceb322c5477f9a0869f7a6b521f09>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
    `commit <https://codeberg.org/freeipa/freeipa/commit/52873581e7ab1de8c02a4d80cdeeb9bf27b2f168>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: support dnsname as request search criterion
    `commit <https://codeberg.org/freeipa/freeipa/commit/b127bad8a93967c09c24edadd31d7d6e5b812186>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: move 'criteria' description to module docstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff7d0661a71ff2c9a66c8c9a1a48837d041f9099>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: avoid mutable default argument
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e9b7773fb613889eacaa95504f1c40f21628c0f>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 
 
 
@@ -805,7 +805,7 @@ Kaleemullah Siddiqui (1)
 
 -  Test for check of HostKeyAlgorithms option in ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac67dc9d385e622750c0e205e7848cf2fde88387>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 
 
 
@@ -833,22 +833,22 @@ Mohammad Rizwan Yusuf (6)
 
 -  ipatests: Test deletion of required principal throws proper error
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0ef4180cfb7616482f8ded16ad5c46fcf9f5286>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  Display principal name while del required principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/87377493bd67939d6e90f08d1e26d1fc3bcfd708>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  WebUI tests: fix PEP8 issues in test_webui/test_user.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/b626a79e831f644a8d6f21576f05a460787f8e2b>`__
 -  webui: check if notification area doesn't intercept menu button
    `commit <https://codeberg.org/freeipa/freeipa/commit/b68f98aa67e9b2d43efe6c6d101cb37d5cef5891>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  ipatests: Test to check password leak in apache error log
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd7dcb19f71b11c9eccb056bfd54f6101c1040c5>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/90eef2f84d3ad61894a1656c529000072e6cb036>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 
 
 
@@ -857,38 +857,38 @@ Rob Crittenden (12)
 
 -  IPA-EPN: Don't treat givenname differently
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf28d4c8d0f085329105a4232c1a2ff3d61f067f>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
    `commit <https://codeberg.org/freeipa/freeipa/commit/4124bb6d6a665dc2fce665af577daa278e6b9f23>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
    `commit <https://codeberg.org/freeipa/freeipa/commit/37a4a79cc00a036ae11640462d880b7ea1ba7524>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
    `commit <https://codeberg.org/freeipa/freeipa/commit/672c9f55b70a05aaa8f0baec6381a8b4ee935216>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
    `commit <https://codeberg.org/freeipa/freeipa/commit/dca3f116a41af5476a8abf860d0dda3b4c80f8b5>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: test using SSL against port 465
    `commit <https://codeberg.org/freeipa/freeipa/commit/6587edd4b283e37da7b214fce4c3c9d013fe1118>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add test for starttls mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc2b3aab5042a9125e74647493c0f4faecd87d20>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe3397393c2fa7121fa05a656d682036bffbe9c>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca1c374ebf58ccc5ed00346876835026958fe7bd>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add index for krbPasswordExpiration for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab444db0accedeefc42264cd03c2abe4ed90ea19>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add a jinja2 e-mail template for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/0869765536cd036221f6cd12921bac18e3e3df46>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Perform baseline healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/435e2bee19030756c8cdc3c809426bd2172c7ce5>`__
 
@@ -899,7 +899,7 @@ Sam Morris (1)
 
 -  Debian: write out only one CA certificate per file
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fcc78b8317f2c2412916016ac66a5a380a41173>`__
-   `#8106 <https://pagure.io/freeipa/issue/8106>`__
+   `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__
 
 
 
@@ -916,57 +916,57 @@ Stanislav Levin (18)
 
 -  Azure: Make dnf repos consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f2bfd9f7bfdc9b9e260e45b725b92521565570b>`__
-   `#8330 <https://pagure.io/freeipa/issue/8330>`__
+   `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__
 -  Azure: Always update apt cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/273f580b95ac5a2cb91ce336cf82b085eb7929e0>`__
 -  Azure: Allow chronyd to sync time
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d01875d12c20855d4be1351717ee4105e34e5ac>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Add custom seccomp profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd58bac1c3feeb7f64c97278e841c553f026e917>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Increase memory limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/97581ec6b3ccb2043f1ad0f26589467badae3819>`__
-   `#8264 <https://pagure.io/freeipa/issue/8264>`__
+   `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/736b8ba5a0c4cfbb0a158d9eae800ae843281b9c>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Pretty print multihost config
    `commit <https://codeberg.org/freeipa/freeipa/commit/5da643f1b270ccad3a261ff700ddc163ea60bc93>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
    `commit <https://codeberg.org/freeipa/freeipa/commit/295d207245a626e57e1024504ba9e0098081adbc>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Specify shell implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d06a4a29fb304856e48f5b91556e735a0a447d8>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Specify Pytest XML report schema
    `commit <https://codeberg.org/freeipa/freeipa/commit/b62f59fdd0b6a0f917ac41da38366b2178a74b17>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/46518b494f215a49c1906508a1bb9661e30dcd98>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/f97341c66a81ee395e4c18129b056d890b941315>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e14cfc4d0fb6f334d4daebe746c38e8356fb349>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove deprecated yield_fixture
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c0192ac3de157ec4ef17c5492bfcb2fe370ac46>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Bump required Pytest
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d10bc8db9f78d2a541bad5b4ce70ec2e6a58c2d>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
    `commit <https://codeberg.org/freeipa/freeipa/commit/d320997807b8fb25a4bbfbf507ecff172c06f284>`__
-   `#8261 <https://pagure.io/freeipa/issue/8261>`__
+   `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__
 -  Azure: Gather coredumps
    `commit <https://codeberg.org/freeipa/freeipa/commit/5325c723dad7d1f47311e0d73bc7b7b58577b870>`__
-   `#8251 <https://pagure.io/freeipa/issue/8251>`__
+   `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__
 -  Azure: Allow distros to install Python they want
    `commit <https://codeberg.org/freeipa/freeipa/commit/60d6defe0e5d82270601bb96bb2d74495db632fc>`__
-   `#8254 <https://pagure.io/freeipa/issue/8254>`__
+   `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__
 
 
 
@@ -1005,7 +1005,7 @@ Sumedh Sidhaye (2)
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
    `commit <https://codeberg.org/freeipa/freeipa/commit/77409e2be01984ff9bdd61989a94845cf9206116>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 
 
 
@@ -1022,23 +1022,23 @@ Serhii Tsymbaliuk (6)
 
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/062022996d6efeef3c0a9d5d0611890bdf416e28>`__
-   `#8325 <https://pagure.io/freeipa/issue/8325>`__
+   `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8c8ba7d476b4f2a9a03be5bebe8a75a8a5028a1>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d3364a543a65eaa6ed94005cdab6dd1d3745c49>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI tests: cover membership management with UI tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/e58ca6a4ab40d876efd1c4bcec888e58c5fc738a>`__
-   `#8298 <https://pagure.io/freeipa/issue/8298>`__
+   `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/46008f5e76af87efe75c7f8700262d026005bd9c>`__
-   `#8284 <https://pagure.io/freeipa/issue/8284>`__
+   `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa09cc29323c2d14985e19f1b2473b62f9df249a>`__
-   `#8222 <https://pagure.io/freeipa/issue/8222>`__
+   `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__
 
 
 
@@ -1055,7 +1055,7 @@ sumenon (7)
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
    `commit <https://codeberg.org/freeipa/freeipa/commit/c59106f005d520f1c84f12a15902cf005162d15c>`__
-   `#8066 <https://pagure.io/freeipa/issue/8066>`__
+   `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bec170288df5052851626304edf2aeabd606c1b>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
@@ -1085,4 +1085,4 @@ Viktor Ashirov (1)
 
 -  Update ACIs with the correct syntax
    `commit <https://codeberg.org/freeipa/freeipa/commit/218e655617400097e5dcd2fa0aae82b21e8c2366>`__
-   `#8301 <https://pagure.io/freeipa/issue/8301>`__
+   `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__

--- a/src/page/Releases/4.8.8.rst
+++ b/src/page/Releases/4.8.8.rst
@@ -95,7 +95,7 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#8326 <https://pagure.io/freeipa/issue/8326>`__ CVE-2020-10747
+-  `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__ CVE-2020-10747
 
 
 
@@ -117,4 +117,4 @@ Christian Heimes (1)
 
 -  Prevent local account takeover
    `commit <https://codeberg.org/freeipa/freeipa/commit/65c2736bd20ffb9d98769e71d905f71d1a4d857e>`__
-   `#8326 <https://pagure.io/freeipa/issue/8326>`__
+   `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__

--- a/src/page/Releases/4.8.9.rst
+++ b/src/page/Releases/4.8.9.rst
@@ -23,7 +23,7 @@ Highlights in 4.8.9
       Paramiko is not compatible with FIPS mode, therefore convert most
       tests to using ssh directly. The only non-converted test is the
       2-prompt OTP test because sshpass does not support 2-prompt
-      password authentication ( https://pagure.io/freeipa/issue/8431 ).
+      password authentication ( https://codeberg.org/freeipa/freeipa/issues/8431 ).
 
 --------------
 
@@ -158,142 +158,142 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#5011 <https://pagure.io/freeipa/issue/5011>`__
+-  `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
    (`rhbz#1527185 <https://bugzilla.redhat.com/show_bug.cgi?id=1527185>`__)
    [RFE] Forward CA requests to dogtag or helper by GSSAPI
--  `#5628 <https://pagure.io/freeipa/issue/5628>`__ webui: Unclear(UX)
+-  `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__ webui: Unclear(UX)
    purpose of OTP field in password reset form on login
--  `#7137 <https://pagure.io/freeipa/issue/7137>`__
+-  `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
    (`rhbz#1484088 <https://bugzilla.redhat.com/show_bug.cgi?id=1484088>`__)
    [RFE]: Able to browse different links from IPA web gui in new tabs
--  `#8129 <https://pagure.io/freeipa/issue/8129>`__ Tests: Replace
+-  `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__ Tests: Replace
    paramiko with OpenSSH
--  `#8151 <https://pagure.io/freeipa/issue/8151>`__ test_commands
+-  `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__ test_commands
    timing-out
--  `#8189 <https://pagure.io/freeipa/issue/8189>`__
+-  `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
    (`rhbz#1810179 <https://bugzilla.redhat.com/show_bug.cgi?id=1810179>`__)
    NIghtly test failure in
    test_integration/test_nfs.py::TestIpaClientAutomountFileRestore::test_nsswitch_backup_restore_sssd
--  `#8300 <https://pagure.io/freeipa/issue/8300>`__ Replace uglify-js
+-  `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__ Replace uglify-js
    with python3-rjsmin
--  `#8304 <https://pagure.io/freeipa/issue/8304>`__ [fed32]
+-  `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__ [fed32]
    client-install does not properly set ChallengeResponseAuthentication
    yes in sshd conf
--  `#8326 <https://pagure.io/freeipa/issue/8326>`__ CVE-2020-10747
--  `#8335 <https://pagure.io/freeipa/issue/8335>`__ [WebUI] manage IPA
+-  `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__ CVE-2020-10747
+-  `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__ [WebUI] manage IPA
    resources as a user from a trusted Active Directory domain
--  `#8336 <https://pagure.io/freeipa/issue/8336>`__ [WebUI] "User
+-  `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__ [WebUI] "User
    attributes for SMB services" section always shown
--  `#8364 <https://pagure.io/freeipa/issue/8364>`__ Nightly test failure
+-  `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__ Nightly test failure
    while establishing trust: Cannot find specified domain or server name
--  `#8366 <https://pagure.io/freeipa/issue/8366>`__ CA-less replica
+-  `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__ CA-less replica
    deployment fails with --setup-ca
--  `#8367 <https://pagure.io/freeipa/issue/8367>`__ IPA-EPN fails to
+-  `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__ IPA-EPN fails to
    build in ONLY_CLIENT mode
--  `#8368 <https://pagure.io/freeipa/issue/8368>`__
+-  `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
    (`rhbz#1846349 <https://bugzilla.redhat.com/show_bug.cgi?id=1846349>`__)
    cannot issue certs with multiple IP addresses corresponding to
    different hosts
--  `#8369 <https://pagure.io/freeipa/issue/8369>`__ cert_find returns
+-  `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__ cert_find returns
    "CA not configured" in CA-less install
--  `#8370 <https://pagure.io/freeipa/issue/8370>`__ ipa-join does not
+-  `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__ ipa-join does not
    set nshardwareplatform and nsosversion
--  `#8371 <https://pagure.io/freeipa/issue/8371>`__ Nightly test failure
+-  `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__ Nightly test failure
    [testing_master_testing] in
    test_integration/test_idviews.py::TestCertsInIDOverrides
--  `#8372 <https://pagure.io/freeipa/issue/8372>`__
+-  `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
    (`rhbz#1849914 <https://bugzilla.redhat.com/show_bug.cgi?id=1849914>`__)
    FreeIPA - Utilize 256-bit AJP connector passwords
--  `#8374 <https://pagure.io/freeipa/issue/8374>`__
+-  `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
    (`rhbz#1847999 <https://bugzilla.redhat.com/show_bug.cgi?id=1847999>`__)
    EPN does not ship its default configuration ( /etc/ipa/epn.conf ) in
    freeipa-client-epn
--  `#8377 <https://pagure.io/freeipa/issue/8377>`__ Nightly test failure
+-  `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__ Nightly test failure
    (timeout) in test_caless_TestReplicaInstall
--  `#8379 <https://pagure.io/freeipa/issue/8379>`__ Nightly test failure
+-  `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__ Nightly test failure
    [testing_master_pki] while installing CA replica
--  `#8381 <https://pagure.io/freeipa/issue/8381>`__ Nightly test failure
+-  `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__ Nightly test failure
    in test_webui/test_loginscreen.py::TestLoginScreen::test_login_view
--  `#8384 <https://pagure.io/freeipa/issue/8384>`__ Provide reliable way
+-  `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__ Provide reliable way
    to know if a server installation is complete
--  `#8388 <https://pagure.io/freeipa/issue/8388>`__ Make help() on
+-  `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__ Make help() on
    plugins more useful
--  `#8391 <https://pagure.io/freeipa/issue/8391>`__ Remove dnf
+-  `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__ Remove dnf
    workaround from test_epn.y
--  `#8395 <https://pagure.io/freeipa/issue/8395>`__ selinux don't audit
+-  `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__ selinux don't audit
    rules deny fetching trust topology
--  `#8396 <https://pagure.io/freeipa/issue/8396>`__ [WebUI] Font type of
+-  `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__ [WebUI] Font type of
    "Enabled" column in user search facet wrong
--  `#8399 <https://pagure.io/freeipa/issue/8399>`__ certmonger attempts
+-  `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__ certmonger attempts
    to add LWCA tracking requests on non-CA server.
--  `#8400 <https://pagure.io/freeipa/issue/8400>`__ sshd template file
+-  `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__ sshd template file
    is installed in a wrong (server) location while used by the client
    side
--  `#8401 <https://pagure.io/freeipa/issue/8401>`__ Create platform
+-  `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__ Create platform
    definitions for freeipa-container
--  `#8403 <https://pagure.io/freeipa/issue/8403>`__ Add option to add
+-  `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__ Add option to add
    ipaapi user as an allowed uid for ifp in /etc/sssd/sssd.conf when
    running ipa-replica-install
--  `#8407 <https://pagure.io/freeipa/issue/8407>`__ Support changelog
+-  `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__ Support changelog
    integrated into main database
--  `#8412 <https://pagure.io/freeipa/issue/8412>`__
+-  `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
    (`rhbz#1857157 <https://bugzilla.redhat.com/show_bug.cgi?id=1857157>`__)
    AVC: httpd cannot connect to ipa-custodia.sock
--  `#8413 <https://pagure.io/freeipa/issue/8413>`__ Nightly test failure
+-  `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8414 <https://pagure.io/freeipa/issue/8414>`__ Nightly test failure
+-  `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8416 <https://pagure.io/freeipa/issue/8416>`__ [WebUI] Error while
+-  `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__ [WebUI] Error while
    adding user ID overrides to group
--  `#8419 <https://pagure.io/freeipa/issue/8419>`__ Azure is reporting a
+-  `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__ Azure is reporting a
    slew of new no-member lint errors
--  `#8425 <https://pagure.io/freeipa/issue/8425>`__ Nightly test failure
+-  `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__ Nightly test failure
    in test_cert.test_cert.TestInstallMasterClient (certmonger timeout)
--  `#8428 <https://pagure.io/freeipa/issue/8428>`__ [ipatests] fails due
+-  `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__ [ipatests] fails due
    to new python-cryptography 3.0
--  `#8429 <https://pagure.io/freeipa/issue/8429>`__ Add fips-mode-setup
+-  `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__ Add fips-mode-setup
    to ipaplatform.paths
--  `#8432 <https://pagure.io/freeipa/issue/8432>`__ test failure in
+-  `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__ test failure in
    test_commands.py::TestIPACommand::test_login_wrong_password:
    AssertionError
--  `#8435 <https://pagure.io/freeipa/issue/8435>`__ [ipatests] failures
+-  `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__ [ipatests] failures
    due to new Pytest6.0 (pypi part)
--  `#8437 <https://pagure.io/freeipa/issue/8437>`__ unit tests for
+-  `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__ unit tests for
    ipa-extdom-extop are failing in Fedora 33
--  `#8439 <https://pagure.io/freeipa/issue/8439>`__ Nightly test failure
+-  `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__ Nightly test failure
    in
    test_integration/test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8440 <https://pagure.io/freeipa/issue/8440>`__
+-  `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
    (`rhbz#1863616 <https://bugzilla.redhat.com/show_bug.cgi?id=1863616>`__)
    CA-less install does not set required permissions on KDC certificate
--  `#8441 <https://pagure.io/freeipa/issue/8441>`__
+-  `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
    (`rhbz#1870202 <https://bugzilla.redhat.com/show_bug.cgi?id=1870202>`__)
    File permissions of /etc/ipa/ca.crt differ between CA-ful and CA-less
--  `#8442 <https://pagure.io/freeipa/issue/8442>`__ [pylint]
+-  `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__ [pylint]
    warnings/errors against pylint 2.5.3
--  `#8444 <https://pagure.io/freeipa/issue/8444>`__
+-  `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance input validation
--  `#8445 <https://pagure.io/freeipa/issue/8445>`__
+-  `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
    (`rhbz#1863079 <https://bugzilla.redhat.com/show_bug.cgi?id=1863079>`__)
    EPN: '[Errno 111] Connection refused' when the SMTP is down
--  `#8447 <https://pagure.io/freeipa/issue/8447>`__ Nightly test failure
+-  `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__ Nightly test failure
    in test_integration/test_ipahealthcheck/TestIpaHealthCheckWithoutDNS
--  `#8449 <https://pagure.io/freeipa/issue/8449>`__
+-  `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance CLI option tests
--  `#8456 <https://pagure.io/freeipa/issue/8456>`__ Need new aci's for
+-  `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__ Need new aci's for
    the new replication changelog entries
--  `#8459 <https://pagure.io/freeipa/issue/8459>`__ [upgrade] handle
+-  `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__ [upgrade] handle
    missing openssh-clients
--  `#8461 <https://pagure.io/freeipa/issue/8461>`__ [ALTLinux] server
+-  `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__ [ALTLinux] server
    uninstall error on missing /var/lib/samba
--  `#8463 <https://pagure.io/freeipa/issue/8463>`__ Nightly test failure
+-  `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8464 <https://pagure.io/freeipa/issue/8464>`__ Increase replication
+-  `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__ Increase replication
    changelog trimming interval
 
 
@@ -331,13 +331,13 @@ Alexander Bokovoy (10)
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/96aa09b947d2b1e50c694853debf2f349197d8a0>`__
-   `#8437 <https://pagure.io/freeipa/issue/8437>`__
+   `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d70addbbf2a99e7398a518bc98d5fe109469bb5>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/42dd1628a1211363c860917e474ecc5b9c1fdb84>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  Get back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ca6129ffdcbe4c794aee669c96a96d2e59134d4>`__
 -  Become FreeIPA 4.8.8
@@ -370,10 +370,10 @@ Alexander Scheel (3)
 
 -  Specify cert_paths when calling PKIConnection
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ded9e2573a00c388533f2a09365c499a4e2961e>`__
-   `#8379 <https://pagure.io/freeipa/issue/8379>`__
+   `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e804bf19da4ee274e735fd49452d4df5d73a002>`__
-   `#8372 <https://pagure.io/freeipa/issue/8372>`__
+   `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
 -  Clarify AJP connector creation process
    `commit <https://codeberg.org/freeipa/freeipa/commit/be48983558a560dadad410a70a4a1684565ed481>`__
 
@@ -384,25 +384,25 @@ Peter Keresztes Schmidt (7)
 
 -  WebUI: Unify adapter property definition for state evaluators
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f9c20ba7585e8f110806596806d292891682932>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0518f7ff6ddc37887970af91c2575c15812fca8>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  Populate nshardwareplatform and nsosversion during join operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/92ef9d1706c331b674eced04a3485de24c200998>`__
-   `#8370 <https://pagure.io/freeipa/issue/8370>`__
+   `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
    `commit <https://codeberg.org/freeipa/freeipa/commit/42ad338c070096dbcab7facb70e57ba6ea63535e>`__
-   `#8396 <https://pagure.io/freeipa/issue/8396>`__
+   `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__
 -  Unify spelling of "One-Time Password"
    `commit <https://codeberg.org/freeipa/freeipa/commit/0320de78571bb75ed17cd31727f7b25360941f67>`__
 -  WebUI: reword OTP info message displayed during PW reset
    `commit <https://codeberg.org/freeipa/freeipa/commit/82475aab31a5f8e06360d43b4e3d5e1aa2daf0fb>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c3bf183634cb5615528daa88339e834e5400530>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 
 
 
@@ -411,50 +411,50 @@ Christian Heimes (17)
 
 -  Treat container subplatforms like main platform
    `commit <https://codeberg.org/freeipa/freeipa/commit/508c5e5d3bd003a854090bae7ebd3dccf74cd6a9>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Don't configure authselect in containers
    `commit <https://codeberg.org/freeipa/freeipa/commit/6926131f258d82b9a8634e3b292c6ecf83f2a5be>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
    `commit <https://codeberg.org/freeipa/freeipa/commit/c68d14b6be858523c06939c2e7f4f4e3de3221de>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Explicitly pass keytab to ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/305deb450c564e561b5facafee8ed6966de7bc83>`__
 -  Write state dir to smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3bf50b1b2611f0dfea699ae7ba134c2857187d9>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
    `commit <https://codeberg.org/freeipa/freeipa/commit/61807788f40c2596686b79f4bbd4e0e766e995dd>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Allow to override ipaplatform with env var
    `commit <https://codeberg.org/freeipa/freeipa/commit/90ae22b8e54fc6108e39ad93f26035446ab728f1>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Teach pylint how dnspython 2.x works
    `commit <https://codeberg.org/freeipa/freeipa/commit/abfe4bfe459ff4f7329d0b0ec674a8cb9c7d99cc>`__
-   `#8419 <https://pagure.io/freeipa/issue/8419>`__
+   `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
    `commit <https://codeberg.org/freeipa/freeipa/commit/d83b760d1f76a3ba8e527dd27551e51a600b22c0>`__
-   `#8412 <https://pagure.io/freeipa/issue/8412>`__
+   `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
 -  Make tab completion in console more useful
    `commit <https://codeberg.org/freeipa/freeipa/commit/c21d3cf001c886889c06facafc44f1f9230203c7>`__
 -  Add \__signature_\_ to plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/e334415fc5c579f9faa1649b4f8e5ba0db0c7429>`__
-   `#8388 <https://pagure.io/freeipa/issue/8388>`__
+   `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__
 -  SELinux: Backport dirsrv_systemctl interface
    `commit <https://codeberg.org/freeipa/freeipa/commit/c72ef1ed965aca79da4576d9579dec5459e14b99>`__
 -  RHEL 8.3 has KRB5 1.18 with KDB 8.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/7473bd11f04f46f2d91068ec3ba4130386d6fc0a>`__
 -  Use old uglifyjs on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cefc6df114b162f3cd33622e87ba5a88dc03f0e>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  Build ipa-selinux package on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/351f3061514cb80faf644f4a067e5a596b087d7e>`__
 -  Prevent local account takeover
    `commit <https://codeberg.org/freeipa/freeipa/commit/930f4b3d1dc03f9e365b007b027d65e146a08f05>`__
-   `#8326 <https://pagure.io/freeipa/issue/8326>`__
+   `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
    `commit <https://codeberg.org/freeipa/freeipa/commit/77fae8c48bbe0f4499f4d8ed91b268568c64cd7c>`__
-   `#8367 <https://pagure.io/freeipa/issue/8367>`__
+   `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__
 
 
 
@@ -463,85 +463,85 @@ François Cami (28)
 
 -  IPA-EPN: enhance input validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/2809084a44e3b174fa48a611e79f04358e1d6dca>`__
-   `#8444 <https://pagure.io/freeipa/issue/8444>`__
+   `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
 -  ipatests: test_epn: update error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4266023e04729db12de2f7e0de4da9e1d00db38>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  IPA-EPN: Fix SMTP connection error handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/53f330b053740b169d211aa16b3b36fb61157bbd>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cf7fb1014ae40fd5a5278f27577a8196a4af051>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  IPA-EPN: fix configuration file typo
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e810d8cf38ec60d76178bd673e218fb05d56c8e>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/b95817e35716bbab000633043817202e17d7c53e>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b8fdd87760cfb8ec739c67298f012cf0bd3ac39>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
    `commit <https://codeberg.org/freeipa/freeipa/commit/9479a393a71fe1de7d62ca2b50a7d3d8698d4ba1>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0d4db548cfa14fbc596a40e742db96cd9ec00bb>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/027d0bbe1c0bafc326815b6ecc224a8f8fc5bd55>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/17759ec76aeac450ce9c85704b68100df75c8af5>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee57dd230191be40a39ef9677b308dee35fa183e>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
    `commit <https://codeberg.org/freeipa/freeipa/commit/262a7121046132fbb7bb101ecf7d595814757819>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/26e58031d1f0c63f6e62a59c52d1da80a85ce9bd>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/326ddff25e8c45da5ae708e036bfa6315d449672>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  tasks: add run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/034526a4bd6a9547cd394d19e5275d24f7f00362>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
    `commit <https://codeberg.org/freeipa/freeipa/commit/64ef1a8e727689cd434888ba555a003934986d13>`__
-   `#8432 <https://pagure.io/freeipa/issue/8432>`__
+   `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__
 -  ipatests: test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf6877a4864cebc15833b1b6638dcd53cc643712>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/59ad3ae4227fa20f0cd0e76b446bb4cfdc08debf>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
    `commit <https://codeberg.org/freeipa/freeipa/commit/020905338423f0539f79f61772f117764ef88717>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/2afe21b884e330018281980004e8175c2f9a3624>`__
-   `#8391 <https://pagure.io/freeipa/issue/8391>`__
+   `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5abea2341b9e478625ea5a46c346550bc648a01>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/766a80c14165e7eca99a44785f00f4b296e4cf62>`__
-   `#8377 <https://pagure.io/freeipa/issue/8377>`__
+   `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
    `commit <https://codeberg.org/freeipa/freeipa/commit/06accac8906f66ebbb31849d6528b39ae006b124>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
    `commit <https://codeberg.org/freeipa/freeipa/commit/2648c218467792e907435eaa5267a0f3457f634f>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b43950d35f78b28d4edde4fda475b5aa84f4587>`__
 -  EPN: ship the configuration file.
    `commit <https://codeberg.org/freeipa/freeipa/commit/23e2935e5c5cb402dd4f6f44eaa4b013e6a8188a>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  .mailmap: add fcami
    `commit <https://codeberg.org/freeipa/freeipa/commit/6de941ce2c04c9ed6c8c33ed01c93fd6baa2fc5f>`__
 
@@ -554,62 +554,62 @@ Florence Blanc-Renaud (20)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3919c9c8d7c2187e4d2a00b8276b241bf23f52b0>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4bd1f17a8aaa65482a6b28c1d6ed0f8ee94f667>`__
-   `#8447 <https://pagure.io/freeipa/issue/8447>`__
+   `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fa03c5f583dad5f654669eb59255b0fc2991837>`__
-   `#8439 <https://pagure.io/freeipa/issue/8439>`__
+   `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__
 -  ipatests: increase test_trust timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/55144ab6a18f275ec1472313755e2d07b71bee03>`__
 -  ipatests: check KDC cert permissions in CA less install
    `commit <https://codeberg.org/freeipa/freeipa/commit/295dd4235f693b7b4b4270b46a28cb6e7b3d00b4>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  CAless installation: set the perms on KDC cert file
    `commit <https://codeberg.org/freeipa/freeipa/commit/81c955e561dd42ab70a39bf636c90e82a9d7d899>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  ipatests: fix test_authselect
    `commit <https://codeberg.org/freeipa/freeipa/commit/4baf6b292f28481ece483bb8ecbd6a0807d9d45a>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/3eaab97e317584bc47d4a27a607267ed90df7ff7>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca880cfb117fc870a6e2710b9e31b2f67d5651e1>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c53c7036a8a214eeb93c241d730d5c737950cd1>`__
-   `#8414 <https://pagure.io/freeipa/issue/8414>`__
+   `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/819bcacb81f942ac31691638beb64f77c0e74a40>`__
-   `#8413 <https://pagure.io/freeipa/issue/8413>`__
+   `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__
 -  sshd template must be part of client package
    `commit <https://codeberg.org/freeipa/freeipa/commit/668fdc63e3e886208dca8bdc5a68a20972150985>`__
-   `#8400 <https://pagure.io/freeipa/issue/8400>`__
+   `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__
 -  Bump requires for selinux-policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/388e793d5c47befbea01c48cdd679c99348ccc85>`__
 -  ipatests: fix the method adding ifp to sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/437fc60639bedbac2e5af85244962f60f374961a>`__
-   `#8371 <https://pagure.io/freeipa/issue/8371>`__
+   `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c7f54d1ffbddbfabd4f4547edeeb38a24152518>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__,
-   `#8381 <https://pagure.io/freeipa/issue/8381>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__,
+   `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__
 -  client install: fix broken sshd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ea611c98b1e01c54e5ce6c64fe108b140631722>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/b317222d515e51504b4c8342008f2981b508c82a>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e325bd0c01eecc6d48b10f9b7f654b16068a522>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
    `commit <https://codeberg.org/freeipa/freeipa/commit/32c4df70e36a0aeafc12e2ade85ee9c915774c44>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f19fda0d1fbd4431b0bd704f5c242e499e66e98>`__
-   `#8364 <https://pagure.io/freeipa/issue/8364>`__
+   `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__
 
 
 
@@ -618,18 +618,18 @@ Fraser Tweedale (5)
 
 -  certupdate: only add LWCA tracking requests on CA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/72d70fa27f61367a5fbc81b171b125ecf85d8fd8>`__
-   `#8399 <https://pagure.io/freeipa/issue/8399>`__
+   `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/d13a33da6d472ed61ea0aaa9d050a8d5638beae5>`__
 -  Define errors_by_code in ipalib.errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bfe6b261fa03ecc05d9f75ef24175f588d45e16>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
    `commit <https://codeberg.org/freeipa/freeipa/commit/128500198d3782a76616cf1d971d5aeb17e8c1da>`__
-   `#8368 <https://pagure.io/freeipa/issue/8368>`__
+   `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
 -  fix cert-find errors in CA-less deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/60a58eac02ed2c0741fbce3c1fb3acceef61fdbc>`__
-   `#8369 <https://pagure.io/freeipa/issue/8369>`__
+   `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__
 
 
 
@@ -639,10 +639,10 @@ Jeremy Frasier (2)
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/6de4b0fb85d9e2c51c60bc921cf6ee078ca1c219>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b8da1b7c7cd5686240b9c8e8c7e41fe9c604c57>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 
 
 
@@ -669,13 +669,13 @@ Mark Reynolds (3)
 
 -  Increase replication changelog trimming to 30 days
    `commit <https://codeberg.org/freeipa/freeipa/commit/14f27d284f4d9a37f2bd599f98602fb2eb84edd1>`__
-   `#8464 <https://pagure.io/freeipa/issue/8464>`__
+   `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2f8c84a74c2aa007027261f052131fcc7041cb4>`__
-   `#8456 <https://pagure.io/freeipa/issue/8456>`__
+   `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__
 -  Issue 8407 - Support changelog integration into main database
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a83d8201a8a7ca56c6173fb643733b350ef5b9b>`__
-   `#8407 <https://pagure.io/freeipa/issue/8407>`__
+   `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__
 
 
 
@@ -698,7 +698,7 @@ Petr Voborník (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a090b429fda35c5a9c3cfb672ab42a5985d00ff9>`__
 -  webui: hide user attributes for SMB services section if empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/691b3cddb275821630f443f22706fa75e7c7a5c8>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 
 
 
@@ -707,10 +707,10 @@ Rob Crittenden (23)
 
 -  ipatests: stop the CA during healthcheck expiration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/715ec234373fc8b4aa0d00a4e9e0126522f38de1>`__
-   `#8463 <https://pagure.io/freeipa/issue/8463>`__
+   `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__
 -  Improve performance of ipa-server-guard
    `commit <https://codeberg.org/freeipa/freeipa/commit/aac717988f63ab4b8b808a6d48ee01e8fcb0c9e7>`__
-   `#8425 <https://pagure.io/freeipa/issue/8425>`__
+   `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f09f97791035cad01e237ed084ffc44f1ff7e85>`__
 -  Added negative test case for --list-sources option
@@ -721,28 +721,28 @@ Rob Crittenden (23)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b1dbcbe9d83ba35f3cfdd01399f123816ec6e5b>`__
 -  Address legacy pylint issues in sysrestore.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/4454af4bf31b73550eb5be2ed14be3e15c585ca3>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Update check_client_configuration to use new client fact
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9e4c686634f5ba41f50f0aa0f75b5e214e25a4d>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Don't use the has_files() to know if client/server is configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb6c48b21118abb198066126647709b7c9e26e10>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee755a580c1f136b2501a395116ddf7e43c913b6>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if IPA client configuration is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/80a7e346a514530ea3af75d2cc338c18ec211537>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if an IPA server installation is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a47748499256544e6692ef0578073938015f7ea>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/da2079ce2cc841aec56da872131112eb24326f81>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a97145c3a76a4d9ebf52b3905410a0bd7bec856>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  ipatests: Test healthcheck revocation checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea288b014414c62389d7b3a7572a665fefc11b0f>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
@@ -761,7 +761,7 @@ Rob Crittenden (23)
    `commit <https://codeberg.org/freeipa/freeipa/commit/66a5a0efd538e31a190ca6ecb775bc1dfc4ee232>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc06361907c8fdb986a581eb3e20abf8a7c1c476>`__
-   `#8429 <https://pagure.io/freeipa/issue/8429>`__
+   `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__
 
 
 
@@ -772,26 +772,26 @@ Stanislav Levin (9)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3084930e596b5d6e9b2b81cf9ce6532feb620b02>`__
 -  uninstall: Clean up no longer used flag
    `commit <https://codeberg.org/freeipa/freeipa/commit/bba69960f6c26b5b97e72359bc382e25a8ca8ec9>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/602f3f3151e58084ebd9b10d3997efeae5417d12>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbf1d858449ff37dbbe73f3853f98578b236615a>`__
-   `#8459 <https://pagure.io/freeipa/issue/8459>`__
+   `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
    `commit <https://codeberg.org/freeipa/freeipa/commit/50cf90f09398c949797f7fe71ae2075799e14a7f>`__
 -  Azure: Switch to dockerhub provider
    `commit <https://codeberg.org/freeipa/freeipa/commit/c89718a60113d1c72fecc3b1549341f2050d6922>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/a55ccdb12de3f39c49513fea3ed695e4900916f5>`__
-   `#8428 <https://pagure.io/freeipa/issue/8428>`__
+   `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__
 -  pylint: Fix warning and error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4c753dc03c48b8c3509e6077dd7fa5074f73670>`__
-   `#8442 <https://pagure.io/freeipa/issue/8442>`__
+   `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/66216e908546b45974a4fbf81804b8184d603b78>`__
-   `#8435 <https://pagure.io/freeipa/issue/8435>`__
+   `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__
 
 
 
@@ -808,21 +808,21 @@ Serhii Tsymbaliuk (5)
 
 -  WebUI tests: Add test case to cover user ID override feature
    `commit <https://codeberg.org/freeipa/freeipa/commit/e35739b7e9f6bb016b37abbd92bdaee71a59a288>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6c460aee8542d4d81cd9970d71051c240156973>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9e3e40f6910d34aaabadeb4a4e1f30d83a29a5d>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
    `commit <https://codeberg.org/freeipa/freeipa/commit/1502cb47df39f58082967012d4f9e227d6971652>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffe7f7b35907f9adab004ce63ce78f67fbd7aed8>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 
 
 

--- a/src/page/Releases/4.9.0.rst
+++ b/src/page/Releases/4.9.0.rst
@@ -181,7 +181,7 @@ Highlights in 4.9.0
       Paramiko is not compatible with FIPS mode, therefore convert most
       tests to using ssh directly. The only non-converted test is the
       2-prompt OTP test because sshpass does not support 2-prompt
-      password authentication ( https://pagure.io/freeipa/issue/8431 ).
+      password authentication ( https://codeberg.org/freeipa/freeipa/issues/8431 ).
 
 --------------
 
@@ -571,968 +571,968 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#298 <https://pagure.io/freeipa/issue/298>`__
+-  `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__
    (`rhbz#587752 <https://bugzilla.redhat.com/show_bug.cgi?id=587752>`__)
    [RFE] Add support for cracklib to password policies
--  `#2018 <https://pagure.io/freeipa/issue/2018>`__
+-  `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
    (`rhbz#1703564 <https://bugzilla.redhat.com/show_bug.cgi?id=1703564>`__)
    Change hostname length limit to 64
--  `#2445 <https://pagure.io/freeipa/issue/2445>`__
+-  `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__
    (`rhbz#798359 <https://bugzilla.redhat.com/show_bug.cgi?id=798359>`__)
    [RFE] IdM password policy should include checks for repeating
    characters
--  `#3299 <https://pagure.io/freeipa/issue/3299>`__ [RFE] Switch the
+-  `#3299 <https://codeberg.org/freeipa/freeipa/issues/3299>`__ [RFE] Switch the
    client to JSON RPC
--  `#3473 <https://pagure.io/freeipa/issue/3473>`__ Switch to using
+-  `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__ Switch to using
    RESTful interface in dogtag CA interface
--  `#3687 <https://pagure.io/freeipa/issue/3687>`__
+-  `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
    (`rhbz#913799 <https://bugzilla.redhat.com/show_bug.cgi?id=913799>`__)
    [RFE] IPA user account expiry warning.
--  `#3827 <https://pagure.io/freeipa/issue/3827>`__ [RFE] Expose TTL in
+-  `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__ [RFE] Expose TTL in
    web UI
--  `#3999 <https://pagure.io/freeipa/issue/3999>`__
+-  `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
    (`rhbz#837604 <https://bugzilla.redhat.com/show_bug.cgi?id=837604>`__)
    [RFE] Fix and Document how to set up Samba File Server with IPA
--  `#4751 <https://pagure.io/freeipa/issue/4751>`__
+-  `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Implement ACME certificate enrolment
--  `#4972 <https://pagure.io/freeipa/issue/4972>`__
+-  `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
    (`rhbz#1206690 <https://bugzilla.redhat.com/show_bug.cgi?id=1206690>`__)
    check for existence of private group is done even if UPG definition
    is disabled
--  `#5011 <https://pagure.io/freeipa/issue/5011>`__
+-  `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
    (`rhbz#1527185 <https://bugzilla.redhat.com/show_bug.cgi?id=1527185>`__)
    [RFE] Forward CA requests to dogtag or helper by GSSAPI
--  `#5062 <https://pagure.io/freeipa/issue/5062>`__
+-  `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
    (`rhbz#1229657 <https://bugzilla.redhat.com/show_bug.cgi?id=1229657>`__)
    [WebUI] Unlock option is enabled for all user.
--  `#5566 <https://pagure.io/freeipa/issue/5566>`__ Permit creation of
+-  `#5566 <https://codeberg.org/freeipa/freeipa/issues/5566>`__ Permit creation of
    PTR records in non-.arpa master zones via the DNS UI
--  `#5608 <https://pagure.io/freeipa/issue/5608>`__
+-  `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
    (`rhbz#1405935 <https://bugzilla.redhat.com/show_bug.cgi?id=1405935>`__)
    [RFE] Add Dogtag configuration extensions
--  `#5628 <https://pagure.io/freeipa/issue/5628>`__ webui: Unclear(UX)
+-  `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__ webui: Unclear(UX)
    purpose of OTP field in password reset form on login
--  `#5662 <https://pagure.io/freeipa/issue/5662>`__
+-  `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
    (`rhbz#1404770 <https://bugzilla.redhat.com/show_bug.cgi?id=1404770>`__)
    ID Views: do not allow custom Views for the masters
--  `#5879 <https://pagure.io/freeipa/issue/5879>`__
+-  `#5879 <https://codeberg.org/freeipa/freeipa/issues/5879>`__
    (`rhbz#1334619 <https://bugzilla.redhat.com/show_bug.cgi?id=1334619>`__)
    Attempt to fix capitalization fails with ipa: ERROR: Type or value
    exists:
--  `#5914 <https://pagure.io/freeipa/issue/5914>`__
+-  `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__
    (`rhbz#1298288 <https://bugzilla.redhat.com/show_bug.cgi?id=1298288>`__)
    invalid setting of DS lock table size
--  `#5948 <https://pagure.io/freeipa/issue/5948>`__
+-  `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__
    (`rhbz#1340463 <https://bugzilla.redhat.com/show_bug.cgi?id=1340463>`__)
    [RFE] Implement pam_pwquality featureset in IPA password policies
--  `#6115 <https://pagure.io/freeipa/issue/6115>`__
+-  `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
    (`rhbz#1357495 <https://bugzilla.redhat.com/show_bug.cgi?id=1357495>`__)
    ipa command provides stack trace when provided with single hypen
    commands
--  `#6210 <https://pagure.io/freeipa/issue/6210>`__
+-  `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
    (`rhbz#1364139 <https://bugzilla.redhat.com/show_bug.cgi?id=1364139>`__,
    `rhbz#1751951 <https://bugzilla.redhat.com/show_bug.cgi?id=1751951>`__)
    When master's IP address does not resolve to its name,
    ipa-replica-install fails
--  `#6423 <https://pagure.io/freeipa/issue/6423>`__ Validate cert
+-  `#6423 <https://codeberg.org/freeipa/freeipa/issues/6423>`__ Validate cert
    requests in Dogtag
--  `#6474 <https://pagure.io/freeipa/issue/6474>`__ Remove ipaplatform
+-  `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__ Remove ipaplatform
    dependency from ipa modules
--  `#6523 <https://pagure.io/freeipa/issue/6523>`__
+-  `#6523 <https://codeberg.org/freeipa/freeipa/issues/6523>`__
    (`rhbz#1482965 <https://bugzilla.redhat.com/show_bug.cgi?id=1482965>`__)
    Review dns_lookup_kdc option for ipa-client-install
--  `#6708 <https://pagure.io/freeipa/issue/6708>`__ Unused config
+-  `#6708 <https://codeberg.org/freeipa/freeipa/issues/6708>`__ Unused config
    options
--  `#6783 <https://pagure.io/freeipa/issue/6783>`__
+-  `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
    (`rhbz#1430365 <https://bugzilla.redhat.com/show_bug.cgi?id=1430365>`__)
    [RFE] Host-group names command rename
--  `#6843 <https://pagure.io/freeipa/issue/6843>`__
+-  `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__
    (`rhbz#1428690 <https://bugzilla.redhat.com/show_bug.cgi?id=1428690>`__)
    ipa-backup does not create log file at /var/log/
--  `#6857 <https://pagure.io/freeipa/issue/6857>`__ ipa_pwd.c: Use
+-  `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__ ipa_pwd.c: Use
    OpenSSL instead of NSS for hashing
--  `#6884 <https://pagure.io/freeipa/issue/6884>`__
+-  `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
    (`rhbz#1441262 <https://bugzilla.redhat.com/show_bug.cgi?id=1441262>`__)
    ipa group-del gives ipa: ERROR: Insufficient access: but still
    deletes group
--  `#6891 <https://pagure.io/freeipa/issue/6891>`__
+-  `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
    (`rhbz#1461914 <https://bugzilla.redhat.com/show_bug.cgi?id=1461914>`__)
    Move FreeIPA SELinux policy from system policy to project policy
--  `#6951 <https://pagure.io/freeipa/issue/6951>`__
+-  `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
    (`rhbz#1449133 <https://bugzilla.redhat.com/show_bug.cgi?id=1449133>`__)
    Update samba config file and use sss idmap module
--  `#6964 <https://pagure.io/freeipa/issue/6964>`__
+-  `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
    (`rhbz#1442413 <https://bugzilla.redhat.com/show_bug.cgi?id=1442413>`__)
    IPA password policy has no password difference checking
--  `#7125 <https://pagure.io/freeipa/issue/7125>`__
+-  `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
    (`rhbz#1480102 <https://bugzilla.redhat.com/show_bug.cgi?id=1480102>`__)
    ipa-server-upgrade failes with "This entry already exists"
--  `#7137 <https://pagure.io/freeipa/issue/7137>`__
+-  `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
    (`rhbz#1484088 <https://bugzilla.redhat.com/show_bug.cgi?id=1484088>`__)
    [RFE]: Able to browse different links from IPA web gui in new tabs
--  `#7181 <https://pagure.io/freeipa/issue/7181>`__
+-  `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
    (`rhbz#1545755 <https://bugzilla.redhat.com/show_bug.cgi?id=1545755>`__)
    ipa-replica-prepare fails for 2nd replica when passwordHistory is
    enabled
--  `#7188 <https://pagure.io/freeipa/issue/7188>`__ Issues after
+-  `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__ Issues after
    promoting one CA-less IPA server to CA-full
--  `#7255 <https://pagure.io/freeipa/issue/7255>`__
+-  `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
    baseidoverride.get_dn() does not default to a default ID view when
    resolving user IDs
--  `#7305 <https://pagure.io/freeipa/issue/7305>`__
+-  `#7305 <https://codeberg.org/freeipa/freeipa/issues/7305>`__
    (`rhbz#1518153 <https://bugzilla.redhat.com/show_bug.cgi?id=1518153>`__)
    PKINIT status not displayed in the web UI (IPA Server >
    Configuration)
--  `#7307 <https://pagure.io/freeipa/issue/7307>`__
+-  `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
    (`rhbz#1518939 <https://bugzilla.redhat.com/show_bug.cgi?id=1518939>`__)
    RFE: Extend IPA to support unadvertised replicas
--  `#7323 <https://pagure.io/freeipa/issue/7323>`__ IPv6 hack for Travis
+-  `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__ IPv6 hack for Travis
    CI
--  `#7329 <https://pagure.io/freeipa/issue/7329>`__ update_ra_cert_store
+-  `#7329 <https://codeberg.org/freeipa/freeipa/issues/7329>`__ update_ra_cert_store
    does not remove private key from NSSDB
--  `#7416 <https://pagure.io/freeipa/issue/7416>`__ Uninstalling IPA
+-  `#7416 <https://codeberg.org/freeipa/freeipa/issues/7416>`__ Uninstalling IPA
    requires on being in a existent working directory
--  `#7522 <https://pagure.io/freeipa/issue/7522>`__ Disable cert
+-  `#7522 <https://codeberg.org/freeipa/freeipa/issues/7522>`__ Disable cert
    publishing in dogtag
--  `#7534 <https://pagure.io/freeipa/issue/7534>`__
+-  `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
    (`rhbz#1569011 <https://bugzilla.redhat.com/show_bug.cgi?id=1569011>`__)
    Investigate failures to restore 389-ds attriubtes on upgrade failure
--  `#7548 <https://pagure.io/freeipa/issue/7548>`__ Need integration
+-  `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__ Need integration
    test for --external-ca-type=ms-cs
--  `#7566 <https://pagure.io/freeipa/issue/7566>`__
+-  `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
    (`rhbz#1591824 <https://bugzilla.redhat.com/show_bug.cgi?id=1591824>`__)
    Installation of replica against a specific master
--  `#7577 <https://pagure.io/freeipa/issue/7577>`__
+-  `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
    (`rhbz#1579296 <https://bugzilla.redhat.com/show_bug.cgi?id=1579296>`__)
    [RFE] DNS package check should be called earlier in installation
    routine
--  `#7597 <https://pagure.io/freeipa/issue/7597>`__
+-  `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
    (`rhbz#1583950 <https://bugzilla.redhat.com/show_bug.cgi?id=1583950>`__)
    IPA: IDM drops all custom attributes when moving account from
    preserved to stage
--  `#7600 <https://pagure.io/freeipa/issue/7600>`__
+-  `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
    (`rhbz#1585020 <https://bugzilla.redhat.com/show_bug.cgi?id=1585020>`__)
    Enable compat tree to provide information about AD users and groups
    on trust agents
--  `#7610 <https://pagure.io/freeipa/issue/7610>`__ ldapupdate.py users
+-  `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__ ldapupdate.py users
    ldap.LOCAL_ERROR and other direct ldap exceptions while relying on
    ipaldap
--  `#7630 <https://pagure.io/freeipa/issue/7630>`__
+-  `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__
    (`rhbz#1613015 <https://bugzilla.redhat.com/show_bug.cgi?id=1613015>`__)
    ipa-restore should check that optional feature packages are installed
    before restoring a backup using a feature
--  `#7676 <https://pagure.io/freeipa/issue/7676>`__
+-  `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
    (`rhbz#1544379 <https://bugzilla.redhat.com/show_bug.cgi?id=1544379>`__)
    ipa-client-install changes system wide ssh configuration
--  `#7677 <https://pagure.io/freeipa/issue/7677>`__ HSM: ipa ca-add
+-  `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__ HSM: ipa ca-add
    fails with error in ipa-pki-retrieve-key
--  `#7695 <https://pagure.io/freeipa/issue/7695>`__
+-  `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
    (`rhbz#1623763 <https://bugzilla.redhat.com/show_bug.cgi?id=1623763>`__)
    ipa service-del should display principal name instead of Invalid
    'principal'.
--  `#7725 <https://pagure.io/freeipa/issue/7725>`__
+-  `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
    (`rhbz#1636765 <https://bugzilla.redhat.com/show_bug.cgi?id=1636765>`__)
    ipa-restore set wrong file permissions and ownership for
    /var/log/dirsrv/slapd- directory
--  `#7804 <https://pagure.io/freeipa/issue/7804>`__
+-  `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
    (`rhbz#1777811 <https://bugzilla.redhat.com/show_bug.cgi?id=1777811>`__)
    \`ipa otptoken-sync\` fails with stack trace
--  `#7810 <https://pagure.io/freeipa/issue/7810>`__ [F28] Require NSS
+-  `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__ [F28] Require NSS
    with fix for p11-kit issue.
--  `#7816 <https://pagure.io/freeipa/issue/7816>`__
+-  `#7816 <https://codeberg.org/freeipa/freeipa/issues/7816>`__
    (`rhbz#1642395 <https://bugzilla.redhat.com/show_bug.cgi?id=1642395>`__)
    [WebUI] not able to set a password for user as Active Directory
    Administrator user
--  `#7870 <https://pagure.io/freeipa/issue/7870>`__
+-  `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
    (`rhbz#1680039 <https://bugzilla.redhat.com/show_bug.cgi?id=1680039>`__)
    [certmonger][upgrade] "Failed to get request: bus, object_path and
    dbus_interface must not be None."
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
    (`rhbz#1686302 <https://bugzilla.redhat.com/show_bug.cgi?id=1686302>`__)
    ipa trust fetch-domains, server parameter ignored
--  `#7902 <https://pagure.io/freeipa/issue/7902>`__
+-  `#7902 <https://codeberg.org/freeipa/freeipa/issues/7902>`__
    389-ds-base-1.4.0.22-1 breaks
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
--  `#7908 <https://pagure.io/freeipa/issue/7908>`__ Write tests for
+-  `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__ Write tests for
    interactive prompt for NTP options.
--  `#7929 <https://pagure.io/freeipa/issue/7929>`__
+-  `#7929 <https://codeberg.org/freeipa/freeipa/issues/7929>`__
    (`rhbz#1712794 <https://bugzilla.redhat.com/show_bug.cgi?id=1712794>`__)
    ERROR: invalid 'PKINIT enabled server': all masters must have IPA
    master role enabled
--  `#7932 <https://pagure.io/freeipa/issue/7932>`__ FreeIPA queries rely
+-  `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__ FreeIPA queries rely
    on missing attribute altsecurityidentities
--  `#7933 <https://pagure.io/freeipa/issue/7933>`__ FreeIPA must index
+-  `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__ FreeIPA must index
    certmap attributes.
--  `#7938 <https://pagure.io/freeipa/issue/7938>`__ 'ipa
+-  `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__ 'ipa
    dnszone-show/find' should display "Dynamic Update" and "Bind update
    policy" by default
--  `#7949 <https://pagure.io/freeipa/issue/7949>`__
+-  `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
    test_integration/test_nfs.py fails at cleanup
--  `#7958 <https://pagure.io/freeipa/issue/7958>`__
+-  `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__
    (`rhbz#1782169 <https://bugzilla.redhat.com/show_bug.cgi?id=1782169>`__)
    traceback in idview
--  `#7961 <https://pagure.io/freeipa/issue/7961>`__ [WebUI] Identity
+-  `#7961 <https://codeberg.org/freeipa/freeipa/issues/7961>`__ [WebUI] Identity
    Manager WebUI requires you to save changes after changing
    specifications before making other change
--  `#7966 <https://pagure.io/freeipa/issue/7966>`__ Add support for
+-  `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__ Add support for
    JSON-RPC in ipa-join
--  `#7971 <https://pagure.io/freeipa/issue/7971>`__
+-  `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
    (`rhbz#1715961 <https://bugzilla.redhat.com/show_bug.cgi?id=1715961>`__)
    [RFE] Include hint for replication_wait_timeout if timeout fails
--  `#7975 <https://pagure.io/freeipa/issue/7975>`__ Accept 389-ds JSON
+-  `#7975 <https://codeberg.org/freeipa/freeipa/issues/7975>`__ Accept 389-ds JSON
    replication status messages
--  `#7985 <https://pagure.io/freeipa/issue/7985>`__ test failure in
+-  `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__ test failure in
    test_dnssec.py::TestInstallDNSSECLast::()::test_disable_reenable_signing_replica::teardown
--  `#7987 <https://pagure.io/freeipa/issue/7987>`__ Python shebang: Use
+-  `#7987 <https://codeberg.org/freeipa/freeipa/issues/7987>`__ Python shebang: Use
    isolated mode
--  `#7989 <https://pagure.io/freeipa/issue/7989>`__ Pytest4.2+ errors
--  `#7991 <https://pagure.io/freeipa/issue/7991>`__ Use profile-based
+-  `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__ Pytest4.2+ errors
+-  `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__ Use profile-based
    renewal for system certificates
--  `#7995 <https://pagure.io/freeipa/issue/7995>`__
+-  `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
    (`rhbz#1711172 <https://bugzilla.redhat.com/show_bug.cgi?id=1711172>`__)
    Removing TLSv1.0, TLSv1.1 from nss.conf
--  `#7996 <https://pagure.io/freeipa/issue/7996>`__
+-  `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__
    \`test_selinuxusermap_plugin\` fails against not default SELinux
    settings
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8004 <https://pagure.io/freeipa/issue/8004>`__ RHEL 8 uses
+-  `#8004 <https://codeberg.org/freeipa/freeipa/issues/8004>`__ RHEL 8 uses
    nis-domainname instead of rhel-domainname
--  `#8005 <https://pagure.io/freeipa/issue/8005>`__
+-  `#8005 <https://codeberg.org/freeipa/freeipa/issues/8005>`__
    (`rhbz#1729099 <https://bugzilla.redhat.com/show_bug.cgi?id=1729099>`__)
    User field separator uses '$$' within ipaSELinuxUserMapOrder
--  `#8007 <https://pagure.io/freeipa/issue/8007>`__ Not stable nodeids
+-  `#8007 <https://codeberg.org/freeipa/freeipa/issues/8007>`__ Not stable nodeids
    within pytest
--  `#8008 <https://pagure.io/freeipa/issue/8008>`__ Azure Pipeline
+-  `#8008 <https://codeberg.org/freeipa/freeipa/issues/8008>`__ Azure Pipeline
    slicing
--  `#8009 <https://pagure.io/freeipa/issue/8009>`__ Missing execution
+-  `#8009 <https://codeberg.org/freeipa/freeipa/issues/8009>`__ Missing execution
    bit on \`ipa-run-tests\` within virtualenv
--  `#8010 <https://pagure.io/freeipa/issue/8010>`__ Extended Kerberos
+-  `#8010 <https://codeberg.org/freeipa/freeipa/issues/8010>`__ Extended Kerberos
    Ticket Policy
--  `#8012 <https://pagure.io/freeipa/issue/8012>`__
+-  `#8012 <https://codeberg.org/freeipa/freeipa/issues/8012>`__
    test_webui/test_loginscreen.py::TestLoginScreen::()::test_reset_password_and_login_view
    failure
--  `#8013 <https://pagure.io/freeipa/issue/8013>`__
+-  `#8013 <https://codeberg.org/freeipa/freeipa/issues/8013>`__
    (`rhbz#1731433 <https://bugzilla.redhat.com/show_bug.cgi?id=1731433>`__)
    ipa service-find does not list cifs service created by
    ipa-client-samba
--  `#8015 <https://pagure.io/freeipa/issue/8015>`__ p11helper:
+-  `#8015 <https://codeberg.org/freeipa/freeipa/issues/8015>`__ p11helper:
    insufficient logging when loading LIBSOFTHSM2_SO
--  `#8017 <https://pagure.io/freeipa/issue/8017>`__
+-  `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
    (`rhbz#1817927 <https://bugzilla.redhat.com/show_bug.cgi?id=1817927>`__)
    host-add --password logs cleartext userpassword to Apache error log
--  `#8019 <https://pagure.io/freeipa/issue/8019>`__
+-  `#8019 <https://codeberg.org/freeipa/freeipa/issues/8019>`__
    (`rhbz#1732524 <https://bugzilla.redhat.com/show_bug.cgi?id=1732524>`__)
    repeated uninstallation of ipa-client-samba crashes
--  `#8020 <https://pagure.io/freeipa/issue/8020>`__ support AES in LWCA
+-  `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__ support AES in LWCA
    key replication
--  `#8021 <https://pagure.io/freeipa/issue/8021>`__
+-  `#8021 <https://codeberg.org/freeipa/freeipa/issues/8021>`__
    (`rhbz#1732528 <https://bugzilla.redhat.com/show_bug.cgi?id=1732528>`__)
    ipa-client-samba can not install samba after uninstallation
--  `#8022 <https://pagure.io/freeipa/issue/8022>`__ azure pipeline: fail
+-  `#8022 <https://codeberg.org/freeipa/freeipa/issues/8022>`__ azure pipeline: fail
    if dnf builddep exits on failure
--  `#8024 <https://pagure.io/freeipa/issue/8024>`__ [WebUI]
+-  `#8024 <https://codeberg.org/freeipa/freeipa/issues/8024>`__ [WebUI]
    test_webui/test_trust.py failed because of request timeout
--  `#8026 <https://pagure.io/freeipa/issue/8026>`__ Update pr-ci
+-  `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__ Update pr-ci
    definitions with master_3client topology
--  `#8027 <https://pagure.io/freeipa/issue/8027>`__ test_nfs.py: migrate
+-  `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__ test_nfs.py: migrate
    to master_3client
--  `#8028 <https://pagure.io/freeipa/issue/8028>`__
+-  `#8028 <https://codeberg.org/freeipa/freeipa/issues/8028>`__
    ipadb_ldap_attr_to_krb5_timestamp() isn't 2038-safe
--  `#8029 <https://pagure.io/freeipa/issue/8029>`__
+-  `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
    (`rhbz#1749788 <https://bugzilla.redhat.com/show_bug.cgi?id=1749788>`__)
    ipa host-find --pkey-only includes SSH keys in output
--  `#8030 <https://pagure.io/freeipa/issue/8030>`__ azure pipelines fail
+-  `#8030 <https://codeberg.org/freeipa/freeipa/issues/8030>`__ azure pipelines fail
    at "Install prerequisites" of Tox job
--  `#8031 <https://pagure.io/freeipa/issue/8031>`__
+-  `#8031 <https://codeberg.org/freeipa/freeipa/issues/8031>`__
    (`rhbz#1734369 <https://bugzilla.redhat.com/show_bug.cgi?id=1734369>`__)
    HBAC Test Validation error when running the HBAC test the second time
    round via the IPA Web GUI
--  `#8034 <https://pagure.io/freeipa/issue/8034>`__ Existing p11-kit
+-  `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__ Existing p11-kit
    config file is not restored on uninstall
--  `#8038 <https://pagure.io/freeipa/issue/8038>`__
+-  `#8038 <https://codeberg.org/freeipa/freeipa/issues/8038>`__
    (`rhbz#1740167 <https://bugzilla.redhat.com/show_bug.cgi?id=1740167>`__)
    ipa-client-automount --uninstall is not restoring nsswitch.conf
--  `#8040 <https://pagure.io/freeipa/issue/8040>`__
+-  `#8040 <https://codeberg.org/freeipa/freeipa/issues/8040>`__
    (`rhbz#1731963 <https://bugzilla.redhat.com/show_bug.cgi?id=1731963>`__)
    ipa migrate-ds fails with internal error.
--  `#8044 <https://pagure.io/freeipa/issue/8044>`__
+-  `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
    (`rhbz#1717008 <https://bugzilla.redhat.com/show_bug.cgi?id=1717008>`__)
    Extdom plugin should not return LDAP_NO_SUCH_OBJECT if there are
    timeout or other errors
--  `#8048 <https://pagure.io/freeipa/issue/8048>`__ Travis-CI sometimes
+-  `#8048 <https://codeberg.org/freeipa/freeipa/issues/8048>`__ Travis-CI sometimes
    fails at dnf
--  `#8052 <https://pagure.io/freeipa/issue/8052>`__ test failure in
+-  `#8052 <https://codeberg.org/freeipa/freeipa/issues/8052>`__ test failure in
    test_integration/test_sudo.py::TestSudo::()::test_domain_resolution_order
    on fedora29
--  `#8053 <https://pagure.io/freeipa/issue/8053>`__ [WebUI] Fix login
+-  `#8053 <https://codeberg.org/freeipa/freeipa/issues/8053>`__ [WebUI] Fix login
    screen loading issue in test_loginscreen
--  `#8054 <https://pagure.io/freeipa/issue/8054>`__
+-  `#8054 <https://codeberg.org/freeipa/freeipa/issues/8054>`__
    (`rhbz#1746557 <https://bugzilla.redhat.com/show_bug.cgi?id=1746557>`__)
    ipa-client-install calls "authselect select sssd --force" at
    uninstall time before restoring user-nsswitch.conf
--  `#8055 <https://pagure.io/freeipa/issue/8055>`__ Test for PG6843:
+-  `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__ Test for PG6843:
    ipa-backup does not create log file at /var/log is failing
--  `#8056 <https://pagure.io/freeipa/issue/8056>`__
+-  `#8056 <https://codeberg.org/freeipa/freeipa/issues/8056>`__
    (`rhbz#1746882 <https://bugzilla.redhat.com/show_bug.cgi?id=1746882>`__)
    BuildRequires is not compatible with %{_libdir}
--  `#8057 <https://pagure.io/freeipa/issue/8057>`__
+-  `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
    (`rhbz#1747895 <https://bugzilla.redhat.com/show_bug.cgi?id=1747895>`__)
    Running ipa-server-install produces SyntaxWarning: "is not" with a
    literal. Did you mean "!="?
--  `#8062 <https://pagure.io/freeipa/issue/8062>`__ Re-add
+-  `#8062 <https://codeberg.org/freeipa/freeipa/issues/8062>`__ Re-add
    configure_nsswitch_database, configure_nsswitch, ... to
    ipaclient.install
--  `#8063 <https://pagure.io/freeipa/issue/8063>`__ Nightly test failure
+-  `#8063 <https://codeberg.org/freeipa/freeipa/issues/8063>`__ Nightly test failure
    in
    test_integration/test_nfs.py::TestIpaClientAutomountFileRestore::()::test_nsswitch_backup_restore_sssd
--  `#8064 <https://pagure.io/freeipa/issue/8064>`__ Request for IPA CI
+-  `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__ Request for IPA CI
    to enable DS audit/auditfail logging
--  `#8066 <https://pagure.io/freeipa/issue/8066>`__
+-  `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
    (`rhbz#1750242 <https://bugzilla.redhat.com/show_bug.cgi?id=1750242>`__)
    Don't use -t option to klist in adtrust code when timestamp is not
    needed
--  `#8067 <https://pagure.io/freeipa/issue/8067>`__
+-  `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
    (`rhbz#1750700 <https://bugzilla.redhat.com/show_bug.cgi?id=1750700>`__)
    add default access control configuration to trusted domain objects
--  `#8070 <https://pagure.io/freeipa/issue/8070>`__ Test failure in
+-  `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__ Test failure in
    test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::()::test_hidden_replica_install
--  `#8073 <https://pagure.io/freeipa/issue/8073>`__ Backup/restore does
+-  `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__ Backup/restore does
    not restore /etc/pkcs11/modules/softhsm2.module
--  `#8075 <https://pagure.io/freeipa/issue/8075>`__ Don't create log
+-  `#8075 <https://codeberg.org/freeipa/freeipa/issues/8075>`__ Don't create log
    file for helper scripts
--  `#8077 <https://pagure.io/freeipa/issue/8077>`__ New pylint 2.4.0
+-  `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__ New pylint 2.4.0
    errors
--  `#8079 <https://pagure.io/freeipa/issue/8079>`__
+-  `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
    (`rhbz#1754530 <https://bugzilla.redhat.com/show_bug.cgi?id=1754530>`__)
    [Security] By default, DNS recursion is open, breaking best practices
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
    (`rhbz#1756432 <https://bugzilla.redhat.com/show_bug.cgi?id=1756432>`__)
    Default client configuration breaks ssh in FIPS mode.
--  `#8084 <https://pagure.io/freeipa/issue/8084>`__
+-  `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
    (`rhbz#1758406 <https://bugzilla.redhat.com/show_bug.cgi?id=1758406>`__)
    KRA authentication fails when IPA CA has custom Subject DN
--  `#8086 <https://pagure.io/freeipa/issue/8086>`__
+-  `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
    (`rhbz#1756568 <https://bugzilla.redhat.com/show_bug.cgi?id=1756568>`__)
    ipa-server-certinstall man page does not match built-in help.
--  `#8094 <https://pagure.io/freeipa/issue/8094>`__ Allow using of a
+-  `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__ Allow using of a
    custom OpenSSL engine for ISC BIND
--  `#8097 <https://pagure.io/freeipa/issue/8097>`__ ipa
+-  `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__ ipa
    user-add-certmapdata is not able to add several entries correctly
--  `#8098 <https://pagure.io/freeipa/issue/8098>`__ Host principals lack
+-  `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__ Host principals lack
    ACI to look up DNS objects in LDAP
--  `#8099 <https://pagure.io/freeipa/issue/8099>`__
+-  `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
    (`rhbz#1762317 <https://bugzilla.redhat.com/show_bug.cgi?id=1762317>`__)
    ipa-backup command is failing on rhel-7.8
--  `#8101 <https://pagure.io/freeipa/issue/8101>`__ Wrong pytest
+-  `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__ Wrong pytest
    requirement in specfile
--  `#8102 <https://pagure.io/freeipa/issue/8102>`__ Pylint 2.4.3 +
+-  `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__ Pylint 2.4.3 +
    Astroid 2.3.2 errors
--  `#8104 <https://pagure.io/freeipa/issue/8104>`__ RFE: Disable
+-  `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__ RFE: Disable
    Stale/Inactive Users - Upstream Design Document
--  `#8105 <https://pagure.io/freeipa/issue/8105>`__
+-  `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
    (`rhbz#1759281 <https://bugzilla.redhat.com/show_bug.cgi?id=1759281>`__)
    getcert with -F option returns before cacert file is created
--  `#8106 <https://pagure.io/freeipa/issue/8106>`__ ca-certificate file
+-  `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__ ca-certificate file
    not being parsed correctly on Ubuntu with p11-kit-trust.so due to
    data inserted by FreeIPA Client install
--  `#8110 <https://pagure.io/freeipa/issue/8110>`__
+-  `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
    (`rhbz#1768015 <https://bugzilla.redhat.com/show_bug.cgi?id=1768015>`__)
    Enable AES SHA 256 and 384 Kerberos enctypes
--  `#8111 <https://pagure.io/freeipa/issue/8111>`__
+-  `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
    (`rhbz#1768959 <https://bugzilla.redhat.com/show_bug.cgi?id=1768959>`__)
    [FIPS] Don't add camellia KRB5 encsalttypes in FIPS mode
--  `#8113 <https://pagure.io/freeipa/issue/8113>`__
+-  `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
    (`rhbz#1755535 <https://bugzilla.redhat.com/show_bug.cgi?id=1755535>`__)
    ipa-advise on a RHEL7 IdM server is not able to generate a
    configuration script for a RHEL8 IdM client
--  `#8114 <https://pagure.io/freeipa/issue/8114>`__ [RFE] Delegate group
+-  `#8114 <https://codeberg.org/freeipa/freeipa/issues/8114>`__ [RFE] Delegate group
    membership management
--  `#8115 <https://pagure.io/freeipa/issue/8115>`__ Nightly test failure
+-  `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__ Nightly test failure
    in fedora-30/test_smb and fedora-29/test_smb
--  `#8116 <https://pagure.io/freeipa/issue/8116>`__ Pylint parallel
+-  `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__ Pylint parallel
    execution with custom plugin
--  `#8118 <https://pagure.io/freeipa/issue/8118>`__ Run smoke tests in
+-  `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__ Run smoke tests in
    FIPS mode
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
    (`rhbz#1769791 <https://bugzilla.redhat.com/show_bug.cgi?id=1769791>`__)
    Invisible part of notification area in Web UI intercepts clicks of
    some page elements
--  `#8122 <https://pagure.io/freeipa/issue/8122>`__
+-  `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
    (`rhbz#1773528 <https://bugzilla.redhat.com/show_bug.cgi?id=1773528>`__)
    group-add-member-manager does not report errors
--  `#8123 <https://pagure.io/freeipa/issue/8123>`__
+-  `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__
    (`rhbz#1773528 <https://bugzilla.redhat.com/show_bug.cgi?id=1773528>`__)
    [WebUI] Finish group membership management UI
--  `#8124 <https://pagure.io/freeipa/issue/8124>`__ Add option to
+-  `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__ Add option to
    ipa-cacert-manage to delete certificates
--  `#8125 <https://pagure.io/freeipa/issue/8125>`__
+-  `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
    (`rhbz#1777809 <https://bugzilla.redhat.com/show_bug.cgi?id=1777809>`__)
    Use default crypto policy for TLS and enable TLS 1.3 support
--  `#8129 <https://pagure.io/freeipa/issue/8129>`__ Tests: Replace
+-  `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__ Tests: Replace
    paramiko with OpenSSH
--  `#8131 <https://pagure.io/freeipa/issue/8131>`__
+-  `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
    (`rhbz#1777920 <https://bugzilla.redhat.com/show_bug.cgi?id=1777920>`__)
    covscan memory leaks report
--  `#8133 <https://pagure.io/freeipa/issue/8133>`__
+-  `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
    check_client_configuration() no longer works with IPA_CONFDIR
--  `#8134 <https://pagure.io/freeipa/issue/8134>`__ ipa user-add is
+-  `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__ ipa user-add is
    inefficient
--  `#8135 <https://pagure.io/freeipa/issue/8135>`__
+-  `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__
    (`rhbz#1777806 <https://bugzilla.redhat.com/show_bug.cgi?id=1777806>`__)
    When Service weight is set as 0 for server in IPA location "IPA Error
    903: InternalError" is displayed
--  `#8137 <https://pagure.io/freeipa/issue/8137>`__ reinstall failed in
+-  `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__ reinstall failed in
    adding delegation layout
--  `#8138 <https://pagure.io/freeipa/issue/8138>`__
+-  `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
    (`rhbz#1780548 <https://bugzilla.redhat.com/show_bug.cgi?id=1780548>`__)
    Man page ipa-cacert-manage does not display correctly on RHEL
--  `#8142 <https://pagure.io/freeipa/issue/8142>`__ check Not Before /
+-  `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__ check Not Before /
    Not After in externally signed CA sanity check
--  `#8143 <https://pagure.io/freeipa/issue/8143>`__
+-  `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
    service.ldap_disable() does not remove "enabledService"
--  `#8144 <https://pagure.io/freeipa/issue/8144>`__ test_nfs.py:
+-  `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__ test_nfs.py:
    umount.nfs4: /home: device is busy
--  `#8148 <https://pagure.io/freeipa/issue/8148>`__
+-  `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
    (`rhbz#1782587 <https://bugzilla.redhat.com/show_bug.cgi?id=1782587>`__)
    add "systemctl restart sssd" to warning message when adding trust
    agents to replicas
--  `#8149 <https://pagure.io/freeipa/issue/8149>`__
+-  `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
    (`rhbz#1783046 <https://bugzilla.redhat.com/show_bug.cgi?id=1783046>`__)
    SIDs of AD domains do not display in ipa-client-samba installer
--  `#8150 <https://pagure.io/freeipa/issue/8150>`__
+-  `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__
    (`rhbz#1784003 <https://bugzilla.redhat.com/show_bug.cgi?id=1784003>`__)
    IPA Server install fail
--  `#8151 <https://pagure.io/freeipa/issue/8151>`__ test_commands
+-  `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__ test_commands
    timing-out
--  `#8153 <https://pagure.io/freeipa/issue/8153>`__
+-  `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__
    (`rhbz#1784761 <https://bugzilla.redhat.com/show_bug.cgi?id=1784761>`__)
    Kerberos ticket policy reset does not reset per-indicator policies
--  `#8157 <https://pagure.io/freeipa/issue/8157>`__ NIghtly test failure
+-  `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__ NIghtly test failure
    in fedora-rawhide/test_webui_network
--  `#8159 <https://pagure.io/freeipa/issue/8159>`__ please migrate to
+-  `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__ please migrate to
    the new Fedora translation platform
--  `#8163 <https://pagure.io/freeipa/issue/8163>`__
+-  `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
    (`rhbz#1782572 <https://bugzilla.redhat.com/show_bug.cgi?id=1782572>`__)
    "Internal Server Error" reported for minor issues implies IPA is
    broken [IdmHackfest2019]
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
    (`rhbz#1788907 <https://bugzilla.redhat.com/show_bug.cgi?id=1788907>`__)
    Renewed certs are not picked up by IPA CAs
--  `#8169 <https://pagure.io/freeipa/issue/8169>`__ NIghtly test failure
+-  `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__ NIghtly test failure
    in fedora-rawhide/test_webui_policy
--  `#8170 <https://pagure.io/freeipa/issue/8170>`__ Nightly test failure
+-  `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__ Nightly test failure
    in
    fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNS
--  `#8173 <https://pagure.io/freeipa/issue/8173>`__ Broken -k argument
+-  `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__ Broken -k argument
    parsing in ipa-run-tests 4.8.4-1 package
--  `#8176 <https://pagure.io/freeipa/issue/8176>`__ External CA is
+-  `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__ External CA is
    tracked for renewals and replaced with a self-signed certificate
--  `#8179 <https://pagure.io/freeipa/issue/8179>`__ Tests broken with
+-  `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__ Tests broken with
    python version < 3.7 (module 're' has no attribute 'Pattern')
--  `#8186 <https://pagure.io/freeipa/issue/8186>`__ Add ipa-ca.$DOMAIN
+-  `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__ Add ipa-ca.$DOMAIN
    alias to IPA server HTTP certificates
--  `#8189 <https://pagure.io/freeipa/issue/8189>`__
+-  `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
    (`rhbz#1810179 <https://bugzilla.redhat.com/show_bug.cgi?id=1810179>`__)
    NIghtly test failure in
    test_integration/test_nfs.py::TestIpaClientAutomountFileRestore::test_nsswitch_backup_restore_sssd
--  `#8190 <https://pagure.io/freeipa/issue/8190>`__
+-  `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
    (`rhbz#1790886 <https://bugzilla.redhat.com/show_bug.cgi?id=1790886>`__)
    ipa-client-automount fails after repeated installation/uninstallation
--  `#8192 <https://pagure.io/freeipa/issue/8192>`__
+-  `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__
    (`rhbz#1665051 <https://bugzilla.redhat.com/show_bug.cgi?id=1665051>`__)
    ipa-adtrust-install does not list service records for manual addition
    to DNS zone
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
    (`rhbz#1801791 <https://bugzilla.redhat.com/show_bug.cgi?id=1801791>`__)
    Re-order 50-externalmembers.update to be after
    80-schema_compat.update
--  `#8196 <https://pagure.io/freeipa/issue/8196>`__ API: dnsrecord_del
+-  `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__ API: dnsrecord_del
    failure with empty list aaaarecord
--  `#8200 <https://pagure.io/freeipa/issue/8200>`__
+-  `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__
    (`rhbz#1803786 <https://bugzilla.redhat.com/show_bug.cgi?id=1803786>`__)
    ipa krb5kdc db: krb5kdc coredump
--  `#8201 <https://pagure.io/freeipa/issue/8201>`__ update
+-  `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__ update
    ssbrowser.html
--  `#8202 <https://pagure.io/freeipa/issue/8202>`__ Azure: add support
+-  `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__ Azure: add support
    for multi-container tests
--  `#8204 <https://pagure.io/freeipa/issue/8204>`__
+-  `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
    (`rhbz#1810148 <https://bugzilla.redhat.com/show_bug.cgi?id=1810148>`__)
    ipa-server-certinstall -> certmonger add_subject template-subject
    dbus 'unable to set arguments' a{sv}
--  `#8207 <https://pagure.io/freeipa/issue/8207>`__ Extend Web UI for
+-  `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__ Extend Web UI for
    Kerberos ticket policy to add authentication indicator support
--  `#8214 <https://pagure.io/freeipa/issue/8214>`__ Support for
+-  `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__ Support for
    opendnssec 2.1.6
--  `#8217 <https://pagure.io/freeipa/issue/8217>`__
+-  `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
    (`rhbz#1810154 <https://bugzilla.redhat.com/show_bug.cgi?id=1810154>`__)
    RFE: ipa-backup should compare locally and globally installed server
    roles
--  `#8219 <https://pagure.io/freeipa/issue/8219>`__ ipatests: unify
+-  `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__ ipatests: unify
    editing of sssd.conf
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
    (`rhbz#1812169 <https://bugzilla.redhat.com/show_bug.cgi?id=1812169>`__)
    Secure AJP connector between Dogtag and Apache proxy
--  `#8222 <https://pagure.io/freeipa/issue/8222>`__ Upgrade dojo.js
--  `#8226 <https://pagure.io/freeipa/issue/8226>`__
+-  `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__ Upgrade dojo.js
+-  `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
    (`rhbz#1813330 <https://bugzilla.redhat.com/show_bug.cgi?id=1813330>`__)
    ipa-restore does not restart httpd
--  `#8228 <https://pagure.io/freeipa/issue/8228>`__ Nightly failure in
+-  `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__ Nightly failure in
    backup/restore while calling 'id admin'
--  `#8233 <https://pagure.io/freeipa/issue/8233>`__ 4.8.5 master
+-  `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__ 4.8.5 master
    Installation error
--  `#8236 <https://pagure.io/freeipa/issue/8236>`__
+-  `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
    (`rhbz#1809835 <https://bugzilla.redhat.com/show_bug.cgi?id=1809835>`__)
    Enforce a check to prevent adding objects from IPA as external
    members of external groups
--  `#8239 <https://pagure.io/freeipa/issue/8239>`__ Actualize Bootstrap
+-  `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__ Actualize Bootstrap
    version
--  `#8240 <https://pagure.io/freeipa/issue/8240>`__
+-  `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__
    (`rhbz#1816784 <https://bugzilla.redhat.com/show_bug.cgi?id=1816784>`__)
    KRA install fails if all KRA members are Hidden Replicas
--  `#8241 <https://pagure.io/freeipa/issue/8241>`__ Build fails on
+-  `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__ Build fails on
    Fedora 30
--  `#8247 <https://pagure.io/freeipa/issue/8247>`__ test_fips PR-CI
+-  `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__ test_fips PR-CI
    templates have a too-short timeout
--  `#8248 <https://pagure.io/freeipa/issue/8248>`__ httpd ccaches
+-  `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__ httpd ccaches
    created during server upgrade aren't cleaned up on uninstall/install
--  `#8251 <https://pagure.io/freeipa/issue/8251>`__ [Azure] Catch
+-  `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__ [Azure] Catch
    coredumps
--  `#8254 <https://pagure.io/freeipa/issue/8254>`__ [Azure] 'Tox' task
+-  `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__ [Azure] 'Tox' task
    fails against Python3.8
--  `#8261 <https://pagure.io/freeipa/issue/8261>`__ [ipatests]
+-  `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__ [ipatests]
    Integration tests fail on non-firewalld distros
--  `#8262 <https://pagure.io/freeipa/issue/8262>`__ test_ipahealthcheck
+-  `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__ test_ipahealthcheck
    needs a higher timeout than 3600
--  `#8264 <https://pagure.io/freeipa/issue/8264>`__ Nightly test failure
+-  `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__ Nightly test failure
    in
    test_integration.test_commands.TestIPACommand.test_hbac_systemd_user
--  `#8265 <https://pagure.io/freeipa/issue/8265>`__ [ipatests]
+-  `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__ [ipatests]
    \`/var/log/ipaupgrade.log\` is not collected
--  `#8266 <https://pagure.io/freeipa/issue/8266>`__ test_webui_server
+-  `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__ test_webui_server
    requires a higher timeout than 3600
--  `#8268 <https://pagure.io/freeipa/issue/8268>`__ Prevent use of too
+-  `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__ Prevent use of too
    long passwords
--  `#8272 <https://pagure.io/freeipa/issue/8272>`__ Use /run instead of
+-  `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__ Use /run instead of
    /var/run
--  `#8273 <https://pagure.io/freeipa/issue/8273>`__
+-  `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
    (`rhbz#1834385 <https://bugzilla.redhat.com/show_bug.cgi?id=1834385>`__)
    Man page syntax issue detected by rpminspect
--  `#8275 <https://pagure.io/freeipa/issue/8275>`__
+-  `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
    (`rhbz#1880628 <https://bugzilla.redhat.com/show_bug.cgi?id=1880628>`__)
    Support systemd-resolved
--  `#8276 <https://pagure.io/freeipa/issue/8276>`__ Add default password
+-  `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__ Add default password
    policy for sysaccounts
--  `#8283 <https://pagure.io/freeipa/issue/8283>`__ Failures and AVCs
+-  `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__ Failures and AVCs
    with OpenDNSSEC 2.1
--  `#8284 <https://pagure.io/freeipa/issue/8284>`__ Upgrade jQuery
+-  `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__ Upgrade jQuery
    version to actual one
--  `#8287 <https://pagure.io/freeipa/issue/8287>`__ named not starting
+-  `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__ named not starting
    after #8079, ipa-ext.conf breaks bind
--  `#8289 <https://pagure.io/freeipa/issue/8289>`__ ipa
+-  `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__ ipa
    servicedelegationtarget-add-member does not allow to add hosts as
    targets
--  `#8290 <https://pagure.io/freeipa/issue/8290>`__ API inconsistencies
--  `#8291 <https://pagure.io/freeipa/issue/8291>`__ krb5kdc crashes in
+-  `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__ API inconsistencies
+-  `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__ krb5kdc crashes in
    IPA plugin on use of IPA Windows principal alias
--  `#8297 <https://pagure.io/freeipa/issue/8297>`__ Fix new pylint 2.5.0
+-  `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__ Fix new pylint 2.5.0
    warnings and errors
--  `#8298 <https://pagure.io/freeipa/issue/8298>`__ [WebUI] Cover
+-  `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__ [WebUI] Cover
    membership management with UI tests
--  `#8300 <https://pagure.io/freeipa/issue/8300>`__ Replace uglify-js
+-  `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__ Replace uglify-js
    with python3-rjsmin
--  `#8301 <https://pagure.io/freeipa/issue/8301>`__ The value of the
+-  `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__ The value of the
    first character in target\* keywords is expected to be a double quote
--  `#8304 <https://pagure.io/freeipa/issue/8304>`__ [fed32]
+-  `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__ [fed32]
    client-install does not properly set ChallengeResponseAuthentication
    yes in sshd conf
--  `#8306 <https://pagure.io/freeipa/issue/8306>`__ Adopt Black code
+-  `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__ Adopt Black code
    style
--  `#8307 <https://pagure.io/freeipa/issue/8307>`__ make devcheck fails
+-  `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__ make devcheck fails
    for test_ipatests_plugins/test_ipa_run_tests.py
--  `#8308 <https://pagure.io/freeipa/issue/8308>`__
+-  `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
    (`rhbz#1829787 <https://bugzilla.redhat.com/show_bug.cgi?id=1829787>`__)
    ipa service-del deletes the required principal when specified in
    lower/upper case
--  `#8309 <https://pagure.io/freeipa/issue/8309>`__ Convert ipaplatform
+-  `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__ Convert ipaplatform
    from namespace package to regular package
--  `#8311 <https://pagure.io/freeipa/issue/8311>`__
+-  `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
    (`rhbz#1825829 <https://bugzilla.redhat.com/show_bug.cgi?id=1825829>`__)
    ipa-advise on a RHEL7 IdM server generate a configuration script for
    client having hardcoded python3
--  `#8312 <https://pagure.io/freeipa/issue/8312>`__ Fix api.env.in_tree
+-  `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__ Fix api.env.in_tree
    detection logic
--  `#8313 <https://pagure.io/freeipa/issue/8313>`__ Values of
+-  `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__ Values of
    api.env.mode are inconsistent
--  `#8315 <https://pagure.io/freeipa/issue/8315>`__
+-  `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
    (`rhbz#1833266 <https://bugzilla.redhat.com/show_bug.cgi?id=1833266>`__)
    [dirsrv] set 'nsslapd-enable-upgrade-hash: off' as this raises
    warnings
--  `#8316 <https://pagure.io/freeipa/issue/8316>`__ [Azure] Whitelist
+-  `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__ [Azure] Whitelist
    clock_adjtime syscall
--  `#8317 <https://pagure.io/freeipa/issue/8317>`__ XML-RCP and CLI
+-  `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__ XML-RCP and CLI
    tests depend on internal --force option
--  `#8319 <https://pagure.io/freeipa/issue/8319>`__ Support server
+-  `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__ Support server
    referrals for enterprise principals
--  `#8322 <https://pagure.io/freeipa/issue/8322>`__ [RFE] Changing
+-  `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__ [RFE] Changing
    default hostgroup is too easy
--  `#8323 <https://pagure.io/freeipa/issue/8323>`__ [Build failure]
+-  `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__ [Build failure]
    Race: make po fails on parallel build
--  `#8325 <https://pagure.io/freeipa/issue/8325>`__ [WebUI] Fix
+-  `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__ [WebUI] Fix
    htmlPrefilter issue in jQuery
--  `#8326 <https://pagure.io/freeipa/issue/8326>`__ CVE-2020-10747
--  `#8328 <https://pagure.io/freeipa/issue/8328>`__ krbtpolicy-mod
+-  `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__ CVE-2020-10747
+-  `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__ krbtpolicy-mod
    cannot handle two auth ind options of the same type at the same time
--  `#8330 <https://pagure.io/freeipa/issue/8330>`__ [Azure] Build job
+-  `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__ [Azure] Build job
    fails on \`tests\` container preparation
--  `#8335 <https://pagure.io/freeipa/issue/8335>`__ [WebUI] manage IPA
+-  `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__ [WebUI] manage IPA
    resources as a user from a trusted Active Directory domain
--  `#8336 <https://pagure.io/freeipa/issue/8336>`__ [WebUI] "User
+-  `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__ [WebUI] "User
    attributes for SMB services" section always shown
--  `#8338 <https://pagure.io/freeipa/issue/8338>`__ [WebUI] Host detail
+-  `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__ [WebUI] Host detail
    with no assigned ID view makes invalid RPC call
--  `#8339 <https://pagure.io/freeipa/issue/8339>`__ [WebUI] User details
+-  `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__ [WebUI] User details
    tab headers don't show member count when on settings tab
--  `#8344 <https://pagure.io/freeipa/issue/8344>`__ Nightly test failure
+-  `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8348 <https://pagure.io/freeipa/issue/8348>`__ Allow managed
+-  `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__ Allow managed
    permissions with ldap:///self bind rule
--  `#8349 <https://pagure.io/freeipa/issue/8349>`__ bind-9.16 and
+-  `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__ bind-9.16 and
    dnssec-enable
--  `#8350 <https://pagure.io/freeipa/issue/8350>`__ bind-9.16 and DLV
--  `#8352 <https://pagure.io/freeipa/issue/8352>`__ RPC API crashes when
+-  `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__ bind-9.16 and DLV
+-  `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__ RPC API crashes when
    a user is disabled while a session exists
--  `#8357 <https://pagure.io/freeipa/issue/8357>`__ Allow managing IPA
+-  `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__ Allow managing IPA
    resources as a user from a trusted Active Directory forest
--  `#8358 <https://pagure.io/freeipa/issue/8358>`__ TTL of DNS record
+-  `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__ TTL of DNS record
    can be set to negative value
--  `#8359 <https://pagure.io/freeipa/issue/8359>`__ [WebUI]
+-  `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__ [WebUI]
    dnsrecord_mod results in JS error
--  `#8360 <https://pagure.io/freeipa/issue/8360>`__ lite-server:
+-  `#8360 <https://codeberg.org/freeipa/freeipa/issues/8360>`__ lite-server:
    Werkzeug deprecation warnings
--  `#8362 <https://pagure.io/freeipa/issue/8362>`__
+-  `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
    (`rhbz#1826659 <https://bugzilla.redhat.com/show_bug.cgi?id=1826659>`__)
    IPA: Ldap authentication failure due to Kerberos principal expiration
    UTC timestamp
--  `#8363 <https://pagure.io/freeipa/issue/8363>`__ DNS config upgrade
+-  `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__ DNS config upgrade
    code fails
--  `#8364 <https://pagure.io/freeipa/issue/8364>`__ Nightly test failure
+-  `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__ Nightly test failure
    while establishing trust: Cannot find specified domain or server name
--  `#8366 <https://pagure.io/freeipa/issue/8366>`__ CA-less replica
+-  `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__ CA-less replica
    deployment fails with --setup-ca
--  `#8367 <https://pagure.io/freeipa/issue/8367>`__ IPA-EPN fails to
+-  `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__ IPA-EPN fails to
    build in ONLY_CLIENT mode
--  `#8368 <https://pagure.io/freeipa/issue/8368>`__
+-  `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
    (`rhbz#1846349 <https://bugzilla.redhat.com/show_bug.cgi?id=1846349>`__)
    cannot issue certs with multiple IP addresses corresponding to
    different hosts
--  `#8369 <https://pagure.io/freeipa/issue/8369>`__
+-  `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__
    (`rhbz#1884819 <https://bugzilla.redhat.com/show_bug.cgi?id=1884819>`__)
    cert_find returns "CA not configured" in CA-less install
--  `#8370 <https://pagure.io/freeipa/issue/8370>`__ ipa-join does not
+-  `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__ ipa-join does not
    set nshardwareplatform and nsosversion
--  `#8371 <https://pagure.io/freeipa/issue/8371>`__ Nightly test failure
+-  `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__ Nightly test failure
    [testing_master_testing] in
    test_integration/test_idviews.py::TestCertsInIDOverrides
--  `#8372 <https://pagure.io/freeipa/issue/8372>`__
+-  `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
    (`rhbz#1849914 <https://bugzilla.redhat.com/show_bug.cgi?id=1849914>`__)
    FreeIPA - Utilize 256-bit AJP connector passwords
--  `#8374 <https://pagure.io/freeipa/issue/8374>`__
+-  `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
    (`rhbz#1847999 <https://bugzilla.redhat.com/show_bug.cgi?id=1847999>`__)
    EPN does not ship its default configuration ( /etc/ipa/epn.conf ) in
    freeipa-client-epn
--  `#8377 <https://pagure.io/freeipa/issue/8377>`__ Nightly test failure
+-  `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__ Nightly test failure
    (timeout) in test_caless_TestReplicaInstall
--  `#8378 <https://pagure.io/freeipa/issue/8378>`__ CA validity past
+-  `#8378 <https://codeberg.org/freeipa/freeipa/issues/8378>`__ CA validity past
    year 2038 breaks cert.py plugin on 32-bit platform
--  `#8379 <https://pagure.io/freeipa/issue/8379>`__ Nightly test failure
+-  `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__ Nightly test failure
    [testing_master_pki] while installing CA replica
--  `#8381 <https://pagure.io/freeipa/issue/8381>`__ Nightly test failure
+-  `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__ Nightly test failure
    in test_webui/test_loginscreen.py::TestLoginScreen::test_login_view
--  `#8383 <https://pagure.io/freeipa/issue/8383>`__ Test with dnspython
+-  `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__ Test with dnspython
    2.0
--  `#8384 <https://pagure.io/freeipa/issue/8384>`__ Provide reliable way
+-  `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__ Provide reliable way
    to know if a server installation is complete
--  `#8388 <https://pagure.io/freeipa/issue/8388>`__ Make help() on
+-  `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__ Make help() on
    plugins more useful
--  `#8391 <https://pagure.io/freeipa/issue/8391>`__ Remove dnf
+-  `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__ Remove dnf
    workaround from test_epn.y
--  `#8394 <https://pagure.io/freeipa/issue/8394>`__ Nightly test failure
+-  `#8394 <https://codeberg.org/freeipa/freeipa/issues/8394>`__ Nightly test failure
    in cert-related tests
--  `#8395 <https://pagure.io/freeipa/issue/8395>`__ selinux don't audit
+-  `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__ selinux don't audit
    rules deny fetching trust topology
--  `#8396 <https://pagure.io/freeipa/issue/8396>`__ [WebUI] Font type of
+-  `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__ [WebUI] Font type of
    "Enabled" column in user search facet wrong
--  `#8399 <https://pagure.io/freeipa/issue/8399>`__ certmonger attempts
+-  `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__ certmonger attempts
    to add LWCA tracking requests on non-CA server.
--  `#8400 <https://pagure.io/freeipa/issue/8400>`__ sshd template file
+-  `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__ sshd template file
    is installed in a wrong (server) location while used by the client
    side
--  `#8401 <https://pagure.io/freeipa/issue/8401>`__ Create platform
+-  `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__ Create platform
    definitions for freeipa-container
--  `#8403 <https://pagure.io/freeipa/issue/8403>`__ Add option to add
+-  `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__ Add option to add
    ipaapi user as an allowed uid for ifp in /etc/sssd/sssd.conf when
    running ipa-replica-install
--  `#8404 <https://pagure.io/freeipa/issue/8404>`__ Detect and fail if
+-  `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__ Detect and fail if
    not enough memory is available for installation
--  `#8405 <https://pagure.io/freeipa/issue/8405>`__ Don't delegate full
+-  `#8405 <https://codeberg.org/freeipa/freeipa/issues/8405>`__ Don't delegate full
    TGT in ipa-join
--  `#8407 <https://pagure.io/freeipa/issue/8407>`__ Support changelog
+-  `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__ Support changelog
    integrated into main database
--  `#8408 <https://pagure.io/freeipa/issue/8408>`__ Nightly test failure
+-  `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions::test_client_enrollment_by_unprivileged_user
--  `#8412 <https://pagure.io/freeipa/issue/8412>`__
+-  `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
    (`rhbz#1857157 <https://bugzilla.redhat.com/show_bug.cgi?id=1857157>`__)
    AVC: httpd cannot connect to ipa-custodia.sock
--  `#8413 <https://pagure.io/freeipa/issue/8413>`__ Nightly test failure
+-  `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8414 <https://pagure.io/freeipa/issue/8414>`__ Nightly test failure
+-  `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8416 <https://pagure.io/freeipa/issue/8416>`__ [WebUI] Error while
+-  `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__ [WebUI] Error while
    adding user ID overrides to group
--  `#8419 <https://pagure.io/freeipa/issue/8419>`__ Azure is reporting a
+-  `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__ Azure is reporting a
    slew of new no-member lint errors
--  `#8424 <https://pagure.io/freeipa/issue/8424>`__ Add ipa.p11-kit to
+-  `#8424 <https://codeberg.org/freeipa/freeipa/issues/8424>`__ Add ipa.p11-kit to
    ipa-client-install man page files list
--  `#8425 <https://pagure.io/freeipa/issue/8425>`__ Nightly test failure
+-  `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__ Nightly test failure
    in test_cert.test_cert.TestInstallMasterClient (certmonger timeout)
--  `#8428 <https://pagure.io/freeipa/issue/8428>`__ [ipatests] fails due
+-  `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__ [ipatests] fails due
    to new python-cryptography 3.0
--  `#8429 <https://pagure.io/freeipa/issue/8429>`__ Add fips-mode-setup
+-  `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__ Add fips-mode-setup
    to ipaplatform.paths
--  `#8432 <https://pagure.io/freeipa/issue/8432>`__ test failure in
+-  `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__ test failure in
    test_commands.py::TestIPACommand::test_login_wrong_password:
    AssertionError
--  `#8435 <https://pagure.io/freeipa/issue/8435>`__ [ipatests] failures
+-  `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__ [ipatests] failures
    due to new Pytest6.0 (pypi part)
--  `#8437 <https://pagure.io/freeipa/issue/8437>`__ unit tests for
+-  `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__ unit tests for
    ipa-extdom-extop are failing in Fedora 33
--  `#8439 <https://pagure.io/freeipa/issue/8439>`__ Nightly test failure
+-  `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__ Nightly test failure
    in
    test_integration/test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8440 <https://pagure.io/freeipa/issue/8440>`__
+-  `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
    (`rhbz#1863616 <https://bugzilla.redhat.com/show_bug.cgi?id=1863616>`__)
    CA-less install does not set required permissions on KDC certificate
--  `#8441 <https://pagure.io/freeipa/issue/8441>`__
+-  `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
    (`rhbz#1870202 <https://bugzilla.redhat.com/show_bug.cgi?id=1870202>`__)
    File permissions of /etc/ipa/ca.crt differ between CA-ful and CA-less
--  `#8442 <https://pagure.io/freeipa/issue/8442>`__ [pylint]
+-  `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__ [pylint]
    warnings/errors against pylint 2.5.3
--  `#8443 <https://pagure.io/freeipa/issue/8443>`__ ipa delegation-add
+-  `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__ ipa delegation-add
    can add permissions and attributes several times
--  `#8444 <https://pagure.io/freeipa/issue/8444>`__
+-  `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance input validation
--  `#8445 <https://pagure.io/freeipa/issue/8445>`__
+-  `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
    (`rhbz#1863079 <https://bugzilla.redhat.com/show_bug.cgi?id=1863079>`__)
    EPN: '[Errno 111] Connection refused' when the SMTP is down
--  `#8446 <https://pagure.io/freeipa/issue/8446>`__ ipa dnszone-add
+-  `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__ ipa dnszone-add
    ignores --name-from-ip option if name is given
--  `#8447 <https://pagure.io/freeipa/issue/8447>`__ Nightly test failure
+-  `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__ Nightly test failure
    in test_integration/test_ipahealthcheck/TestIpaHealthCheckWithoutDNS
--  `#8449 <https://pagure.io/freeipa/issue/8449>`__
+-  `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance CLI option tests
--  `#8456 <https://pagure.io/freeipa/issue/8456>`__ Need new aci's for
+-  `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__ Need new aci's for
    the new replication changelog entries
--  `#8458 <https://pagure.io/freeipa/issue/8458>`__ auto-upgrade will
+-  `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__ auto-upgrade will
    never happen for existing installations
--  `#8459 <https://pagure.io/freeipa/issue/8459>`__ [upgrade] handle
+-  `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__ [upgrade] handle
    missing openssh-clients
--  `#8461 <https://pagure.io/freeipa/issue/8461>`__ [ALTLinux] server
+-  `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__ [ALTLinux] server
    uninstall error on missing /var/lib/samba
--  `#8463 <https://pagure.io/freeipa/issue/8463>`__ Nightly test failure
+-  `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8464 <https://pagure.io/freeipa/issue/8464>`__ Increase replication
+-  `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__ Increase replication
    changelog trimming interval
--  `#8468 <https://pagure.io/freeipa/issue/8468>`__ [pylint] new
+-  `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__ [pylint] new
    warnings on dev branch
--  `#8472 <https://pagure.io/freeipa/issue/8472>`__ [tracker] Nightly
+-  `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__ [tracker] Nightly
    test failure in
    test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
--  `#8473 <https://pagure.io/freeipa/issue/8473>`__ Nightly test failure
+-  `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__ Nightly test failure
    in all webui tests: Invalid or corrupt jarfile /opt/selenium.jar
--  `#8474 <https://pagure.io/freeipa/issue/8474>`__ Mozilla's NSS
+-  `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__ Mozilla's NSS
    without DBM
--  `#8475 <https://pagure.io/freeipa/issue/8475>`__ Azure: tox task and
+-  `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__ Azure: tox task and
    virtualenv 20+
--  `#8481 <https://pagure.io/freeipa/issue/8481>`__ Nightly test failure
+-  `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__ Nightly test failure
    in rawhide in tasks.configure_dns_for_trust
--  `#8482 <https://pagure.io/freeipa/issue/8482>`__ Nightly test failure
+-  `#8482 <https://codeberg.org/freeipa/freeipa/issues/8482>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_source_ipahealthcheck_meta_services_check
--  `#8488 <https://pagure.io/freeipa/issue/8488>`__
+-  `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux blocks custodia key replication / retrieval for sub-CAs
--  `#8490 <https://pagure.io/freeipa/issue/8490>`__
+-  `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
    (`rhbz#1875001 <https://bugzilla.redhat.com/show_bug.cgi?id=1875001>`__)
    It is not possible to edit KDC database when the FreeIPA server is
    running
--  `#8491 <https://pagure.io/freeipa/issue/8491>`__ Unindexed searches
+-  `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__ Unindexed searches
    in FreeIPA git master
--  `#8493 <https://pagure.io/freeipa/issue/8493>`__ Synchronize index
+-  `#8493 <https://codeberg.org/freeipa/freeipa/issues/8493>`__ Synchronize index
    LDIF and index update files
--  `#8494 <https://pagure.io/freeipa/issue/8494>`__ Azure Pipelines are
+-  `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__ Azure Pipelines are
    broken due to docker compose tool upgrade
--  `#8496 <https://pagure.io/freeipa/issue/8496>`__ [Tracker] Multiple
+-  `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__ [Tracker] Multiple
    nightly test failures in test_dnssec
--  `#8498 <https://pagure.io/freeipa/issue/8498>`__ Check 3rd-party IPA
+-  `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__ Check 3rd-party IPA
    server HTTP cert for ipa-ca.$DOMAIN dnsName on CA replicas
--  `#8501 <https://pagure.io/freeipa/issue/8501>`__ Unify how FreeIPA
+-  `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__ Unify how FreeIPA
    gets FQDN of current host
--  `#8502 <https://pagure.io/freeipa/issue/8502>`__ Don't create DirSRV
+-  `#8502 <https://codeberg.org/freeipa/freeipa/issues/8502>`__ Don't create DirSRV
    SSCA
--  `#8503 <https://pagure.io/freeipa/issue/8503>`__
+-  `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
    (`rhbz#1879604 <https://bugzilla.redhat.com/show_bug.cgi?id=1879604>`__)
    pkispawn logs files are empty
--  `#8505 <https://pagure.io/freeipa/issue/8505>`__ Nightly failure
+-  `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__ Nightly failure
    (fedora31) in
    test_integration/test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8507 <https://pagure.io/freeipa/issue/8507>`__ [WebUI] Backport
+-  `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__ [WebUI] Backport
    jQuery patches from newer versions of the library (e.g. 3.5.0)
--  `#8510 <https://pagure.io/freeipa/issue/8510>`__
+-  `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
    (`rhbz#1881630 <https://bugzilla.redhat.com/show_bug.cgi?id=1881630>`__)
    create_active_user and kinit_as_user should collect kdcinfo.REALM on
    failure
--  `#8511 <https://pagure.io/freeipa/issue/8511>`__ The selinux
+-  `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__ The selinux
    subpackage does not have a requirement to match the server install
--  `#8512 <https://pagure.io/freeipa/issue/8512>`__ Import of psutil can
+-  `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__ Import of psutil can
    trigger SELinux violation
--  `#8513 <https://pagure.io/freeipa/issue/8513>`__
+-  `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux module fails to load: Re-declaration of type node_t
--  `#8514 <https://pagure.io/freeipa/issue/8514>`__
+-  `#8514 <https://codeberg.org/freeipa/freeipa/issues/8514>`__
    (`rhbz#1885126 <https://bugzilla.redhat.com/show_bug.cgi?id=1885126>`__)
    Nightly failure (enforcing mode) in
    test_acme.py::TestACME::test_mod_md
--  `#8515 <https://pagure.io/freeipa/issue/8515>`__
+-  `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
    (`rhbz#1882340 <https://bugzilla.redhat.com/show_bug.cgi?id=1882340>`__)
    nsslapd-db-locks patching no longer works
--  `#8516 <https://pagure.io/freeipa/issue/8516>`__ Nightly test failure
+-  `#8516 <https://codeberg.org/freeipa/freeipa/issues/8516>`__ Nightly test failure
    (master) in ipa trust-add
--  `#8518 <https://pagure.io/freeipa/issue/8518>`__ Upgrade F32 to F33
+-  `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__ Upgrade F32 to F33
    fails in DNS upgrade code
--  `#8519 <https://pagure.io/freeipa/issue/8519>`__ Fedora container
+-  `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__ Fedora container
    platform is incomplete
--  `#8521 <https://pagure.io/freeipa/issue/8521>`__ Speed up
+-  `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__ Speed up
    ipa-server-install
--  `#8522 <https://pagure.io/freeipa/issue/8522>`__ Remove
+-  `#8522 <https://codeberg.org/freeipa/freeipa/issues/8522>`__ Remove
    cainstance.migrate_profiles_to_ldap()
--  `#8523 <https://pagure.io/freeipa/issue/8523>`__ Topology Graph
+-  `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__ Topology Graph
    returns Runtime Error
--  `#8524 <https://pagure.io/freeipa/issue/8524>`__
+-  `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Deploy & manage the ACME service topology wide from a single system
--  `#8528 <https://pagure.io/freeipa/issue/8528>`__ Use separate logs
+-  `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__ Use separate logs
    for AD Trust and DNS installer
--  `#8529 <https://pagure.io/freeipa/issue/8529>`__ ipa-ca record
+-  `#8529 <https://codeberg.org/freeipa/freeipa/issues/8529>`__ ipa-ca record
    incomplete when hostname is not in DNS
--  `#8530 <https://pagure.io/freeipa/issue/8530>`__
+-  `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
    (`rhbz#1859185 <https://bugzilla.redhat.com/show_bug.cgi?id=1859185>`__)
    Running ipa-server-install fails on machine where libsss_sudo is not
    installed
--  `#8531 <https://pagure.io/freeipa/issue/8531>`__ RFE: Use host keytab
+-  `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__ RFE: Use host keytab
    to obtain ticket for ipa-certupdate
--  `#8533 <https://pagure.io/freeipa/issue/8533>`__ Nightly failure in
+-  `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__ Nightly failure in
    ipa-replica-install configuring renewals: DBusException:
    org.freedesktop.DBus.Error.NoReply
--  `#8535 <https://pagure.io/freeipa/issue/8535>`__
+-  `#8535 <https://codeberg.org/freeipa/freeipa/issues/8535>`__
    (`rhbz#1887928 <https://bugzilla.redhat.com/show_bug.cgi?id=1887928>`__)
    RPM spec moves ssh server config to a snippet but does not ensure
    sshd_config includes the snippet
--  `#8536 <https://pagure.io/freeipa/issue/8536>`__ RFE: ipatests: run
+-  `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__ RFE: ipatests: run
    healthcheck on hidden replica
--  `#8541 <https://pagure.io/freeipa/issue/8541>`__ Nightly failure
+-  `#8541 <https://codeberg.org/freeipa/freeipa/issues/8541>`__ Nightly failure
    (fed33) in test_installation.py::TestInstallMaster::test_selinux_avcs
--  `#8545 <https://pagure.io/freeipa/issue/8545>`__
+-  `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
    (`rhbz#1869605 <https://bugzilla.redhat.com/show_bug.cgi?id=1869605>`__)
    KRA Transport and Storage Certificates do not renew
--  `#8551 <https://pagure.io/freeipa/issue/8551>`__
+-  `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
    (`rhbz#1784657 <https://bugzilla.redhat.com/show_bug.cgi?id=1784657>`__)
    Unlock user accounts after a password reset and replicate that unlock
    to all IdM servers
--  `#8554 <https://pagure.io/freeipa/issue/8554>`__
+-  `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
    (`rhbz#1891056 <https://bugzilla.redhat.com/show_bug.cgi?id=1891056>`__)
    ipa-kdb: support subordinate/superior UPN suffixes
--  `#8555 <https://pagure.io/freeipa/issue/8555>`__
+-  `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
    (`rhbz#1340463 <https://bugzilla.redhat.com/show_bug.cgi?id=1340463>`__)
    Nightly test failure in test_pwpolicy.py::test_pwpolicy::test_misc
--  `#8558 <https://pagure.io/freeipa/issue/8558>`__ Create backend entry
+-  `#8558 <https://codeberg.org/freeipa/freeipa/issues/8558>`__ Create backend entry
    before creating mapping tree entry for ipaca backend
--  `#8559 <https://pagure.io/freeipa/issue/8559>`__ Nightly test failure
+-  `#8559 <https://codeberg.org/freeipa/freeipa/issues/8559>`__ Nightly test failure
    in test_trust.py::TestTrust::test_password_login_as_aduser
--  `#8560 <https://pagure.io/freeipa/issue/8560>`__ Nightly test failure
+-  `#8560 <https://codeberg.org/freeipa/freeipa/issues/8560>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_encryption
--  `#8563 <https://pagure.io/freeipa/issue/8563>`__ Nightly test failure
+-  `#8563 <https://codeberg.org/freeipa/freeipa/issues/8563>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_riplugincheck
--  `#8566 <https://pagure.io/freeipa/issue/8566>`__ Subordinate suffixes
+-  `#8566 <https://codeberg.org/freeipa/freeipa/issues/8566>`__ Subordinate suffixes
    aren't treated as subordinate in trust to Active Directory (crash
    part)
--  `#8567 <https://pagure.io/freeipa/issue/8567>`__
+-  `#8567 <https://codeberg.org/freeipa/freeipa/issues/8567>`__
    (`rhbz#1894800 <https://bugzilla.redhat.com/show_bug.cgi?id=1894800>`__)
    IPA WebUI inaccessible after upgrading to RHEL 8.3.-
    idoverride-memberof.js missing
--  `#8572 <https://pagure.io/freeipa/issue/8572>`__ Nightly failure in
+-  `#8572 <https://codeberg.org/freeipa/freeipa/issues/8572>`__ Nightly failure in
    test_acme.py::TestACMECALess::test_enable_caless_to_cafull_replica
--  `#8573 <https://pagure.io/freeipa/issue/8573>`__ Nightly failure in
+-  `#8573 <https://codeberg.org/freeipa/freeipa/issues/8573>`__ Nightly failure in
    test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS::test_ipa_dns_systemrecords_check
--  `#8578 <https://pagure.io/freeipa/issue/8578>`__ EPN: SMTP client
+-  `#8578 <https://codeberg.org/freeipa/freeipa/issues/8578>`__ EPN: SMTP client
    downgrade smtp_security from \`starttls\` to \`none\`
--  `#8579 <https://pagure.io/freeipa/issue/8579>`__ EPN: SMTP client
+-  `#8579 <https://codeberg.org/freeipa/freeipa/issues/8579>`__ EPN: SMTP client
    doesn't validate server certificate
--  `#8580 <https://pagure.io/freeipa/issue/8580>`__ EPN: SMTP client
+-  `#8580 <https://codeberg.org/freeipa/freeipa/issues/8580>`__ EPN: SMTP client
    authentication by certificate
--  `#8581 <https://pagure.io/freeipa/issue/8581>`__ Nightly test failure
+-  `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__ Nightly test failure
    in test_acme.py::TestACME::test_third_party_certs (updates-testing)
--  `#8584 <https://pagure.io/freeipa/issue/8584>`__ ACME communication
+-  `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__ ACME communication
    with dogtag REST endpoints should be using the cookie it creates
--  `#8585 <https://pagure.io/freeipa/issue/8585>`__ Compile warnings on
+-  `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__ Compile warnings on
    rawhide
--  `#8587 <https://pagure.io/freeipa/issue/8587>`__ client-only build
+-  `#8587 <https://codeberg.org/freeipa/freeipa/issues/8587>`__ client-only build
    fails due to unconditional use of pwquality features
--  `#8589 <https://pagure.io/freeipa/issue/8589>`__
+-  `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
    (`rhbz#1812871 <https://bugzilla.redhat.com/show_bug.cgi?id=1812871>`__)
    Intermittent IdM Client Registration Failures
--  `#8590 <https://pagure.io/freeipa/issue/8590>`__ Nightly test failure
+-  `#8590 <https://codeberg.org/freeipa/freeipa/issues/8590>`__ Nightly test failure
    in
    test_integration/test_krbtpolicy.py::TestPWPolicy::test_krbtpolicy_default::setup
--  `#8595 <https://pagure.io/freeipa/issue/8595>`__ Allow ipa-ca as a
+-  `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__ Allow ipa-ca as a
    name for an IPA server
--  `#8596 <https://pagure.io/freeipa/issue/8596>`__
+-  `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
    (`rhbz#1895197 <https://bugzilla.redhat.com/show_bug.cgi?id=1895197>`__)
    improve IPA PKI susbsystem detection by other means than a directory
    presence, use pki-server subsystem-find
--  `#8597 <https://pagure.io/freeipa/issue/8597>`__
+-  `#8597 <https://codeberg.org/freeipa/freeipa/issues/8597>`__
    (`rhbz#1901068 <https://bugzilla.redhat.com/show_bug.cgi?id=1901068>`__)
    Traceback while doing ipa-backup
--  `#8601 <https://pagure.io/freeipa/issue/8601>`__ Nightly test failure
+-  `#8601 <https://codeberg.org/freeipa/freeipa/issues/8601>`__ Nightly test failure
    in test_trust.py::TestTrust::test_subordinate_suffix
--  `#8603 <https://pagure.io/freeipa/issue/8603>`__
+-  `#8603 <https://codeberg.org/freeipa/freeipa/issues/8603>`__
    (`rhbz#1902727 <https://bugzilla.redhat.com/show_bug.cgi?id=1902727>`__)
    ipa-acme-manage enable fails after upgrade
--  `#8613 <https://pagure.io/freeipa/issue/8613>`__ mod_auth_gssapi
+-  `#8613 <https://codeberg.org/freeipa/freeipa/issues/8613>`__ mod_auth_gssapi
    cannot create unique ccache as it runs under apache and not ipaapi
--  `#8615 <https://pagure.io/freeipa/issue/8615>`__ ipa-rewrite.conf
+-  `#8615 <https://codeberg.org/freeipa/freeipa/issues/8615>`__ ipa-rewrite.conf
    upgrade is failing due to missing variable definition
--  `#8616 <https://pagure.io/freeipa/issue/8616>`__ xmlrpc tests
+-  `#8616 <https://codeberg.org/freeipa/freeipa/issues/8616>`__ xmlrpc tests
    test_user_plugin failure
--  `#8617 <https://pagure.io/freeipa/issue/8617>`__ systemd: enforce
+-  `#8617 <https://codeberg.org/freeipa/freeipa/issues/8617>`__ systemd: enforce
    en_US.UTF-8 locale in systemd units
--  `#8623 <https://pagure.io/freeipa/issue/8623>`__ ipaConfigString:
+-  `#8623 <https://codeberg.org/freeipa/freeipa/issues/8623>`__ ipaConfigString:
    configuredService left where enabledService needed
--  `#8624 <https://pagure.io/freeipa/issue/8624>`__ host/ principals
+-  `#8624 <https://codeberg.org/freeipa/freeipa/issues/8624>`__ host/ principals
    missing from getprincs enumeration
--  `#8629 <https://pagure.io/freeipa/issue/8629>`__ NIghtly test failure
+-  `#8629 <https://codeberg.org/freeipa/freeipa/issues/8629>`__ NIghtly test failure
    (master) in test_webui/test_user.py::test_user::test_add_user_special
--  `#8630 <https://pagure.io/freeipa/issue/8630>`__
+-  `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
    (`rhbz#1909876 <https://bugzilla.redhat.com/show_bug.cgi?id=1909876>`__)
    Do not resolve user/group UID/GID in the service constructors
 
@@ -1554,7 +1554,7 @@ Armando Neto (26)
    `commit <https://codeberg.org/freeipa/freeipa/commit/26ae95f4b492b98078b5deb16825df3fd525f305>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/21186540f0425840e544a3cead8da909744aeac0>`__
-   `#8473 <https://pagure.io/freeipa/issue/8473>`__
+   `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
 -  ipatests: bump pr-ci templates
@@ -1577,12 +1577,12 @@ Armando Neto (26)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: Improve test_commands reliability
    `commit <https://codeberg.org/freeipa/freeipa/commit/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
 -  travis: Remove CI integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
-   `#7323 <https://pagure.io/freeipa/issue/7323>`__
+   `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__
 -  prci: bump template version for temp_commit and nightly_latest
    `commit <https://codeberg.org/freeipa/freeipa/commit/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
 -  prci: bump fedora release
@@ -1614,19 +1614,19 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3058d528a0f7a647f5090b4bcd3b2a19e7b54fd>`__
 -  odsexporterinstance: use late binding for UID/GID resolution
    `commit <https://codeberg.org/freeipa/freeipa/commit/eca22818c911646a111d2257213ee22737e2555f>`__
-   `#8630 <https://pagure.io/freeipa/issue/8630>`__
+   `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
 -  dnskeysyncinstance: use late binding for UID/GID resolution
    `commit <https://codeberg.org/freeipa/freeipa/commit/eae9f0d80c8fe67fdd44a9c772ce2c4234b35ba0>`__
-   `#8630 <https://pagure.io/freeipa/issue/8630>`__
+   `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
 -  opendnssecinstance: use late binding for UID/GID resolution
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb42b1097a89c5e863bd4fd1714d5ce84a47b718>`__
-   `#8630 <https://pagure.io/freeipa/issue/8630>`__
+   `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
 -  tests_webui: fix wrong user name key for trail space case
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d13d704b9552ab8ec1c7c5428655297fbdbf09c>`__
-   `#8629 <https://pagure.io/freeipa/issue/8629>`__
+   `#8629 <https://codeberg.org/freeipa/freeipa/issues/8629>`__
 -  tests_webui: flip leading and trailing space password test
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9bdd3e93048ff4f08c2d53f1fd89b05dcd7861c>`__
-   `#8629 <https://pagure.io/freeipa/issue/8629>`__
+   `#8629 <https://codeberg.org/freeipa/freeipa/issues/8629>`__
 -  Update IPA translation template before release
    `commit <https://codeberg.org/freeipa/freeipa/commit/4db85bed81ba9a8cca0f34ca067312d15c9f2868>`__
 -  Update po/zh_CN translation before release
@@ -1681,30 +1681,30 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f6b4a0780c704dfb58675f367ff8bb50e5e1788>`__
 -  upgrade: ensure service state is synchronized with the server state
    `commit <https://codeberg.org/freeipa/freeipa/commit/56c8b174d183fe7c4001ec3eb3fab650a0695994>`__
-   `#8623 <https://pagure.io/freeipa/issue/8623>`__
+   `#8623 <https://codeberg.org/freeipa/freeipa/issues/8623>`__
 -  upgrade: do not overshadow service module in upgrade_configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/59432e92a54b2d4881af882b559aa33793c4558e>`__
 -  service: handle empty list of services to update their state
    `commit <https://codeberg.org/freeipa/freeipa/commit/06fbb8b42e29de23b9e9ae9e212a9ce39f09e407>`__
-   `#8623 <https://pagure.io/freeipa/issue/8623>`__
+   `#8623 <https://codeberg.org/freeipa/freeipa/issues/8623>`__
 -  ipa-kdb: use predefined filters for a wild-card searches
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d1594c3c6136559de7df88fb2a9895a3c47463a>`__
-   `#8624 <https://pagure.io/freeipa/issue/8624>`__
+   `#8624 <https://codeberg.org/freeipa/freeipa/issues/8624>`__
 -  Back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5cd9d0792328e0070457a96b8bd32aa365a7892>`__
 -  Become FreeIPA 4.9.0rc3
    `commit <https://codeberg.org/freeipa/freeipa/commit/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
 -  systemd: enforce en_US.UTF-8 locale in systemd units
    `commit <https://codeberg.org/freeipa/freeipa/commit/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
-   `#8617 <https://pagure.io/freeipa/issue/8617>`__
+   `#8617 <https://codeberg.org/freeipa/freeipa/issues/8617>`__
 -  upgrade: provide DOMAIN to the server upgrade dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__,
-   `#8615 <https://pagure.io/freeipa/issue/8615>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__,
+   `#8615 <https://codeberg.org/freeipa/freeipa/issues/8615>`__
 -  Allow mod_auth_gssapi to create and access ccaches in
    /run/ipa/ccaches
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
-   `#8613 <https://pagure.io/freeipa/issue/8613>`__
+   `#8613 <https://codeberg.org/freeipa/freeipa/issues/8613>`__
 -  Correct SELinux policy requirements
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
 -  Back to git snapshots
@@ -1717,10 +1717,10 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
 -  ad trust: accept subordinate domains of the forest trust root
    `commit <https://codeberg.org/freeipa/freeipa/commit/381cc5e8eae1b7437fc15cb699983887d398f498>`__
-   `#8554 <https://pagure.io/freeipa/issue/8554>`__
+   `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
 -  util: Fix client-only build
    `commit <https://codeberg.org/freeipa/freeipa/commit/244704cc156dba0731671c55661d82073f970c9b>`__
-   `#8587 <https://pagure.io/freeipa/issue/8587>`__
+   `#8587 <https://codeberg.org/freeipa/freeipa/issues/8587>`__
 -  Become FreeIPA 4.9.0 release candidate 1
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1f3e3b836f357cd3fe8698a4ecdc92c919a6306>`__
 -  Translations: update translations template
@@ -1738,25 +1738,25 @@ Alexander Bokovoy (189)
 -  ipa-acme-manage: user a cookie created for the communication with
    dogtag REST endpoints
    `commit <https://codeberg.org/freeipa/freeipa/commit/935a46158251d52b16f6e0f531a8851778795c67>`__
-   `#8584 <https://pagure.io/freeipa/issue/8584>`__
+   `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__
 -  ipa-otpd: fix gcc complaints in Rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/b36f224892152af786e69bb166497e6fd9c44cd6>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-sam: fix gcc complaints on Rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-kdb: fix gcc complaints in kdb tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-kdb: fix gcc complaints
    `commit <https://codeberg.org/freeipa/freeipa/commit/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  wgi/plugins.py: ignore empty plugin directories
    `commit <https://codeberg.org/freeipa/freeipa/commit/91706690e0c894864c93716c4fbecb285722e77d>`__
-   `#8567 <https://pagure.io/freeipa/issue/8567>`__
+   `#8567 <https://codeberg.org/freeipa/freeipa/issues/8567>`__
 -  ipa-kdb: fix crash in MS-PAC cache init code
    `commit <https://codeberg.org/freeipa/freeipa/commit/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
-   `#8566 <https://pagure.io/freeipa/issue/8566>`__
+   `#8566 <https://codeberg.org/freeipa/freeipa/issues/8566>`__
 -  rpcserver: fix exception handling for FAST armor failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
 -  rpcserver: fallback to non-armored kinit in case of trusted domains
@@ -1765,23 +1765,23 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
 -  ipa-kdb: support subordinate/superior UPN suffixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
-   `#8554 <https://pagure.io/freeipa/issue/8554>`__
+   `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
 -  Pre-populate IP addresses for the name server upgrades
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
-   `#8518 <https://pagure.io/freeipa/issue/8518>`__
+   `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__
 -  Specify memory limits as strings for docker compose
    `commit <https://codeberg.org/freeipa/freeipa/commit/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
-   `#8494 <https://pagure.io/freeipa/issue/8494>`__
+   `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
    `commit <https://codeberg.org/freeipa/freeipa/commit/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
-   `#8344 <https://pagure.io/freeipa/issue/8344>`__
+   `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__
 -  Add new contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/11a64478b32985e3c92258aecdd97a28b2351176>`__
 -  Add alternative email to the mailmap for myself
@@ -1791,16 +1791,16 @@ Alexander Bokovoy (189)
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
-   `#8437 <https://pagure.io/freeipa/issue/8437>`__
+   `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
    `commit <https://codeberg.org/freeipa/freeipa/commit/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  handle Y2038 in timestamp to datetime conversions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
-   `#8378 <https://pagure.io/freeipa/issue/8378>`__
+   `#8378 <https://codeberg.org/freeipa/freeipa/issues/8378>`__
 -  update list of contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
 -  Update translation files
@@ -1808,83 +1808,83 @@ Alexander Bokovoy (189)
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
    `commit <https://codeberg.org/freeipa/freeipa/commit/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
-   `#8357 <https://pagure.io/freeipa/issue/8357>`__
+   `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 -  tests: account for ID overrides as members of groups and roles
    `commit <https://codeberg.org/freeipa/freeipa/commit/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  Support adding user ID overrides as group and role members
    `commit <https://codeberg.org/freeipa/freeipa/commit/bee4204039dac9cd858e823b839183ba2cdbd216>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  support using trust-related operations in the server console
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecc0a96d161717960058e22eecad43754de06f11>`__
 -  Add design page for managing IPA resources as a user from a trusted
    Active Directory forest
    `commit <https://codeberg.org/freeipa/freeipa/commit/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
-   `#7816 <https://pagure.io/freeipa/issue/7816>`__,
-   `#8357 <https://pagure.io/freeipa/issue/8357>`__
+   `#7816 <https://codeberg.org/freeipa/freeipa/issues/7816>`__,
+   `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
    `commit <https://codeberg.org/freeipa/freeipa/commit/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9a6027410814832f9228621abd2bbd2acebb944>`__
-   `#8362 <https://pagure.io/freeipa/issue/8362>`__
+   `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
 -  azure: do not run test_commands due to failures in low memory cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
 -  test_smb: test S4U2Self operation by IPA service
    `commit <https://codeberg.org/freeipa/freeipa/commit/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5876f30d4000424cc8122498c411f812b3a0959>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add asserted identity SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
    `commit <https://codeberg.org/freeipa/freeipa/commit/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
    `commit <https://codeberg.org/freeipa/freeipa/commit/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
    `commit <https://codeberg.org/freeipa/freeipa/commit/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
-   `#8328 <https://pagure.io/freeipa/issue/8328>`__
+   `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__
 -  service delegation: allow to add and remove host principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
-   `#8289 <https://pagure.io/freeipa/issue/8289>`__
+   `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
    `commit <https://codeberg.org/freeipa/freeipa/commit/d986e844bbd37ccc7a532175631a55acd315cda3>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  Azure Pipelines: switch to Fedora 32
    `commit <https://codeberg.org/freeipa/freeipa/commit/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
 -  Azure Pipelines: Override services known to not work in containers
@@ -1893,10 +1893,10 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a009b9e0342ca2633355fb9347855676110d678c>`__
 -  CVE-2020-1722: prevent use of too long passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
-   `#8268 <https://pagure.io/freeipa/issue/8268>`__
+   `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__
 -  Allow rename of a host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
-   `#6783 <https://pagure.io/freeipa/issue/6783>`__
+   `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
 -  Add 'api' and 'aci' targets to make
    `commit <https://codeberg.org/freeipa/freeipa/commit/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
 -  Remove Fedora repository fastmirror selection
@@ -1904,23 +1904,23 @@ Alexander Bokovoy (189)
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/527f30be76f0da6d4453745ace25f64948c0504f>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  Fix indentation levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/38204856fd72e5191bae07a47907314aacf43d1a>`__
 -  ipatests: always skip additional input for group-add-member
    --external
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  po: update Chinese (China) translation
    `commit <https://codeberg.org/freeipa/freeipa/commit/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
 -  po: update Ukrainian translation
@@ -1973,10 +1973,10 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
 -  Update translation infrastructure
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Keep ipa.pot translation file in git for weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/92e36258cee838a378729d06fc4134b5c4428f87>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Do not force any particular sphinx theme
    `commit <https://codeberg.org/freeipa/freeipa/commit/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
 -  Override master document for ReadTheDocs
@@ -1987,51 +1987,51 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
 -  Prevent adding IPA objects as external members of external groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec73de969f55b7a005b6401029f87fe6a225a417>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Tighten permissions on PKI proxy configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba904672a21add3b0ab1808c5640ac786f194aad>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
-   `#8200 <https://pagure.io/freeipa/issue/8200>`__
+   `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
-   `#8192 <https://pagure.io/freeipa/issue/8192>`__
+   `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__
 -  Update Azure Pipelines to use Fedora 31
    `commit <https://codeberg.org/freeipa/freeipa/commit/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
 -  install/updates: move external members past schema compat update
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff547a2777d63609faba42101e9802f5e988fa00>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Reset per-indicator Kerberos policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
-   `#8153 <https://pagure.io/freeipa/issue/8153>`__
+   `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__
 -  ipa-client-samba: map domain sid of trust domain properly for display
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d402b69eb484a14944ccc23fcf945963977e348>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9dd757763c76402e07f533f19e269eeebc554fa>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  covscan: free encryption types in case there is an error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  Add Authentication Indicator Kerberos ticket policy options
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Allow presence of LDAP attribute options
    `commit <https://codeberg.org/freeipa/freeipa/commit/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba466a802129cbe61964653fdfddacd5d43f6771>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Update contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/d243c188f26c50a056be5e88554daec6116f5f8f>`__
 -  Update translations
@@ -2040,18 +2040,18 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
 -  adtrust: add default read_keys permission for TDO objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/0be98884991ff14720dfce428e4f23ebc4a42311>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  add default access control when migrating trust objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  adtrust: avoid using timestamp in klist output
    `commit <https://codeberg.org/freeipa/freeipa/commit/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
-   `#8066 <https://pagure.io/freeipa/issue/8066>`__
+   `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
 -  Mark failing test as xfail for use of python-dns make_ds method
    `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
    `commit <https://codeberg.org/freeipa/freeipa/commit/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 -  Update contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
 -  Update translations
@@ -2060,25 +2060,25 @@ Alexander Bokovoy (189)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
 -  Restore SELinux context for p11-kit config overrides
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
-   `#7810 <https://pagure.io/freeipa/issue/7810>`__
+   `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__
 -  Change RA agent certificate profile to caSubsystemCert
    `commit <https://codeberg.org/freeipa/freeipa/commit/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
 -  certmaprule: add negative test for altSecurityIdentities
    `commit <https://codeberg.org/freeipa/freeipa/commit/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__
 -  certmap rules: altSecurityIdentities should only be used for trusted
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__
 -  Create indexes for altSecurityIdentities and ipaCertmapData
    attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/725899595f42b607989db96d849e1b4f01de7faa>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__,
-   `#7933 <https://pagure.io/freeipa/issue/7933>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__,
+   `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__
 -  Add altSecurityIdentities attribute from MS-WSPP schema definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__,
-   `#7933 <https://pagure.io/freeipa/issue/7933>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__,
+   `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__
 -  Use stage and phase attempt counters when saving test artifacts
    `commit <https://codeberg.org/freeipa/freeipa/commit/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
 -  Use any nodejs version instead of forcing a version before nodejs 11
@@ -2105,10 +2105,10 @@ Alexandre Mulatinho (2)
 
 -  ipa-join: allowing call with jsonrpc into freeipa API
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-scripts: fix all ipa command line scripts to operate with -I
    `commit <https://codeberg.org/freeipa/freeipa/commit/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
-   `#7987 <https://pagure.io/freeipa/issue/7987>`__
+   `#7987 <https://codeberg.org/freeipa/freeipa/issues/7987>`__
 
 
 
@@ -2150,14 +2150,14 @@ Anuja More (18)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
 -  Add integration test for otp kerberos ticket policy.
    `commit <https://codeberg.org/freeipa/freeipa/commit/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  ipatests: filter_users should be applied correctly.
    `commit <https://codeberg.org/freeipa/freeipa/commit/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
 -  ipatests : Login via ssh using private-key for ipa-user should work.
    `commit <https://codeberg.org/freeipa/freeipa/commit/836b90f65244a0407e74627b550297d0962d882e>`__
 -  Extdom plugin should not return error (32)/'No such object'
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -2184,10 +2184,10 @@ Alexander Scheel (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2efc44d00266d844cbac26381eea2340a2c8dfe4>`__
 -  Specify cert_paths when calling PKIConnection
    `commit <https://codeberg.org/freeipa/freeipa/commit/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
-   `#8379 <https://pagure.io/freeipa/issue/8379>`__
+   `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
-   `#8372 <https://pagure.io/freeipa/issue/8372>`__
+   `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
 -  Clarify AJP connector creation process
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
 
@@ -2198,7 +2198,7 @@ Antonio Torres Moríñigo (1)
 
 -  ipa-client-install manpage: add ipa.p11-kit to list of files created
    `commit <https://codeberg.org/freeipa/freeipa/commit/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
-   `#8424 <https://pagure.io/freeipa/issue/8424>`__
+   `#8424 <https://codeberg.org/freeipa/freeipa/issues/8424>`__
 
 
 
@@ -2207,103 +2207,103 @@ Peter Keresztes Schmidt (33)
 
 -  WebUI: Unify adapter property definition for state evaluators
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
    `commit <https://codeberg.org/freeipa/freeipa/commit/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  ipa-backup/restore: remove remaining chdir calls
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
-   `#7416 <https://pagure.io/freeipa/issue/7416>`__
+   `#7416 <https://codeberg.org/freeipa/freeipa/issues/7416>`__
 -  ipa-join: handle JSON-RPC error codes
    `commit <https://codeberg.org/freeipa/freeipa/commit/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
-   `#8408 <https://pagure.io/freeipa/issue/8408>`__
+   `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__
 -  ipa-join: extract common JSON-RPC response parsing to common function
    `commit <https://codeberg.org/freeipa/freeipa/commit/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
-   `#8408 <https://pagure.io/freeipa/issue/8408>`__
+   `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__
 -  ipa-join: Generalize XML-RPC references in man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: Use bool type where appropriate
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: select {JSON,XML}-RPC at build time
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: implement JSON-RPC based unenrollment
    `commit <https://codeberg.org/freeipa/freeipa/commit/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: extract unenrollment code common to JSON and XML-RPC to
    separate function
    `commit <https://codeberg.org/freeipa/freeipa/commit/677659c8da27de7b256b7067e513f089892d05b8>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: switch to jansson for json handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/25205f44a10b9e4846121d1a9b05aafa74485292>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: buffer curl response before parsing json
    `commit <https://codeberg.org/freeipa/freeipa/commit/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: improve curl error handling in JSON-RPC code
    `commit <https://codeberg.org/freeipa/freeipa/commit/c197918e8d220f10676f42b3589e47599b7a11e5>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: don't set TLS related curl options for JSON-RPC
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  Populate nshardwareplatform and nsosversion during join operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
-   `#8370 <https://pagure.io/freeipa/issue/8370>`__
+   `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
    `commit <https://codeberg.org/freeipa/freeipa/commit/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
-   `#8396 <https://pagure.io/freeipa/issue/8396>`__
+   `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__
 -  Unify spelling of "One-Time Password"
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
 -  WebUI: reword OTP info message displayed during PW reset
    `commit <https://codeberg.org/freeipa/freeipa/commit/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
    `commit <https://codeberg.org/freeipa/freeipa/commit/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 -  Split named custom config to allow changes in options stanza
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
-   `#8287 <https://pagure.io/freeipa/issue/8287>`__
+   `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__
 -  lite-server: Fix werkzeug deprecation warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
-   `#8360 <https://pagure.io/freeipa/issue/8360>`__
+   `#8360 <https://codeberg.org/freeipa/freeipa/issues/8360>`__
 -  util: replace NSS usage with OpenSSL
    `commit <https://codeberg.org/freeipa/freeipa/commit/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  util: add unit test for pw hashing
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  po: remove zanata config since translation was moved to weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Remove unused support for dm_password arg from ldapupdate.connect
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f232a30116751f38722c65ae607c6e6958c8061>`__
-   `#7610 <https://pagure.io/freeipa/issue/7610>`__
+   `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__
 -  Use ipaldap exceptions rather than ldap error codes in LDAP updater
    `commit <https://codeberg.org/freeipa/freeipa/commit/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
-   `#7610 <https://pagure.io/freeipa/issue/7610>`__
+   `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__
 -  Specify min and max values for TTL of a DNS record
    `commit <https://codeberg.org/freeipa/freeipa/commit/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
-   `#8358 <https://pagure.io/freeipa/issue/8358>`__
+   `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
 -  WebUI: Expose TTL of DNS records
    `commit <https://codeberg.org/freeipa/freeipa/commit/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
-   `#3827 <https://pagure.io/freeipa/issue/3827>`__
+   `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
-   `#8359 <https://pagure.io/freeipa/issue/8359>`__
+   `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__
 -  WebUI: Use data adapter to load facet header data
    `commit <https://codeberg.org/freeipa/freeipa/commit/517c7ab2153e701355732bc8d49076653e090a01>`__
-   `#8339 <https://pagure.io/freeipa/issue/8339>`__
+   `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
    `commit <https://codeberg.org/freeipa/freeipa/commit/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
-   `#8338 <https://pagure.io/freeipa/issue/8338>`__
+   `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__
 -  Remove remains of unused config options
    `commit <https://codeberg.org/freeipa/freeipa/commit/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
-   `#6708 <https://pagure.io/freeipa/issue/6708>`__
+   `#6708 <https://codeberg.org/freeipa/freeipa/issues/6708>`__
 
 
 
@@ -2328,86 +2328,86 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
 -  Replace nodename with ipa_gethostfqdn()
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  Unify access to FQDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  Reuse main LDAP connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Speed up cainstance.migrate_profiles_to_ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__,
-   `#8522 <https://pagure.io/freeipa/issue/8522>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__,
+   `#8522 <https://codeberg.org/freeipa/freeipa/issues/8522>`__
 -  Lookup ipa-ca record with NSS
    `commit <https://codeberg.org/freeipa/freeipa/commit/731c5b211041ee18940082b29e6a21b3f084fc57>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__,
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__,
-   `#8529 <https://pagure.io/freeipa/issue/8529>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__,
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__,
+   `#8529 <https://codeberg.org/freeipa/freeipa/issues/8529>`__
 -  Simplify update code
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Don't add 127.0.0.1 to resolv.conf twice
    `commit <https://codeberg.org/freeipa/freeipa/commit/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Require(post) systemd with resolved enabled on F33
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Replace sudo with runuser
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  Use separate install logs for AD and DNS instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
-   `#8528 <https://pagure.io/freeipa/issue/8528>`__
+   `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__
 -  Spawn PKI: Execute more steps early
    `commit <https://codeberg.org/freeipa/freeipa/commit/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Dogtag: Remove set_audit_renewal step
    `commit <https://codeberg.org/freeipa/freeipa/commit/8882680ee167c535e7539fe0452892aae617aac3>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Skip offline dse.ldif patching by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Remove magic sleep from create_index_task
    `commit <https://codeberg.org/freeipa/freeipa/commit/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Remove root-autobind configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Verify freeipa-selinux's ipa module is loaded
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
 -  Check ca_wrapped in ipa-custodia-check
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  Retry chronyc waitsync only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  configure_dns_resolver: call self.restore_context
    `commit <https://codeberg.org/freeipa/freeipa/commit/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
-   `#8518 <https://pagure.io/freeipa/issue/8518>`__
+   `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__
 -  Drop unused extended sleep feature from Sleeper
    `commit <https://codeberg.org/freeipa/freeipa/commit/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Faster certmonger wait_for_request()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b79191f7107fbc1890631f4c65be48b646798131>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Add helper for poll/sleep loops with timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Add missing fedora_container platform members
    `commit <https://codeberg.org/freeipa/freeipa/commit/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
-   `#8519 <https://pagure.io/freeipa/issue/8519>`__
+   `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__
 -  Add more indices
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
 -  Use single update LDIF for indices
    `commit <https://codeberg.org/freeipa/freeipa/commit/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
-   `#8493 <https://pagure.io/freeipa/issue/8493>`__
+   `#8493 <https://codeberg.org/freeipa/freeipa/issues/8493>`__
 -  Also backup DNS config drop-ins
    `commit <https://codeberg.org/freeipa/freeipa/commit/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Ensure that resolved.conf.d is accessible
    `commit <https://codeberg.org/freeipa/freeipa/commit/34e47778b47748e94792455699b35e8c126c5db7>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Fix compiler warning in ipa-kdb
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
 -  Fix compiler warnings in libotp
@@ -2416,30 +2416,30 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
 -  trust-add: Catch correct exception when chown SSSD
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
-   `#8516 <https://pagure.io/freeipa/issue/8516>`__
+   `#8516 <https://codeberg.org/freeipa/freeipa/issues/8516>`__
 -  Fix nsslapd-db-lock tuning of BDB backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ebe41525116639ec512205319197dd278e15e6>`__
-   `#5914 <https://pagure.io/freeipa/issue/5914>`__,
-   `#8515 <https://pagure.io/freeipa/issue/8515>`__
+   `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__,
+   `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
 -  Create systemd-resolved configuration on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
 -  Configure systemd-resolved to use IPA's BIND
    `commit <https://codeberg.org/freeipa/freeipa/commit/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Use new API for auto-forwarders
    `commit <https://codeberg.org/freeipa/freeipa/commit/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Configure NetworkManager to use systemd-resolved
    `commit <https://codeberg.org/freeipa/freeipa/commit/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Add helpers for resolve1 and nameservers
    `commit <https://codeberg.org/freeipa/freeipa/commit/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Make git a build requirement
    `commit <https://codeberg.org/freeipa/freeipa/commit/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
 -  Delay import of psutil to avoid AVC
    `commit <https://codeberg.org/freeipa/freeipa/commit/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
-   `#8512 <https://pagure.io/freeipa/issue/8512>`__
+   `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__
 -  Add User and Group to all ipaplatform.constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc128cae471dae6e070953333d5d76f211aa7688>`__
 -  Use new classes for run_command and Service
@@ -2452,47 +2452,47 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
 -  Don't create DS SSCA and self-signed cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
-   `#8502 <https://pagure.io/freeipa/issue/8502>`__
+   `#8502 <https://codeberg.org/freeipa/freeipa/issues/8502>`__
 -  Duplicate CA CRT: ignore expected cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/b606fa6cca87706730fa20bfa437956194398c82>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Add krbPrincipalName pres index correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  Only restart DS when duplicate cacrt was found
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Treat container subplatforms like main platform
    `commit <https://codeberg.org/freeipa/freeipa/commit/e89b40071356b1c3050accee54f8332531d9bac2>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Don't configure authselect in containers
    `commit <https://codeberg.org/freeipa/freeipa/commit/999485909a0bc654570f05cd2127d86d14d6f25a>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Explicitly pass keytab to ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
 -  Write state dir to smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/64b20aad283c6a0a9557e77993b09679a72efa88>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
    `commit <https://codeberg.org/freeipa/freeipa/commit/02986ff42b97dceb689abb32cf937da993880ddd>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Allow to override ipaplatform with env var
    `commit <https://codeberg.org/freeipa/freeipa/commit/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Teach pylint how dnspython 2.x works
    `commit <https://codeberg.org/freeipa/freeipa/commit/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
-   `#8419 <https://pagure.io/freeipa/issue/8419>`__
+   `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
    `commit <https://codeberg.org/freeipa/freeipa/commit/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
-   `#8412 <https://pagure.io/freeipa/issue/8412>`__
+   `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
 -  Make tab completion in console more useful
    `commit <https://codeberg.org/freeipa/freeipa/commit/80794f6b5e263566a1da9685aba82762208a6219>`__
 -  Add \__signature_\_ to plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/069f41a01e65f07367000c6d9605167242a88736>`__
-   `#8388 <https://pagure.io/freeipa/issue/8388>`__
+   `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__
 -  Run test_fips in DS and PKI nightly
    `commit <https://codeberg.org/freeipa/freeipa/commit/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
 -  SELinux: Backport dirsrv_systemctl interface
@@ -2509,15 +2509,15 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/523f70ae46127161556a0881fc9a01e138a90666>`__
 -  Use old uglifyjs on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e3346f0a7d820cb3643044884657fa60a80f918>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  Build ipa-selinux package on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
 -  Prevent local account takeover
    `commit <https://codeberg.org/freeipa/freeipa/commit/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
-   `#8326 <https://pagure.io/freeipa/issue/8326>`__
+   `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
    `commit <https://codeberg.org/freeipa/freeipa/commit/a18d406b5631f80134e202ae3310580683937f92>`__
-   `#8367 <https://pagure.io/freeipa/issue/8367>`__
+   `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__
 -  Auto-generated ipa-epn files to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
 -  Overhaul bind upgrade process
@@ -2530,96 +2530,96 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
    `commit <https://codeberg.org/freeipa/freeipa/commit/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
-   `#8363 <https://pagure.io/freeipa/issue/8363>`__
+   `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__
 -  libotp: Replace NSS with OpenSSL HMAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  Include named config files in backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
 -  Handle DatabaseError in RPC-Server connect()
    `commit <https://codeberg.org/freeipa/freeipa/commit/d79a7a9696ff634141bdff3423157d08513da310>`__
-   `#8352 <https://pagure.io/freeipa/issue/8352>`__
+   `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__
 -  Allow permissions with 'self' bindruletype
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dda004f270f321685597be276ca51e6b32fcd59>`__
-   `#8348 <https://pagure.io/freeipa/issue/8348>`__
+   `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__
 -  make: serialize strip-po / strip-pot
    `commit <https://codeberg.org/freeipa/freeipa/commit/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
-   `#8323 <https://pagure.io/freeipa/issue/8323>`__
+   `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__
 -  Remove obsolete BIND named.conf options
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5964b71572579acad9d1731b62eb3c088358c6f>`__
-   `#8349 <https://pagure.io/freeipa/issue/8349>`__,
-   `#8350 <https://pagure.io/freeipa/issue/8350>`__
+   `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__,
+   `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__
 -  Add ipa-print-pac to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
 -  Allow dnsrecord-add --force on clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Explain the effect of OPT_X_TLS_PROTOCOL_MIN
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3e117156436bbf715232bea730a9172c14a8c1f>`__
 -  Check for freeipa-server-dns package early
    `commit <https://codeberg.org/freeipa/freeipa/commit/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
-   `#7577 <https://pagure.io/freeipa/issue/7577>`__
+   `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
 -  Hard-code in_tree=True for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa31ef123a544378f04a2177524c9f72181a812>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Fix detection logic for api.env.in_tree
    `commit <https://codeberg.org/freeipa/freeipa/commit/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
-   `#8312 <https://pagure.io/freeipa/issue/8312>`__
+   `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__
 -  Make api.env.mode consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
-   `#8313 <https://pagure.io/freeipa/issue/8313>`__
+   `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__
 -  Disable password schema update on LDAP bind
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
-   `#8315 <https://pagure.io/freeipa/issue/8315>`__
+   `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
 -  Use httpd 2.4 syntax for access control
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
 -  Let GH auto-notify and auto-close stale PRs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
 -  Fix make devcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
-   `#8307 <https://pagure.io/freeipa/issue/8307>`__
+   `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__
 -  Simplify pki proxy conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/19ea1b97a1559609014e0784c6f973c0e073878a>`__
 -  Make check_required_principal() case-insensitive
    `commit <https://codeberg.org/freeipa/freeipa/commit/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
-   `#8308 <https://pagure.io/freeipa/issue/8308>`__
+   `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
 -  Make ipaplatform a regular top-level package
    `commit <https://codeberg.org/freeipa/freeipa/commit/490682ac3cab8978635655bdcc880f28227e900b>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__,
-   `#8309 <https://pagure.io/freeipa/issue/8309>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__,
+   `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__
 -  Reconfigure pycodestyle
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Manually reformat ipapython/version.py.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Silence W601 .has_key() is deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E722 do not use bare 'except'
    `commit <https://codeberg.org/freeipa/freeipa/commit/186d739d7f54989e9ed6ea08371825b29f21b811>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
    `commit <https://codeberg.org/freeipa/freeipa/commit/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E714 test for object identity should be 'is not'
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c9bba8e1ad1def3745497de24b14786148a64af>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E713 test for membership should be 'not in'
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E712 comparison to True / False
    `commit <https://codeberg.org/freeipa/freeipa/commit/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E711 comparison to None
    `commit <https://codeberg.org/freeipa/freeipa/commit/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E266 too many leading '#' for block comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Address issues found by new pylint 2.5.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
-   `#8297 <https://pagure.io/freeipa/issue/8297>`__
+   `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__
 -  Require Sphinx >2.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7415c3ddcdbd826bc25761d78840c4417381571>`__
 -  Fix /doc/workshop subtree merge
@@ -2630,31 +2630,31 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
 -  Define default password policy for sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Use api.env.container_sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Fix exception escape warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
 -  Fix APIVersion.__getnewargs_\_
    `commit <https://codeberg.org/freeipa/freeipa/commit/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
 -  servrole: takes_params must be a tuple
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
-   `#8290 <https://pagure.io/freeipa/issue/8290>`__
+   `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__
 -  Improve Sphinx building and linting
    `commit <https://codeberg.org/freeipa/freeipa/commit/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
 -  Fix various OpenDNSSEC 2.1 issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
-   `#8283 <https://pagure.io/freeipa/issue/8283>`__
+   `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__
 -  Use /run and /run/lock instead of /var
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
-   `#8272 <https://pagure.io/freeipa/issue/8272>`__
+   `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__
 -  po: fix LINGUAS to use whitespace separation
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  SELinux: apache_manage_pid_files for F30
    `commit <https://codeberg.org/freeipa/freeipa/commit/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
-   `#8241 <https://pagure.io/freeipa/issue/8241>`__
+   `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__
 -  Add pytest OpenSSH transport with password
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8602b158680a92903b930a9d9a25e9c2c458685>`__
 -  Add explicit syntax language to code blocks
@@ -2675,21 +2675,21 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
 -  Move freeipa-selinux dependency to freeipa-common
    `commit <https://codeberg.org/freeipa/freeipa/commit/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate ipa_custodia policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Allow hosts to read DNS records for IP SAN
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
-   `#8098 <https://pagure.io/freeipa/issue/8098>`__
+   `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__
 -  Cleanup SELinux policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate SELinux policy into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
 -  dnsrecord: Treat empty list arguments correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
-   `#8196 <https://pagure.io/freeipa/issue/8196>`__
+   `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__
 -  Remove dependency on custodia package
    `commit <https://codeberg.org/freeipa/freeipa/commit/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
 -  lite-setup: configure lite-server test env
@@ -2698,112 +2698,112 @@ Christian Heimes (182)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a55e82d916b38472bd38032946ea9b249a765f2>`__
 -  Make assert_error compatible with Python 3.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/10b62ad6bc967e022202d657b7493440fb5cf736>`__
-   `#8179 <https://pagure.io/freeipa/issue/8179>`__
+   `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__
 -  Print LDAP diagnostic messages on error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
 -  Fix get_trusted_domain_object_from_sid()
    `commit <https://codeberg.org/freeipa/freeipa/commit/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
-   `#7958 <https://pagure.io/freeipa/issue/7958>`__
+   `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__
 -  Check valid before/after of external certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix service ldap_disable()
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
-   `#8143 <https://pagure.io/freeipa/issue/8143>`__
+   `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
 -  Require idstart to be larger than UID_MAX
    `commit <https://codeberg.org/freeipa/freeipa/commit/44b3791bc3a14ede0708538347954871df6496fa>`__
-   `#8137 <https://pagure.io/freeipa/issue/8137>`__
+   `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__
 -  Fix lite-server to work with GSS_NAME
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
 -  Fix logic of check_client_configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
-   `#8133 <https://pagure.io/freeipa/issue/8133>`__
+   `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
-   `#8134 <https://pagure.io/freeipa/issue/8134>`__
+   `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__
 -  Don't run test_smb in gating tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
 -  Don't hard-code client's TLS versions and ciphers
    `commit <https://codeberg.org/freeipa/freeipa/commit/639bb71940daddd15efb3b4fa922d185235c0b33>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
    `commit <https://codeberg.org/freeipa/freeipa/commit/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Enable TLS 1.3 support on the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Skip paramiko tests in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  FIPS: server key has different name in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/d153957990b7456d53af5903a0e62b2716f61183>`__
 -  Remove FIPS noise from SSHd
    `commit <https://codeberg.org/freeipa/freeipa/commit/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
 -  Fix otptoken_sync plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Add test case for OTP login
    `commit <https://codeberg.org/freeipa/freeipa/commit/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Show group-add/remove-member-manager failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
-   `#8122 <https://pagure.io/freeipa/issue/8122>`__
+   `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
 -  Test installation with (fake) userspace FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
-   `#8118 <https://pagure.io/freeipa/issue/8118>`__
+   `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__
 -  Use default ssh host key algorithms
    `commit <https://codeberg.org/freeipa/freeipa/commit/97a31e69e8399933d45006c744ddafcf036eca5f>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 -  Add tests for member management
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
 -  Add group membership management
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
-   `#8114 <https://pagure.io/freeipa/issue/8114>`__
+   `#8114 <https://codeberg.org/freeipa/freeipa/issues/8114>`__
 -  Skip commented lines after substitution
    `commit <https://codeberg.org/freeipa/freeipa/commit/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
-   `#8111 <https://pagure.io/freeipa/issue/8111>`__
+   `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
 -  Block camellia in krbenctypes update in FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc56642bf9e59821322903e7470be6ec1d857034>`__
-   `#8111 <https://pagure.io/freeipa/issue/8111>`__
+   `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
 -  Don't install a preexec_fn by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
 -  Don't create log files from help scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
-   `#8075 <https://pagure.io/freeipa/issue/8075>`__
+   `#8075 <https://codeberg.org/freeipa/freeipa/issues/8075>`__
 -  Add new env vars to pylint plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  Fix wrong use of identity operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  Enable literal-comparison linter again
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  Replace %{_libdir} macro in BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/51836c0594d9f97ace8392c03d47aae883b87724>`__
-   `#8056 <https://pagure.io/freeipa/issue/8056>`__
+   `#8056 <https://codeberg.org/freeipa/freeipa/issues/8056>`__
 -  Fix ca_initialize_hsm_state
    `commit <https://codeberg.org/freeipa/freeipa/commit/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
 -  Store HSM token and state
    `commit <https://codeberg.org/freeipa/freeipa/commit/076d955b9373ad8603f3885ea6841d367f866327>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
 -  Allow insecure binds for migration
    `commit <https://codeberg.org/freeipa/freeipa/commit/a36556e1064900af7a75ca6f07aba66212cf321a>`__
-   `#8040 <https://pagure.io/freeipa/issue/8040>`__
+   `#8040 <https://codeberg.org/freeipa/freeipa/issues/8040>`__
 -  Don't move keys when key backup is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
-   `#7677 <https://pagure.io/freeipa/issue/7677>`__
+   `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__
 -  Update comments to explain caSubsystemCert switch
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
 -  Test external CA with DNS name constraints
    `commit <https://codeberg.org/freeipa/freeipa/commit/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
 -  Add PKCS#11 module name to p11helper errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/94b4af55b0b4f376e687fae777c51678b99816f3>`__
-   `#8015 <https://pagure.io/freeipa/issue/8015>`__
+   `#8015 <https://codeberg.org/freeipa/freeipa/issues/8015>`__
 -  Use nis-domainname.service on all RH platforms
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
-   `#8004 <https://pagure.io/freeipa/issue/8004>`__
+   `#8004 <https://codeberg.org/freeipa/freeipa/issues/8004>`__
 
 
 
@@ -2814,7 +2814,7 @@ Cédric Jeanneret (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
 -  Prevents DNS Amplification Attack and allow to customize named
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c2710446718828e6840ac34ea6fc704ae6790db>`__
-   `#8079 <https://pagure.io/freeipa/issue/8079>`__
+   `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
 -  Add new tip for dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
 
@@ -2825,19 +2825,19 @@ Changmin Teng (5)
 
 -  Add design document
    `commit <https://codeberg.org/freeipa/freeipa/commit/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Modify webUI to adhere to new IPA server API
    `commit <https://codeberg.org/freeipa/freeipa/commit/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Implement user pre-authentication control with kdcpolicy plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Extend the list of supported pre-auth mechanisms in IPA server API
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Add new authentication indicators in kdc.conf.template
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -2882,154 +2882,154 @@ François Cami (97)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b3f87196dedbfb207dccb70893f5c1d466e96f7>`__
 -  ipa-client-install: unilaterally set dns_lookup_kdc to True
    `commit <https://codeberg.org/freeipa/freeipa/commit/352f2beeb77b3a08fabc94ccb08d0b561b457408>`__
-   `#6523 <https://pagure.io/freeipa/issue/6523>`__
+   `#6523 <https://codeberg.org/freeipa/freeipa/issues/6523>`__
 -  ipatests: make sure dns_lookup_kdc is always true
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c965a07f6cca68a039bbaae5d6a54067f5f38c5>`__
-   `#6523 <https://pagure.io/freeipa/issue/6523>`__
+   `#6523 <https://codeberg.org/freeipa/freeipa/issues/6523>`__
 -  ipatests: run freeipa-healthcheck on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
-   `#8536 <https://pagure.io/freeipa/issue/8536>`__
+   `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__
 -  ipatests: tasks: add user_del
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
-   `#8536 <https://pagure.io/freeipa/issue/8536>`__
+   `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__
 -  ipatests: kinit_as_user improvements
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: create_active_user improvements
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0586f33a60a44e340889ec5adea0800bde21592>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: add get_kdcinfo
    `commit <https://codeberg.org/freeipa/freeipa/commit/884e0d36e9f655d0456229d0e259592e65714660>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: add check_if_sssd_is_online
    `commit <https://codeberg.org/freeipa/freeipa/commit/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
-   `#8513 <https://pagure.io/freeipa/issue/8513>`__
+   `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
    `commit <https://codeberg.org/freeipa/freeipa/commit/7823da0630379d642f4a19b3ae0c063963041a82>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
    `commit <https://codeberg.org/freeipa/freeipa/commit/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  ipatests: check that pkispawn log is not empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/c31bf3d430763ef5b0ef28510995af48dccde287>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  SELinux Policy: let custodia replicate keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/68328299c881df497dab32b145157d6e0e42d6c6>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  ipatests: test_epn: update error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  IPA-EPN: enhance input validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/97006786dfed7947aaa96737201ef7e0e53dd952>`__
-   `#8444 <https://pagure.io/freeipa/issue/8444>`__
+   `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
 -  IPA-EPN: Fix SMTP connection error handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
    `commit <https://codeberg.org/freeipa/freeipa/commit/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  IPA-EPN: fix configuration file typo
    `commit <https://codeberg.org/freeipa/freeipa/commit/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
    `commit <https://codeberg.org/freeipa/freeipa/commit/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/763d3b059bccc37744764985b57d97554a2a6947>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
    `commit <https://codeberg.org/freeipa/freeipa/commit/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  tasks: add run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
    `commit <https://codeberg.org/freeipa/freeipa/commit/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
-   `#8432 <https://pagure.io/freeipa/issue/8432>`__
+   `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
    `commit <https://codeberg.org/freeipa/freeipa/commit/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
-   `#8391 <https://pagure.io/freeipa/issue/8391>`__
+   `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
    `commit <https://codeberg.org/freeipa/freeipa/commit/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
 -  EPN: ship the configuration file.
    `commit <https://codeberg.org/freeipa/freeipa/commit/6efe9917970f81a400793d4339d6826d8350ec55>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
-   `#8377 <https://pagure.io/freeipa/issue/8377>`__
+   `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__
 -  .mailmap: add fcami
    `commit <https://codeberg.org/freeipa/freeipa/commit/533ec75494127694692a46503e031df51a83f0c2>`__
 -  IPA-EPN: Test suite.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3805eff4178285f0189c355d17594b5e09dce9b0>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: First version.
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
@@ -3038,117 +3038,117 @@ François Cami (97)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
 -  IPA-EPN: Add design draft
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  doc/Makefile: use sphinx-build -W by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/7558e1413dca240a77893352b5bb62bd21103b46>`__
 -  Makefile.am: add doclint to fastcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
 -  ipatests: increase test_webui_server timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
-   `#8266 <https://pagure.io/freeipa/issue/8266>`__
+   `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
-   `#8262 <https://pagure.io/freeipa/issue/8262>`__
+   `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__
 -  ipatests: move ipa_backup to tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  pr-ci templates: update test_fips timeouts
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
-   `#8247 <https://pagure.io/freeipa/issue/8247>`__
+   `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3665ba928b25c017465588bd505e93d15d72290f>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  test_backup_and_restore: add server role verification steps
    `commit <https://codeberg.org/freeipa/freeipa/commit/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  pr-ci templates: update test_fips timeouts
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
-   `#8247 <https://pagure.io/freeipa/issue/8247>`__
+   `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9804558bbe745df1141c84f00be83edcbe06c91>`__
-   `#8240 <https://pagure.io/freeipa/issue/8240>`__
+   `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__
 -  8-sudorule.rst: add sudo and su-l as services for bob's HBAC rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
 -  ipa-restore: restart services at the end
    `commit <https://codeberg.org/freeipa/freeipa/commit/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
-   `#8226 <https://pagure.io/freeipa/issue/8226>`__
+   `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f9d5281848a4de3acd669caa277d1b830722b71>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipa-client-automount: call save_domain() for each change
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 -  ipatests/test_nfs.py: wait before umount
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
-   `#8144 <https://pagure.io/freeipa/issue/8144>`__
+   `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__
 -  ipatests: fix pr-ci templates' indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
-   `#8148 <https://pagure.io/freeipa/issue/8148>`__
+   `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
 -  DSU: add Design for Disable Stale Users
    `commit <https://codeberg.org/freeipa/freeipa/commit/438094f868e1a96444e148d9a2481b559cab9a11>`__
-   `#8104 <https://pagure.io/freeipa/issue/8104>`__
+   `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__
 -  ipatests: nightly_f29: disable TestIpaClientAutomountFileRestore
    `commit <https://codeberg.org/freeipa/freeipa/commit/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
-   `#8063 <https://pagure.io/freeipa/issue/8063>`__
+   `#8063 <https://codeberg.org/freeipa/freeipa/issues/8063>`__
 -  ipatests: temporarily remove test_smb from gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
 -  ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
 -  ipapython/ipachangeconf.py: change "is not 0" for "!= 0"
    `commit <https://codeberg.org/freeipa/freeipa/commit/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  authconfig.py: restore user-nsswitch.conf at uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
-   `#8054 <https://pagure.io/freeipa/issue/8054>`__
+   `#8054 <https://codeberg.org/freeipa/freeipa/issues/8054>`__
 -  ipatests: remove xfail in TestIpaClientAutomountFileRestore
    `commit <https://codeberg.org/freeipa/freeipa/commit/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
 -  ipa-client-automount: always restore nsswitch.conf at uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
-   `#8038 <https://pagure.io/freeipa/issue/8038>`__
+   `#8038 <https://codeberg.org/freeipa/freeipa/issues/8038>`__
 -  ipatests: check that ipa-client-automount restores nsswitch.conf at
    uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
 -  travis-ci: make dnf invocations more resilient
    `commit <https://codeberg.org/freeipa/freeipa/commit/c709f131712370d567064bb286d32d36f2307e0f>`__
-   `#8048 <https://pagure.io/freeipa/issue/8048>`__
+   `#8048 <https://codeberg.org/freeipa/freeipa/issues/8048>`__
 -  azure-pipelines.yml: switch to Python 3.7
    `commit <https://codeberg.org/freeipa/freeipa/commit/70b96d76cb97b386da27e05d81240f946b206378>`__
-   `#8030 <https://pagure.io/freeipa/issue/8030>`__
+   `#8030 <https://codeberg.org/freeipa/freeipa/issues/8030>`__
 -  test_nfs.py: switch to master_3repl
    `commit <https://codeberg.org/freeipa/freeipa/commit/80561224abcdc738a127e1ad70f3966cbb955c66>`__
-   `#8027 <https://pagure.io/freeipa/issue/8027>`__
+   `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
-   `#7949 <https://pagure.io/freeipa/issue/7949>`__
+   `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
 -  prci_definitions: add master_3client topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
-   `#8026 <https://pagure.io/freeipa/issue/8026>`__
+   `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__
 -  ipapython/admintool.py: use SERVER_NOT_CONFIGURED
    `commit <https://codeberg.org/freeipa/freeipa/commit/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
 -  ipa-client-samba: remove state on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
-   `#8021 <https://pagure.io/freeipa/issue/8021>`__
+   `#8021 <https://codeberg.org/freeipa/freeipa/issues/8021>`__
 -  ipatests: test ipa-client-samba after --uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
 -  ipa-client-samba: remove and restore smb.conf only on first uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b65551b3107e46853afcc4901a60ea6e661a511>`__
-   `#8019 <https://pagure.io/freeipa/issue/8019>`__
+   `#8019 <https://codeberg.org/freeipa/freeipa/issues/8019>`__
 -  ipatests: test multiple invocations of ipa-client-samba --uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/68b85703d8ab2ede823d96e317dd106de27b108b>`__
 -  ipatests/azure: display actual dnf repo URLs
@@ -3161,199 +3161,199 @@ Florence Blanc-Renaud (94)
 
 -  ipatests: add test for PKI subsystem detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
-   `#8596 <https://pagure.io/freeipa/issue/8596>`__
+   `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
 -  Improve PKI subsystem detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
-   `#8596 <https://pagure.io/freeipa/issue/8596>`__
+   `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
 -  xmlrpctests: remove harcoded expiration date from test_user_plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
-   `#8616 <https://pagure.io/freeipa/issue/8616>`__
+   `#8616 <https://codeberg.org/freeipa/freeipa/issues/8616>`__
 -  ipatests: fix TestTrust::test_subordinate_suffix
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
-   `#8601 <https://pagure.io/freeipa/issue/8601>`__
+   `#8601 <https://codeberg.org/freeipa/freeipa/issues/8601>`__
 -  Always define the path DNSSEC_OPENSSL_CONF
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
-   `#8597 <https://pagure.io/freeipa/issue/8597>`__
+   `#8597 <https://codeberg.org/freeipa/freeipa/issues/8597>`__
 -  ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst
    from gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/a33530f2f6cc7933edc537eb5055d4f147741654>`__
-   `#8496 <https://pagure.io/freeipa/issue/8496>`__
+   `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__
 -  ipatests: ipa-acme-manage status returns 3 on a CA-less server
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
-   `#8572 <https://pagure.io/freeipa/issue/8572>`__
+   `#8572 <https://codeberg.org/freeipa/freeipa/issues/8572>`__
 -  ipatests: IPADNSSystemRecordsCheck also checks for AAAA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
-   `#8573 <https://pagure.io/freeipa/issue/8573>`__
+   `#8573 <https://codeberg.org/freeipa/freeipa/issues/8573>`__
 -  ipatests: curl outputs the cookie in stderr and not in sdtout
    `commit <https://codeberg.org/freeipa/freeipa/commit/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
-   `#8559 <https://pagure.io/freeipa/issue/8559>`__
+   `#8559 <https://codeberg.org/freeipa/freeipa/issues/8559>`__
 -  ipatests: properly handle journalctl return code
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb7d09642205cba07ef614065d106f7f84d8921b>`__
-   `#8541 <https://pagure.io/freeipa/issue/8541>`__
+   `#8541 <https://codeberg.org/freeipa/freeipa/issues/8541>`__
 -  rpmspec: ensure ipa snippet for sshd is always included
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
-   `#8535 <https://pagure.io/freeipa/issue/8535>`__
+   `#8535 <https://codeberg.org/freeipa/freeipa/issues/8535>`__
 -  ipatests: add tests to 389ds regression
    `commit <https://codeberg.org/freeipa/freeipa/commit/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
 -  test_smb: skip test_smb_service_s4u2self for fed31
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
-   `#8505 <https://pagure.io/freeipa/issue/8505>`__
+   `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
-   `#8481 <https://pagure.io/freeipa/issue/8481>`__
+   `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__
 -  ipatests: fix bind service name
    `commit <https://codeberg.org/freeipa/freeipa/commit/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
-   `#8482 <https://pagure.io/freeipa/issue/8482>`__
+   `#8482 <https://codeberg.org/freeipa/freeipa/issues/8482>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec67022af204f1d34bb2da302aa0e3b874812399>`__
-   `#8472 <https://pagure.io/freeipa/issue/8472>`__
+   `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__
 -  ipatests: remove xfail from test_dnssec
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2711321679f99be9a8521f07c81e715bad74b06>`__
-   `#8447 <https://pagure.io/freeipa/issue/8447>`__
+   `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__
 -  ipatests: collect IPA_RENEWAL_LOCK file
    `commit <https://codeberg.org/freeipa/freeipa/commit/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
-   `#8439 <https://pagure.io/freeipa/issue/8439>`__
+   `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__
 -  ipatests: check KDC cert permissions in CA less install
    `commit <https://codeberg.org/freeipa/freeipa/commit/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  CAless installation: set the perms on KDC cert file
    `commit <https://codeberg.org/freeipa/freeipa/commit/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  ipatests: increase test_trust timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a3c98d236758274a719c2beeca2080df1390594>`__
 -  ipatests: fix test_authselect
    `commit <https://codeberg.org/freeipa/freeipa/commit/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/aac570bb4558798ef0b868a88a3b796361c400ba>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
    `commit <https://codeberg.org/freeipa/freeipa/commit/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
-   `#8414 <https://pagure.io/freeipa/issue/8414>`__
+   `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
-   `#8413 <https://pagure.io/freeipa/issue/8413>`__
+   `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__
 -  sshd template must be part of client package
    `commit <https://codeberg.org/freeipa/freeipa/commit/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
-   `#8400 <https://pagure.io/freeipa/issue/8400>`__
+   `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__
 -  Add test_dnssec to 389ds nightly tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17cf8edb4073fb1db67e5541409dd28943909750>`__
 -  ipa cert-show: fix the code setting revocation reason
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
-   `#8394 <https://pagure.io/freeipa/issue/8394>`__
+   `#8394 <https://codeberg.org/freeipa/freeipa/issues/8394>`__
 -  Bump requires for selinux-policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
 -  ipatests: fix the method adding ifp to sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
-   `#8371 <https://pagure.io/freeipa/issue/8371>`__
+   `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc11b98e4a6650040731405a0e954e20be12afa6>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__,
-   `#8381 <https://pagure.io/freeipa/issue/8381>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__,
+   `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__
 -  client install: fix broken sshd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipatests: Update the pki-master-f32 image version
    `commit <https://codeberg.org/freeipa/freeipa/commit/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
    `commit <https://codeberg.org/freeipa/freeipa/commit/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
    `commit <https://codeberg.org/freeipa/freeipa/commit/14876657794949e8acfeb63e7ccaa512becde7e1>`__
-   `#8364 <https://pagure.io/freeipa/issue/8364>`__
+   `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
-   `#6884 <https://pagure.io/freeipa/issue/6884>`__
+   `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
    `commit <https://codeberg.org/freeipa/freeipa/commit/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
-   `#8311 <https://pagure.io/freeipa/issue/8311>`__
+   `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
 -  Man pages: fix syntax issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
-   `#8273 <https://pagure.io/freeipa/issue/8273>`__
+   `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
 -  ipatests: wait for SSSD to become online in backup/restore tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3753862401b8500b7498d2723ccb727b5dd6263e>`__
-   `#8228 <https://pagure.io/freeipa/issue/8228>`__
+   `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  idviews: prevent applying to a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  opendnssec2.1 support: move all ods tasks to specific file
    `commit <https://codeberg.org/freeipa/freeipa/commit/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
    `commit <https://codeberg.org/freeipa/freeipa/commit/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  With opendnssec 2, read the zone list from file
    `commit <https://codeberg.org/freeipa/freeipa/commit/b857828180c650d7b2db17663a9413323eaef73d>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Remove the from opendnssec conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support opendnssec 2.1.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/233a18b2a24d814518a119bd3f1688a0eb361917>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/9eb1be875276c61127663c3860228f03a66ebfbd>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  ipatests: fix modify_sssd_conf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
 -  ipatests: update packages for rawhide and updates-testing nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
 -  ipatests: fix backup and restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae140ae40692154ce692c03901f6e17c0e227498>`__
-   `#8170 <https://pagure.io/freeipa/issue/8170>`__
+   `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__
 -  AD user without override receive InternalServerError with API
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 -  ipa-cacert-manage man page: fix indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
-   `#8138 <https://pagure.io/freeipa/issue/8138>`__
+   `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
 -  ipatests: fix test_crlgen_manage
@@ -3362,81 +3362,81 @@ Florence Blanc-Renaud (94)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
 -  ipatests: generic uninstall should call ipa server-del
    `commit <https://codeberg.org/freeipa/freeipa/commit/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  Nightly definition: use right template for krbtpolicy
    `commit <https://codeberg.org/freeipa/freeipa/commit/094cf629b338b78d13b15b87b4844c487c150e39>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  test_ipalib: add test for DNParam class
    `commit <https://codeberg.org/freeipa/freeipa/commit/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  XMLRPCtest: add a test for add-certmapdata with multiple
    subject/issuer
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  DNParam: raise Exception when multiple values provided to a 1-val
    param
    `commit <https://codeberg.org/freeipa/freeipa/commit/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
-   `#8113 <https://pagure.io/freeipa/issue/8113>`__
+   `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/921f500240fc0861e099a97a2b412e8610eaf198>`__
-   `#8099 <https://pagure.io/freeipa/issue/8099>`__
+   `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
 -  ipa-server-certinstall manpage: add missing options
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
-   `#8086 <https://pagure.io/freeipa/issue/8086>`__
+   `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/121971a51e6a652f3bc0c8c481a361954bab886e>`__
-   `#8070 <https://pagure.io/freeipa/issue/8070>`__
+   `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/387ee6e60f398efcdaf91c8097794ed24179150d>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipatests: fix fedora29 nightly definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
 -  replica install: enforce --server arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
    `commit <https://codeberg.org/freeipa/freeipa/commit/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/055ea253dfe0182671cba16916840a013daa8b74>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 -  ipatests: enable 389-ds audit log and collect audit file
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
-   `#8064 <https://pagure.io/freeipa/issue/8064>`__
+   `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__
 -  ipatests: add nightly definition for DS integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1af6aa27c6a3c69185507fb99da172526875db3>`__
 -  config plugin: replace 'is 0' with '== 0'
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  ipatests: fix wrong xfail in test_domain_resolution_order
    `commit <https://codeberg.org/freeipa/freeipa/commit/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
-   `#8052 <https://pagure.io/freeipa/issue/8052>`__
+   `#8052 <https://codeberg.org/freeipa/freeipa/issues/8052>`__
 -  Nightly test definition: add missing tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
 -  xmlrpc test: add test for preserved > stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 -  test_xmlrpc: fix
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
-   `#7902 <https://pagure.io/freeipa/issue/7902>`__
+   `#7902 <https://codeberg.org/freeipa/freeipa/issues/7902>`__
 -  Azure pipeline: report failure in prepare-build step
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
-   `#8022 <https://pagure.io/freeipa/issue/8022>`__
+   `#8022 <https://codeberg.org/freeipa/freeipa/issues/8022>`__
 -  upgrade: remove ipaCert and key from /etc/httpd/alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
-   `#7329 <https://pagure.io/freeipa/issue/7329>`__
+   `#7329 <https://codeberg.org/freeipa/freeipa/issues/7329>`__
 
 
 
@@ -3457,10 +3457,10 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
 -  dns: allow PTR records in arbitrary zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
-   `#5566 <https://pagure.io/freeipa/issue/5566>`__
+   `#5566 <https://codeberg.org/freeipa/freeipa/issues/5566>`__
 -  ipa_sam: do not modify static buffer holding fqdn
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  spec: require pki-acme if pki-ca >= 10.10
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
 -  install: simplify host name verification
@@ -3469,134 +3469,134 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b54d936487202a16031e5fdc23f5dfabde28af58>`__
 -  certupdate: update config after deployment becomes CA-ful
    `commit <https://codeberg.org/freeipa/freeipa/commit/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  cainstance: extract function import_ra_key
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  cainstance.update_ipa_conf: allow specifying ca_host
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  acme: delete ACME RA account on server uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: enable mod_md tests on Fedora
    `commit <https://codeberg.org/freeipa/freeipa/commit/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certbot dns-01 test
    `commit <https://codeberg.org/freeipa/freeipa/commit/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certbot dns script
    `commit <https://codeberg.org/freeipa/freeipa/commit/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add revocation test
    `commit <https://codeberg.org/freeipa/freeipa/commit/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: handle alternative schema ldif location
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add mod_md integration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration tests to gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb6d84903967bc6176d8a0817b602ba314129417>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration test to nightly CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add ipa-acme-manage command
    `commit <https://codeberg.org/freeipa/freeipa/commit/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: configure engine.conf and disable by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/00a84464eae31150714f667df67774ebe34b8514>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: configure ACME service on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certificate profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add Dogtag ACL to allow ACME agents to revoke certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: create ACME RA account
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  dogtaginstance: add ensure_group method
    `commit <https://codeberg.org/freeipa/freeipa/commit/a21823da7fcce521838764df5280295ccbdb8157>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  dogtaginstance: extract user creation to subroutine.
    `commit <https://codeberg.org/freeipa/freeipa/commit/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: set up ACME service when configuring CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: ipa-pki-proxy: proxy /acme to Dogtag
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  certupdate: only add LWCA tracking requests on CA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4462a94433e75da622118873d300d61a8e5f53f>`__
-   `#8399 <https://pagure.io/freeipa/issue/8399>`__
+   `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__
 -  tests: fix cleanup for CATracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  ca plugin: improve doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  ca-del: require CA to already be disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
 -  ra.get_certificate: use REST API
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  extract virtual operation access check subroutine
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__,
-   `#6423 <https://pagure.io/freeipa/issue/6423>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__,
+   `#6423 <https://codeberg.org/freeipa/freeipa/issues/6423>`__
 -  Define errors_by_code in ipalib.errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
    `commit <https://codeberg.org/freeipa/freeipa/commit/68ada5f2040bb207a5402220fb93e360bae215fe>`__
-   `#8368 <https://pagure.io/freeipa/issue/8368>`__
+   `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
 -  fix cert-find errors in CA-less deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/19544d53aeada733eb63d596be0a8576b17b9d04>`__
-   `#8369 <https://pagure.io/freeipa/issue/8369>`__
+   `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__
 -  upgrade: avoid stopping certmonger when fixing requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d9012f682a2dcff7676580fbc622771b427fcef>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
    `commit <https://codeberg.org/freeipa/freeipa/commit/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7c45641fe356364175899399b51b07987b44a1b>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: support dnsname as request search criterion
    `commit <https://codeberg.org/freeipa/freeipa/commit/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: move 'criteria' description to module docstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: avoid mutable default argument
    `commit <https://codeberg.org/freeipa/freeipa/commit/0711c4a0d45f9e28459596552ca751890b13c265>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  add resources section
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
 -  typospotting
@@ -3722,101 +3722,101 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
 -  Do not renew externally-signed CA as self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/769180c2c60205a453f87d7d1b88c27d238728db>`__
-   `#8176 <https://pagure.io/freeipa/issue/8176>`__
+   `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a2cc961666af1e41e127f043d571a93da800ef5>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix test regressions caused by certificate validation changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  ipatests: assert_error: allow regexp match
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  removed unused function export_pem_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
 -  test_integration: add tests for custom CA subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/e767386e7120be3515d6a34529b51ae658248038>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/326d417d98b092e175623cd28e46586df00e60a2>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  Bump Dogtag min version to 10.7.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  ipa-pki-retrieve-key: request AES encryption (with fallback)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  NSSWrappedCertDB: accept optional symmetric algorithm
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  IPASecStore: support extra key arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  dsinstance: add proflie when tracking certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  ipatests: test ipa-server-upgrade in CA-less deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/65d9a9be520ea9402143d9f06878eff53647925a>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  Use RENEWAL_CA_NAME and RA_AGENT_PROFILE constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb779baadf0df3333bd853599a21e81907c8c116>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  cainstance: add profile to IPA RA tracking request
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: fix spurious certmonger re-tracking
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: log missing/misconfigured tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: update KRA tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/482866e47e20520fbe39ef05439badbb3069bef6>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: always add profile to tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f4e2f96b022a056777fed59583f204edb797a2e>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtaginstance: avoid special cases for Server-Cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtag-ipa-ca-renew-agent: always use profile-based renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  certmonger: use long options when invoking dogtag-ipa-renew-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: add profile to Dogtag tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtaginstance: add profile to tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c388f5a228b767dfd92bd824dfced166acda143>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  ci: add --external-ca-profile tests to gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  ci: add --external-ca-profile tests to nightly
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c8352fe8536be0e630fdb910dc90831847ad119>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Collapse --external-ca-profile tests into single class
    `commit <https://codeberg.org/freeipa/freeipa/commit/80e76f094c234710ff58917e7ce4661d823c4de7>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Add more tests for --external-ca-profile handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/b15bd50e6db919279e25a8bed796df4836b845a8>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Fix use of incorrect variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/7171142aaf91d6079798d015af9862d6e5474c8c>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__,
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__,
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  install: fix --external-ca-profile option
    `commit <https://codeberg.org/freeipa/freeipa/commit/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__,
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__,
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  move MSCSTemplate classes to ipalib
    `commit <https://codeberg.org/freeipa/freeipa/commit/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 
 
 
@@ -3848,10 +3848,10 @@ Jeremy Frasier (2)
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/12529d7ef184846ca3852821b813c725b22e11c6>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 
 
 
@@ -3884,12 +3884,12 @@ Kaleemullah Siddiqui (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/592f3fe65986077ec0a19158d061a371c86307c7>`__
 -  Test for check of HostKeyAlgorithms option in ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 -  Fix for regression from PR#3962
    `commit <https://codeberg.org/freeipa/freeipa/commit/939ee59c2716aa2abf93ac78d44df937105b430d>`__
 -  Tests for backup-restore when pkg required is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
-   `#7630 <https://pagure.io/freeipa/issue/7630>`__
+   `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__
 
 
 
@@ -3933,15 +3933,15 @@ Michal Polovka (7)
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
-   `#2018 <https://pagure.io/freeipa/issue/2018>`__
+   `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/253779afc4432d02aa37b44dda789c4b152568fb>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__,
-   `#8055 <https://pagure.io/freeipa/issue/8055>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__,
+   `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__
 
 
 
@@ -3950,19 +3950,19 @@ Mark Reynolds (5)
 
 -  Accept 389-ds JSON replication status messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
-   `#7975 <https://pagure.io/freeipa/issue/7975>`__
+   `#7975 <https://codeberg.org/freeipa/freeipa/issues/7975>`__
 -  Reorder creation of the CA mapping tree and database backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
-   `#8558 <https://pagure.io/freeipa/issue/8558>`__
+   `#8558 <https://codeberg.org/freeipa/freeipa/issues/8558>`__
 -  Increase replication changelog trimming to 30 days
    `commit <https://codeberg.org/freeipa/freeipa/commit/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
-   `#8464 <https://pagure.io/freeipa/issue/8464>`__
+   `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
-   `#8456 <https://pagure.io/freeipa/issue/8456>`__
+   `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__
 -  Issue 8407 - Support changelog integration into main database
    `commit <https://codeberg.org/freeipa/freeipa/commit/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
-   `#8407 <https://pagure.io/freeipa/issue/8407>`__
+   `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__
 
 
 
@@ -3971,17 +3971,17 @@ Mohammad Rizwan (29)
 
 -  ipatests: Test certmonger IPA responder switched to JSONRPC
    `commit <https://codeberg.org/freeipa/freeipa/commit/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
-   `#3299 <https://pagure.io/freeipa/issue/3299>`__
+   `#3299 <https://codeberg.org/freeipa/freeipa/issues/3299>`__
 -  Move acme client installation part to classmethod
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4a6b0e5662f539b8438cdbc593eb713ea8c6da2>`__
 -  PEP8 fixes for test_acme.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
 -  External-CA scenarios for ACME service
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  ipatests: Check if ACME is enabled on all CA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  PEP8 fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
 -  ipatests: add --skip-overlap-check option to prepare_reverse_zone()
@@ -3998,51 +3998,51 @@ Mohammad Rizwan (29)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c02920529306aaa1a8be1fae185390e2e115859>`__
 -  webui: check if notification area doesn't intercept menu button
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  ipatests: Test deletion of required principal throws proper error
    `commit <https://codeberg.org/freeipa/freeipa/commit/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  Display principal name while del required principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  ipatests: Test to check password leak in apache error log
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 -  ipatests: Skip test using paramiko when FIPS is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if getcert creates cacert file with -F option
    `commit <https://codeberg.org/freeipa/freeipa/commit/9bcc57d9e01625a122811a50f78acde247b5791d>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Move wait_for_request() method to tasks.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
 -  Test if server installer lock Bind9 recursion
    `commit <https://codeberg.org/freeipa/freeipa/commit/1556f3f767c3fab7634b46a9193e363887558db0>`__
-   `#8079 <https://pagure.io/freeipa/issue/8079>`__
+   `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
 -  Add certmonger wait_for_request that uses run_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/806795422934c3220856bcaaf8810cdebd782fd4>`__
 -  Test if certmonger reads the token in HSM
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
-   `#8110 <https://pagure.io/freeipa/issue/8110>`__
+   `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
 -  Add test to nightly yamls
    `commit <https://codeberg.org/freeipa/freeipa/commit/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
 -  Installation of replica against a specific server
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  Check file ownership and permission for dirsrv log instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/7aec6f10374129d75cd99a4012980516ca535551>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 
 
 
@@ -4051,7 +4051,7 @@ ndehadra (1)
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
-   `#7307 <https://pagure.io/freeipa/issue/7307>`__
+   `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
 
 
 
@@ -4102,7 +4102,7 @@ Slava Aseev (1)
 
 -  ipa-kdb: handle dates up to 2106-02-07 06:28:16
    `commit <https://codeberg.org/freeipa/freeipa/commit/18721cc83035359a2f7d49cfe09e7f4b1376b090>`__
-   `#8028 <https://pagure.io/freeipa/issue/8028>`__
+   `#8028 <https://codeberg.org/freeipa/freeipa/issues/8028>`__
 
 
 
@@ -4113,7 +4113,7 @@ Petr Voborník (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
 -  webui: hide user attributes for SMB services section if empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 
 
 
@@ -4130,267 +4130,267 @@ Rob Crittenden (141)
 
 -  Skip the ACME mod_md test when the client is in enforcing mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
-   `#8514 <https://pagure.io/freeipa/issue/8514>`__
+   `#8514 <https://codeberg.org/freeipa/freeipa/issues/8514>`__
 -  Increase timeout for krbtpolicy to 4800
    `commit <https://codeberg.org/freeipa/freeipa/commit/28ed75ca0251724e34a447174ae775edca9763e2>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Enable the ccache sweep systemd timer
    `commit <https://codeberg.org/freeipa/freeipa/commit/068d08577d97258267917f81363a1a033a681803>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  ipatests: test that stale caches are removed using the sweeper
    `commit <https://codeberg.org/freeipa/freeipa/commit/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Generate a unique cache for each connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Convert reset_to_default_policy into a pytest fixture
    `commit <https://codeberg.org/freeipa/freeipa/commit/848dffb59273493ef3abde2a86864e85c8d19eff>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  VERSION: back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
 -  ipatests: Test that ipa-ca.$domain can retrieve CRLs without redirect
    `commit <https://codeberg.org/freeipa/freeipa/commit/b478bf99d9f158dabae145169f242b2b5d26404c>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__
 -  Allow Apache to answer to ipa-ca requests without a redirect
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__
 -  Move where the restore state is marked during IPA server upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
-   `#7534 <https://pagure.io/freeipa/issue/7534>`__
+   `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
 -  Reorder when ACME is enabled to fix failure on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
-   `#8603 <https://pagure.io/freeipa/issue/8603>`__
+   `#8603 <https://codeberg.org/freeipa/freeipa/issues/8603>`__
 -  Remove test for minimum ACME support and rely on package deps
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
 -  Require PKI 10.10+ for KRA profile and ACME support
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e530e93c37ee71a560714e26285cd85e71557c9>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__,
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__,
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  Test that the KRA profiles can renewal its three certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  Change KRA profiles in certmonger tracking so they can renew
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9e1c014f601a567f4aa5135d02883c498835268>`__
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  ipatests: Increase timeout for ACME in gating.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: honor class inheritance in TestACMEwithExternalCA
    `commit <https://codeberg.org/freeipa/freeipa/commit/75ad5757528491616f7f4e596bb9f6b152944d99>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: configure MDStoreDir for mod_md ACME test
    `commit <https://codeberg.org/freeipa/freeipa/commit/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Clean up existing ACME registration and certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d286e79515c8a6c856a5acde6300271422acfac>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Configure a replica in TestACMEwithExternalCA
    `commit <https://codeberg.org/freeipa/freeipa/commit/de5baf8516cde060f1606070b2a8824f71178f16>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: call the CALess install method to generate the CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Test that Match ProxyCommand masks on no shell exec
    `commit <https://codeberg.org/freeipa/freeipa/commit/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
-   `#7676 <https://pagure.io/freeipa/issue/7676>`__
+   `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
 -  Create IPA ssh client configuration and move ProxyCommand
    `commit <https://codeberg.org/freeipa/freeipa/commit/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
-   `#7676 <https://pagure.io/freeipa/issue/7676>`__
+   `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
 -  ipatests: Test that ipa-certupdate can run without credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
-   `#8531 <https://pagure.io/freeipa/issue/8531>`__
+   `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__
 -  Use host keytab to obtain credentials needed for ipa-certupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a09ce9f3fa503eeefe394856be538892652accf>`__
-   `#8531 <https://pagure.io/freeipa/issue/8531>`__
+   `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__
 -  ipatests: Test that password reset unlocks users too
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
-   `#8551 <https://pagure.io/freeipa/issue/8551>`__
+   `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
 -  On password reset also set krbLastAdminUnlock to unlock account
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
-   `#8551 <https://pagure.io/freeipa/issue/8551>`__
+   `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
 -  Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test
    `commit <https://codeberg.org/freeipa/freeipa/commit/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Catch EmptyResult exception in update_idranges
    `commit <https://codeberg.org/freeipa/freeipa/commit/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  Test that ipapwpolicy objectclass is added on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/f86250a9a592f2549bc1446c8e3493b256618107>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  Add ipwpwdpolicy objectclass to all policies on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  ipatests: Add tests for requiring ipa-ca SAN when ACME is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  Change the return codes of ipa-acme-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  Require an ipa-ca SAN on 3rd party certs if ACME is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  ipatests: Collect the let's encrypt log
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4ef64b229541200564131e927cd0b4b32662fe2>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Add a status option to ipa-acme-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Don't install ACME if full support is not available
    `commit <https://codeberg.org/freeipa/freeipa/commit/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Centralize enable/disable of the ACME service
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Let dogtag.py be imported if the api is not initialized
    `commit <https://codeberg.org/freeipa/freeipa/commit/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Enable importing LDIF files not shipped by IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Use a state to determine if a 389-ds upgrade is in progress
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
-   `#7534 <https://pagure.io/freeipa/issue/7534>`__
+   `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
 -  ipatests: Add test_pwpolicy to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Requirements and design for libpwquality integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add SELinux policy so kadmind can read the crackdb dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/68aa7c05542422aca05bec4967133be09a32496e>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  ipatests: add test for password policies
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe44835970eca197543eb3c908c51a240204d846>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add a raiseonerr option to ldappasswd_user_change
    `commit <https://codeberg.org/freeipa/freeipa/commit/be2efc12d37018794200fee874f27d83e0442ea4>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Pass the user to the password policy check in the kdb driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/6da070e655c5d084a825607ed3be604c809b12f0>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add a unit test for libpwquality-based password policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/46d0096218488a961125b6d97a9210b68e5434e5>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Extend password policy to evaluate passwords using libpwpolicy
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Require libpwolicy and configure it in the build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fc2eda4e15e9592132062036d70acad3bab401c>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add new pwpolicy objectclass to test_xmprpc/objectclasses.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Extend IPA pwquality plugin to include libpwquality support
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b452e54045bb957e6f787209b4498eefc5df779>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add LDAP schema for new libpwquality attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Don't restart certmonger after stopping tracking in uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
-   `#8533 <https://pagure.io/freeipa/issue/8533>`__
+   `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
    `commit <https://codeberg.org/freeipa/freeipa/commit/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Test that ccaches are cleaned up during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Require a matching server package for the selinux subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
-   `#8511 <https://pagure.io/freeipa/issue/8511>`__
+   `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__
 -  Add index for more trust-related attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  ipatests: Add tests for checking available memory
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e4431af7066ce298008973b6caddc170645c98d>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  Use ACI class set_permissions() method to set permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  De-duplicate ACI attributes and permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
    `commit <https://codeberg.org/freeipa/freeipa/commit/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
    `commit <https://codeberg.org/freeipa/freeipa/commit/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Set the certmonger subject with a string, not an object
    `commit <https://codeberg.org/freeipa/freeipa/commit/f249c51bf4342341378e63953386e9ac4070be54>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  cli: When parsing options require name/value pairs
    `commit <https://codeberg.org/freeipa/freeipa/commit/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 -  ipatests: stop the CA during healthcheck expiration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
-   `#8463 <https://pagure.io/freeipa/issue/8463>`__
+   `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__
 -  Improve performance of ipa-server-guard
    `commit <https://codeberg.org/freeipa/freeipa/commit/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
-   `#8425 <https://pagure.io/freeipa/issue/8425>`__
+   `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__
 -  ipatests: Add test for is_ipa_configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/25e042d3d1e04972d4536b1fa793811e6b047559>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Use is_ipa_configured from ipalib.facts
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Fall back to old server installation detection when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
 -  Added negative test case for --list-sources option
@@ -4401,28 +4401,28 @@ Rob Crittenden (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
 -  Address legacy pylint issues in sysrestore.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Update check_client_configuration to use new client fact
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Don't use the has_files() to know if client/server is configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e027134815512862ad6ae77867e74a83aee2b59>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if IPA client configuration is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/4758db121ea0c555dab89bc1781c8752f188e414>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if an IPA server installation is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  ipatests: Test healthcheck revocation checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
@@ -4441,44 +4441,44 @@ Rob Crittenden (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
    `commit <https://codeberg.org/freeipa/freeipa/commit/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
-   `#8429 <https://pagure.io/freeipa/issue/8429>`__
+   `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__
 -  Don't delegate the TGT in ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
-   `#8405 <https://pagure.io/freeipa/issue/8405>`__
+   `#8405 <https://codeberg.org/freeipa/freeipa/issues/8405>`__
 -  IPA-EPN: Don't treat givenname differently
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b266d39570f447db0f571a8b8085eb6c0403509>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
    `commit <https://codeberg.org/freeipa/freeipa/commit/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: test using SSL against port 465
    `commit <https://codeberg.org/freeipa/freeipa/commit/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add test for starttls mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add index for krbPasswordExpiration for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add a jinja2 e-mail template for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/03caa7f965d889848675158503286cde00d635c9>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Perform baseline healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
 -  Test that pwpolicy only applied on Kerberos entries
@@ -4493,52 +4493,52 @@ Rob Crittenden (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/44e73428441a070f26a791ee2816f2989713ba8d>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
    `commit <https://codeberg.org/freeipa/freeipa/commit/f589a8952c33a25794e577077bb3c0bda740667c>`__
-   `#8135 <https://pagure.io/freeipa/issue/8135>`__
+   `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4966f9c3f9566603be24e09f4803b3183898272>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  Add tests for ipa-cacert-manage delete command
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
    `commit <https://codeberg.org/freeipa/freeipa/commit/02ce407f5e10e670d4788778037892b58f80adc0>`__
 -  Add integration test for Kerberos ticket policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Conditionally restart certmonger after client installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3593e5362206fd9287e97fe2cee229a1117811ff>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Add conditional restart (try-restart) capability to services
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Enable AES SHA 256 and 384-bit enctypes in Kerberos
    `commit <https://codeberg.org/freeipa/freeipa/commit/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
-   `#8110 <https://pagure.io/freeipa/issue/8110>`__
+   `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
 -  Disable dogtag cert publishing
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
-   `#7522 <https://pagure.io/freeipa/issue/7522>`__
+   `#7522 <https://codeberg.org/freeipa/freeipa/issues/7522>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 -  Report if a certmonger CA is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
-   `#7870 <https://pagure.io/freeipa/issue/7870>`__
+   `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffb4b624fc8bfd870958976ec25b74677e740841>`__
-   `#8034 <https://pagure.io/freeipa/issue/8034>`__
+   `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__
 -  Don't log host passwords when they are set/modified
    `commit <https://codeberg.org/freeipa/freeipa/commit/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  Skip lock and fork in ipa-server-guard on unsupported ops
    `commit <https://codeberg.org/freeipa/freeipa/commit/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
 -  Defer initializing the API in dogtag-ipa-ca-renew-agent-submit
@@ -4547,26 +4547,26 @@ Rob Crittenden (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5db48f151ba4aef2baebc40a4d357403a922d362>`__
 -  Log dogtag auth timeout in install, provide hint to increase it
    `commit <https://codeberg.org/freeipa/freeipa/commit/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Log the replication wait timeout for debugging purposes
    `commit <https://codeberg.org/freeipa/freeipa/commit/54035982e5850ec59611798a9e172a044969106f>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Replace replication_wait_timeout with certmonger_wait_timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Use tasks to configure automount nsswitch settings
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
 -  Move ipachangeconf from ipaclient.install to ipapython
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  httpinstance: add pinfile when tracking certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  Remove posixAccount from service_find search filter
    `commit <https://codeberg.org/freeipa/freeipa/commit/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
-   `#8013 <https://pagure.io/freeipa/issue/8013>`__
+   `#8013 <https://codeberg.org/freeipa/freeipa/issues/8013>`__
 
 
 
@@ -4575,12 +4575,12 @@ Robbie Harwood (17)
 
 -  Fix krbtpolicy tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
-   `#8590 <https://pagure.io/freeipa/issue/8590>`__
+   `#8590 <https://codeberg.org/freeipa/freeipa/issues/8590>`__
 -  Drop upper bound on krb5 version in freeipa.spec
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
 -  ipa-kdb: implement AS-REQ lifetime jitter
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
-   `#8010 <https://pagure.io/freeipa/issue/8010>`__
+   `#8010 <https://codeberg.org/freeipa/freeipa/issues/8010>`__
 -  Update kdcpolicy design doc for jitter implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/249097c62414abc99256af9dc622c284745081e4>`__
 -  Drop support for DAL version 5.0
@@ -4635,7 +4635,7 @@ Rafael Guterres Jeffman (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
 -  Re-add function façades removed by commit 2da9088.
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
-   `#8062 <https://pagure.io/freeipa/issue/8062>`__
+   `#8062 <https://codeberg.org/freeipa/freeipa/issues/8062>`__
 
 
 
@@ -4660,7 +4660,7 @@ Sam Morris (1)
 
 -  Debian: write out only one CA certificate per file
    `commit <https://codeberg.org/freeipa/freeipa/commit/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
-   `#8106 <https://pagure.io/freeipa/issue/8106>`__
+   `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__
 
 
 
@@ -4669,10 +4669,10 @@ Sumit Bose (2)
 
 -  ipa-kdb: Remove keys if password auth is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -4691,15 +4691,15 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
 -  EPN: Allow authentication by SMTP client's certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/17f430efc4cf438b6c052465b8252688bc5822f9>`__
-   `#8580 <https://pagure.io/freeipa/issue/8580>`__
+   `#8580 <https://codeberg.org/freeipa/freeipa/issues/8580>`__
 -  EPN: Enable certificate validation and hostname checking
    `commit <https://codeberg.org/freeipa/freeipa/commit/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
-   `#8579 <https://pagure.io/freeipa/issue/8579>`__
+   `#8579 <https://codeberg.org/freeipa/freeipa/issues/8579>`__
 -  test_epn: Standardize EPN configs for deduplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
 -  EPN: Don't downgrade security
    `commit <https://codeberg.org/freeipa/freeipa/commit/94adee3c73f039fc2d985afd1681cd64ece55116>`__
-   `#8578 <https://pagure.io/freeipa/issue/8578>`__
+   `#8578 <https://codeberg.org/freeipa/freeipa/issues/8578>`__
 -  ipatests: Respect platform's openssl dir
    `commit <https://codeberg.org/freeipa/freeipa/commit/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
 -  dns: Make use of \`resolve_address\` of a current resolver instead of
@@ -4707,17 +4707,17 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b450c9bd324a3c89ea03d898592cfed832184802>`__
 -  dnspython: Add compatibility shim
    `commit <https://codeberg.org/freeipa/freeipa/commit/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
-   `#8383 <https://pagure.io/freeipa/issue/8383>`__
+   `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__
 -  tox: Don't expand symlinks
    `commit <https://codeberg.org/freeipa/freeipa/commit/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
-   `#8475 <https://pagure.io/freeipa/issue/8475>`__
+   `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__
 -  Azure: Increase verbosity for Tox task
    `commit <https://codeberg.org/freeipa/freeipa/commit/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3d10871300498150c41f3acc154688f1ee48ceb>`__
 -  nss: Raise exception earlier on unsupported DB type
    `commit <https://codeberg.org/freeipa/freeipa/commit/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
-   `#8474 <https://pagure.io/freeipa/issue/8474>`__
+   `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__
 -  Azure: base: Collect both install and uninstall logs
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
 -  Azure: Drop dependency on UsePythonVersion task
@@ -4726,129 +4726,129 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
 -  ipa-dnskeysyncd: Raise loglevel to DEBUG
    `commit <https://codeberg.org/freeipa/freeipa/commit/92157bc880600be137c634d5def788c1bf8c5e8a>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Include crypto policy in openssl config
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Don't override custom command line options for named
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecfaf897b937e2333296d32960b2cc13843048f9>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  service: Allow service to clean up its state
    `commit <https://codeberg.org/freeipa/freeipa/commit/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  spec: Bump required openssl-pkcs11 and softhsm
    `commit <https://codeberg.org/freeipa/freeipa/commit/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Make use of 'pkcs11' OpenSSL engine for BIND on Fedora31
    `commit <https://codeberg.org/freeipa/freeipa/commit/721435cf7f2ed41fe807c34022fed31c792b4497>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  upgrade: Handle migration of BIND OpenSSL engine
    `commit <https://codeberg.org/freeipa/freeipa/commit/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  DNSKeySyncInstance: Populate named/ods uid/gid on instantiation
    `commit <https://codeberg.org/freeipa/freeipa/commit/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Allow using of a custom OpenSSL engine for BIND
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Remove no longer used paths
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  spec: Require ldns-utils
    `commit <https://codeberg.org/freeipa/freeipa/commit/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  pylint: Ignore \`raise-missing-from\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/8831b9b6498b834c77dce2e0b96854be105810f9>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec6369ca009139af69aa4214e82fc411184b428f>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Teach pylint about more RRs types
    `commit <https://codeberg.org/freeipa/freeipa/commit/de105aa8fc8281c28c359d607c2b43154103a399>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  spec: Move ipa-cldap plugin out to freeipa-server-trust-ad package
    `commit <https://codeberg.org/freeipa/freeipa/commit/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
 -  uninstall: Clean up no longer used flag
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
-   `#8459 <https://pagure.io/freeipa/issue/8459>`__
+   `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
 -  Azure: Switch to dockerhub provider
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a344a5d932db148b1921c03906d2843b3622cb>`__
-   `#8428 <https://pagure.io/freeipa/issue/8428>`__
+   `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__
 -  pylint: Fix warning and error
    `commit <https://codeberg.org/freeipa/freeipa/commit/c81cac70acd304f34f875af5096c407a44f1395b>`__
-   `#8442 <https://pagure.io/freeipa/issue/8442>`__
+   `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
-   `#8435 <https://pagure.io/freeipa/issue/8435>`__
+   `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__
 -  Azure: Make dnf repos consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/26f96595b010396f055c7d11a645be57fc637863>`__
-   `#8330 <https://pagure.io/freeipa/issue/8330>`__
+   `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__
 -  Azure: Always update apt cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
 -  Azure: Allow chronyd to sync time
    `commit <https://codeberg.org/freeipa/freeipa/commit/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Add custom seccomp profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Increase memory limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
-   `#8264 <https://pagure.io/freeipa/issue/8264>`__
+   `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/63747bc0c041382536e2cad121bb591e42df3a2f>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Pretty print multihost config
    `commit <https://codeberg.org/freeipa/freeipa/commit/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
    `commit <https://codeberg.org/freeipa/freeipa/commit/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Specify shell implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/974395704ad3a0c992324a080e96e1160f324153>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Specify Pytest XML report schema
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
    `commit <https://codeberg.org/freeipa/freeipa/commit/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove deprecated yield_fixture
    `commit <https://codeberg.org/freeipa/freeipa/commit/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Bump required Pytest
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba162b9b47004da633a2c140409982725f5e0960>`__
-   `#8261 <https://pagure.io/freeipa/issue/8261>`__
+   `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__
 -  Azure: Gather coredumps
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
-   `#8251 <https://pagure.io/freeipa/issue/8251>`__
+   `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__
 -  Azure: Allow distros to install Python they want
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
-   `#8254 <https://pagure.io/freeipa/issue/8254>`__
+   `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__
 -  pki-proxy: Don't rely on running apache until it's configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
-   `#8233 <https://pagure.io/freeipa/issue/8233>`__
+   `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__
 -  spec: Take the ownership over '/usr/libexec/ipa/custodia'
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
 -  Azure: Report elapsed time
@@ -4865,81 +4865,81 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
 -  pylint: Run Pylint over Azure Python scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Add support for testing multi IPA environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  yamllint: Lint all the YAML files
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa104daf77902172f087c7026052fd9a59b4861a>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
    `commit <https://codeberg.org/freeipa/freeipa/commit/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to run integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/879855ce705770834d0be8182818ae672bc72063>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow SSH for Docker environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to not provide tests to be ignored
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  ipatests: Allow zero-length arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/902821e8aa47936acac713023bff9a4009d8dfb7>`__
-   `#8173 <https://pagure.io/freeipa/issue/8173>`__
+   `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__
 -  lint: Make Pylint-2.4 happy again
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Clean up comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/a309de6c08987b1cf9645111414d1c52b4525190>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
    `commit <https://codeberg.org/freeipa/freeipa/commit/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Teach Pylint how to handle request.context
    `commit <https://codeberg.org/freeipa/freeipa/commit/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  ipatests: Properly kill gpg-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/19462788f162491e0aedaaf42528cae7104b8068>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c7447fd42548d28df6200e354afdc03355b94b6>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/292d686c0b7935dd219559b10de3a393b712a990>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  Fix errors found by Pylint-2.4.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
-   `#8102 <https://pagure.io/freeipa/issue/8102>`__
+   `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__
 -  Install language packs for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
 -  Restore running of 'test_ipaserver' tests on Azure
    `commit <https://codeberg.org/freeipa/freeipa/commit/16149831daf12826c1c39d4109a0014b86fbb072>`__
 -  Setup DNS for AP Docker container
    `commit <https://codeberg.org/freeipa/freeipa/commit/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 -  Fixed errors newly exposed by pylint 2.4.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 -  Avoid use of '/tmp' for pip operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7500220c443c6051178211eadd64392ca7bd08a>`__
-   `#8009 <https://pagure.io/freeipa/issue/8009>`__
+   `#8009 <https://codeberg.org/freeipa/freeipa/issues/8009>`__
 -  Make use of Azure Pipeline slicing
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
-   `#8008 <https://pagure.io/freeipa/issue/8008>`__
+   `#8008 <https://codeberg.org/freeipa/freeipa/issues/8008>`__
 -  Simplify ipa-run-tests script
    `commit <https://codeberg.org/freeipa/freeipa/commit/2312b38a678d30b73c08dae19db7f8b74361a957>`__
-   `#8007 <https://pagure.io/freeipa/issue/8007>`__
+   `#8007 <https://codeberg.org/freeipa/freeipa/issues/8007>`__
 -  Fix \`test_webui.test_selinuxusermap\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
-   `#7996 <https://pagure.io/freeipa/issue/7996>`__,
-   `#8005 <https://pagure.io/freeipa/issue/8005>`__
+   `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__,
+   `#8005 <https://codeberg.org/freeipa/freeipa/issues/8005>`__
 
 
 
@@ -4981,7 +4981,7 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
 -  ipatests: provide AD admin password when trying to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/aae30eb708b04c54807bc226b93ca14e09561b87>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  ipatests: remove test_ordering
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
 -  ipatests: add test for SSSD updating expired cache items
@@ -4990,40 +4990,40 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
 -  ipatests: remove invalid parameter from sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: replace utility for editing sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/9450aef75f2ac064ea182c942d39400287a38bab>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
    `commit <https://codeberg.org/freeipa/freeipa/commit/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
 -  ipatests: add test_trust suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
 -  ipatests: add check for output contents of ipa-client-samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/15fd36612ea451cec2e1302a462fa440663fcc74>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 -  ipatests: enable test_smb.py in gating.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
 -  ipatests: replace ad hoc backup with FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: refactor FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: in DNS zone file add A record for name server
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
 -  ipatests: strip newline character when getting name of temp file
    `commit <https://codeberg.org/freeipa/freeipa/commit/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
    `commit <https://codeberg.org/freeipa/freeipa/commit/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
-   `#7995 <https://pagure.io/freeipa/issue/7995>`__
+   `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
@@ -5036,7 +5036,7 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
 -  ipatests: refactor and extend tests for IPA-Samba integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipatests: modify run_command to allow specify successful return codes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
 -  ipatests: add utility functions related to using and managing user
@@ -5067,17 +5067,17 @@ Sumedh Sidhaye (6)
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
    `commit <https://codeberg.org/freeipa/freeipa/commit/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
 -  Test: To check ipa replica-manage del does not fail
    `commit <https://codeberg.org/freeipa/freeipa/commit/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
-   `#7929 <https://pagure.io/freeipa/issue/7929>`__
+   `#7929 <https://codeberg.org/freeipa/freeipa/issues/7929>`__
 
 
 
@@ -5103,94 +5103,94 @@ Serhii Tsymbaliuk (28)
 -  WebUI tests: Add simple test to check topology graph page is
    available
    `commit <https://codeberg.org/freeipa/freeipa/commit/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
-   `#8523 <https://pagure.io/freeipa/issue/8523>`__
+   `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__
 -  WebUI: Fix topology graph navigation crash
    `commit <https://codeberg.org/freeipa/freeipa/commit/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
-   `#8523 <https://pagure.io/freeipa/issue/8523>`__
+   `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__
 -  WebUI: Fix jQuery DOM manipulation issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/29b41aef0a49d5460631a8543f0f6620d4696790>`__
-   `#8507 <https://pagure.io/freeipa/issue/8507>`__
+   `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__
 -  WebUI tests: Add test case to cover user ID override feature
    `commit <https://codeberg.org/freeipa/freeipa/commit/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
    `commit <https://codeberg.org/freeipa/freeipa/commit/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
    `commit <https://codeberg.org/freeipa/freeipa/commit/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
-   `#8325 <https://pagure.io/freeipa/issue/8325>`__
+   `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__
 -  WebUI tests: Test all available fields on "Kerberos Ticket Policy"
    page
    `commit <https://codeberg.org/freeipa/freeipa/commit/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
-   `#8207 <https://pagure.io/freeipa/issue/8207>`__
+   `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__
 -  WebUI: Add authentication indicator specific fields to "Kerberos
    Ticket Policy" page
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
-   `#8207 <https://pagure.io/freeipa/issue/8207>`__
+   `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3645854c11b0489215a27077a633755638f00268>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/33ca0745585ae3fcd466631a069e244bea74be88>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI tests: cover membership management with UI tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
-   `#8298 <https://pagure.io/freeipa/issue/8298>`__
+   `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
-   `#8284 <https://pagure.io/freeipa/issue/8284>`__
+   `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
    `commit <https://codeberg.org/freeipa/freeipa/commit/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
-   `#8222 <https://pagure.io/freeipa/issue/8222>`__
+   `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
-   `#8239 <https://pagure.io/freeipa/issue/8239>`__
+   `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4634a59c98ae922708f9211786b67505dada736>`__
-   `#8157 <https://pagure.io/freeipa/issue/8157>`__
+   `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
-   `#8169 <https://pagure.io/freeipa/issue/8169>`__
+   `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__
 -  WebUI: Fix notification area layout
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
-   `#8123 <https://pagure.io/freeipa/issue/8123>`__
+   `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__
 -  WebUI: Fix new test initialization on "HBAC Test" page
    `commit <https://codeberg.org/freeipa/freeipa/commit/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
-   `#8031 <https://pagure.io/freeipa/issue/8031>`__
+   `#8031 <https://codeberg.org/freeipa/freeipa/issues/8031>`__
 -  WebUI: Fix changing category on HBAC/Sudo/etc Rule pages
    `commit <https://codeberg.org/freeipa/freeipa/commit/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
-   `#7961 <https://pagure.io/freeipa/issue/7961>`__
+   `#7961 <https://codeberg.org/freeipa/freeipa/issues/7961>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
    `commit <https://codeberg.org/freeipa/freeipa/commit/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
-   `#5062 <https://pagure.io/freeipa/issue/5062>`__
+   `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
 -  WebUI tests: Fix login screen loading issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
-   `#8053 <https://pagure.io/freeipa/issue/8053>`__
+   `#8053 <https://codeberg.org/freeipa/freeipa/issues/8053>`__
 -  WebUI tests: Fix request timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16ea8e652a3a3b555087646b9887bc77934d175>`__
-   `#8024 <https://pagure.io/freeipa/issue/8024>`__
+   `#8024 <https://codeberg.org/freeipa/freeipa/issues/8024>`__
 -  WebUI: Add PKINIT status field to 'Configuration' page
    `commit <https://codeberg.org/freeipa/freeipa/commit/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
-   `#7305 <https://pagure.io/freeipa/issue/7305>`__
+   `#7305 <https://codeberg.org/freeipa/freeipa/issues/7305>`__
 -  WebUI tests: Fix timeout issues for reset password tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/6316a006327426af9365f865633cf6767ff699a9>`__
-   `#8012 <https://pagure.io/freeipa/issue/8012>`__
+   `#8012 <https://codeberg.org/freeipa/freeipa/issues/8012>`__
 
 
 
@@ -5212,10 +5212,10 @@ Sudhir Menon (36)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7be1a2470c220da30154305e869149d808c0ec2>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_riplugincheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b1230e5b083084eecf3aeb027223d5501a45924>`__
-   `#8563 <https://pagure.io/freeipa/issue/8563>`__
+   `#8563 <https://codeberg.org/freeipa/freeipa/issues/8563>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_encryption
    `commit <https://codeberg.org/freeipa/freeipa/commit/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
-   `#8560 <https://pagure.io/freeipa/issue/8560>`__
+   `#8560 <https://codeberg.org/freeipa/freeipa/issues/8560>`__
 -  ipatests: ipa-healthcheck test for DS RIPluginCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/686414d2017b8122df04b04493909a12db8ccd66>`__
 -  ipatests: ipa-healthcheck test for EncryptionCheck
@@ -5261,7 +5261,7 @@ Sudhir Menon (36)
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
    `commit <https://codeberg.org/freeipa/freeipa/commit/555f8a038dae139ad161c5dab51e2378f8894b81>`__
-   `#8066 <https://pagure.io/freeipa/issue/8066>`__
+   `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
@@ -5281,7 +5281,7 @@ Sudhir Menon (36)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
 -  Added testcase to check capitalization fix while running ipa user-mod
    `commit <https://codeberg.org/freeipa/freeipa/commit/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
-   `#5879 <https://pagure.io/freeipa/issue/5879>`__
+   `#5879 <https://codeberg.org/freeipa/freeipa/issues/5879>`__
 
 
 
@@ -5290,17 +5290,17 @@ Tibor Dudlák (5)
 
 -  Add container environment check to replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
-   `#6210 <https://pagure.io/freeipa/issue/6210>`__
+   `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
 -  Increase ntp_options test timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
 -  ipatests: refactor TestNTPoptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
 -  ipatests: Add tests for interactive chronyd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 -  ipatests: Update test tasks for client to be interactive
    `commit <https://codeberg.org/freeipa/freeipa/commit/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 
 
 
@@ -5376,7 +5376,7 @@ Thomas Woerner (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/51fcca535236e309dc6431ad68bad36bf8f56823>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
-   `#8150 <https://pagure.io/freeipa/issue/8150>`__
+   `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__
 -  Enable TestInstallMasterDNSRepeatedly in prci_definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
 -  Test repeated installation of the primary with DNS enabled and domain
@@ -5390,7 +5390,7 @@ Viktor Ashirov (1)
 
 -  Update ACIs with the correct syntax
    `commit <https://codeberg.org/freeipa/freeipa/commit/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
-   `#8301 <https://pagure.io/freeipa/issue/8301>`__
+   `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__
 
 
 
@@ -5401,7 +5401,7 @@ Vit Mojzis (5)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2f9912b78d723441f241abb453971dd78cf5d6e>`__
 -  selinux: disable ipa_custodia when installing custom policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/3aad16a75ef06d20d111773268df30ee04274db7>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  selinux: Remove obsolete memcached access
    `commit <https://codeberg.org/freeipa/freeipa/commit/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
 -  selinux: move BUILD_SELINUX_POLICY definition
@@ -5442,6 +5442,6 @@ Zdenek Pytela (2)
 
 -  Add ipa_pki_retrieve_key_exec() interface
    `commit <https://codeberg.org/freeipa/freeipa/commit/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  Allow ipa-adtrust-install restart sssd and dirsrv services
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__

--- a/src/page/Releases/4.9.0rc1.rst
+++ b/src/page/Releases/4.9.0rc1.rst
@@ -509,904 +509,904 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#298 <https://pagure.io/freeipa/issue/298>`__
+-  `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__
    (`rhbz#587752 <https://bugzilla.redhat.com/show_bug.cgi?id=587752>`__)
    [RFE] Add support for cracklib to password policies
--  `#2018 <https://pagure.io/freeipa/issue/2018>`__
+-  `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
    (`rhbz#1703564 <https://bugzilla.redhat.com/show_bug.cgi?id=1703564>`__)
    Change hostname length limit to 64
--  `#2445 <https://pagure.io/freeipa/issue/2445>`__
+-  `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__
    (`rhbz#798359 <https://bugzilla.redhat.com/show_bug.cgi?id=798359>`__)
    [RFE] IdM password policy should include checks for repeating
    characters
--  `#3473 <https://pagure.io/freeipa/issue/3473>`__ Switch to using
+-  `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__ Switch to using
    RESTful interface in dogtag CA interface
--  `#3687 <https://pagure.io/freeipa/issue/3687>`__
+-  `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
    (`rhbz#913799 <https://bugzilla.redhat.com/show_bug.cgi?id=913799>`__)
    [RFE] IPA user account expiry warning.
--  `#3827 <https://pagure.io/freeipa/issue/3827>`__ [RFE] Expose TTL in
+-  `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__ [RFE] Expose TTL in
    web UI
--  `#3999 <https://pagure.io/freeipa/issue/3999>`__
+-  `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
    (`rhbz#837604 <https://bugzilla.redhat.com/show_bug.cgi?id=837604>`__)
    [RFE] Fix and Document how to set up Samba File Server with IPA
--  `#4751 <https://pagure.io/freeipa/issue/4751>`__
+-  `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Implement ACME certificate enrolment
--  `#4972 <https://pagure.io/freeipa/issue/4972>`__
+-  `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
    (`rhbz#1206690 <https://bugzilla.redhat.com/show_bug.cgi?id=1206690>`__)
    check for existence of private group is done even if UPG definition
    is disabled
--  `#5011 <https://pagure.io/freeipa/issue/5011>`__
+-  `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
    (`rhbz#1527185 <https://bugzilla.redhat.com/show_bug.cgi?id=1527185>`__)
    [RFE] Forward CA requests to dogtag or helper by GSSAPI
--  `#5062 <https://pagure.io/freeipa/issue/5062>`__
+-  `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
    (`rhbz#1229657 <https://bugzilla.redhat.com/show_bug.cgi?id=1229657>`__)
    [WebUI] Unlock option is enabled for all user.
--  `#5566 <https://pagure.io/freeipa/issue/5566>`__ Permit creation of
+-  `#5566 <https://codeberg.org/freeipa/freeipa/issues/5566>`__ Permit creation of
    PTR records in non-.arpa master zones via the DNS UI
--  `#5608 <https://pagure.io/freeipa/issue/5608>`__
+-  `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
    (`rhbz#1405935 <https://bugzilla.redhat.com/show_bug.cgi?id=1405935>`__)
    [RFE] Add Dogtag configuration extensions
--  `#5628 <https://pagure.io/freeipa/issue/5628>`__ webui: Unclear(UX)
+-  `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__ webui: Unclear(UX)
    purpose of OTP field in password reset form on login
--  `#5662 <https://pagure.io/freeipa/issue/5662>`__
+-  `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
    (`rhbz#1404770 <https://bugzilla.redhat.com/show_bug.cgi?id=1404770>`__)
    ID Views: do not allow custom Views for the masters
--  `#5879 <https://pagure.io/freeipa/issue/5879>`__
+-  `#5879 <https://codeberg.org/freeipa/freeipa/issues/5879>`__
    (`rhbz#1334619 <https://bugzilla.redhat.com/show_bug.cgi?id=1334619>`__)
    Attempt to fix capitalization fails with ipa: ERROR: Type or value
    exists:
--  `#5914 <https://pagure.io/freeipa/issue/5914>`__
+-  `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__
    (`rhbz#1298288 <https://bugzilla.redhat.com/show_bug.cgi?id=1298288>`__)
    invalid setting of DS lock table size
--  `#5948 <https://pagure.io/freeipa/issue/5948>`__
+-  `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__
    (`rhbz#1340463 <https://bugzilla.redhat.com/show_bug.cgi?id=1340463>`__)
    [RFE] Implement pam_pwquality featureset in IPA password policies
--  `#6115 <https://pagure.io/freeipa/issue/6115>`__
+-  `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
    (`rhbz#1357495 <https://bugzilla.redhat.com/show_bug.cgi?id=1357495>`__)
    ipa command provides stack trace when provided with single hypen
    commands
--  `#6210 <https://pagure.io/freeipa/issue/6210>`__
+-  `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
    (`rhbz#1364139 <https://bugzilla.redhat.com/show_bug.cgi?id=1364139>`__,
    `rhbz#1751951 <https://bugzilla.redhat.com/show_bug.cgi?id=1751951>`__)
    When master's IP address does not resolve to its name,
    ipa-replica-install fails
--  `#6423 <https://pagure.io/freeipa/issue/6423>`__ Validate cert
+-  `#6423 <https://codeberg.org/freeipa/freeipa/issues/6423>`__ Validate cert
    requests in Dogtag
--  `#6474 <https://pagure.io/freeipa/issue/6474>`__ Remove ipaplatform
+-  `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__ Remove ipaplatform
    dependency from ipa modules
--  `#6708 <https://pagure.io/freeipa/issue/6708>`__ Unused config
+-  `#6708 <https://codeberg.org/freeipa/freeipa/issues/6708>`__ Unused config
    options
--  `#6783 <https://pagure.io/freeipa/issue/6783>`__
+-  `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
    (`rhbz#1430365 <https://bugzilla.redhat.com/show_bug.cgi?id=1430365>`__)
    [RFE] Host-group names command rename
--  `#6843 <https://pagure.io/freeipa/issue/6843>`__
+-  `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__
    (`rhbz#1428690 <https://bugzilla.redhat.com/show_bug.cgi?id=1428690>`__)
    ipa-backup does not create log file at /var/log/
--  `#6857 <https://pagure.io/freeipa/issue/6857>`__ ipa_pwd.c: Use
+-  `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__ ipa_pwd.c: Use
    OpenSSL instead of NSS for hashing
--  `#6884 <https://pagure.io/freeipa/issue/6884>`__
+-  `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
    (`rhbz#1441262 <https://bugzilla.redhat.com/show_bug.cgi?id=1441262>`__)
    ipa group-del gives ipa: ERROR: Insufficient access: but still
    deletes group
--  `#6891 <https://pagure.io/freeipa/issue/6891>`__
+-  `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
    (`rhbz#1461914 <https://bugzilla.redhat.com/show_bug.cgi?id=1461914>`__)
    Move FreeIPA SELinux policy from system policy to project policy
--  `#6951 <https://pagure.io/freeipa/issue/6951>`__
+-  `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
    (`rhbz#1449133 <https://bugzilla.redhat.com/show_bug.cgi?id=1449133>`__)
    Update samba config file and use sss idmap module
--  `#6964 <https://pagure.io/freeipa/issue/6964>`__
+-  `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
    (`rhbz#1442413 <https://bugzilla.redhat.com/show_bug.cgi?id=1442413>`__)
    IPA password policy has no password difference checking
--  `#7125 <https://pagure.io/freeipa/issue/7125>`__
+-  `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
    (`rhbz#1480102 <https://bugzilla.redhat.com/show_bug.cgi?id=1480102>`__)
    ipa-server-upgrade failes with "This entry already exists"
--  `#7137 <https://pagure.io/freeipa/issue/7137>`__
+-  `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
    (`rhbz#1484088 <https://bugzilla.redhat.com/show_bug.cgi?id=1484088>`__)
    [RFE]: Able to browse different links from IPA web gui in new tabs
--  `#7181 <https://pagure.io/freeipa/issue/7181>`__
+-  `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
    (`rhbz#1545755 <https://bugzilla.redhat.com/show_bug.cgi?id=1545755>`__)
    ipa-replica-prepare fails for 2nd replica when passwordHistory is
    enabled
--  `#7188 <https://pagure.io/freeipa/issue/7188>`__ Issues after
+-  `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__ Issues after
    promoting one CA-less IPA server to CA-full
--  `#7255 <https://pagure.io/freeipa/issue/7255>`__
+-  `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
    baseidoverride.get_dn() does not default to a default ID view when
    resolving user IDs
--  `#7305 <https://pagure.io/freeipa/issue/7305>`__
+-  `#7305 <https://codeberg.org/freeipa/freeipa/issues/7305>`__
    (`rhbz#1518153 <https://bugzilla.redhat.com/show_bug.cgi?id=1518153>`__)
    PKINIT status not displayed in the web UI (IPA Server >
    Configuration)
--  `#7307 <https://pagure.io/freeipa/issue/7307>`__
+-  `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
    (`rhbz#1518939 <https://bugzilla.redhat.com/show_bug.cgi?id=1518939>`__)
    RFE: Extend IPA to support unadvertised replicas
--  `#7323 <https://pagure.io/freeipa/issue/7323>`__ IPv6 hack for Travis
+-  `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__ IPv6 hack for Travis
    CI
--  `#7329 <https://pagure.io/freeipa/issue/7329>`__ update_ra_cert_store
+-  `#7329 <https://codeberg.org/freeipa/freeipa/issues/7329>`__ update_ra_cert_store
    does not remove private key from NSSDB
--  `#7416 <https://pagure.io/freeipa/issue/7416>`__ Uninstalling IPA
+-  `#7416 <https://codeberg.org/freeipa/freeipa/issues/7416>`__ Uninstalling IPA
    requires on being in a existent working directory
--  `#7522 <https://pagure.io/freeipa/issue/7522>`__ Disable cert
+-  `#7522 <https://codeberg.org/freeipa/freeipa/issues/7522>`__ Disable cert
    publishing in dogtag
--  `#7534 <https://pagure.io/freeipa/issue/7534>`__
+-  `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
    (`rhbz#1569011 <https://bugzilla.redhat.com/show_bug.cgi?id=1569011>`__)
    Investigate failures to restore 389-ds attriubtes on upgrade failure
--  `#7548 <https://pagure.io/freeipa/issue/7548>`__ Need integration
+-  `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__ Need integration
    test for --external-ca-type=ms-cs
--  `#7566 <https://pagure.io/freeipa/issue/7566>`__
+-  `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
    (`rhbz#1591824 <https://bugzilla.redhat.com/show_bug.cgi?id=1591824>`__)
    Installation of replica against a specific master
--  `#7577 <https://pagure.io/freeipa/issue/7577>`__
+-  `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
    (`rhbz#1579296 <https://bugzilla.redhat.com/show_bug.cgi?id=1579296>`__)
    [RFE] DNS package check should be called earlier in installation
    routine
--  `#7597 <https://pagure.io/freeipa/issue/7597>`__
+-  `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
    (`rhbz#1583950 <https://bugzilla.redhat.com/show_bug.cgi?id=1583950>`__)
    IPA: IDM drops all custom attributes when moving account from
    preserved to stage
--  `#7600 <https://pagure.io/freeipa/issue/7600>`__
+-  `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
    (`rhbz#1585020 <https://bugzilla.redhat.com/show_bug.cgi?id=1585020>`__)
    Enable compat tree to provide information about AD users and groups
    on trust agents
--  `#7610 <https://pagure.io/freeipa/issue/7610>`__ ldapupdate.py users
+-  `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__ ldapupdate.py users
    ldap.LOCAL_ERROR and other direct ldap exceptions while relying on
    ipaldap
--  `#7630 <https://pagure.io/freeipa/issue/7630>`__
+-  `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__
    (`rhbz#1613015 <https://bugzilla.redhat.com/show_bug.cgi?id=1613015>`__)
    ipa-restore should check that optional feature packages are installed
    before restoring a backup using a feature
--  `#7677 <https://pagure.io/freeipa/issue/7677>`__ HSM: ipa ca-add
+-  `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__ HSM: ipa ca-add
    fails with error in ipa-pki-retrieve-key
--  `#7695 <https://pagure.io/freeipa/issue/7695>`__
+-  `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
    (`rhbz#1623763 <https://bugzilla.redhat.com/show_bug.cgi?id=1623763>`__)
    ipa service-del should display principal name instead of Invalid
    'principal'.
--  `#7725 <https://pagure.io/freeipa/issue/7725>`__
+-  `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
    (`rhbz#1636765 <https://bugzilla.redhat.com/show_bug.cgi?id=1636765>`__)
    ipa-restore set wrong file permissions and ownership for
    /var/log/dirsrv/slapd- directory
--  `#7804 <https://pagure.io/freeipa/issue/7804>`__
+-  `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
    (`rhbz#1777811 <https://bugzilla.redhat.com/show_bug.cgi?id=1777811>`__)
    \`ipa otptoken-sync\` fails with stack trace
--  `#7810 <https://pagure.io/freeipa/issue/7810>`__ [F28] Require NSS
+-  `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__ [F28] Require NSS
    with fix for p11-kit issue.
--  `#7816 <https://pagure.io/freeipa/issue/7816>`__
+-  `#7816 <https://codeberg.org/freeipa/freeipa/issues/7816>`__
    (`rhbz#1642395 <https://bugzilla.redhat.com/show_bug.cgi?id=1642395>`__)
    [WebUI] not able to set a password for user as Active Directory
    Administrator user
--  `#7870 <https://pagure.io/freeipa/issue/7870>`__
+-  `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
    (`rhbz#1680039 <https://bugzilla.redhat.com/show_bug.cgi?id=1680039>`__)
    [certmonger][upgrade] "Failed to get request: bus, object_path and
    dbus_interface must not be None."
--  `#7895 <https://pagure.io/freeipa/issue/7895>`__
+-  `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
    (`rhbz#1686302 <https://bugzilla.redhat.com/show_bug.cgi?id=1686302>`__)
    ipa trust fetch-domains, server parameter ignored
--  `#7902 <https://pagure.io/freeipa/issue/7902>`__
+-  `#7902 <https://codeberg.org/freeipa/freeipa/issues/7902>`__
    389-ds-base-1.4.0.22-1 breaks
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
--  `#7908 <https://pagure.io/freeipa/issue/7908>`__ Write tests for
+-  `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__ Write tests for
    interactive prompt for NTP options.
--  `#7929 <https://pagure.io/freeipa/issue/7929>`__
+-  `#7929 <https://codeberg.org/freeipa/freeipa/issues/7929>`__
    (`rhbz#1712794 <https://bugzilla.redhat.com/show_bug.cgi?id=1712794>`__)
    ERROR: invalid 'PKINIT enabled server': all masters must have IPA
    master role enabled
--  `#7932 <https://pagure.io/freeipa/issue/7932>`__ FreeIPA queries rely
+-  `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__ FreeIPA queries rely
    on missing attribute altsecurityidentities
--  `#7933 <https://pagure.io/freeipa/issue/7933>`__ FreeIPA must index
+-  `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__ FreeIPA must index
    certmap attributes.
--  `#7938 <https://pagure.io/freeipa/issue/7938>`__ 'ipa
+-  `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__ 'ipa
    dnszone-show/find' should display "Dynamic Update" and "Bind update
    policy" by default
--  `#7949 <https://pagure.io/freeipa/issue/7949>`__
+-  `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
    test_integration/test_nfs.py fails at cleanup
--  `#7958 <https://pagure.io/freeipa/issue/7958>`__
+-  `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__
    (`rhbz#1782169 <https://bugzilla.redhat.com/show_bug.cgi?id=1782169>`__)
    traceback in idview
--  `#7961 <https://pagure.io/freeipa/issue/7961>`__ [WebUI] Identity
+-  `#7961 <https://codeberg.org/freeipa/freeipa/issues/7961>`__ [WebUI] Identity
    Manager WebUI requires you to save changes after changing
    specifications before making other change
--  `#7966 <https://pagure.io/freeipa/issue/7966>`__ Add support for
+-  `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__ Add support for
    JSON-RPC in ipa-join
--  `#7971 <https://pagure.io/freeipa/issue/7971>`__
+-  `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
    (`rhbz#1715961 <https://bugzilla.redhat.com/show_bug.cgi?id=1715961>`__)
    [RFE] Include hint for replication_wait_timeout if timeout fails
--  `#7985 <https://pagure.io/freeipa/issue/7985>`__ test failure in
+-  `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__ test failure in
    test_dnssec.py::TestInstallDNSSECLast::()::test_disable_reenable_signing_replica::teardown
--  `#7987 <https://pagure.io/freeipa/issue/7987>`__ Python shebang: Use
+-  `#7987 <https://codeberg.org/freeipa/freeipa/issues/7987>`__ Python shebang: Use
    isolated mode
--  `#7989 <https://pagure.io/freeipa/issue/7989>`__ Pytest4.2+ errors
--  `#7991 <https://pagure.io/freeipa/issue/7991>`__ Use profile-based
+-  `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__ Pytest4.2+ errors
+-  `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__ Use profile-based
    renewal for system certificates
--  `#7995 <https://pagure.io/freeipa/issue/7995>`__
+-  `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
    (`rhbz#1711172 <https://bugzilla.redhat.com/show_bug.cgi?id=1711172>`__)
    Removing TLSv1.0, TLSv1.1 from nss.conf
--  `#7996 <https://pagure.io/freeipa/issue/7996>`__
+-  `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__
    \`test_selinuxusermap_plugin\` fails against not default SELinux
    settings
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8004 <https://pagure.io/freeipa/issue/8004>`__ RHEL 8 uses
+-  `#8004 <https://codeberg.org/freeipa/freeipa/issues/8004>`__ RHEL 8 uses
    nis-domainname instead of rhel-domainname
--  `#8005 <https://pagure.io/freeipa/issue/8005>`__
+-  `#8005 <https://codeberg.org/freeipa/freeipa/issues/8005>`__
    (`rhbz#1729099 <https://bugzilla.redhat.com/show_bug.cgi?id=1729099>`__)
    User field separator uses '$$' within ipaSELinuxUserMapOrder
--  `#8007 <https://pagure.io/freeipa/issue/8007>`__ Not stable nodeids
+-  `#8007 <https://codeberg.org/freeipa/freeipa/issues/8007>`__ Not stable nodeids
    within pytest
--  `#8008 <https://pagure.io/freeipa/issue/8008>`__ Azure Pipeline
+-  `#8008 <https://codeberg.org/freeipa/freeipa/issues/8008>`__ Azure Pipeline
    slicing
--  `#8009 <https://pagure.io/freeipa/issue/8009>`__ Missing execution
+-  `#8009 <https://codeberg.org/freeipa/freeipa/issues/8009>`__ Missing execution
    bit on \`ipa-run-tests\` within virtualenv
--  `#8010 <https://pagure.io/freeipa/issue/8010>`__ Extended Kerberos
+-  `#8010 <https://codeberg.org/freeipa/freeipa/issues/8010>`__ Extended Kerberos
    Ticket Policy
--  `#8012 <https://pagure.io/freeipa/issue/8012>`__
+-  `#8012 <https://codeberg.org/freeipa/freeipa/issues/8012>`__
    test_webui/test_loginscreen.py::TestLoginScreen::()::test_reset_password_and_login_view
    failure
--  `#8013 <https://pagure.io/freeipa/issue/8013>`__
+-  `#8013 <https://codeberg.org/freeipa/freeipa/issues/8013>`__
    (`rhbz#1731433 <https://bugzilla.redhat.com/show_bug.cgi?id=1731433>`__)
    ipa service-find does not list cifs service created by
    ipa-client-samba
--  `#8015 <https://pagure.io/freeipa/issue/8015>`__ p11helper:
+-  `#8015 <https://codeberg.org/freeipa/freeipa/issues/8015>`__ p11helper:
    insufficient logging when loading LIBSOFTHSM2_SO
--  `#8017 <https://pagure.io/freeipa/issue/8017>`__
+-  `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
    (`rhbz#1817927 <https://bugzilla.redhat.com/show_bug.cgi?id=1817927>`__)
    host-add --password logs cleartext userpassword to Apache error log
--  `#8019 <https://pagure.io/freeipa/issue/8019>`__
+-  `#8019 <https://codeberg.org/freeipa/freeipa/issues/8019>`__
    (`rhbz#1732524 <https://bugzilla.redhat.com/show_bug.cgi?id=1732524>`__)
    repeated uninstallation of ipa-client-samba crashes
--  `#8020 <https://pagure.io/freeipa/issue/8020>`__ support AES in LWCA
+-  `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__ support AES in LWCA
    key replication
--  `#8021 <https://pagure.io/freeipa/issue/8021>`__
+-  `#8021 <https://codeberg.org/freeipa/freeipa/issues/8021>`__
    (`rhbz#1732528 <https://bugzilla.redhat.com/show_bug.cgi?id=1732528>`__)
    ipa-client-samba can not install samba after uninstallation
--  `#8022 <https://pagure.io/freeipa/issue/8022>`__ azure pipeline: fail
+-  `#8022 <https://codeberg.org/freeipa/freeipa/issues/8022>`__ azure pipeline: fail
    if dnf builddep exits on failure
--  `#8024 <https://pagure.io/freeipa/issue/8024>`__ [WebUI]
+-  `#8024 <https://codeberg.org/freeipa/freeipa/issues/8024>`__ [WebUI]
    test_webui/test_trust.py failed because of request timeout
--  `#8026 <https://pagure.io/freeipa/issue/8026>`__ Update pr-ci
+-  `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__ Update pr-ci
    definitions with master_3client topology
--  `#8027 <https://pagure.io/freeipa/issue/8027>`__ test_nfs.py: migrate
+-  `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__ test_nfs.py: migrate
    to master_3client
--  `#8029 <https://pagure.io/freeipa/issue/8029>`__
+-  `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
    (`rhbz#1749788 <https://bugzilla.redhat.com/show_bug.cgi?id=1749788>`__)
    ipa host-find --pkey-only includes SSH keys in output
--  `#8030 <https://pagure.io/freeipa/issue/8030>`__ azure pipelines fail
+-  `#8030 <https://codeberg.org/freeipa/freeipa/issues/8030>`__ azure pipelines fail
    at "Install prerequisites" of Tox job
--  `#8031 <https://pagure.io/freeipa/issue/8031>`__
+-  `#8031 <https://codeberg.org/freeipa/freeipa/issues/8031>`__
    (`rhbz#1734369 <https://bugzilla.redhat.com/show_bug.cgi?id=1734369>`__)
    HBAC Test Validation error when running the HBAC test the second time
    round via the IPA Web GUI
--  `#8034 <https://pagure.io/freeipa/issue/8034>`__ Existing p11-kit
+-  `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__ Existing p11-kit
    config file is not restored on uninstall
--  `#8038 <https://pagure.io/freeipa/issue/8038>`__
+-  `#8038 <https://codeberg.org/freeipa/freeipa/issues/8038>`__
    (`rhbz#1740167 <https://bugzilla.redhat.com/show_bug.cgi?id=1740167>`__)
    ipa-client-automount --uninstall is not restoring nsswitch.conf
--  `#8040 <https://pagure.io/freeipa/issue/8040>`__
+-  `#8040 <https://codeberg.org/freeipa/freeipa/issues/8040>`__
    (`rhbz#1731963 <https://bugzilla.redhat.com/show_bug.cgi?id=1731963>`__)
    ipa migrate-ds fails with internal error.
--  `#8044 <https://pagure.io/freeipa/issue/8044>`__
+-  `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
    (`rhbz#1717008 <https://bugzilla.redhat.com/show_bug.cgi?id=1717008>`__)
    Extdom plugin should not return LDAP_NO_SUCH_OBJECT if there are
    timeout or other errors
--  `#8048 <https://pagure.io/freeipa/issue/8048>`__ Travis-CI sometimes
+-  `#8048 <https://codeberg.org/freeipa/freeipa/issues/8048>`__ Travis-CI sometimes
    fails at dnf
--  `#8052 <https://pagure.io/freeipa/issue/8052>`__ test failure in
+-  `#8052 <https://codeberg.org/freeipa/freeipa/issues/8052>`__ test failure in
    test_integration/test_sudo.py::TestSudo::()::test_domain_resolution_order
    on fedora29
--  `#8053 <https://pagure.io/freeipa/issue/8053>`__ [WebUI] Fix login
+-  `#8053 <https://codeberg.org/freeipa/freeipa/issues/8053>`__ [WebUI] Fix login
    screen loading issue in test_loginscreen
--  `#8054 <https://pagure.io/freeipa/issue/8054>`__
+-  `#8054 <https://codeberg.org/freeipa/freeipa/issues/8054>`__
    (`rhbz#1746557 <https://bugzilla.redhat.com/show_bug.cgi?id=1746557>`__)
    ipa-client-install calls "authselect select sssd --force" at
    uninstall time before restoring user-nsswitch.conf
--  `#8055 <https://pagure.io/freeipa/issue/8055>`__ Test for PG6843:
+-  `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__ Test for PG6843:
    ipa-backup does not create log file at /var/log is failing
--  `#8056 <https://pagure.io/freeipa/issue/8056>`__
+-  `#8056 <https://codeberg.org/freeipa/freeipa/issues/8056>`__
    (`rhbz#1746882 <https://bugzilla.redhat.com/show_bug.cgi?id=1746882>`__)
    BuildRequires is not compatible with %{_libdir}
--  `#8057 <https://pagure.io/freeipa/issue/8057>`__
+-  `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
    (`rhbz#1747895 <https://bugzilla.redhat.com/show_bug.cgi?id=1747895>`__)
    Running ipa-server-install produces SyntaxWarning: "is not" with a
    literal. Did you mean "!="?
--  `#8062 <https://pagure.io/freeipa/issue/8062>`__ Re-add
+-  `#8062 <https://codeberg.org/freeipa/freeipa/issues/8062>`__ Re-add
    configure_nsswitch_database, configure_nsswitch, ... to
    ipaclient.install
--  `#8063 <https://pagure.io/freeipa/issue/8063>`__ Nightly test failure
+-  `#8063 <https://codeberg.org/freeipa/freeipa/issues/8063>`__ Nightly test failure
    in
    test_integration/test_nfs.py::TestIpaClientAutomountFileRestore::()::test_nsswitch_backup_restore_sssd
--  `#8064 <https://pagure.io/freeipa/issue/8064>`__ Request for IPA CI
+-  `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__ Request for IPA CI
    to enable DS audit/auditfail logging
--  `#8066 <https://pagure.io/freeipa/issue/8066>`__
+-  `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
    (`rhbz#1750242 <https://bugzilla.redhat.com/show_bug.cgi?id=1750242>`__)
    Don't use -t option to klist in adtrust code when timestamp is not
    needed
--  `#8067 <https://pagure.io/freeipa/issue/8067>`__
+-  `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
    (`rhbz#1750700 <https://bugzilla.redhat.com/show_bug.cgi?id=1750700>`__)
    add default access control configuration to trusted domain objects
--  `#8070 <https://pagure.io/freeipa/issue/8070>`__ Test failure in
+-  `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__ Test failure in
    test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::()::test_hidden_replica_install
--  `#8073 <https://pagure.io/freeipa/issue/8073>`__ Backup/restore does
+-  `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__ Backup/restore does
    not restore /etc/pkcs11/modules/softhsm2.module
--  `#8075 <https://pagure.io/freeipa/issue/8075>`__ Don't create log
+-  `#8075 <https://codeberg.org/freeipa/freeipa/issues/8075>`__ Don't create log
    file for helper scripts
--  `#8077 <https://pagure.io/freeipa/issue/8077>`__ New pylint 2.4.0
+-  `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__ New pylint 2.4.0
    errors
--  `#8079 <https://pagure.io/freeipa/issue/8079>`__
+-  `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
    (`rhbz#1754530 <https://bugzilla.redhat.com/show_bug.cgi?id=1754530>`__)
    [Security] By default, DNS recursion is open, breaking best practices
--  `#8082 <https://pagure.io/freeipa/issue/8082>`__
+-  `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
    (`rhbz#1756432 <https://bugzilla.redhat.com/show_bug.cgi?id=1756432>`__)
    Default client configuration breaks ssh in FIPS mode.
--  `#8084 <https://pagure.io/freeipa/issue/8084>`__
+-  `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
    (`rhbz#1758406 <https://bugzilla.redhat.com/show_bug.cgi?id=1758406>`__)
    KRA authentication fails when IPA CA has custom Subject DN
--  `#8086 <https://pagure.io/freeipa/issue/8086>`__
+-  `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
    (`rhbz#1756568 <https://bugzilla.redhat.com/show_bug.cgi?id=1756568>`__)
    ipa-server-certinstall man page does not match built-in help.
--  `#8094 <https://pagure.io/freeipa/issue/8094>`__ Allow using of a
+-  `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__ Allow using of a
    custom OpenSSL engine for ISC BIND
--  `#8097 <https://pagure.io/freeipa/issue/8097>`__ ipa
+-  `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__ ipa
    user-add-certmapdata is not able to add several entries correctly
--  `#8098 <https://pagure.io/freeipa/issue/8098>`__ Host principals lack
+-  `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__ Host principals lack
    ACI to look up DNS objects in LDAP
--  `#8099 <https://pagure.io/freeipa/issue/8099>`__
+-  `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
    (`rhbz#1762317 <https://bugzilla.redhat.com/show_bug.cgi?id=1762317>`__)
    ipa-backup command is failing on rhel-7.8
--  `#8101 <https://pagure.io/freeipa/issue/8101>`__ Wrong pytest
+-  `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__ Wrong pytest
    requirement in specfile
--  `#8102 <https://pagure.io/freeipa/issue/8102>`__ Pylint 2.4.3 +
+-  `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__ Pylint 2.4.3 +
    Astroid 2.3.2 errors
--  `#8104 <https://pagure.io/freeipa/issue/8104>`__ RFE: Disable
+-  `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__ RFE: Disable
    Stale/Inactive Users - Upstream Design Document
--  `#8105 <https://pagure.io/freeipa/issue/8105>`__
+-  `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
    (`rhbz#1759281 <https://bugzilla.redhat.com/show_bug.cgi?id=1759281>`__)
    getcert with -F option returns before cacert file is created
--  `#8106 <https://pagure.io/freeipa/issue/8106>`__ ca-certificate file
+-  `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__ ca-certificate file
    not being parsed correctly on Ubuntu with p11-kit-trust.so due to
    data inserted by FreeIPA Client install
--  `#8110 <https://pagure.io/freeipa/issue/8110>`__
+-  `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
    (`rhbz#1768015 <https://bugzilla.redhat.com/show_bug.cgi?id=1768015>`__)
    Enable AES SHA 256 and 384 Kerberos enctypes
--  `#8111 <https://pagure.io/freeipa/issue/8111>`__
+-  `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
    (`rhbz#1768959 <https://bugzilla.redhat.com/show_bug.cgi?id=1768959>`__)
    [FIPS] Don't add camellia KRB5 encsalttypes in FIPS mode
--  `#8113 <https://pagure.io/freeipa/issue/8113>`__
+-  `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
    (`rhbz#1755535 <https://bugzilla.redhat.com/show_bug.cgi?id=1755535>`__)
    ipa-advise on a RHEL7 IdM server is not able to generate a
    configuration script for a RHEL8 IdM client
--  `#8114 <https://pagure.io/freeipa/issue/8114>`__ [RFE] Delegate group
+-  `#8114 <https://codeberg.org/freeipa/freeipa/issues/8114>`__ [RFE] Delegate group
    membership management
--  `#8115 <https://pagure.io/freeipa/issue/8115>`__ Nightly test failure
+-  `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__ Nightly test failure
    in fedora-30/test_smb and fedora-29/test_smb
--  `#8116 <https://pagure.io/freeipa/issue/8116>`__ Pylint parallel
+-  `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__ Pylint parallel
    execution with custom plugin
--  `#8118 <https://pagure.io/freeipa/issue/8118>`__ Run smoke tests in
+-  `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__ Run smoke tests in
    FIPS mode
--  `#8120 <https://pagure.io/freeipa/issue/8120>`__
+-  `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
    (`rhbz#1769791 <https://bugzilla.redhat.com/show_bug.cgi?id=1769791>`__)
    Invisible part of notification area in Web UI intercepts clicks of
    some page elements
--  `#8122 <https://pagure.io/freeipa/issue/8122>`__
+-  `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
    (`rhbz#1773528 <https://bugzilla.redhat.com/show_bug.cgi?id=1773528>`__)
    group-add-member-manager does not report errors
--  `#8123 <https://pagure.io/freeipa/issue/8123>`__
+-  `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__
    (`rhbz#1773528 <https://bugzilla.redhat.com/show_bug.cgi?id=1773528>`__)
    [WebUI] Finish group membership management UI
--  `#8124 <https://pagure.io/freeipa/issue/8124>`__ Add option to
+-  `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__ Add option to
    ipa-cacert-manage to delete certificates
--  `#8125 <https://pagure.io/freeipa/issue/8125>`__
+-  `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
    (`rhbz#1777809 <https://bugzilla.redhat.com/show_bug.cgi?id=1777809>`__)
    Use default crypto policy for TLS and enable TLS 1.3 support
--  `#8129 <https://pagure.io/freeipa/issue/8129>`__ Tests: Replace
+-  `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__ Tests: Replace
    paramiko with OpenSSH
--  `#8131 <https://pagure.io/freeipa/issue/8131>`__
+-  `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
    (`rhbz#1777920 <https://bugzilla.redhat.com/show_bug.cgi?id=1777920>`__)
    covscan memory leaks report
--  `#8133 <https://pagure.io/freeipa/issue/8133>`__
+-  `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
    check_client_configuration() no longer works with IPA_CONFDIR
--  `#8134 <https://pagure.io/freeipa/issue/8134>`__ ipa user-add is
+-  `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__ ipa user-add is
    inefficient
--  `#8135 <https://pagure.io/freeipa/issue/8135>`__
+-  `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__
    (`rhbz#1777806 <https://bugzilla.redhat.com/show_bug.cgi?id=1777806>`__)
    When Service weight is set as 0 for server in IPA location "IPA Error
    903: InternalError" is displayed
--  `#8137 <https://pagure.io/freeipa/issue/8137>`__ reinstall failed in
+-  `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__ reinstall failed in
    adding delegation layout
--  `#8138 <https://pagure.io/freeipa/issue/8138>`__
+-  `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
    (`rhbz#1780548 <https://bugzilla.redhat.com/show_bug.cgi?id=1780548>`__)
    Man page ipa-cacert-manage does not display correctly on RHEL
--  `#8142 <https://pagure.io/freeipa/issue/8142>`__ check Not Before /
+-  `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__ check Not Before /
    Not After in externally signed CA sanity check
--  `#8143 <https://pagure.io/freeipa/issue/8143>`__
+-  `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
    service.ldap_disable() does not remove "enabledService"
--  `#8144 <https://pagure.io/freeipa/issue/8144>`__ test_nfs.py:
+-  `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__ test_nfs.py:
    umount.nfs4: /home: device is busy
--  `#8148 <https://pagure.io/freeipa/issue/8148>`__
+-  `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
    (`rhbz#1782587 <https://bugzilla.redhat.com/show_bug.cgi?id=1782587>`__)
    add "systemctl restart sssd" to warning message when adding trust
    agents to replicas
--  `#8149 <https://pagure.io/freeipa/issue/8149>`__
+-  `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
    (`rhbz#1783046 <https://bugzilla.redhat.com/show_bug.cgi?id=1783046>`__)
    SIDs of AD domains do not display in ipa-client-samba installer
--  `#8150 <https://pagure.io/freeipa/issue/8150>`__
+-  `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__
    (`rhbz#1784003 <https://bugzilla.redhat.com/show_bug.cgi?id=1784003>`__)
    IPA Server install fail
--  `#8151 <https://pagure.io/freeipa/issue/8151>`__ test_commands
+-  `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__ test_commands
    timing-out
--  `#8153 <https://pagure.io/freeipa/issue/8153>`__
+-  `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__
    (`rhbz#1784761 <https://bugzilla.redhat.com/show_bug.cgi?id=1784761>`__)
    Kerberos ticket policy reset does not reset per-indicator policies
--  `#8157 <https://pagure.io/freeipa/issue/8157>`__ NIghtly test failure
+-  `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__ NIghtly test failure
    in fedora-rawhide/test_webui_network
--  `#8159 <https://pagure.io/freeipa/issue/8159>`__ please migrate to
+-  `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__ please migrate to
    the new Fedora translation platform
--  `#8163 <https://pagure.io/freeipa/issue/8163>`__
+-  `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
    (`rhbz#1782572 <https://bugzilla.redhat.com/show_bug.cgi?id=1782572>`__)
    "Internal Server Error" reported for minor issues implies IPA is
    broken [IdmHackfest2019]
--  `#8164 <https://pagure.io/freeipa/issue/8164>`__
+-  `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
    (`rhbz#1788907 <https://bugzilla.redhat.com/show_bug.cgi?id=1788907>`__)
    Renewed certs are not picked up by IPA CAs
--  `#8169 <https://pagure.io/freeipa/issue/8169>`__ NIghtly test failure
+-  `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__ NIghtly test failure
    in fedora-rawhide/test_webui_policy
--  `#8170 <https://pagure.io/freeipa/issue/8170>`__ Nightly test failure
+-  `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__ Nightly test failure
    in
    fedora-rawhide/test_backup_and_restore_TestBackupReinstallRestoreWithDNS
--  `#8173 <https://pagure.io/freeipa/issue/8173>`__ Broken -k argument
+-  `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__ Broken -k argument
    parsing in ipa-run-tests 4.8.4-1 package
--  `#8176 <https://pagure.io/freeipa/issue/8176>`__ External CA is
+-  `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__ External CA is
    tracked for renewals and replaced with a self-signed certificate
--  `#8179 <https://pagure.io/freeipa/issue/8179>`__ Tests broken with
+-  `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__ Tests broken with
    python version < 3.7 (module 're' has no attribute 'Pattern')
--  `#8186 <https://pagure.io/freeipa/issue/8186>`__ Add ipa-ca.$DOMAIN
+-  `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__ Add ipa-ca.$DOMAIN
    alias to IPA server HTTP certificates
--  `#8189 <https://pagure.io/freeipa/issue/8189>`__
+-  `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
    (`rhbz#1810179 <https://bugzilla.redhat.com/show_bug.cgi?id=1810179>`__)
    NIghtly test failure in
    test_integration/test_nfs.py::TestIpaClientAutomountFileRestore::test_nsswitch_backup_restore_sssd
--  `#8190 <https://pagure.io/freeipa/issue/8190>`__
+-  `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
    (`rhbz#1790886 <https://bugzilla.redhat.com/show_bug.cgi?id=1790886>`__)
    ipa-client-automount fails after repeated installation/uninstallation
--  `#8192 <https://pagure.io/freeipa/issue/8192>`__
+-  `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__
    (`rhbz#1665051 <https://bugzilla.redhat.com/show_bug.cgi?id=1665051>`__)
    ipa-adtrust-install does not list service records for manual addition
    to DNS zone
--  `#8193 <https://pagure.io/freeipa/issue/8193>`__
+-  `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
    (`rhbz#1801791 <https://bugzilla.redhat.com/show_bug.cgi?id=1801791>`__)
    Re-order 50-externalmembers.update to be after
    80-schema_compat.update
--  `#8196 <https://pagure.io/freeipa/issue/8196>`__ API: dnsrecord_del
+-  `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__ API: dnsrecord_del
    failure with empty list aaaarecord
--  `#8200 <https://pagure.io/freeipa/issue/8200>`__
+-  `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__
    (`rhbz#1803786 <https://bugzilla.redhat.com/show_bug.cgi?id=1803786>`__)
    ipa krb5kdc db: krb5kdc coredump
--  `#8201 <https://pagure.io/freeipa/issue/8201>`__ update
+-  `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__ update
    ssbrowser.html
--  `#8202 <https://pagure.io/freeipa/issue/8202>`__ Azure: add support
+-  `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__ Azure: add support
    for multi-container tests
--  `#8204 <https://pagure.io/freeipa/issue/8204>`__
+-  `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
    (`rhbz#1810148 <https://bugzilla.redhat.com/show_bug.cgi?id=1810148>`__)
    ipa-server-certinstall -> certmonger add_subject template-subject
    dbus 'unable to set arguments' a{sv}
--  `#8207 <https://pagure.io/freeipa/issue/8207>`__ Extend Web UI for
+-  `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__ Extend Web UI for
    Kerberos ticket policy to add authentication indicator support
--  `#8214 <https://pagure.io/freeipa/issue/8214>`__ Support for
+-  `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__ Support for
    opendnssec 2.1.6
--  `#8217 <https://pagure.io/freeipa/issue/8217>`__
+-  `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
    (`rhbz#1810154 <https://bugzilla.redhat.com/show_bug.cgi?id=1810154>`__)
    RFE: ipa-backup should compare locally and globally installed server
    roles
--  `#8219 <https://pagure.io/freeipa/issue/8219>`__ ipatests: unify
+-  `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__ ipatests: unify
    editing of sssd.conf
--  `#8221 <https://pagure.io/freeipa/issue/8221>`__
+-  `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
    (`rhbz#1812169 <https://bugzilla.redhat.com/show_bug.cgi?id=1812169>`__)
    Secure AJP connector between Dogtag and Apache proxy
--  `#8222 <https://pagure.io/freeipa/issue/8222>`__ Upgrade dojo.js
--  `#8226 <https://pagure.io/freeipa/issue/8226>`__
+-  `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__ Upgrade dojo.js
+-  `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
    (`rhbz#1813330 <https://bugzilla.redhat.com/show_bug.cgi?id=1813330>`__)
    ipa-restore does not restart httpd
--  `#8228 <https://pagure.io/freeipa/issue/8228>`__ Nightly failure in
+-  `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__ Nightly failure in
    backup/restore while calling 'id admin'
--  `#8233 <https://pagure.io/freeipa/issue/8233>`__ 4.8.5 master
+-  `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__ 4.8.5 master
    Installation error
--  `#8236 <https://pagure.io/freeipa/issue/8236>`__
+-  `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
    (`rhbz#1809835 <https://bugzilla.redhat.com/show_bug.cgi?id=1809835>`__)
    Enforce a check to prevent adding objects from IPA as external
    members of external groups
--  `#8239 <https://pagure.io/freeipa/issue/8239>`__ Actualize Bootstrap
+-  `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__ Actualize Bootstrap
    version
--  `#8240 <https://pagure.io/freeipa/issue/8240>`__
+-  `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__
    (`rhbz#1816784 <https://bugzilla.redhat.com/show_bug.cgi?id=1816784>`__)
    KRA install fails if all KRA members are Hidden Replicas
--  `#8241 <https://pagure.io/freeipa/issue/8241>`__ Build fails on
+-  `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__ Build fails on
    Fedora 30
--  `#8247 <https://pagure.io/freeipa/issue/8247>`__ test_fips PR-CI
+-  `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__ test_fips PR-CI
    templates have a too-short timeout
--  `#8248 <https://pagure.io/freeipa/issue/8248>`__ httpd ccaches
+-  `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__ httpd ccaches
    created during server upgrade aren't cleaned up on uninstall/install
--  `#8251 <https://pagure.io/freeipa/issue/8251>`__ [Azure] Catch
+-  `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__ [Azure] Catch
    coredumps
--  `#8254 <https://pagure.io/freeipa/issue/8254>`__ [Azure] 'Tox' task
+-  `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__ [Azure] 'Tox' task
    fails against Python3.8
--  `#8261 <https://pagure.io/freeipa/issue/8261>`__ [ipatests]
+-  `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__ [ipatests]
    Integration tests fail on non-firewalld distros
--  `#8262 <https://pagure.io/freeipa/issue/8262>`__ test_ipahealthcheck
+-  `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__ test_ipahealthcheck
    needs a higher timeout than 3600
--  `#8264 <https://pagure.io/freeipa/issue/8264>`__ Nightly test failure
+-  `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__ Nightly test failure
    in
    test_integration.test_commands.TestIPACommand.test_hbac_systemd_user
--  `#8265 <https://pagure.io/freeipa/issue/8265>`__ [ipatests]
+-  `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__ [ipatests]
    \`/var/log/ipaupgrade.log\` is not collected
--  `#8266 <https://pagure.io/freeipa/issue/8266>`__ test_webui_server
+-  `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__ test_webui_server
    requires a higher timeout than 3600
--  `#8268 <https://pagure.io/freeipa/issue/8268>`__ Prevent use of too
+-  `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__ Prevent use of too
    long passwords
--  `#8272 <https://pagure.io/freeipa/issue/8272>`__ Use /run instead of
+-  `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__ Use /run instead of
    /var/run
--  `#8273 <https://pagure.io/freeipa/issue/8273>`__
+-  `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
    (`rhbz#1834385 <https://bugzilla.redhat.com/show_bug.cgi?id=1834385>`__)
    Man page syntax issue detected by rpminspect
--  `#8275 <https://pagure.io/freeipa/issue/8275>`__
+-  `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
    (`rhbz#1880628 <https://bugzilla.redhat.com/show_bug.cgi?id=1880628>`__)
    Support systemd-resolved
--  `#8276 <https://pagure.io/freeipa/issue/8276>`__ Add default password
+-  `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__ Add default password
    policy for sysaccounts
--  `#8283 <https://pagure.io/freeipa/issue/8283>`__ Failures and AVCs
+-  `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__ Failures and AVCs
    with OpenDNSSEC 2.1
--  `#8284 <https://pagure.io/freeipa/issue/8284>`__ Upgrade jQuery
+-  `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__ Upgrade jQuery
    version to actual one
--  `#8287 <https://pagure.io/freeipa/issue/8287>`__ named not starting
+-  `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__ named not starting
    after #8079, ipa-ext.conf breaks bind
--  `#8289 <https://pagure.io/freeipa/issue/8289>`__ ipa
+-  `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__ ipa
    servicedelegationtarget-add-member does not allow to add hosts as
    targets
--  `#8290 <https://pagure.io/freeipa/issue/8290>`__ API inconsistencies
--  `#8291 <https://pagure.io/freeipa/issue/8291>`__ krb5kdc crashes in
+-  `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__ API inconsistencies
+-  `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__ krb5kdc crashes in
    IPA plugin on use of IPA Windows principal alias
--  `#8297 <https://pagure.io/freeipa/issue/8297>`__ Fix new pylint 2.5.0
+-  `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__ Fix new pylint 2.5.0
    warnings and errors
--  `#8298 <https://pagure.io/freeipa/issue/8298>`__ [WebUI] Cover
+-  `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__ [WebUI] Cover
    membership management with UI tests
--  `#8300 <https://pagure.io/freeipa/issue/8300>`__ Replace uglify-js
+-  `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__ Replace uglify-js
    with python3-rjsmin
--  `#8301 <https://pagure.io/freeipa/issue/8301>`__ The value of the
+-  `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__ The value of the
    first character in target\* keywords is expected to be a double quote
--  `#8304 <https://pagure.io/freeipa/issue/8304>`__ [fed32]
+-  `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__ [fed32]
    client-install does not properly set ChallengeResponseAuthentication
    yes in sshd conf
--  `#8306 <https://pagure.io/freeipa/issue/8306>`__ Adopt Black code
+-  `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__ Adopt Black code
    style
--  `#8307 <https://pagure.io/freeipa/issue/8307>`__ make devcheck fails
+-  `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__ make devcheck fails
    for test_ipatests_plugins/test_ipa_run_tests.py
--  `#8308 <https://pagure.io/freeipa/issue/8308>`__
+-  `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
    (`rhbz#1829787 <https://bugzilla.redhat.com/show_bug.cgi?id=1829787>`__)
    ipa service-del deletes the required principal when specified in
    lower/upper case
--  `#8309 <https://pagure.io/freeipa/issue/8309>`__ Convert ipaplatform
+-  `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__ Convert ipaplatform
    from namespace package to regular package
--  `#8311 <https://pagure.io/freeipa/issue/8311>`__
+-  `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
    (`rhbz#1825829 <https://bugzilla.redhat.com/show_bug.cgi?id=1825829>`__)
    ipa-advise on a RHEL7 IdM server generate a configuration script for
    client having hardcoded python3
--  `#8312 <https://pagure.io/freeipa/issue/8312>`__ Fix api.env.in_tree
+-  `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__ Fix api.env.in_tree
    detection logic
--  `#8313 <https://pagure.io/freeipa/issue/8313>`__ Values of
+-  `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__ Values of
    api.env.mode are inconsistent
--  `#8315 <https://pagure.io/freeipa/issue/8315>`__
+-  `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
    (`rhbz#1833266 <https://bugzilla.redhat.com/show_bug.cgi?id=1833266>`__)
    [dirsrv] set 'nsslapd-enable-upgrade-hash: off' as this raises
    warnings
--  `#8316 <https://pagure.io/freeipa/issue/8316>`__ [Azure] Whitelist
+-  `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__ [Azure] Whitelist
    clock_adjtime syscall
--  `#8317 <https://pagure.io/freeipa/issue/8317>`__ XML-RCP and CLI
+-  `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__ XML-RCP and CLI
    tests depend on internal --force option
--  `#8319 <https://pagure.io/freeipa/issue/8319>`__ Support server
+-  `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__ Support server
    referrals for enterprise principals
--  `#8322 <https://pagure.io/freeipa/issue/8322>`__ [RFE] Changing
+-  `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__ [RFE] Changing
    default hostgroup is too easy
--  `#8323 <https://pagure.io/freeipa/issue/8323>`__ [Build failure]
+-  `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__ [Build failure]
    Race: make po fails on parallel build
--  `#8325 <https://pagure.io/freeipa/issue/8325>`__ [WebUI] Fix
+-  `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__ [WebUI] Fix
    htmlPrefilter issue in jQuery
--  `#8326 <https://pagure.io/freeipa/issue/8326>`__ CVE-2020-10747
--  `#8328 <https://pagure.io/freeipa/issue/8328>`__ krbtpolicy-mod
+-  `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__ CVE-2020-10747
+-  `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__ krbtpolicy-mod
    cannot handle two auth ind options of the same type at the same time
--  `#8330 <https://pagure.io/freeipa/issue/8330>`__ [Azure] Build job
+-  `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__ [Azure] Build job
    fails on \`tests\` container preparation
--  `#8335 <https://pagure.io/freeipa/issue/8335>`__ [WebUI] manage IPA
+-  `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__ [WebUI] manage IPA
    resources as a user from a trusted Active Directory domain
--  `#8336 <https://pagure.io/freeipa/issue/8336>`__ [WebUI] "User
+-  `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__ [WebUI] "User
    attributes for SMB services" section always shown
--  `#8338 <https://pagure.io/freeipa/issue/8338>`__ [WebUI] Host detail
+-  `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__ [WebUI] Host detail
    with no assigned ID view makes invalid RPC call
--  `#8339 <https://pagure.io/freeipa/issue/8339>`__ [WebUI] User details
+-  `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__ [WebUI] User details
    tab headers don't show member count when on settings tab
--  `#8344 <https://pagure.io/freeipa/issue/8344>`__ Nightly test failure
+-  `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8348 <https://pagure.io/freeipa/issue/8348>`__ Allow managed
+-  `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__ Allow managed
    permissions with ldap:///self bind rule
--  `#8349 <https://pagure.io/freeipa/issue/8349>`__ bind-9.16 and
+-  `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__ bind-9.16 and
    dnssec-enable
--  `#8350 <https://pagure.io/freeipa/issue/8350>`__ bind-9.16 and DLV
--  `#8352 <https://pagure.io/freeipa/issue/8352>`__ RPC API crashes when
+-  `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__ bind-9.16 and DLV
+-  `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__ RPC API crashes when
    a user is disabled while a session exists
--  `#8357 <https://pagure.io/freeipa/issue/8357>`__ Allow managing IPA
+-  `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__ Allow managing IPA
    resources as a user from a trusted Active Directory forest
--  `#8358 <https://pagure.io/freeipa/issue/8358>`__ TTL of DNS record
+-  `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__ TTL of DNS record
    can be set to negative value
--  `#8359 <https://pagure.io/freeipa/issue/8359>`__ [WebUI]
+-  `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__ [WebUI]
    dnsrecord_mod results in JS error
--  `#8360 <https://pagure.io/freeipa/issue/8360>`__ lite-server:
+-  `#8360 <https://codeberg.org/freeipa/freeipa/issues/8360>`__ lite-server:
    Werkzeug deprecation warnings
--  `#8362 <https://pagure.io/freeipa/issue/8362>`__
+-  `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
    (`rhbz#1826659 <https://bugzilla.redhat.com/show_bug.cgi?id=1826659>`__)
    IPA: Ldap authentication failure due to Kerberos principal expiration
    UTC timestamp
--  `#8363 <https://pagure.io/freeipa/issue/8363>`__ DNS config upgrade
+-  `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__ DNS config upgrade
    code fails
--  `#8364 <https://pagure.io/freeipa/issue/8364>`__ Nightly test failure
+-  `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__ Nightly test failure
    while establishing trust: Cannot find specified domain or server name
--  `#8366 <https://pagure.io/freeipa/issue/8366>`__ CA-less replica
+-  `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__ CA-less replica
    deployment fails with --setup-ca
--  `#8367 <https://pagure.io/freeipa/issue/8367>`__ IPA-EPN fails to
+-  `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__ IPA-EPN fails to
    build in ONLY_CLIENT mode
--  `#8368 <https://pagure.io/freeipa/issue/8368>`__
+-  `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
    (`rhbz#1846349 <https://bugzilla.redhat.com/show_bug.cgi?id=1846349>`__)
    cannot issue certs with multiple IP addresses corresponding to
    different hosts
--  `#8369 <https://pagure.io/freeipa/issue/8369>`__ cert_find returns
+-  `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__ cert_find returns
    "CA not configured" in CA-less install
--  `#8370 <https://pagure.io/freeipa/issue/8370>`__ ipa-join does not
+-  `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__ ipa-join does not
    set nshardwareplatform and nsosversion
--  `#8371 <https://pagure.io/freeipa/issue/8371>`__ Nightly test failure
+-  `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__ Nightly test failure
    [testing_master_testing] in
    test_integration/test_idviews.py::TestCertsInIDOverrides
--  `#8372 <https://pagure.io/freeipa/issue/8372>`__
+-  `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
    (`rhbz#1849914 <https://bugzilla.redhat.com/show_bug.cgi?id=1849914>`__)
    FreeIPA - Utilize 256-bit AJP connector passwords
--  `#8374 <https://pagure.io/freeipa/issue/8374>`__
+-  `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
    (`rhbz#1847999 <https://bugzilla.redhat.com/show_bug.cgi?id=1847999>`__)
    EPN does not ship its default configuration ( /etc/ipa/epn.conf ) in
    freeipa-client-epn
--  `#8377 <https://pagure.io/freeipa/issue/8377>`__ Nightly test failure
+-  `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__ Nightly test failure
    (timeout) in test_caless_TestReplicaInstall
--  `#8378 <https://pagure.io/freeipa/issue/8378>`__ CA validity past
+-  `#8378 <https://codeberg.org/freeipa/freeipa/issues/8378>`__ CA validity past
    year 2038 breaks cert.py plugin on 32-bit platform
--  `#8379 <https://pagure.io/freeipa/issue/8379>`__ Nightly test failure
+-  `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__ Nightly test failure
    [testing_master_pki] while installing CA replica
--  `#8381 <https://pagure.io/freeipa/issue/8381>`__ Nightly test failure
+-  `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__ Nightly test failure
    in test_webui/test_loginscreen.py::TestLoginScreen::test_login_view
--  `#8383 <https://pagure.io/freeipa/issue/8383>`__ Test with dnspython
+-  `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__ Test with dnspython
    2.0
--  `#8384 <https://pagure.io/freeipa/issue/8384>`__ Provide reliable way
+-  `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__ Provide reliable way
    to know if a server installation is complete
--  `#8388 <https://pagure.io/freeipa/issue/8388>`__ Make help() on
+-  `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__ Make help() on
    plugins more useful
--  `#8391 <https://pagure.io/freeipa/issue/8391>`__ Remove dnf
+-  `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__ Remove dnf
    workaround from test_epn.y
--  `#8394 <https://pagure.io/freeipa/issue/8394>`__ Nightly test failure
+-  `#8394 <https://codeberg.org/freeipa/freeipa/issues/8394>`__ Nightly test failure
    in cert-related tests
--  `#8395 <https://pagure.io/freeipa/issue/8395>`__ selinux don't audit
+-  `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__ selinux don't audit
    rules deny fetching trust topology
--  `#8396 <https://pagure.io/freeipa/issue/8396>`__ [WebUI] Font type of
+-  `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__ [WebUI] Font type of
    "Enabled" column in user search facet wrong
--  `#8399 <https://pagure.io/freeipa/issue/8399>`__ certmonger attempts
+-  `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__ certmonger attempts
    to add LWCA tracking requests on non-CA server.
--  `#8400 <https://pagure.io/freeipa/issue/8400>`__ sshd template file
+-  `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__ sshd template file
    is installed in a wrong (server) location while used by the client
    side
--  `#8401 <https://pagure.io/freeipa/issue/8401>`__ Create platform
+-  `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__ Create platform
    definitions for freeipa-container
--  `#8403 <https://pagure.io/freeipa/issue/8403>`__ Add option to add
+-  `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__ Add option to add
    ipaapi user as an allowed uid for ifp in /etc/sssd/sssd.conf when
    running ipa-replica-install
--  `#8404 <https://pagure.io/freeipa/issue/8404>`__ Detect and fail if
+-  `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__ Detect and fail if
    not enough memory is available for installation
--  `#8405 <https://pagure.io/freeipa/issue/8405>`__ Don't delegate full
+-  `#8405 <https://codeberg.org/freeipa/freeipa/issues/8405>`__ Don't delegate full
    TGT in ipa-join
--  `#8407 <https://pagure.io/freeipa/issue/8407>`__ Support changelog
+-  `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__ Support changelog
    integrated into main database
--  `#8408 <https://pagure.io/freeipa/issue/8408>`__ Nightly test failure
+-  `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions::test_client_enrollment_by_unprivileged_user
--  `#8412 <https://pagure.io/freeipa/issue/8412>`__
+-  `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
    (`rhbz#1857157 <https://bugzilla.redhat.com/show_bug.cgi?id=1857157>`__)
    AVC: httpd cannot connect to ipa-custodia.sock
--  `#8413 <https://pagure.io/freeipa/issue/8413>`__ Nightly test failure
+-  `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8414 <https://pagure.io/freeipa/issue/8414>`__ Nightly test failure
+-  `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1::test_sssd_config_allows_ipaapi_access_to_ifp
--  `#8416 <https://pagure.io/freeipa/issue/8416>`__ [WebUI] Error while
+-  `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__ [WebUI] Error while
    adding user ID overrides to group
--  `#8419 <https://pagure.io/freeipa/issue/8419>`__ Azure is reporting a
+-  `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__ Azure is reporting a
    slew of new no-member lint errors
--  `#8425 <https://pagure.io/freeipa/issue/8425>`__ Nightly test failure
+-  `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__ Nightly test failure
    in test_cert.test_cert.TestInstallMasterClient (certmonger timeout)
--  `#8428 <https://pagure.io/freeipa/issue/8428>`__ [ipatests] fails due
+-  `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__ [ipatests] fails due
    to new python-cryptography 3.0
--  `#8429 <https://pagure.io/freeipa/issue/8429>`__ Add fips-mode-setup
+-  `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__ Add fips-mode-setup
    to ipaplatform.paths
--  `#8432 <https://pagure.io/freeipa/issue/8432>`__ test failure in
+-  `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__ test failure in
    test_commands.py::TestIPACommand::test_login_wrong_password:
    AssertionError
--  `#8435 <https://pagure.io/freeipa/issue/8435>`__ [ipatests] failures
+-  `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__ [ipatests] failures
    due to new Pytest6.0 (pypi part)
--  `#8437 <https://pagure.io/freeipa/issue/8437>`__ unit tests for
+-  `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__ unit tests for
    ipa-extdom-extop are failing in Fedora 33
--  `#8439 <https://pagure.io/freeipa/issue/8439>`__ Nightly test failure
+-  `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__ Nightly test failure
    in
    test_integration/test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8440 <https://pagure.io/freeipa/issue/8440>`__
+-  `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
    (`rhbz#1863616 <https://bugzilla.redhat.com/show_bug.cgi?id=1863616>`__)
    CA-less install does not set required permissions on KDC certificate
--  `#8441 <https://pagure.io/freeipa/issue/8441>`__
+-  `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
    (`rhbz#1870202 <https://bugzilla.redhat.com/show_bug.cgi?id=1870202>`__)
    File permissions of /etc/ipa/ca.crt differ between CA-ful and CA-less
--  `#8442 <https://pagure.io/freeipa/issue/8442>`__ [pylint]
+-  `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__ [pylint]
    warnings/errors against pylint 2.5.3
--  `#8443 <https://pagure.io/freeipa/issue/8443>`__ ipa delegation-add
+-  `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__ ipa delegation-add
    can add permissions and attributes several times
--  `#8444 <https://pagure.io/freeipa/issue/8444>`__
+-  `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance input validation
--  `#8445 <https://pagure.io/freeipa/issue/8445>`__
+-  `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
    (`rhbz#1863079 <https://bugzilla.redhat.com/show_bug.cgi?id=1863079>`__)
    EPN: '[Errno 111] Connection refused' when the SMTP is down
--  `#8446 <https://pagure.io/freeipa/issue/8446>`__ ipa dnszone-add
+-  `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__ ipa dnszone-add
    ignores --name-from-ip option if name is given
--  `#8447 <https://pagure.io/freeipa/issue/8447>`__ Nightly test failure
+-  `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__ Nightly test failure
    in test_integration/test_ipahealthcheck/TestIpaHealthCheckWithoutDNS
--  `#8449 <https://pagure.io/freeipa/issue/8449>`__
+-  `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
    (`rhbz#1866291 <https://bugzilla.redhat.com/show_bug.cgi?id=1866291>`__)
    EPN: enhance CLI option tests
--  `#8456 <https://pagure.io/freeipa/issue/8456>`__ Need new aci's for
+-  `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__ Need new aci's for
    the new replication changelog entries
--  `#8458 <https://pagure.io/freeipa/issue/8458>`__ auto-upgrade will
+-  `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__ auto-upgrade will
    never happen for existing installations
--  `#8459 <https://pagure.io/freeipa/issue/8459>`__ [upgrade] handle
+-  `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__ [upgrade] handle
    missing openssh-clients
--  `#8461 <https://pagure.io/freeipa/issue/8461>`__ [ALTLinux] server
+-  `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__ [ALTLinux] server
    uninstall error on missing /var/lib/samba
--  `#8463 <https://pagure.io/freeipa/issue/8463>`__ Nightly test failure
+-  `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#8464 <https://pagure.io/freeipa/issue/8464>`__ Increase replication
+-  `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__ Increase replication
    changelog trimming interval
--  `#8468 <https://pagure.io/freeipa/issue/8468>`__ [pylint] new
+-  `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__ [pylint] new
    warnings on dev branch
--  `#8472 <https://pagure.io/freeipa/issue/8472>`__ [tracker] Nightly
+-  `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__ [tracker] Nightly
    test failure in
    test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA
--  `#8473 <https://pagure.io/freeipa/issue/8473>`__ Nightly test failure
+-  `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__ Nightly test failure
    in all webui tests: Invalid or corrupt jarfile /opt/selenium.jar
--  `#8474 <https://pagure.io/freeipa/issue/8474>`__ Mozilla's NSS
+-  `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__ Mozilla's NSS
    without DBM
--  `#8475 <https://pagure.io/freeipa/issue/8475>`__ Azure: tox task and
+-  `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__ Azure: tox task and
    virtualenv 20+
--  `#8481 <https://pagure.io/freeipa/issue/8481>`__ Nightly test failure
+-  `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__ Nightly test failure
    in rawhide in tasks.configure_dns_for_trust
--  `#8482 <https://pagure.io/freeipa/issue/8482>`__ Nightly test failure
+-  `#8482 <https://codeberg.org/freeipa/freeipa/issues/8482>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_source_ipahealthcheck_meta_services_check
--  `#8488 <https://pagure.io/freeipa/issue/8488>`__
+-  `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux blocks custodia key replication / retrieval for sub-CAs
--  `#8490 <https://pagure.io/freeipa/issue/8490>`__
+-  `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
    (`rhbz#1875001 <https://bugzilla.redhat.com/show_bug.cgi?id=1875001>`__)
    It is not possible to edit KDC database when the FreeIPA server is
    running
--  `#8491 <https://pagure.io/freeipa/issue/8491>`__ Unindexed searches
+-  `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__ Unindexed searches
    in FreeIPA git master
--  `#8493 <https://pagure.io/freeipa/issue/8493>`__ Synchronize index
+-  `#8493 <https://codeberg.org/freeipa/freeipa/issues/8493>`__ Synchronize index
    LDIF and index update files
--  `#8494 <https://pagure.io/freeipa/issue/8494>`__ Azure Pipelines are
+-  `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__ Azure Pipelines are
    broken due to docker compose tool upgrade
--  `#8496 <https://pagure.io/freeipa/issue/8496>`__ [Tracker] Multiple
+-  `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__ [Tracker] Multiple
    nightly test failures in test_dnssec
--  `#8498 <https://pagure.io/freeipa/issue/8498>`__ Check 3rd-party IPA
+-  `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__ Check 3rd-party IPA
    server HTTP cert for ipa-ca.$DOMAIN dnsName on CA replicas
--  `#8501 <https://pagure.io/freeipa/issue/8501>`__ Unify how FreeIPA
+-  `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__ Unify how FreeIPA
    gets FQDN of current host
--  `#8502 <https://pagure.io/freeipa/issue/8502>`__ Don't create DirSRV
+-  `#8502 <https://codeberg.org/freeipa/freeipa/issues/8502>`__ Don't create DirSRV
    SSCA
--  `#8503 <https://pagure.io/freeipa/issue/8503>`__
+-  `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
    (`rhbz#1879604 <https://bugzilla.redhat.com/show_bug.cgi?id=1879604>`__)
    pkispawn logs files are empty
--  `#8505 <https://pagure.io/freeipa/issue/8505>`__ Nightly failure
+-  `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__ Nightly failure
    (fedora31) in
    test_integration/test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#8507 <https://pagure.io/freeipa/issue/8507>`__ [WebUI] Backport
+-  `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__ [WebUI] Backport
    jQuery patches from newer versions of the library (e.g. 3.5.0)
--  `#8510 <https://pagure.io/freeipa/issue/8510>`__
+-  `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
    (`rhbz#1881630 <https://bugzilla.redhat.com/show_bug.cgi?id=1881630>`__)
    create_active_user and kinit_as_user should collect kdcinfo.REALM on
    failure
--  `#8511 <https://pagure.io/freeipa/issue/8511>`__ The selinux
+-  `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__ The selinux
    subpackage does not have a requirement to match the server install
--  `#8512 <https://pagure.io/freeipa/issue/8512>`__ Import of psutil can
+-  `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__ Import of psutil can
    trigger SELinux violation
--  `#8513 <https://pagure.io/freeipa/issue/8513>`__
+-  `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
    (`rhbz#1868432 <https://bugzilla.redhat.com/show_bug.cgi?id=1868432>`__)
    SELinux module fails to load: Re-declaration of type node_t
--  `#8515 <https://pagure.io/freeipa/issue/8515>`__
+-  `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
    (`rhbz#1882340 <https://bugzilla.redhat.com/show_bug.cgi?id=1882340>`__)
    nsslapd-db-locks patching no longer works
--  `#8516 <https://pagure.io/freeipa/issue/8516>`__ Nightly test failure
+-  `#8516 <https://codeberg.org/freeipa/freeipa/issues/8516>`__ Nightly test failure
    (master) in ipa trust-add
--  `#8518 <https://pagure.io/freeipa/issue/8518>`__ Upgrade F32 to F33
+-  `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__ Upgrade F32 to F33
    fails in DNS upgrade code
--  `#8519 <https://pagure.io/freeipa/issue/8519>`__ Fedora container
+-  `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__ Fedora container
    platform is incomplete
--  `#8521 <https://pagure.io/freeipa/issue/8521>`__ Speed up
+-  `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__ Speed up
    ipa-server-install
--  `#8522 <https://pagure.io/freeipa/issue/8522>`__ Remove
+-  `#8522 <https://codeberg.org/freeipa/freeipa/issues/8522>`__ Remove
    cainstance.migrate_profiles_to_ldap()
--  `#8523 <https://pagure.io/freeipa/issue/8523>`__ Topology Graph
+-  `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__ Topology Graph
    returns Runtime Error
--  `#8524 <https://pagure.io/freeipa/issue/8524>`__
+-  `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Deploy & manage the ACME service topology wide from a single system
--  `#8528 <https://pagure.io/freeipa/issue/8528>`__ Use separate logs
+-  `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__ Use separate logs
    for AD Trust and DNS installer
--  `#8529 <https://pagure.io/freeipa/issue/8529>`__ ipa-ca record
+-  `#8529 <https://codeberg.org/freeipa/freeipa/issues/8529>`__ ipa-ca record
    incomplete when hostname is not in DNS
--  `#8530 <https://pagure.io/freeipa/issue/8530>`__
+-  `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
    (`rhbz#1859185 <https://bugzilla.redhat.com/show_bug.cgi?id=1859185>`__)
    Running ipa-server-install fails on machine where libsss_sudo is not
    installed
--  `#8533 <https://pagure.io/freeipa/issue/8533>`__ Nightly failure in
+-  `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__ Nightly failure in
    ipa-replica-install configuring renewals: DBusException:
    org.freedesktop.DBus.Error.NoReply
--  `#8535 <https://pagure.io/freeipa/issue/8535>`__
+-  `#8535 <https://codeberg.org/freeipa/freeipa/issues/8535>`__
    (`rhbz#1887928 <https://bugzilla.redhat.com/show_bug.cgi?id=1887928>`__)
    RPM spec moves ssh server config to a snippet but does not ensure
    sshd_config includes the snippet
--  `#8536 <https://pagure.io/freeipa/issue/8536>`__ RFE: ipatests: run
+-  `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__ RFE: ipatests: run
    healthcheck on hidden replica
--  `#8541 <https://pagure.io/freeipa/issue/8541>`__ Nightly failure
+-  `#8541 <https://codeberg.org/freeipa/freeipa/issues/8541>`__ Nightly failure
    (fed33) in test_installation.py::TestInstallMaster::test_selinux_avcs
--  `#8551 <https://pagure.io/freeipa/issue/8551>`__
+-  `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
    (`rhbz#1784657 <https://bugzilla.redhat.com/show_bug.cgi?id=1784657>`__)
    Unlock user accounts after a password reset and replicate that unlock
    to all IdM servers
--  `#8554 <https://pagure.io/freeipa/issue/8554>`__
+-  `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
    (`rhbz#1891056 <https://bugzilla.redhat.com/show_bug.cgi?id=1891056>`__)
    ipa-kdb: support subordinate/superior UPN suffixes
--  `#8555 <https://pagure.io/freeipa/issue/8555>`__
+-  `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
    (`rhbz#1340463 <https://bugzilla.redhat.com/show_bug.cgi?id=1340463>`__)
    Nightly test failure in test_pwpolicy.py::test_pwpolicy::test_misc
--  `#8558 <https://pagure.io/freeipa/issue/8558>`__ Create backend entry
+-  `#8558 <https://codeberg.org/freeipa/freeipa/issues/8558>`__ Create backend entry
    before creating mapping tree entry for ipaca backend
--  `#8559 <https://pagure.io/freeipa/issue/8559>`__ Nightly test failure
+-  `#8559 <https://codeberg.org/freeipa/freeipa/issues/8559>`__ Nightly test failure
    in test_trust.py::TestTrust::test_password_login_as_aduser
--  `#8560 <https://pagure.io/freeipa/issue/8560>`__ Nightly test failure
+-  `#8560 <https://codeberg.org/freeipa/freeipa/issues/8560>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_encryption
--  `#8563 <https://pagure.io/freeipa/issue/8563>`__ Nightly test failure
+-  `#8563 <https://codeberg.org/freeipa/freeipa/issues/8563>`__ Nightly test failure
    in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_riplugincheck
--  `#8566 <https://pagure.io/freeipa/issue/8566>`__ Subordinate suffixes
+-  `#8566 <https://codeberg.org/freeipa/freeipa/issues/8566>`__ Subordinate suffixes
    aren't treated as subordinate in trust to Active Directory (crash
    part)
--  `#8567 <https://pagure.io/freeipa/issue/8567>`__
+-  `#8567 <https://codeberg.org/freeipa/freeipa/issues/8567>`__
    (`rhbz#1894800 <https://bugzilla.redhat.com/show_bug.cgi?id=1894800>`__)
    IPA WebUI inaccessible after upgrading to RHEL 8.3.-
    idoverride-memberof.js missing
--  `#8572 <https://pagure.io/freeipa/issue/8572>`__ Nightly failure in
+-  `#8572 <https://codeberg.org/freeipa/freeipa/issues/8572>`__ Nightly failure in
    test_acme.py::TestACMECALess::test_enable_caless_to_cafull_replica
--  `#8573 <https://pagure.io/freeipa/issue/8573>`__ Nightly failure in
+-  `#8573 <https://codeberg.org/freeipa/freeipa/issues/8573>`__ Nightly failure in
    test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS::test_ipa_dns_systemrecords_check
--  `#8578 <https://pagure.io/freeipa/issue/8578>`__ EPN: SMTP client
+-  `#8578 <https://codeberg.org/freeipa/freeipa/issues/8578>`__ EPN: SMTP client
    downgrade smtp_security from \`starttls\` to \`none\`
--  `#8579 <https://pagure.io/freeipa/issue/8579>`__ EPN: SMTP client
+-  `#8579 <https://codeberg.org/freeipa/freeipa/issues/8579>`__ EPN: SMTP client
    doesn't validate server certificate
--  `#8580 <https://pagure.io/freeipa/issue/8580>`__ EPN: SMTP client
+-  `#8580 <https://codeberg.org/freeipa/freeipa/issues/8580>`__ EPN: SMTP client
    authentication by certificate
--  `#8584 <https://pagure.io/freeipa/issue/8584>`__ ACME communication
+-  `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__ ACME communication
    with dogtag REST endpoints should be using the cookie it creates
--  `#8585 <https://pagure.io/freeipa/issue/8585>`__ Compile warnings on
+-  `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__ Compile warnings on
    rawhide
 
 
@@ -1425,7 +1425,7 @@ Armando Neto (25)
    `commit <https://codeberg.org/freeipa/freeipa/commit/26ae95f4b492b98078b5deb16825df3fd525f305>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/21186540f0425840e544a3cead8da909744aeac0>`__
-   `#8473 <https://pagure.io/freeipa/issue/8473>`__
+   `#8473 <https://codeberg.org/freeipa/freeipa/issues/8473>`__
 -  ipatests: Bump PR-CI templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/b279b3a7c91a1cf1de4b5cc5884912a4ca854d4c>`__
 -  ipatests: bump pr-ci templates
@@ -1448,12 +1448,12 @@ Armando Neto (25)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a22e8734805cc897ef59840dac932cb9d7c52a25>`__
 -  ipatests: Skip test_sss_ssh_authorizedkeys method
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef1b8d0f49d729e0a04d839916772406a9b222f0>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: Improve test_commands reliability
    `commit <https://codeberg.org/freeipa/freeipa/commit/0926cb87da4d22b4f4d649a97b293cdff3cc78e8>`__
 -  travis: Remove CI integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/2319b38c8f6a8fcdc4eb02d12ffa53e97c29fc03>`__
-   `#7323 <https://pagure.io/freeipa/issue/7323>`__
+   `#7323 <https://codeberg.org/freeipa/freeipa/issues/7323>`__
 -  prci: bump template version for temp_commit and nightly_latest
    `commit <https://codeberg.org/freeipa/freeipa/commit/e536824425ae7dba515dfe8c9e88e41b52c15701>`__
 -  prci: bump fedora release
@@ -1496,25 +1496,25 @@ Alexander Bokovoy (140)
 -  ipa-acme-manage: user a cookie created for the communication with
    dogtag REST endpoints
    `commit <https://codeberg.org/freeipa/freeipa/commit/935a46158251d52b16f6e0f531a8851778795c67>`__
-   `#8584 <https://pagure.io/freeipa/issue/8584>`__
+   `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__
 -  ipa-otpd: fix gcc complaints in Rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/b36f224892152af786e69bb166497e6fd9c44cd6>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-sam: fix gcc complaints on Rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/d99b7d0b0131d6474696bdab67375c4606137d9e>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-kdb: fix gcc complaints in kdb tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc11c56544ccdde96889d0f866899a9abea83b3e>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  ipa-kdb: fix gcc complaints
    `commit <https://codeberg.org/freeipa/freeipa/commit/f513a55ded8c7806970c715f6dc3fe0d5ed3d1f7>`__
-   `#8585 <https://pagure.io/freeipa/issue/8585>`__
+   `#8585 <https://codeberg.org/freeipa/freeipa/issues/8585>`__
 -  wgi/plugins.py: ignore empty plugin directories
    `commit <https://codeberg.org/freeipa/freeipa/commit/91706690e0c894864c93716c4fbecb285722e77d>`__
-   `#8567 <https://pagure.io/freeipa/issue/8567>`__
+   `#8567 <https://codeberg.org/freeipa/freeipa/issues/8567>`__
 -  ipa-kdb: fix crash in MS-PAC cache init code
    `commit <https://codeberg.org/freeipa/freeipa/commit/81cbee4e3ff2e667946e0d41097b402257608b7e>`__
-   `#8566 <https://pagure.io/freeipa/issue/8566>`__
+   `#8566 <https://codeberg.org/freeipa/freeipa/issues/8566>`__
 -  rpcserver: fix exception handling for FAST armor failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/563d0a07293f8d06a394c3ba6cfb85990099d711>`__
 -  rpcserver: fallback to non-armored kinit in case of trusted domains
@@ -1523,23 +1523,23 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ba0494c266a3c918dba5d3c8ead8e06be819f3b>`__
 -  ipa-kdb: support subordinate/superior UPN suffixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b6d1ab854387840f7526d6d59ddc7102231957f>`__
-   `#8554 <https://pagure.io/freeipa/issue/8554>`__
+   `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
 -  Pre-populate IP addresses for the name server upgrades
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c393c09e0ca6b180841ab89b5259c623de91e15>`__
-   `#8518 <https://pagure.io/freeipa/issue/8518>`__
+   `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__
 -  Specify memory limits as strings for docker compose
    `commit <https://codeberg.org/freeipa/freeipa/commit/31bc0df6a2a7fe2a7cc965436411e75844aebbe0>`__
-   `#8494 <https://pagure.io/freeipa/issue/8494>`__
+   `#8494 <https://codeberg.org/freeipa/freeipa/issues/8494>`__
 -  ipa-kdb: test kadmin.local getprincs command
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba1a7b97c192221af8f4823b82ea1bcf9a2b491c>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  ipa-kdb: support getprincs request in kadmin.local
    `commit <https://codeberg.org/freeipa/freeipa/commit/d00106b34de231bc67cdee904dbdccc21c8fcbc6>`__
-   `#8490 <https://pagure.io/freeipa/issue/8490>`__
+   `#8490 <https://codeberg.org/freeipa/freeipa/issues/8490>`__
 -  test_smb: make sure both smbserver and smbclient use IPA master for
    DNS
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a01f576e0b32b38bfd57498d154a061f84ff728>`__
-   `#8344 <https://pagure.io/freeipa/issue/8344>`__
+   `#8344 <https://codeberg.org/freeipa/freeipa/issues/8344>`__
 -  Add new contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/11a64478b32985e3c92258aecdd97a28b2351176>`__
 -  Add alternative email to the mailmap for myself
@@ -1549,16 +1549,16 @@ Alexander Bokovoy (140)
 -  extdom-extop: refactor tests to use unshare+chroot to override
    nss_files configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a42bc0960b8151961dbbce0013c3e28d4078526>`__
-   `#8437 <https://pagure.io/freeipa/issue/8437>`__
+   `#8437 <https://codeberg.org/freeipa/freeipa/issues/8437>`__
 -  selinux: support running ipa-custodia with PrivateTmp=yes
    `commit <https://codeberg.org/freeipa/freeipa/commit/91713f4f0a1033943ccf949fb3bfed2447e3ea0f>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  selinux: allow oddjobd to set up ipa_helper_t context for execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6055e6c9f6e88f8174c3bc920ff46583a14822f>`__
-   `#8395 <https://pagure.io/freeipa/issue/8395>`__
+   `#8395 <https://codeberg.org/freeipa/freeipa/issues/8395>`__
 -  handle Y2038 in timestamp to datetime conversions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f6ca418ee9e823b63680ab1213160884fe59cf6>`__
-   `#8378 <https://pagure.io/freeipa/issue/8378>`__
+   `#8378 <https://codeberg.org/freeipa/freeipa/issues/8378>`__
 -  update list of contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/296ddcd32c67b5a59d4f957544f79fd024237bb3>`__
 -  Update translation files
@@ -1566,83 +1566,83 @@ Alexander Bokovoy (140)
 -  ipatests: test that adding Active Directory user to a role makes it
    an administrator
    `commit <https://codeberg.org/freeipa/freeipa/commit/9248d23ae8e8573b6877851c1d1b31878a7bd1d4>`__
-   `#8357 <https://pagure.io/freeipa/issue/8357>`__
+   `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__
 -  Web UI: allow users from trusted Active Directory forest manage IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ba64b1ac3fa1709c09b30754138946ddc9c2839>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 -  tests: account for ID overrides as members of groups and roles
    `commit <https://codeberg.org/freeipa/freeipa/commit/306304bb7fb35c88d987e8460aacad6cad0ae888>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  Support adding user ID overrides as group and role members
    `commit <https://codeberg.org/freeipa/freeipa/commit/bee4204039dac9cd858e823b839183ba2cdbd216>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  idviews: handle unqualified ID override lookups from Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/973e0c04e460c99f601b0292ff9c64dd0882432e>`__
-   `#7255 <https://pagure.io/freeipa/issue/7255>`__
+   `#7255 <https://codeberg.org/freeipa/freeipa/issues/7255>`__
 -  support using trust-related operations in the server console
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecc0a96d161717960058e22eecad43754de06f11>`__
 -  Add design page for managing IPA resources as a user from a trusted
    Active Directory forest
    `commit <https://codeberg.org/freeipa/freeipa/commit/28389fe8af3fb2f36e18864668fb167aa8daca99>`__
-   `#7816 <https://pagure.io/freeipa/issue/7816>`__,
-   `#8357 <https://pagure.io/freeipa/issue/8357>`__
+   `#7816 <https://codeberg.org/freeipa/freeipa/issues/7816>`__,
+   `#8357 <https://codeberg.org/freeipa/freeipa/issues/8357>`__
 -  kdb: handle enterprise principal lookup in AS_REQ
    `commit <https://codeberg.org/freeipa/freeipa/commit/676774d3fb8a0921afd678d5b0bbe30bcb082420>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-pwd-extop: use timegm() instead of mktime() to preserve timezone
    offset
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9a6027410814832f9228621abd2bbd2acebb944>`__
-   `#8362 <https://pagure.io/freeipa/issue/8362>`__
+   `#8362 <https://codeberg.org/freeipa/freeipa/issues/8362>`__
 -  azure: do not run test_commands due to failures in low memory cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ff972c23f16f371ca578bfd105a85c3ffdb4f8b>`__
 -  test_smb: test S4U2Self operation by IPA service
    `commit <https://codeberg.org/freeipa/freeipa/commit/52da0d6a287e3b78fbed033a48e7302715227e1c>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: refactor principal lookup to support S4U2Self correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5876f30d4000424cc8122498c411f812b3a0959>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: cache local TGS in the driver context
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef59cb845254e2bc278d3e3f2705b6b11ba7d04d>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add primary group to list of groups in MS-PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/3611fc5043fbde808e4307c596d8994c60bc1cc5>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: Always allow services to get PAC if needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e20a96c3091f9216cd2bcb1c5853593ed5de88c>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add asserted identity SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/015ae275981c0b4214d5f1fb86b7f2ee61f63229>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  kdb: add minimal server referrals support for enterprise principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/44a255d423e5c097c5de83b3c0f754ab61c5b96e>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-tests: add a test to make sure MS-PAC is produced by KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f881ca0f2545b9dea9214f796beb478a1662bbb>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-print-pac: acquire and print PAC record for a user
    `commit <https://codeberg.org/freeipa/freeipa/commit/23a49538f1d4e5cd01cc867bcfede73f3008aa74>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  ipa-kdb: add UPN_DNS_INFO PAC structure
    `commit <https://codeberg.org/freeipa/freeipa/commit/0317255b5329e4ff3e1aa4a86b52b60d30f4614b>`__
-   `#8319 <https://pagure.io/freeipa/issue/8319>`__
+   `#8319 <https://codeberg.org/freeipa/freeipa/issues/8319>`__
 -  baseldap: de-duplicate passed attributes when checking for limits
    `commit <https://codeberg.org/freeipa/freeipa/commit/32c6b02eedf1243aa3ae716e7526118fe14fae59>`__
-   `#8328 <https://pagure.io/freeipa/issue/8328>`__
+   `#8328 <https://codeberg.org/freeipa/freeipa/issues/8328>`__
 -  service delegation: allow to add and remove host principals
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f82d281ccb4eb823ec5086f107410d7f8100c7d>`__
-   `#8289 <https://pagure.io/freeipa/issue/8289>`__
+   `#8289 <https://codeberg.org/freeipa/freeipa/issues/8289>`__
 -  WebUI: use python3-rjsmin to minify JavaScript files
    `commit <https://codeberg.org/freeipa/freeipa/commit/d986e844bbd37ccc7a532175631a55acd315cda3>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  test_smb: test that we can auth as NetBIOS alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fc213d10deacf107f5ca225a0095bdf215dc73b>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: fix memory handling in ipadb_find_principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/999af8e2ef5330bfb488a20e2b7c669064b73d69>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  kdb: initialize flags in ipadb_delete_principal()
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b9233615e611f8ec52986a57ca50dfceb558c1a>`__
-   `#8291 <https://pagure.io/freeipa/issue/8291>`__
+   `#8291 <https://codeberg.org/freeipa/freeipa/issues/8291>`__
 -  Azure Pipelines: switch to Fedora 32
    `commit <https://codeberg.org/freeipa/freeipa/commit/f66ef8484daef7ce08d38193a2dbd583a03ec28d>`__
 -  Azure Pipelines: Override services known to not work in containers
@@ -1651,10 +1651,10 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a009b9e0342ca2633355fb9347855676110d678c>`__
 -  CVE-2020-1722: prevent use of too long passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbf5df4a66b68f62a9e063c43a30b46e539c603b>`__
-   `#8268 <https://pagure.io/freeipa/issue/8268>`__
+   `#8268 <https://codeberg.org/freeipa/freeipa/issues/8268>`__
 -  Allow rename of a host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/6472a107d6b4f231dd9d9d8587ba550dfa8b0b0a>`__
-   `#6783 <https://pagure.io/freeipa/issue/6783>`__
+   `#6783 <https://codeberg.org/freeipa/freeipa/issues/6783>`__
 -  Add 'api' and 'aci' targets to make
    `commit <https://codeberg.org/freeipa/freeipa/commit/01b207bcd5ea53f7f588771c530318cab1f9d0ef>`__
 -  Remove Fedora repository fastmirror selection
@@ -1662,23 +1662,23 @@ Alexander Bokovoy (140)
 -  ipa-pwd-extop: don't check password policy for non-Kerberos account
    set by DM or a passsync manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9c41df6fd39b8d6bc879a9321b3f76eb1847b06>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipa-pwd-extop: use SLAPI_BIND_TARGET_SDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/527f30be76f0da6d4453745ace25f64948c0504f>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: test sysaccount password change with a password policy
    applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/a620ac0f6f2505b6e9242f21dc0314c45747336e>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  ipatests: allow changing sysaccount passwords as cn=Directory Manager
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c191ddf6d75090c80f567dd665bdacc44ef8883>`__
-   `#7181 <https://pagure.io/freeipa/issue/7181>`__
+   `#7181 <https://codeberg.org/freeipa/freeipa/issues/7181>`__
 -  Fix indentation levels
    `commit <https://codeberg.org/freeipa/freeipa/commit/38204856fd72e5191bae07a47907314aacf43d1a>`__
 -  ipatests: always skip additional input for group-add-member
    --external
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1c45df4b25ea2a96a2b5fe59e3d7edf4303c04e>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  po: update Chinese (China) translation
    `commit <https://codeberg.org/freeipa/freeipa/commit/42e86692b6b12728e0fb7e3bc17613ef072b624a>`__
 -  po: update Ukrainian translation
@@ -1731,10 +1731,10 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fc932a2a859898d718d850fbcd558a1e960e91f>`__
 -  Update translation infrastructure
    `commit <https://codeberg.org/freeipa/freeipa/commit/b4722f3917d6c2a6849931e9c68896f83a0cc09b>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Keep ipa.pot translation file in git for weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/92e36258cee838a378729d06fc4134b5c4428f87>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Do not force any particular sphinx theme
    `commit <https://codeberg.org/freeipa/freeipa/commit/452ef8cc76c9b3634e5812e81b5350bba5c59cf4>`__
 -  Override master document for ReadTheDocs
@@ -1745,51 +1745,51 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/acfe34e25b4f1469bee255cc82a70479efb990fa>`__
 -  Prevent adding IPA objects as external members of external groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/2997a74abcfdb0ad1c0b5356949e557c3b624d3c>`__
-   `#8236 <https://pagure.io/freeipa/issue/8236>`__
+   `#8236 <https://codeberg.org/freeipa/freeipa/issues/8236>`__
 -  Secure AJP connector between Dogtag and Apache proxy
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec73de969f55b7a005b6401029f87fe6a225a417>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Tighten permissions on PKI proxy configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/593fac1ca9381a51ee59fac994d818ed9619bd8e>`__
-   `#8221 <https://pagure.io/freeipa/issue/8221>`__
+   `#8221 <https://codeberg.org/freeipa/freeipa/issues/8221>`__
 -  Azure Pipelines: re-enable nodejs:12 stream for Fedora 31+
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba904672a21add3b0ab1808c5640ac786f194aad>`__
 -  kdb: make sure audit_as_req callback signature change is preserved
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5291963a148c34582d90f2aa269e4a2214f9f6f>`__
-   `#8200 <https://pagure.io/freeipa/issue/8200>`__
+   `#8200 <https://codeberg.org/freeipa/freeipa/issues/8200>`__
 -  adtrust: print DNS records for external DNS case after role is
    enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3dbb36867ebf52483834ceb247050a24cf74d7c>`__
-   `#8192 <https://pagure.io/freeipa/issue/8192>`__
+   `#8192 <https://codeberg.org/freeipa/freeipa/issues/8192>`__
 -  Update Azure Pipelines to use Fedora 31
    `commit <https://codeberg.org/freeipa/freeipa/commit/43a97082bbdf5992dcd355fdcb28ff3bfe66ab59>`__
 -  install/updates: move external members past schema compat update
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff547a2777d63609faba42101e9802f5e988fa00>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Reset per-indicator Kerberos policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ed5eca762e136a1db9d3c20ec068d562b215699>`__
-   `#8153 <https://pagure.io/freeipa/issue/8153>`__
+   `#8153 <https://codeberg.org/freeipa/freeipa/issues/8153>`__
 -  ipa-client-samba: map domain sid of trust domain properly for display
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d402b69eb484a14944ccc23fcf945963977e348>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  DNS install check: allow overlapping zone to be from the master
    itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd7fdaa77d00042d44bec23291f0d0be36bead5e>`__
 -  covscan: free ucs2-encoded password copy when generating NTLM hash
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9dd757763c76402e07f533f19e269eeebc554fa>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  covscan: free encryption types in case there is an error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3ad78538e1dd2f63f171ef1c2b470a1a4f47a8c>`__
-   `#8131 <https://pagure.io/freeipa/issue/8131>`__
+   `#8131 <https://codeberg.org/freeipa/freeipa/issues/8131>`__
 -  Add Authentication Indicator Kerberos ticket policy options
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5f32165d6105a48d9de85a8d29925b58beb9f91>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Allow presence of LDAP attribute options
    `commit <https://codeberg.org/freeipa/freeipa/commit/9db6f65a8536781f6bca20ff8031de18c0f79397>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Do not run trust upgrade code if master lacks Samba bindings
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba466a802129cbe61964653fdfddacd5d43f6771>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Update contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/d243c188f26c50a056be5e88554daec6116f5f8f>`__
 -  Update translations
@@ -1798,18 +1798,18 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/19d51683cad9ee091d25c56431a8b5a538e3fe10>`__
 -  adtrust: add default read_keys permission for TDO objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/0be98884991ff14720dfce428e4f23ebc4a42311>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  add default access control when migrating trust objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/9aeb6bae23dc21b97dbd784f8d954ee0dcde1d8f>`__
-   `#8067 <https://pagure.io/freeipa/issue/8067>`__
+   `#8067 <https://codeberg.org/freeipa/freeipa/issues/8067>`__
 -  adtrust: avoid using timestamp in klist output
    `commit <https://codeberg.org/freeipa/freeipa/commit/80e4c18b75af989d5839aba7e6a1efc06da16f81>`__
-   `#8066 <https://pagure.io/freeipa/issue/8066>`__
+   `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
 -  Mark failing test as xfail for use of python-dns make_ds method
    `commit <https://codeberg.org/freeipa/freeipa/commit/24c6ce27b215ce6584ef3d38bcb8cfd68af20ce6>`__
 -  ipa-extdom-extop: test timed out getgrgid_r
    `commit <https://codeberg.org/freeipa/freeipa/commit/c78cb9404e4fad9a8f4f778cee59c1c2b9038a49>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 -  Update contributors
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef80a0746fa190a7e47df087bf1c513867a024ac>`__
 -  Update translations
@@ -1818,25 +1818,25 @@ Alexander Bokovoy (140)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9938e3d842615d042003362fd6fdce0194b8e5c>`__
 -  Restore SELinux context for p11-kit config overrides
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f969a5929e8a2f54fd732ea0c8d0a4931250d23>`__
-   `#7810 <https://pagure.io/freeipa/issue/7810>`__
+   `#7810 <https://codeberg.org/freeipa/freeipa/issues/7810>`__
 -  Change RA agent certificate profile to caSubsystemCert
    `commit <https://codeberg.org/freeipa/freeipa/commit/802a54bfc8b698ca962b383beb3684a4b1af1865>`__
 -  certmaprule: add negative test for altSecurityIdentities
    `commit <https://codeberg.org/freeipa/freeipa/commit/95c2b34c4b468a9b766b24172e34ff2d8b6c9530>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__
 -  certmap rules: altSecurityIdentities should only be used for trusted
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ca4d484e7492bf469d73c6e627cc6df46eebf8>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__
 -  Create indexes for altSecurityIdentities and ipaCertmapData
    attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/725899595f42b607989db96d849e1b4f01de7faa>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__,
-   `#7933 <https://pagure.io/freeipa/issue/7933>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__,
+   `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__
 -  Add altSecurityIdentities attribute from MS-WSPP schema definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a83eea20bdd0c1c6302eada774ef3d8cfa04e36>`__
-   `#7932 <https://pagure.io/freeipa/issue/7932>`__,
-   `#7933 <https://pagure.io/freeipa/issue/7933>`__
+   `#7932 <https://codeberg.org/freeipa/freeipa/issues/7932>`__,
+   `#7933 <https://codeberg.org/freeipa/freeipa/issues/7933>`__
 -  Use stage and phase attempt counters when saving test artifacts
    `commit <https://codeberg.org/freeipa/freeipa/commit/0187a746c9197d5447e08ce2be49e3e021aae49b>`__
 -  Use any nodejs version instead of forcing a version before nodejs 11
@@ -1863,10 +1863,10 @@ Alexandre Mulatinho (2)
 
 -  ipa-join: allowing call with jsonrpc into freeipa API
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e414d22919822bb6f18b8b03f223de9e08569ef>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-scripts: fix all ipa command line scripts to operate with -I
    `commit <https://codeberg.org/freeipa/freeipa/commit/a38a38435991e81970a4da2cf69382a1f8cc6cf4>`__
-   `#7987 <https://pagure.io/freeipa/issue/7987>`__
+   `#7987 <https://codeberg.org/freeipa/freeipa/issues/7987>`__
 
 
 
@@ -1908,14 +1908,14 @@ Anuja More (18)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfc998eae2c8dab93e8d6f6e2ae26f8f857e0021>`__
 -  Add integration test for otp kerberos ticket policy.
    `commit <https://codeberg.org/freeipa/freeipa/commit/83ec9296a906d10b44c80d6534b94f03b443b2e6>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  ipatests: filter_users should be applied correctly.
    `commit <https://codeberg.org/freeipa/freeipa/commit/0162f3aafd63c07f100ee8146a39dab05acbae7d>`__
 -  ipatests : Login via ssh using private-key for ipa-user should work.
    `commit <https://codeberg.org/freeipa/freeipa/commit/836b90f65244a0407e74627b550297d0962d882e>`__
 -  Extdom plugin should not return error (32)/'No such object'
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5e0693aa27c1002c4b57ea33533047fc0aafef8>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -1940,10 +1940,10 @@ Alexander Scheel (3)
 
 -  Specify cert_paths when calling PKIConnection
    `commit <https://codeberg.org/freeipa/freeipa/commit/a087d82e785ac238f47c9a84e2b5abfae7c29cf4>`__
-   `#8379 <https://pagure.io/freeipa/issue/8379>`__
+   `#8379 <https://codeberg.org/freeipa/freeipa/issues/8379>`__
 -  Configure PKI AJP Secret with 256-bit secret
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ecea7800ab7d44f47ef26264dfb8c33aadeca49>`__
-   `#8372 <https://pagure.io/freeipa/issue/8372>`__
+   `#8372 <https://codeberg.org/freeipa/freeipa/issues/8372>`__
 -  Clarify AJP connector creation process
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5e9bd61d6a0a8fc8f06592b9cf14bd576404d51>`__
 
@@ -1954,103 +1954,103 @@ Peter Keresztes Schmidt (33)
 
 -  WebUI: Unify adapter property definition for state evaluators
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d87cd4ae1bf0bd7814fb53bcfb8540e479d842b>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  WebUI: Make object_class_evaluator evaluator compatible with batch
    responses
    `commit <https://codeberg.org/freeipa/freeipa/commit/df5526fbc71e9215456287dac396ca8a4d8082e3>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 -  ipa-backup/restore: remove remaining chdir calls
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf8ef6fd2d275ea50758770c72db7faf4cedf0e3>`__
-   `#7416 <https://pagure.io/freeipa/issue/7416>`__
+   `#7416 <https://codeberg.org/freeipa/freeipa/issues/7416>`__
 -  ipa-join: handle JSON-RPC error codes
    `commit <https://codeberg.org/freeipa/freeipa/commit/6dfefc97459376a2ac4fb079a19b49e70056fd14>`__
-   `#8408 <https://pagure.io/freeipa/issue/8408>`__
+   `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__
 -  ipa-join: extract common JSON-RPC response parsing to common function
    `commit <https://codeberg.org/freeipa/freeipa/commit/4696644f3fc996da2a88d91d29af11a56ecae0c3>`__
-   `#8408 <https://pagure.io/freeipa/issue/8408>`__
+   `#8408 <https://codeberg.org/freeipa/freeipa/issues/8408>`__
 -  ipa-join: Generalize XML-RPC references in man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cc977b993c30add2ba6ec2f823d782cc4d99f7f>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: Use bool type where appropriate
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1b117a28b670c71e60fdd1c0ec0c6ef8f8f438b>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: select {JSON,XML}-RPC at build time
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6940772dd9d5f550e9ce4ff20c779864ad4eb68>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: implement JSON-RPC based unenrollment
    `commit <https://codeberg.org/freeipa/freeipa/commit/62503e4fd0e92aae60da49e6917ac62ea52def96>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: extract unenrollment code common to JSON and XML-RPC to
    separate function
    `commit <https://codeberg.org/freeipa/freeipa/commit/677659c8da27de7b256b7067e513f089892d05b8>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: switch to jansson for json handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/25205f44a10b9e4846121d1a9b05aafa74485292>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: buffer curl response before parsing json
    `commit <https://codeberg.org/freeipa/freeipa/commit/c905f94f9b829faec03a016ebd7a344caf3ca144>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: improve curl error handling in JSON-RPC code
    `commit <https://codeberg.org/freeipa/freeipa/commit/c197918e8d220f10676f42b3589e47599b7a11e5>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  ipa-join: don't set TLS related curl options for JSON-RPC
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e7e4f0e262caef0bae1518a575bb98f69a9d7e1>`__
-   `#7966 <https://pagure.io/freeipa/issue/7966>`__
+   `#7966 <https://codeberg.org/freeipa/freeipa/issues/7966>`__
 -  Populate nshardwareplatform and nsosversion during join operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f640f8672f2bec7b560a2838e2451a190abf6cf>`__
-   `#8370 <https://pagure.io/freeipa/issue/8370>`__
+   `#8370 <https://codeberg.org/freeipa/freeipa/issues/8370>`__
 -  WebUI: Fix rendering of boolean_status_formatter
    `commit <https://codeberg.org/freeipa/freeipa/commit/459bc6bae7a899414b49adc783a0fc5d26093a1d>`__
-   `#8396 <https://pagure.io/freeipa/issue/8396>`__
+   `#8396 <https://codeberg.org/freeipa/freeipa/issues/8396>`__
 -  Unify spelling of "One-Time Password"
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea5c0a1f7c1b2902a74731787710bee40542330f>`__
 -  WebUI: reword OTP info message displayed during PW reset
    `commit <https://codeberg.org/freeipa/freeipa/commit/d63a91da4bb1b20b2cb0601bcb3a640ab8511151>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 -  WebUI: move OTP to be the last field in the PW reset form
    `commit <https://codeberg.org/freeipa/freeipa/commit/13b177822ea8382c9c5986862424f8ff8f08f16f>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__
 -  Split named custom config to allow changes in options stanza
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5cbdb57e50cfc62f61affda19ce878b2abd33de>`__
-   `#8287 <https://pagure.io/freeipa/issue/8287>`__
+   `#8287 <https://codeberg.org/freeipa/freeipa/issues/8287>`__
 -  lite-server: Fix werkzeug deprecation warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/88d1dcc52aaf7a4d63416e6427fe523679b6ec6f>`__
-   `#8360 <https://pagure.io/freeipa/issue/8360>`__
+   `#8360 <https://codeberg.org/freeipa/freeipa/issues/8360>`__
 -  util: replace NSS usage with OpenSSL
    `commit <https://codeberg.org/freeipa/freeipa/commit/68af4f39c19fb52fcf6ed674b883ee30026bdb4b>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  util: add unit test for pw hashing
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2d854886fdaa4d61965c1af6c02060d816a1fbf>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  po: remove zanata config since translation was moved to weblate
    `commit <https://codeberg.org/freeipa/freeipa/commit/894b3f1d0bcaaf432eea4536c7a7c120b3fcd7a2>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  Remove unused support for dm_password arg from ldapupdate.connect
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f232a30116751f38722c65ae607c6e6958c8061>`__
-   `#7610 <https://pagure.io/freeipa/issue/7610>`__
+   `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__
 -  Use ipaldap exceptions rather than ldap error codes in LDAP updater
    `commit <https://codeberg.org/freeipa/freeipa/commit/e66036481477ec8efc27c697e8a0d7adaf8a691d>`__
-   `#7610 <https://pagure.io/freeipa/issue/7610>`__
+   `#7610 <https://codeberg.org/freeipa/freeipa/issues/7610>`__
 -  Specify min and max values for TTL of a DNS record
    `commit <https://codeberg.org/freeipa/freeipa/commit/373f8cdce707e250e88f43cd59aeae3e1b5d9d12>`__
-   `#8358 <https://pagure.io/freeipa/issue/8358>`__
+   `#8358 <https://codeberg.org/freeipa/freeipa/issues/8358>`__
 -  WebUI: Add units to some DNS zone and IPA config fields
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f239aebca25635bf04ba7241511cedbef6d2d65>`__
 -  WebUI: Expose TTL of DNS records
    `commit <https://codeberg.org/freeipa/freeipa/commit/187968d472a0187a170d3ba10996091cfcc2ba5f>`__
-   `#3827 <https://pagure.io/freeipa/issue/3827>`__
+   `#3827 <https://codeberg.org/freeipa/freeipa/issues/3827>`__
 -  WebUI: Refresh DNS record data correctly after mod operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d2cd3a273686bc2c0a9b4d8c066a2bdff23a710>`__
-   `#8359 <https://pagure.io/freeipa/issue/8359>`__
+   `#8359 <https://codeberg.org/freeipa/freeipa/issues/8359>`__
 -  WebUI: Use data adapter to load facet header data
    `commit <https://codeberg.org/freeipa/freeipa/commit/517c7ab2153e701355732bc8d49076653e090a01>`__
-   `#8339 <https://pagure.io/freeipa/issue/8339>`__
+   `#8339 <https://codeberg.org/freeipa/freeipa/issues/8339>`__
 -  WebUI: Fix invalid RPC calls when link widget has no pkey passed
    `commit <https://codeberg.org/freeipa/freeipa/commit/7de1a93ce44d3afe582884a6c9c803b5d4614afb>`__
-   `#8338 <https://pagure.io/freeipa/issue/8338>`__
+   `#8338 <https://codeberg.org/freeipa/freeipa/issues/8338>`__
 -  Remove remains of unused config options
    `commit <https://codeberg.org/freeipa/freeipa/commit/1606174457a3db5f8300fca2230f211d5f72dfa1>`__
-   `#6708 <https://pagure.io/freeipa/issue/6708>`__
+   `#6708 <https://codeberg.org/freeipa/freeipa/issues/6708>`__
 
 
 
@@ -2065,86 +2065,86 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b66b961fdd3d0b7f3c37bd245decf700e720708c>`__
 -  Replace nodename with ipa_gethostfqdn()
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d4ed65b83f6ed8bb7f3da05561698cbea692bb3>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  Unify access to FQDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/e28ec76898a0240e416910b9cfea24e82e7d91ba>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  Reuse main LDAP connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa58071221bfb37159db6d6dc4f3bcfd088d80b1>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Speed up cainstance.migrate_profiles_to_ldap
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9d34c8e66590c6ddb18a227fa0201cacdc7d72d>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__,
-   `#8522 <https://pagure.io/freeipa/issue/8522>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__,
+   `#8522 <https://codeberg.org/freeipa/freeipa/issues/8522>`__
 -  Lookup ipa-ca record with NSS
    `commit <https://codeberg.org/freeipa/freeipa/commit/731c5b211041ee18940082b29e6a21b3f084fc57>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__,
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__,
-   `#8529 <https://pagure.io/freeipa/issue/8529>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__,
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__,
+   `#8529 <https://codeberg.org/freeipa/freeipa/issues/8529>`__
 -  Simplify update code
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3abae825ce09ac7976969f61fb41ab448f1699f>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Don't add 127.0.0.1 to resolv.conf twice
    `commit <https://codeberg.org/freeipa/freeipa/commit/814328ea3c9173c5e89c1b8370f2459fa67ae763>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Require(post) systemd with resolved enabled on F33
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ba5a6a46e8f9e47cad82efa37a4ea79e5428dd6>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Replace sudo with runuser
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ed21bba4d41edea8a84924287c92d048a102d1c>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  Use separate install logs for AD and DNS instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/6860c6376087cf4a3b099444232baf2a6a4d3945>`__
-   `#8528 <https://pagure.io/freeipa/issue/8528>`__
+   `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__
 -  Spawn PKI: Execute more steps early
    `commit <https://codeberg.org/freeipa/freeipa/commit/942fe07eb53dbbacb33352bbb67039abf73b2544>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Dogtag: Remove set_audit_renewal step
    `commit <https://codeberg.org/freeipa/freeipa/commit/8882680ee167c535e7539fe0452892aae617aac3>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Skip offline dse.ldif patching by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/9eccaf62697f5281729c7d0f38265c66a7264e25>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Remove magic sleep from create_index_task
    `commit <https://codeberg.org/freeipa/freeipa/commit/daec8049610ad7bbe0718276d2e7d6ffc1a7f66e>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Remove root-autobind configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/37a0af6a8cc716acd589b6295039af8ae20720fa>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Verify freeipa-selinux's ipa module is loaded
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a9cd30255bc42e2c9ea5d6c4e3cca550f567f99>`__
 -  Check ca_wrapped in ipa-custodia-check
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbb6484dbe31cc8ae4efb9729e3417f001a6637c>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  Retry chronyc waitsync only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3ed5ff29bb389c28feb1d5398e76d4b04926c>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  configure_dns_resolver: call self.restore_context
    `commit <https://codeberg.org/freeipa/freeipa/commit/38d083e344c63287d1080c44ef3841a85a61f1b5>`__
-   `#8518 <https://pagure.io/freeipa/issue/8518>`__
+   `#8518 <https://codeberg.org/freeipa/freeipa/issues/8518>`__
 -  Drop unused extended sleep feature from Sleeper
    `commit <https://codeberg.org/freeipa/freeipa/commit/1921d33d41f5b0e1632f7876a0acbde5462ea8be>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Faster certmonger wait_for_request()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b79191f7107fbc1890631f4c65be48b646798131>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Add helper for poll/sleep loops with timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa67177f4cbea0f51574e890c3a8543ff603d5d2>`__
-   `#8521 <https://pagure.io/freeipa/issue/8521>`__
+   `#8521 <https://codeberg.org/freeipa/freeipa/issues/8521>`__
 -  Add missing fedora_container platform members
    `commit <https://codeberg.org/freeipa/freeipa/commit/1684b0f2c3de8f6dd3d15945c87bfe7e887f966c>`__
-   `#8519 <https://pagure.io/freeipa/issue/8519>`__
+   `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__
 -  Add more indices
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f0ec27e9f13ed40b8e58162d99bf9b0e8b4afd5>`__
 -  Use single update LDIF for indices
    `commit <https://codeberg.org/freeipa/freeipa/commit/e46c3792f3419f807864adc1cb36887fe6c9e36c>`__
-   `#8493 <https://pagure.io/freeipa/issue/8493>`__
+   `#8493 <https://codeberg.org/freeipa/freeipa/issues/8493>`__
 -  Also backup DNS config drop-ins
    `commit <https://codeberg.org/freeipa/freeipa/commit/ced1dcb1d9343a6fd0b021551eaf0b2c1d92a2c9>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Ensure that resolved.conf.d is accessible
    `commit <https://codeberg.org/freeipa/freeipa/commit/34e47778b47748e94792455699b35e8c126c5db7>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Fix compiler warning in ipa-kdb
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c52ef2b64e510dae9cee29eaa05b18859a063b7>`__
 -  Fix compiler warnings in libotp
@@ -2153,30 +2153,30 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fde06ac303ca1acecfc51a4cbbcfe41fc650e08>`__
 -  trust-add: Catch correct exception when chown SSSD
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e30a48d3cde4cab57a711503764bb9dddf2d53b>`__
-   `#8516 <https://pagure.io/freeipa/issue/8516>`__
+   `#8516 <https://codeberg.org/freeipa/freeipa/issues/8516>`__
 -  Fix nsslapd-db-lock tuning of BDB backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ebe41525116639ec512205319197dd278e15e6>`__
-   `#5914 <https://pagure.io/freeipa/issue/5914>`__,
-   `#8515 <https://pagure.io/freeipa/issue/8515>`__
+   `#5914 <https://codeberg.org/freeipa/freeipa/issues/5914>`__,
+   `#8515 <https://codeberg.org/freeipa/freeipa/issues/8515>`__
 -  Create systemd-resolved configuration on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/79b9982b86b68c708275afaaf1927c24db7c2eb1>`__
 -  Configure systemd-resolved to use IPA's BIND
    `commit <https://codeberg.org/freeipa/freeipa/commit/d12f1b4b39ef514c2bcb75b55c3f300767aca64d>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Use new API for auto-forwarders
    `commit <https://codeberg.org/freeipa/freeipa/commit/528c519cb5a30df691f00edba6ef6f3a6ab7df56>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Configure NetworkManager to use systemd-resolved
    `commit <https://codeberg.org/freeipa/freeipa/commit/e64f27fdf8970c22052ec010f3b7bada084c743b>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Add helpers for resolve1 and nameservers
    `commit <https://codeberg.org/freeipa/freeipa/commit/96edff0b8c526763d75dc45d26841dc2cd1a70cf>`__
-   `#8275 <https://pagure.io/freeipa/issue/8275>`__
+   `#8275 <https://codeberg.org/freeipa/freeipa/issues/8275>`__
 -  Make git a build requirement
    `commit <https://codeberg.org/freeipa/freeipa/commit/644bd0e46b405fde889952eecb2e8ab34913bbc3>`__
 -  Delay import of psutil to avoid AVC
    `commit <https://codeberg.org/freeipa/freeipa/commit/80fca8d7010ab8ed2190ef8fb57d882c61e89723>`__
-   `#8512 <https://pagure.io/freeipa/issue/8512>`__
+   `#8512 <https://codeberg.org/freeipa/freeipa/issues/8512>`__
 -  Add User and Group to all ipaplatform.constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc128cae471dae6e070953333d5d76f211aa7688>`__
 -  Use new classes for run_command and Service
@@ -2189,47 +2189,47 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/87cf2a3c789929337abc3ae38192ee64cfd6c9e3>`__
 -  Don't create DS SSCA and self-signed cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c86baf0ade9c9045cc0f3b3c7fb0e7c580e29a4>`__
-   `#8502 <https://pagure.io/freeipa/issue/8502>`__
+   `#8502 <https://codeberg.org/freeipa/freeipa/issues/8502>`__
 -  Duplicate CA CRT: ignore expected cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/b606fa6cca87706730fa20bfa437956194398c82>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Add krbPrincipalName pres index correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/05da1f7f7fcfc3963f6d2764a192fb45e08f480b>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  Only restart DS when duplicate cacrt was found
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a2b6ca6ee4d62e5d69cadd9eca21fb95d243c8d>`__
-   `#7125 <https://pagure.io/freeipa/issue/7125>`__
+   `#7125 <https://codeberg.org/freeipa/freeipa/issues/7125>`__
 -  Treat container subplatforms like main platform
    `commit <https://codeberg.org/freeipa/freeipa/commit/e89b40071356b1c3050accee54f8332531d9bac2>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Don't configure authselect in containers
    `commit <https://codeberg.org/freeipa/freeipa/commit/999485909a0bc654570f05cd2127d86d14d6f25a>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Convert ipa-httpd-pwdreader into Python script
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f6502db03576c92b25f4460fb98d75e0fe68f28>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Explicitly pass keytab to ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/664007e031bec3b1c6f4a9518f427e139b026a1e>`__
 -  Write state dir to smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/64b20aad283c6a0a9557e77993b09679a72efa88>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Add ipaplatform for Fedora and RHEL container
    `commit <https://codeberg.org/freeipa/freeipa/commit/02986ff42b97dceb689abb32cf937da993880ddd>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Allow to override ipaplatform with env var
    `commit <https://codeberg.org/freeipa/freeipa/commit/eec5c9d8206f8ca612677369fdd3fce39205fa32>`__
-   `#8401 <https://pagure.io/freeipa/issue/8401>`__
+   `#8401 <https://codeberg.org/freeipa/freeipa/issues/8401>`__
 -  Teach pylint how dnspython 2.x works
    `commit <https://codeberg.org/freeipa/freeipa/commit/eff65495f38b2e3b3c09d3646a52f13d9495e320>`__
-   `#8419 <https://pagure.io/freeipa/issue/8419>`__
+   `#8419 <https://codeberg.org/freeipa/freeipa/issues/8419>`__
 -  Add missing SELinux rule for ipa-custodia.sock
    `commit <https://codeberg.org/freeipa/freeipa/commit/69da03b4ca16ca42fe6828d7e2e4b525f8f1087e>`__
-   `#8412 <https://pagure.io/freeipa/issue/8412>`__
+   `#8412 <https://codeberg.org/freeipa/freeipa/issues/8412>`__
 -  Make tab completion in console more useful
    `commit <https://codeberg.org/freeipa/freeipa/commit/80794f6b5e263566a1da9685aba82762208a6219>`__
 -  Add \__signature_\_ to plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/069f41a01e65f07367000c6d9605167242a88736>`__
-   `#8388 <https://pagure.io/freeipa/issue/8388>`__
+   `#8388 <https://codeberg.org/freeipa/freeipa/issues/8388>`__
 -  Run test_fips in DS and PKI nightly
    `commit <https://codeberg.org/freeipa/freeipa/commit/a90eefafc98e1bf5a379440695d58f00a9a70e45>`__
 -  SELinux: Backport dirsrv_systemctl interface
@@ -2246,15 +2246,15 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/523f70ae46127161556a0881fc9a01e138a90666>`__
 -  Use old uglifyjs on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e3346f0a7d820cb3643044884657fa60a80f918>`__
-   `#8300 <https://pagure.io/freeipa/issue/8300>`__
+   `#8300 <https://codeberg.org/freeipa/freeipa/issues/8300>`__
 -  Build ipa-selinux package on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a3b5f3affe16efcbf93af5c1bfd95a0c7999e5b>`__
 -  Prevent local account takeover
    `commit <https://codeberg.org/freeipa/freeipa/commit/4911a3f05514a7c0ac66e4ef5004581cced8519f>`__
-   `#8326 <https://pagure.io/freeipa/issue/8326>`__
+   `#8326 <https://codeberg.org/freeipa/freeipa/issues/8326>`__
 -  Move ipa-epn systemd files and run RPM hooks
    `commit <https://codeberg.org/freeipa/freeipa/commit/a18d406b5631f80134e202ae3310580683937f92>`__
-   `#8367 <https://pagure.io/freeipa/issue/8367>`__
+   `#8367 <https://codeberg.org/freeipa/freeipa/issues/8367>`__
 -  Auto-generated ipa-epn files to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc8448341199176166f8ee548d0fbb44d32d21b7>`__
 -  Overhaul bind upgrade process
@@ -2267,96 +2267,96 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cddd07f68a28f1b1c21103e9edd6e31a6e4c3716>`__
 -  Fix named.conf update bug NAMED_DNSSEC_VALIDATION
    `commit <https://codeberg.org/freeipa/freeipa/commit/379b560c75bbd5ba9d73a65b5ddfcf086dab3c48>`__
-   `#8363 <https://pagure.io/freeipa/issue/8363>`__
+   `#8363 <https://codeberg.org/freeipa/freeipa/issues/8363>`__
 -  libotp: Replace NSS with OpenSSL HMAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/be47ec9799ef7708f181d1b20fc238f23539a9b0>`__
-   `#6857 <https://pagure.io/freeipa/issue/6857>`__
+   `#6857 <https://codeberg.org/freeipa/freeipa/issues/6857>`__
 -  Include named config files in backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e5d40e2d2a53e44270fb18a7be3b0d7e346f46d>`__
 -  Handle DatabaseError in RPC-Server connect()
    `commit <https://codeberg.org/freeipa/freeipa/commit/d79a7a9696ff634141bdff3423157d08513da310>`__
-   `#8352 <https://pagure.io/freeipa/issue/8352>`__
+   `#8352 <https://codeberg.org/freeipa/freeipa/issues/8352>`__
 -  Allow permissions with 'self' bindruletype
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dda004f270f321685597be276ca51e6b32fcd59>`__
-   `#8348 <https://pagure.io/freeipa/issue/8348>`__
+   `#8348 <https://codeberg.org/freeipa/freeipa/issues/8348>`__
 -  make: serialize strip-po / strip-pot
    `commit <https://codeberg.org/freeipa/freeipa/commit/d20cda218960960fa4d1ab790f31edd4cac49ccc>`__
-   `#8323 <https://pagure.io/freeipa/issue/8323>`__
+   `#8323 <https://codeberg.org/freeipa/freeipa/issues/8323>`__
 -  Remove obsolete BIND named.conf options
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5964b71572579acad9d1731b62eb3c088358c6f>`__
-   `#8349 <https://pagure.io/freeipa/issue/8349>`__,
-   `#8350 <https://pagure.io/freeipa/issue/8350>`__
+   `#8349 <https://codeberg.org/freeipa/freeipa/issues/8349>`__,
+   `#8350 <https://codeberg.org/freeipa/freeipa/issues/8350>`__
 -  Add ipa-print-pac to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1c6ee7d41e3512ac4aa7bf5e85634475aa9c22e>`__
 -  Allow dnsrecord-add --force on clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad8e0af0770caf039ff6c431a3182238c1952f8f>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Explain the effect of OPT_X_TLS_PROTOCOL_MIN
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3e117156436bbf715232bea730a9172c14a8c1f>`__
 -  Check for freeipa-server-dns package early
    `commit <https://codeberg.org/freeipa/freeipa/commit/8de73c1590de048eb6cfc3c56acfe737ca78b8a9>`__
-   `#7577 <https://pagure.io/freeipa/issue/7577>`__
+   `#7577 <https://codeberg.org/freeipa/freeipa/issues/7577>`__
 -  Hard-code in_tree=True for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa31ef123a544378f04a2177524c9f72181a812>`__
-   `#8317 <https://pagure.io/freeipa/issue/8317>`__
+   `#8317 <https://codeberg.org/freeipa/freeipa/issues/8317>`__
 -  Fix detection logic for api.env.in_tree
    `commit <https://codeberg.org/freeipa/freeipa/commit/13c3997baa97b7974870cb2353caa4ced8f134d1>`__
-   `#8312 <https://pagure.io/freeipa/issue/8312>`__
+   `#8312 <https://codeberg.org/freeipa/freeipa/issues/8312>`__
 -  Make api.env.mode consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/82ba4db11eaf8cb6ff3f2c4d2d228c14493a704c>`__
-   `#8313 <https://pagure.io/freeipa/issue/8313>`__
+   `#8313 <https://codeberg.org/freeipa/freeipa/issues/8313>`__
 -  Disable password schema update on LDAP bind
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa341020c883b3d8e6117f6f515f5ed0e19c04e7>`__
-   `#8315 <https://pagure.io/freeipa/issue/8315>`__
+   `#8315 <https://codeberg.org/freeipa/freeipa/issues/8315>`__
 -  Use httpd 2.4 syntax for access control
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bfe5ff689163ab1b9763c86c2b0355a07b2c33c>`__
 -  Let GH auto-notify and auto-close stale PRs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf64295753e09df3e320a8a95c36db91f8bfa7b2>`__
 -  Fix make devcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5c52bfe3f9a1e1b0d2043d3e7f7fe5aa18d9fb6>`__
-   `#8307 <https://pagure.io/freeipa/issue/8307>`__
+   `#8307 <https://codeberg.org/freeipa/freeipa/issues/8307>`__
 -  Simplify pki proxy conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/19ea1b97a1559609014e0784c6f973c0e073878a>`__
 -  Make check_required_principal() case-insensitive
    `commit <https://codeberg.org/freeipa/freeipa/commit/fefd1153d5e7bed9627a3b89de8d6a86f7a0bdfb>`__
-   `#8308 <https://pagure.io/freeipa/issue/8308>`__
+   `#8308 <https://codeberg.org/freeipa/freeipa/issues/8308>`__
 -  Make ipaplatform a regular top-level package
    `commit <https://codeberg.org/freeipa/freeipa/commit/490682ac3cab8978635655bdcc880f28227e900b>`__
-   `#6474 <https://pagure.io/freeipa/issue/6474>`__,
-   `#8309 <https://pagure.io/freeipa/issue/8309>`__
+   `#6474 <https://codeberg.org/freeipa/freeipa/issues/6474>`__,
+   `#8309 <https://codeberg.org/freeipa/freeipa/issues/8309>`__
 -  Reconfigure pycodestyle
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6be661244f0fa7ee74afa1587e39a3f8e04ac6a>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Manually reformat ipapython/version.py.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/6386c0cbdd990b065066818a41e91fa9504af1ad>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Silence W601 .has_key() is deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/c544d18f1a80808ab8c087db751b2074d23f06ce>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E722 do not use bare 'except'
    `commit <https://codeberg.org/freeipa/freeipa/commit/186d739d7f54989e9ed6ea08371825b29f21b811>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E721 do not compare types, use 'isinstance()'
    `commit <https://codeberg.org/freeipa/freeipa/commit/31fa527e1b2fc626d941081ae1764b0bb4d20612>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E714 test for object identity should be 'is not'
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c9bba8e1ad1def3745497de24b14786148a64af>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E713 test for membership should be 'not in'
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0818e1809a6520f42fd945cae1a69949a7e948f>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E712 comparison to True / False
    `commit <https://codeberg.org/freeipa/freeipa/commit/690b5519f86545ef6705c53c16c1f3474cb0d656>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E711 comparison to None
    `commit <https://codeberg.org/freeipa/freeipa/commit/9661807385d8ecf1a5ee9aa446d4ad7644a54ec0>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Fix E266 too many leading '#' for block comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/86d76efcef3ca1336a686795c5aa27e813d8e89a>`__
-   `#8306 <https://pagure.io/freeipa/issue/8306>`__
+   `#8306 <https://codeberg.org/freeipa/freeipa/issues/8306>`__
 -  Address issues found by new pylint 2.5.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/9941c9ee955ea52a48d9dc4d991c2292a839ae52>`__
-   `#8297 <https://pagure.io/freeipa/issue/8297>`__
+   `#8297 <https://codeberg.org/freeipa/freeipa/issues/8297>`__
 -  Require Sphinx >2.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7415c3ddcdbd826bc25761d78840c4417381571>`__
 -  Fix /doc/workshop subtree merge
@@ -2367,31 +2367,31 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2608cfe8ae48f287cede5e04972f910601f3a6d>`__
 -  Define default password policy for sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca6d6781c741fe5aedc68f8de592b9806ebe21d7>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Use api.env.container_sysaccounts
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb24641e8ffdc1083565b9de9496606cd458cf8d>`__
-   `#8276 <https://pagure.io/freeipa/issue/8276>`__
+   `#8276 <https://codeberg.org/freeipa/freeipa/issues/8276>`__
 -  Fix exception escape warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/24cc13db898e07523227d04af9a15ea90eeacc3c>`__
 -  Fix APIVersion.__getnewargs_\_
    `commit <https://codeberg.org/freeipa/freeipa/commit/49f909c9d3abb08a9f6492fbdfeb33534889e37f>`__
 -  servrole: takes_params must be a tuple
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6476f591b0c2a2aa3dec280e3e4025d3ae4cfb2>`__
-   `#8290 <https://pagure.io/freeipa/issue/8290>`__
+   `#8290 <https://codeberg.org/freeipa/freeipa/issues/8290>`__
 -  Improve Sphinx building and linting
    `commit <https://codeberg.org/freeipa/freeipa/commit/1717b5b08fa9e937f4b902f76be18df27ffc3238>`__
 -  Fix various OpenDNSSEC 2.1 issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/e881e35783bb250bbdbc575cee4df2af6bc2eb88>`__
-   `#8283 <https://pagure.io/freeipa/issue/8283>`__
+   `#8283 <https://codeberg.org/freeipa/freeipa/issues/8283>`__
 -  Use /run and /run/lock instead of /var
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdf11371693936e4ff6cc4d0e245b19493df564c>`__
-   `#8272 <https://pagure.io/freeipa/issue/8272>`__
+   `#8272 <https://codeberg.org/freeipa/freeipa/issues/8272>`__
 -  po: fix LINGUAS to use whitespace separation
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac5cb4260320a4509c840f679633eb36a79f6f99>`__
-   `#8159 <https://pagure.io/freeipa/issue/8159>`__
+   `#8159 <https://codeberg.org/freeipa/freeipa/issues/8159>`__
 -  SELinux: apache_manage_pid_files for F30
    `commit <https://codeberg.org/freeipa/freeipa/commit/e913fdc8aa545df606168ae3d7ed3006fce44cee>`__
-   `#8241 <https://pagure.io/freeipa/issue/8241>`__
+   `#8241 <https://codeberg.org/freeipa/freeipa/issues/8241>`__
 -  Add pytest OpenSSH transport with password
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8602b158680a92903b930a9d9a25e9c2c458685>`__
 -  Add explicit syntax language to code blocks
@@ -2412,21 +2412,21 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/080a5831ea0683a38e4d470d3d04dcf1e70eaf00>`__
 -  Move freeipa-selinux dependency to freeipa-common
    `commit <https://codeberg.org/freeipa/freeipa/commit/d23322434f71c02505b4b85e85e184d274eaeb2d>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate ipa_custodia policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a55a722237b2d32c55eddddfb9c753c06e1eb5ee>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Allow hosts to read DNS records for IP SAN
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a9ac1f58694b28c96b8bdb22eaf506f7019ac65>`__
-   `#8098 <https://pagure.io/freeipa/issue/8098>`__
+   `#8098 <https://codeberg.org/freeipa/freeipa/issues/8098>`__
 -  Cleanup SELinux policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/b88562b2c866eef0b75e1aca9b32d55fbc2b3a8d>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  Integrate SELinux policy into build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/9288901f9be4f71894a0ee69f3996b680ba3dca0>`__
 -  dnsrecord: Treat empty list arguments correctly
    `commit <https://codeberg.org/freeipa/freeipa/commit/856fdbc183b31ea7432749ff3acb3ff5b73937e6>`__
-   `#8196 <https://pagure.io/freeipa/issue/8196>`__
+   `#8196 <https://codeberg.org/freeipa/freeipa/issues/8196>`__
 -  Remove dependency on custodia package
    `commit <https://codeberg.org/freeipa/freeipa/commit/209e0ac8a6a70dda2f3db7108991187683f0db73>`__
 -  lite-setup: configure lite-server test env
@@ -2435,112 +2435,112 @@ Christian Heimes (181)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a55e82d916b38472bd38032946ea9b249a765f2>`__
 -  Make assert_error compatible with Python 3.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/10b62ad6bc967e022202d657b7493440fb5cf736>`__
-   `#8179 <https://pagure.io/freeipa/issue/8179>`__
+   `#8179 <https://codeberg.org/freeipa/freeipa/issues/8179>`__
 -  Print LDAP diagnostic messages on error
    `commit <https://codeberg.org/freeipa/freeipa/commit/e107b8e4fe1f205cc1bf992aae2e46a7ab02ebb6>`__
 -  Fix get_trusted_domain_object_from_sid()
    `commit <https://codeberg.org/freeipa/freeipa/commit/c30a0c22681ec4a5d6cdf341a69d144f6ab3a0a8>`__
-   `#7958 <https://pagure.io/freeipa/issue/7958>`__
+   `#7958 <https://codeberg.org/freeipa/freeipa/issues/7958>`__
 -  Check valid before/after of external certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/d30dd52920a06ded11b9dfe136108343bb2896a3>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix service ldap_disable()
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cae7f4ee6fbfed99930a87e78d7e37bdb740e43>`__
-   `#8143 <https://pagure.io/freeipa/issue/8143>`__
+   `#8143 <https://codeberg.org/freeipa/freeipa/issues/8143>`__
 -  Require idstart to be larger than UID_MAX
    `commit <https://codeberg.org/freeipa/freeipa/commit/44b3791bc3a14ede0708538347954871df6496fa>`__
-   `#8137 <https://pagure.io/freeipa/issue/8137>`__
+   `#8137 <https://codeberg.org/freeipa/freeipa/issues/8137>`__
 -  Fix lite-server to work with GSS_NAME
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbfb011da7d79b1eb4ace7d8cb45aa8a86f3eaba>`__
 -  Fix logic of check_client_configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf9f9bb326a2efae2e459a15be5d17878cb40da0>`__
-   `#8133 <https://pagure.io/freeipa/issue/8133>`__
+   `#8133 <https://codeberg.org/freeipa/freeipa/issues/8133>`__
 -  Optimize user-add by caching ldap2.has_upg()
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcb33e44e7f3125347341f6003bf1fff6055b433>`__
-   `#8134 <https://pagure.io/freeipa/issue/8134>`__
+   `#8134 <https://codeberg.org/freeipa/freeipa/issues/8134>`__
 -  Don't run test_smb in gating tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/28929897ab3a9132b56ec6f70470032e7bff7d00>`__
 -  Don't hard-code client's TLS versions and ciphers
    `commit <https://codeberg.org/freeipa/freeipa/commit/639bb71940daddd15efb3b4fa922d185235c0b33>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Update Apache HTTPd for RHBZ#1775146
    `commit <https://codeberg.org/freeipa/freeipa/commit/0198eca7959d86a080ea5e465fa0021ceceeddcc>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Enable TLS 1.3 support on the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/0451db9d3f6342038ba421c767ca002c83f6c1b2>`__
-   `#8125 <https://pagure.io/freeipa/issue/8125>`__
+   `#8125 <https://codeberg.org/freeipa/freeipa/issues/8125>`__
 -  Skip paramiko tests in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a17a916728cef30f8f245ed77cc9e849b227fc8>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  FIPS: server key has different name in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/d153957990b7456d53af5903a0e62b2716f61183>`__
 -  Remove FIPS noise from SSHd
    `commit <https://codeberg.org/freeipa/freeipa/commit/20ef79c02cf321f3d35c0408b9bf5887c04b11fe>`__
 -  Fix otptoken_sync plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8b98555fcbdc76c2e728d0c93cbbabeebad9a26>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Add test case for OTP login
    `commit <https://codeberg.org/freeipa/freeipa/commit/095d3f9bc94e5d43f5ebb89b88ee87b330af5c1d>`__
-   `#7804 <https://pagure.io/freeipa/issue/7804>`__
+   `#7804 <https://codeberg.org/freeipa/freeipa/issues/7804>`__
 -  Show group-add/remove-member-manager failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/b216701d9a0fcc08479b0976ba332a6a7a50171b>`__
-   `#8122 <https://pagure.io/freeipa/issue/8122>`__
+   `#8122 <https://codeberg.org/freeipa/freeipa/issues/8122>`__
 -  Test installation with (fake) userspace FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/8124b1bd4cc3857c8ab4ee8cd5330b5315a23787>`__
-   `#8118 <https://pagure.io/freeipa/issue/8118>`__
+   `#8118 <https://codeberg.org/freeipa/freeipa/issues/8118>`__
 -  Use default ssh host key algorithms
    `commit <https://codeberg.org/freeipa/freeipa/commit/97a31e69e8399933d45006c744ddafcf036eca5f>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 -  Add tests for member management
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f4c41ab2609171029e0a4334585688fc7c054f2>`__
 -  Add group membership management
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0a1f084b64bd0ca570999594f8e25d4e8808938>`__
-   `#8114 <https://pagure.io/freeipa/issue/8114>`__
+   `#8114 <https://codeberg.org/freeipa/freeipa/issues/8114>`__
 -  Skip commented lines after substitution
    `commit <https://codeberg.org/freeipa/freeipa/commit/560acf37482fe5c7df1abd2d087e33a18b1cbe38>`__
-   `#8111 <https://pagure.io/freeipa/issue/8111>`__
+   `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
 -  Block camellia in krbenctypes update in FIPS
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc56642bf9e59821322903e7470be6ec1d857034>`__
-   `#8111 <https://pagure.io/freeipa/issue/8111>`__
+   `#8111 <https://codeberg.org/freeipa/freeipa/issues/8111>`__
 -  Don't install a preexec_fn by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b8c81a5bc194ffac7ea713930d6b922d10285d4>`__
 -  Don't create log files from help scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/90f72324549f2bceba3e051efb2a1b43c467ff8a>`__
-   `#8075 <https://pagure.io/freeipa/issue/8075>`__
+   `#8075 <https://codeberg.org/freeipa/freeipa/issues/8075>`__
 -  Add new env vars to pylint plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d7eb0a972b3031d7f28f71b1a768395a8127853>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  Fix wrong use of identity operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fc4b8c25cb4f1ee49cbf9b47610168b24a9ee56>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  Enable literal-comparison linter again
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d2125f654268fa2b80c86af3b51b63fa02f6a69>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  Replace %{_libdir} macro in BuildRequires
    `commit <https://codeberg.org/freeipa/freeipa/commit/51836c0594d9f97ace8392c03d47aae883b87724>`__
-   `#8056 <https://pagure.io/freeipa/issue/8056>`__
+   `#8056 <https://codeberg.org/freeipa/freeipa/issues/8056>`__
 -  Fix ca_initialize_hsm_state
    `commit <https://codeberg.org/freeipa/freeipa/commit/bebe09f3e4ddcc1332395aaa6b662fa4580d8304>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
 -  Store HSM token and state
    `commit <https://codeberg.org/freeipa/freeipa/commit/076d955b9373ad8603f3885ea6841d367f866327>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__
 -  Allow insecure binds for migration
    `commit <https://codeberg.org/freeipa/freeipa/commit/a36556e1064900af7a75ca6f07aba66212cf321a>`__
-   `#8040 <https://pagure.io/freeipa/issue/8040>`__
+   `#8040 <https://codeberg.org/freeipa/freeipa/issues/8040>`__
 -  Don't move keys when key backup is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/17c2e31fdc77183b49edc728cc775c4078bf782e>`__
-   `#7677 <https://pagure.io/freeipa/issue/7677>`__
+   `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__
 -  Update comments to explain caSubsystemCert switch
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c82585e52c9cdcf6317bbc029935f8e339bffc6>`__
 -  Test external CA with DNS name constraints
    `commit <https://codeberg.org/freeipa/freeipa/commit/69138c848d605ddcb997c8d3f6d51ebdc561c8a6>`__
 -  Add PKCS#11 module name to p11helper errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/94b4af55b0b4f376e687fae777c51678b99816f3>`__
-   `#8015 <https://pagure.io/freeipa/issue/8015>`__
+   `#8015 <https://codeberg.org/freeipa/freeipa/issues/8015>`__
 -  Use nis-domainname.service on all RH platforms
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2c929270c6184022b58799b61bb640cdcdf10a8>`__
-   `#8004 <https://pagure.io/freeipa/issue/8004>`__
+   `#8004 <https://codeberg.org/freeipa/freeipa/issues/8004>`__
 
 
 
@@ -2551,7 +2551,7 @@ Cédric Jeanneret (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae256fa52440da70c9c0943601a2d62caf5bb292>`__
 -  Prevents DNS Amplification Attack and allow to customize named
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c2710446718828e6840ac34ea6fc704ae6790db>`__
-   `#8079 <https://pagure.io/freeipa/issue/8079>`__
+   `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
 -  Add new tip for dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf7006376d2c40f17786e1f5813755a9b5bc60b2>`__
 
@@ -2562,19 +2562,19 @@ Changmin Teng (5)
 
 -  Add design document
    `commit <https://codeberg.org/freeipa/freeipa/commit/952dd2a50fe3c3dc099b14af23cd050048235fa3>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Modify webUI to adhere to new IPA server API
    `commit <https://codeberg.org/freeipa/freeipa/commit/b66e8a1ee295e11e286979a0bd9ce303cbab2aa5>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Implement user pre-authentication control with kdcpolicy plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/15ff9c8fecdff5556e27b7c9eebd45d327044bc0>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Extend the list of supported pre-auth mechanisms in IPA server API
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0570404ef5a79dfc08d7959d21e9e4843973faf>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Add new authentication indicators in kdc.conf.template
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c0a35f1e79033585786c2567aedcb3b4c10a6b6>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 
 
 
@@ -2615,148 +2615,148 @@ François Cami (93)
 
 -  ipatests: run freeipa-healthcheck on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/5de67028d07b998da0adf5d13ac70bef7c03e7a7>`__
-   `#8536 <https://pagure.io/freeipa/issue/8536>`__
+   `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__
 -  ipatests: tasks: add user_del
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bbb997150fedf8ac5d8ef106414a0ffcf9e921b>`__
-   `#8536 <https://pagure.io/freeipa/issue/8536>`__
+   `#8536 <https://codeberg.org/freeipa/freeipa/issues/8536>`__
 -  ipatests: kinit_as_user improvements
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d95794edfc41ffc61bd2eb38621837dbdb01e85>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: create_active_user improvements
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0586f33a60a44e340889ec5adea0800bde21592>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: add get_kdcinfo
    `commit <https://codeberg.org/freeipa/freeipa/commit/884e0d36e9f655d0456229d0e259592e65714660>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  ipatests: add check_if_sssd_is_online
    `commit <https://codeberg.org/freeipa/freeipa/commit/a63eeaaec6dfa939faa2958354aa41da46a07cee>`__
-   `#8510 <https://pagure.io/freeipa/issue/8510>`__
+   `#8510 <https://codeberg.org/freeipa/freeipa/issues/8510>`__
 -  SELinux: do not double-define node_t and pki_tomcat_cert_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/36c6a2e7493f8135b0adaaf1c056486a9d576c84>`__
-   `#8513 <https://pagure.io/freeipa/issue/8513>`__
+   `#8513 <https://codeberg.org/freeipa/freeipa/issues/8513>`__
 -  SELinux Policy: Allow tomcat_t to read kerberos keytabs
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f2bce43108db5f1fa651a63eea38b33242495cf>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: make interfaces for kernel modules non-optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/f774642b6384c5e2da644c1c812d8dd48946dacc>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: flag ipa_pki_retrieve_key_exec_t as domain_type
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b3c4b84d4ca80019d27a7643fcb1a03bb208072>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_custodia_pki_tomcat_exec_t =>
    ipa_custodia_pki_tomcat_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/09816f4dbcb00e6c58754c2d74a6d8072e2871c3>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: ipa_pki_retrieve_key_exec_t => ipa_pki_retrieve_key_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/820beca4ac2aaa00a713e0bf5e50ecf79fe89dfc>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux Policy: let custodia_t map custodia_tmp_t
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea9db4a9032b768486b0a93e4222a087053f87bb>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  SELinux: Add dedicated policy for ipa-pki-retrieve-key
    `commit <https://codeberg.org/freeipa/freeipa/commit/7823da0630379d642f4a19b3ae0c063963041a82>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  ipatests: enhance TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfeea1644a35307d95a62fd47a71e9c97f20e066>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  dogtaginstance.py: add --debug to pkispawn
    `commit <https://codeberg.org/freeipa/freeipa/commit/be7bf98b3b8cb1db9d4baa5548991ac72049ade8>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  ipatests: check that pkispawn log is not empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/c31bf3d430763ef5b0ef28510995af48dccde287>`__
-   `#8503 <https://pagure.io/freeipa/issue/8503>`__
+   `#8503 <https://codeberg.org/freeipa/freeipa/issues/8503>`__
 -  SELinux Policy: let custodia replicate keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/68328299c881df497dab32b145157d6e0e42d6c6>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  ipatests: test_epn: update error messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/5452f020f93d57a48c4ae34675cc7e480b66fccf>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  IPA-EPN: enhance input validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/97006786dfed7947aaa96737201ef7e0e53dd952>`__
-   `#8444 <https://pagure.io/freeipa/issue/8444>`__
+   `#8444 <https://codeberg.org/freeipa/freeipa/issues/8444>`__
 -  IPA-EPN: Fix SMTP connection error handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/22cf65b09a56d94857aa8253ae2b79c34f82b0b8>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  ipatests: test_epn: add test_EPN_connection_refused
    `commit <https://codeberg.org/freeipa/freeipa/commit/6edf648d7bb368b1703bd2796d4cb090db64577a>`__
-   `#8445 <https://pagure.io/freeipa/issue/8445>`__
+   `#8445 <https://codeberg.org/freeipa/freeipa/issues/8445>`__
 -  IPA-EPN: fix configuration file typo
    `commit <https://codeberg.org/freeipa/freeipa/commit/3bd03ea9d16bbaf66f84e08dffc5c165897bce41>`__
 -  IPA-EPN: Use a helper to retrieve LDAP attributes from an entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/5fc526b1af9c14cf2809986c0d74d1a2343767b5>`__
 -  ipatests: test_epn: test_EPN_nbdays enhancements
    `commit <https://codeberg.org/freeipa/freeipa/commit/41333b631d3ffa8d32d5bd5c2b69f2f51bb62c21>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: tasks.py: fix ipa-epn invocation
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1750e2a18ed0e537608cfdee7eed3ffa090d443>`__
-   `#8449 <https://pagure.io/freeipa/issue/8449>`__
+   `#8449 <https://codeberg.org/freeipa/freeipa/issues/8449>`__
 -  ipatests: test_otp: convert test_2fa_enable_single_prompt to
    run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/763d3b059bccc37744764985b57d97554a2a6947>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: ui_driver: convert run_cmd_on_ui_host to
    tasks.py::run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f055787ac389e4164f3de5369bade1d4b218b0>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_login_wrong_password: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/326e13347c89f2a3287209e95e2b7cd00aa3d80c>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/112386f76a4e3bfec9962013ac8ebaadf950ff6f>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_from_controller: refactor
    `commit <https://codeberg.org/freeipa/freeipa/commit/27ed8260ba6307fdc22beb10d6f25d13b336ded8>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_user_permissions: test_selinux_user_optimized
    Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7a2b703b1514112da1d93ee2e3edf24cfb1f7>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_commands: test_ssh_key_connection: Paramiko=>OpenSSH
    `commit <https://codeberg.org/freeipa/freeipa/commit/73ae4c77f38a7453fa166a01a683c6cd638f2746>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  tasks: add run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5148c65412d92a7d586cefec66cbabb099fc22f>`__
-   `#8129 <https://pagure.io/freeipa/issue/8129>`__
+   `#8129 <https://codeberg.org/freeipa/freeipa/issues/8129>`__
 -  ipatests: test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/178d80969c52fbd0c6de28729d9c5281e9ca2578>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: re-enable test_sss_ssh_authorizedkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7ed159769de26b24a0df86786eecdd07fe5e224>`__
-   `#8151 <https://pagure.io/freeipa/issue/8151>`__
+   `#8151 <https://codeberg.org/freeipa/freeipa/issues/8151>`__
 -  ipatests: test_commands: test_login_wrong_password: look farther in
    time
    `commit <https://codeberg.org/freeipa/freeipa/commit/3546fef0bbefba59c754f2fb18f4eeac2c3437ce>`__
-   `#8432 <https://pagure.io/freeipa/issue/8432>`__
+   `#8432 <https://codeberg.org/freeipa/freeipa/issues/8432>`__
 -  ipatests: xfail TestIpaClientAutomountFileRestore's final test
    `commit <https://codeberg.org/freeipa/freeipa/commit/27e9988fe2de33e9b833e59614dd151e83ff0336>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove dnf workaround from test_epn.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/630c408f9e236fc4f9ad0fc7195813a3770f8ff3>`__
-   `#8391 <https://pagure.io/freeipa/issue/8391>`__
+   `#8391 <https://codeberg.org/freeipa/freeipa/issues/8391>`__
 -  ipatests: display SSSD kdcinfo in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/0df4e8813d573f3e6ad1d084823764cf40a4b5c9>`__
 -  ipatests: ipa_epn: uninstall/reinstall ipa-client-epn
    `commit <https://codeberg.org/freeipa/freeipa/commit/73c02f635de8d28ca2c2481035ceb8fa06e500f3>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  ipatests: check that EPN's configuration file is installed.
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d4f022b3bff73bcadeb3f260afc4b8162a23af4>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  man pages: fix epn.conf.5 and ipa-epn.1 formatting
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d7aeaebb2875a367fe274061f54b5fede44f522>`__
 -  EPN: ship the configuration file.
    `commit <https://codeberg.org/freeipa/freeipa/commit/6efe9917970f81a400793d4339d6826d8350ec55>`__
-   `#8374 <https://pagure.io/freeipa/issue/8374>`__
+   `#8374 <https://codeberg.org/freeipa/freeipa/issues/8374>`__
 -  ipatests: increase test_caless_TestReplicaInstall timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5e6fe057caf81caa0f95ad7a9cded604b9eaf32>`__
-   `#8377 <https://pagure.io/freeipa/issue/8377>`__
+   `#8377 <https://codeberg.org/freeipa/freeipa/issues/8377>`__
 -  .mailmap: add fcami
    `commit <https://codeberg.org/freeipa/freeipa/commit/533ec75494127694692a46503e031df51a83f0c2>`__
 -  IPA-EPN: Test suite.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3805eff4178285f0189c355d17594b5e09dce9b0>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: First version.
    `commit <https://codeberg.org/freeipa/freeipa/commit/b8886c3e97b88739ea1d2471d692a5582234fcb9>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  ipatests: add KRB5_TRACE to kinit in test_adtrust_install.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f8c560ffd37ea7c23a609fb0b3713a133d9f15f>`__
 -  tasks.py: add krb5_trace to create_active_user and kinit_as_user
@@ -2765,117 +2765,117 @@ François Cami (93)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1632827caf4fe34419ed0f14f35d5959e013aadd>`__
 -  IPA-EPN: Add design draft
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d2272f9667d35ef88f04153c49e0621c5d56d66>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  doc/Makefile: use sphinx-build -W by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/7558e1413dca240a77893352b5bb62bd21103b46>`__
 -  Makefile.am: add doclint to fastcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/51d15176a4434b9c47aa2b99476f3137a361d30c>`__
 -  ipatests: increase test_webui_server timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/306adf6b5112a61d4e5b60b027de59bc24c13b55>`__
-   `#8266 <https://pagure.io/freeipa/issue/8266>`__
+   `#8266 <https://codeberg.org/freeipa/freeipa/issues/8266>`__
 -  ipatests: increase test_ipahealthcheck timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a793b7da507d694aeab09e5d3a6d7ddd728acbc>`__
-   `#8262 <https://pagure.io/freeipa/issue/8262>`__
+   `#8262 <https://codeberg.org/freeipa/freeipa/issues/8262>`__
 -  ipatests: move ipa_backup to tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/a087fd9255ed5d16b6a84a7b84f0507dad5b200e>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  pr-ci templates: update test_fips timeouts
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fb0d2f11799ed9533011c2a273fdf53e73f914c>`__
-   `#8247 <https://pagure.io/freeipa/issue/8247>`__
+   `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__
 -  ipa-backup: Make sure all roles are installed on the current master.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3665ba928b25c017465588bd505e93d15d72290f>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  test_backup_and_restore: add server role verification steps
    `commit <https://codeberg.org/freeipa/freeipa/commit/9324bba6b7db4152ff85017d59000fc204ce2c90>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  ipatests: test ipa-backup with different role configurations.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a9b66b5302903f4abe75c3ee93b457f5c1dc405>`__
-   `#8217 <https://pagure.io/freeipa/issue/8217>`__
+   `#8217 <https://codeberg.org/freeipa/freeipa/issues/8217>`__
 -  pr-ci templates: update test_fips timeouts
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee80d0dbfbaeaf0fea8fc9a5a5aa5d0500721f4f>`__
-   `#8247 <https://pagure.io/freeipa/issue/8247>`__
+   `#8247 <https://codeberg.org/freeipa/freeipa/issues/8247>`__
 -  ipatests: test_replica_promotion.py: test KRA on Hidden Replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9804558bbe745df1141c84f00be83edcbe06c91>`__
-   `#8240 <https://pagure.io/freeipa/issue/8240>`__
+   `#8240 <https://codeberg.org/freeipa/freeipa/issues/8240>`__
 -  8-sudorule.rst: add sudo and su-l as services for bob's HBAC rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3bd27cfe9d4b03b0ff89265fdf357750c65eaeaa>`__
 -  ipa-restore: restart services at the end
    `commit <https://codeberg.org/freeipa/freeipa/commit/1eb6a9bf16e02b16328091cb98b13358cf372ee1>`__
-   `#8226 <https://pagure.io/freeipa/issue/8226>`__
+   `#8226 <https://codeberg.org/freeipa/freeipa/issues/8226>`__
 -  ipatests: make sure ipa-client-automount reverts sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f9d5281848a4de3acd669caa277d1b830722b71>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipa-client-automount: call save_domain() for each change
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1b6e3ba9b174fbe86dc2567fb8429d2e6473640>`__
-   `#8190 <https://pagure.io/freeipa/issue/8190>`__
+   `#8190 <https://codeberg.org/freeipa/freeipa/issues/8190>`__
 -  ipatests: expect "Dynamic Update" and "Bind update policy" in default
    dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/5fe8fc6298d2681f921ff51f9f17d09023bc0745>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 -  ipaserver/plugins/dns.py: add "Dynamic Update" and "Bind update
    policy" to default dnszone\* output
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b95d4cc508bca20eff272ecb36ad9d52878157e>`__
-   `#7938 <https://pagure.io/freeipa/issue/7938>`__
+   `#7938 <https://codeberg.org/freeipa/freeipa/issues/7938>`__
 -  ipatests/test_nfs.py: wait before umount
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8f1ed121308901d9edfe038fc2c1be83cc3eaf6>`__
-   `#8144 <https://pagure.io/freeipa/issue/8144>`__
+   `#8144 <https://codeberg.org/freeipa/freeipa/issues/8144>`__
 -  ipatests: fix pr-ci templates' indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/6462cc0f3acca871bb4fcd73e4fe929631b5385c>`__
 -  adtrust.py: mention restarting sssd when adding trust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/d5dad53e70857b47ab89c8ba78b0d8fe7d8fae0b>`__
-   `#8148 <https://pagure.io/freeipa/issue/8148>`__
+   `#8148 <https://codeberg.org/freeipa/freeipa/issues/8148>`__
 -  DSU: add Design for Disable Stale Users
    `commit <https://codeberg.org/freeipa/freeipa/commit/438094f868e1a96444e148d9a2481b559cab9a11>`__
-   `#8104 <https://pagure.io/freeipa/issue/8104>`__
+   `#8104 <https://codeberg.org/freeipa/freeipa/issues/8104>`__
 -  ipatests: nightly_f29: disable TestIpaClientAutomountFileRestore
    `commit <https://codeberg.org/freeipa/freeipa/commit/f44b73b97c35d0eb210091a46b4d5084c49b2d45>`__
-   `#8063 <https://pagure.io/freeipa/issue/8063>`__
+   `#8063 <https://codeberg.org/freeipa/freeipa/issues/8063>`__
 -  ipatests: temporarily remove test_smb from gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6db4980d844ee69b70df0e38c9aea9be1c74618>`__
 -  ipa_client_automount.py: fix typo (idmap.conf => idmapd.conf)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ac7169de29de47a1951b56ec021b5f1fded0f69>`__
 -  ipapython/ipachangeconf.py: change "is not 0" for "!= 0"
    `commit <https://codeberg.org/freeipa/freeipa/commit/02262ac7cfa52926fd0c943ddf6e96269e90e218>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  authconfig.py: restore user-nsswitch.conf at uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/73f049c75f0b1ed269cb8ebcb5c2158d2bc8b614>`__
-   `#8054 <https://pagure.io/freeipa/issue/8054>`__
+   `#8054 <https://codeberg.org/freeipa/freeipa/issues/8054>`__
 -  ipatests: remove xfail in TestIpaClientAutomountFileRestore
    `commit <https://codeberg.org/freeipa/freeipa/commit/03a228aaf6418a93b2a59bef46a94c9bf7528077>`__
 -  ipa-client-automount: always restore nsswitch.conf at uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/b27ad6e9f956a2485eee09b647b45c4901a1f928>`__
-   `#8038 <https://pagure.io/freeipa/issue/8038>`__
+   `#8038 <https://codeberg.org/freeipa/freeipa/issues/8038>`__
 -  ipatests: check that ipa-client-automount restores nsswitch.conf at
    uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/405dcc6becfca504dce7e06c6f0849a9c06df4c6>`__
 -  travis-ci: make dnf invocations more resilient
    `commit <https://codeberg.org/freeipa/freeipa/commit/c709f131712370d567064bb286d32d36f2307e0f>`__
-   `#8048 <https://pagure.io/freeipa/issue/8048>`__
+   `#8048 <https://codeberg.org/freeipa/freeipa/issues/8048>`__
 -  azure-pipelines.yml: switch to Python 3.7
    `commit <https://codeberg.org/freeipa/freeipa/commit/70b96d76cb97b386da27e05d81240f946b206378>`__
-   `#8030 <https://pagure.io/freeipa/issue/8030>`__
+   `#8030 <https://codeberg.org/freeipa/freeipa/issues/8030>`__
 -  test_nfs.py: switch to master_3repl
    `commit <https://codeberg.org/freeipa/freeipa/commit/80561224abcdc738a127e1ad70f3966cbb955c66>`__
-   `#8027 <https://pagure.io/freeipa/issue/8027>`__
+   `#8027 <https://codeberg.org/freeipa/freeipa/issues/8027>`__
 -  ipatests: rename config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/526b85a66e9ab90a5c4ef3f9ecca200664e1af9e>`__
 -  test_nfs.py: switch to
    tasks.config_replica_resolvconf_with_master_data()
    `commit <https://codeberg.org/freeipa/freeipa/commit/21cd9775ec314421949259b825bb05dcbfab9f8f>`__
-   `#7949 <https://pagure.io/freeipa/issue/7949>`__
+   `#7949 <https://codeberg.org/freeipa/freeipa/issues/7949>`__
 -  prci_definitions: add master_3client topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/a66124ba198324fc454d51073ced8756c8ac3d2c>`__
-   `#8026 <https://pagure.io/freeipa/issue/8026>`__
+   `#8026 <https://codeberg.org/freeipa/freeipa/issues/8026>`__
 -  ipapython/admintool.py: use SERVER_NOT_CONFIGURED
    `commit <https://codeberg.org/freeipa/freeipa/commit/402246a72990f77591f5efaec7ff0bc0cf82f416>`__
 -  ipa-client-samba: remove state on uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd2cbaecfce6b7b607619b34503b62c8afbbe594>`__
-   `#8021 <https://pagure.io/freeipa/issue/8021>`__
+   `#8021 <https://codeberg.org/freeipa/freeipa/issues/8021>`__
 -  ipatests: test ipa-client-samba after --uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed6ee90c547cd27a3731f177dc9917176a714b49>`__
 -  ipa-client-samba: remove and restore smb.conf only on first uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b65551b3107e46853afcc4901a60ea6e661a511>`__
-   `#8019 <https://pagure.io/freeipa/issue/8019>`__
+   `#8019 <https://codeberg.org/freeipa/freeipa/issues/8019>`__
 -  ipatests: test multiple invocations of ipa-client-samba --uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/68b85703d8ab2ede823d96e317dd106de27b108b>`__
 -  ipatests/azure: display actual dnf repo URLs
@@ -2889,183 +2889,183 @@ Florence Blanc-Renaud (89)
 -  ipatests: temporarily remove test_dnssec.py::TestInstallDNSSECFirst
    from gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/a33530f2f6cc7933edc537eb5055d4f147741654>`__
-   `#8496 <https://pagure.io/freeipa/issue/8496>`__
+   `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__
 -  ipatests: ipa-acme-manage status returns 3 on a CA-less server
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d2a4f25f777db69f5b314bf62bee6ec95fb3317>`__
-   `#8572 <https://pagure.io/freeipa/issue/8572>`__
+   `#8572 <https://codeberg.org/freeipa/freeipa/issues/8572>`__
 -  ipatests: IPADNSSystemRecordsCheck also checks for AAAA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab9ef13f278bf02fc018e20a4aefb20976049e71>`__
-   `#8573 <https://pagure.io/freeipa/issue/8573>`__
+   `#8573 <https://codeberg.org/freeipa/freeipa/issues/8573>`__
 -  ipatests: curl outputs the cookie in stderr and not in sdtout
    `commit <https://codeberg.org/freeipa/freeipa/commit/c053b5e0d6a06ad17b1d427a8345bca792981b47>`__
-   `#8559 <https://pagure.io/freeipa/issue/8559>`__
+   `#8559 <https://codeberg.org/freeipa/freeipa/issues/8559>`__
 -  ipatests: properly handle journalctl return code
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb7d09642205cba07ef614065d106f7f84d8921b>`__
-   `#8541 <https://pagure.io/freeipa/issue/8541>`__
+   `#8541 <https://codeberg.org/freeipa/freeipa/issues/8541>`__
 -  rpmspec: ensure ipa snippet for sshd is always included
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbd7d7718948245e1b47ca921136eca03b3f52c2>`__
-   `#8535 <https://pagure.io/freeipa/issue/8535>`__
+   `#8535 <https://codeberg.org/freeipa/freeipa/issues/8535>`__
 -  ipatests: add tests to 389ds regression
    `commit <https://codeberg.org/freeipa/freeipa/commit/58d8af0433e1cfc1b3d14acfe2c1bb9d73946e54>`__
 -  test_smb: skip test_smb_service_s4u2self for fed31
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ba15027d4fdca6aabda00494d29a528e1ce53d4>`__
-   `#8505 <https://pagure.io/freeipa/issue/8505>`__
+   `#8505 <https://codeberg.org/freeipa/freeipa/issues/8505>`__
 -  dnsforwardzone-add: support dnspython 2.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbc7881e36fa67d4ae648c1f55f96a43850de557>`__
-   `#8481 <https://pagure.io/freeipa/issue/8481>`__
+   `#8481 <https://codeberg.org/freeipa/freeipa/issues/8481>`__
 -  ipatests: fix bind service name
    `commit <https://codeberg.org/freeipa/freeipa/commit/50fdc8089a4f7970d6dfa3dc843b75b3e6f31d3c>`__
-   `#8482 <https://pagure.io/freeipa/issue/8482>`__
+   `#8482 <https://codeberg.org/freeipa/freeipa/issues/8482>`__
 -  ipatests: add missing healthcheck test in PRCI nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c15e996943ca6789c29f2be1db96a5b37479fcb>`__
 -  ipatests: run test_ipahealthcheck.py::TestIpaHealthCheck separately
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec67022af204f1d34bb2da302aa0e3b874812399>`__
-   `#8472 <https://pagure.io/freeipa/issue/8472>`__
+   `#8472 <https://codeberg.org/freeipa/freeipa/issues/8472>`__
 -  ipatests: remove xfail from test_dnssec
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7a6c468ca25073f9cb83c174851a9e17779b943>`__
 -  ipatests: fix TestIpaHealthCheckWithoutDNS failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2711321679f99be9a8521f07c81e715bad74b06>`__
-   `#8447 <https://pagure.io/freeipa/issue/8447>`__
+   `#8447 <https://codeberg.org/freeipa/freeipa/issues/8447>`__
 -  ipatests: collect IPA_RENEWAL_LOCK file
    `commit <https://codeberg.org/freeipa/freeipa/commit/606f1abd05e0cb89ae7bba26272065bc51ea3d1c>`__
 -  ipatests: fix test_ipahealthcheck.py::TestIpaHealthCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/d55e339df32f35e5e37aad78eebe1bdb0fd2361d>`__
-   `#8439 <https://pagure.io/freeipa/issue/8439>`__
+   `#8439 <https://codeberg.org/freeipa/freeipa/issues/8439>`__
 -  ipatests: check KDC cert permissions in CA less install
    `commit <https://codeberg.org/freeipa/freeipa/commit/a26e0ba558aa76323d90b807f2201992d6ee58b4>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  CAless installation: set the perms on KDC cert file
    `commit <https://codeberg.org/freeipa/freeipa/commit/9335bd9299e54928a057cbd31de40aca0ef207b2>`__
-   `#8440 <https://pagure.io/freeipa/issue/8440>`__
+   `#8440 <https://codeberg.org/freeipa/freeipa/issues/8440>`__
 -  ipatests: increase test_trust timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a3c98d236758274a719c2beeca2080df1390594>`__
 -  ipatests: fix test_authselect
    `commit <https://codeberg.org/freeipa/freeipa/commit/143b23cb7598ad51d68be8e08e39b4382d182fee>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: remove the xfail for test_nfs.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/aac570bb4558798ef0b868a88a3b796361c400ba>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipa-client-install: use the authselect backup during uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/f12d37724f7801b4bae4feee7c2c4db5474d142e>`__
-   `#8189 <https://pagure.io/freeipa/issue/8189>`__
+   `#8189 <https://codeberg.org/freeipa/freeipa/issues/8189>`__
 -  ipatests: Fix TestReplicaPromotionLevel1
    `commit <https://codeberg.org/freeipa/freeipa/commit/062e18c4f0c3febcac7db99e8a7e4c690684db60>`__
-   `#8414 <https://pagure.io/freeipa/issue/8414>`__
+   `#8414 <https://codeberg.org/freeipa/freeipa/issues/8414>`__
 -  ipatests: fix TestUnprivilegedUserPermissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fc1947c4875595edf48000ef3a01d0ae9ffd3c1>`__
-   `#8413 <https://pagure.io/freeipa/issue/8413>`__
+   `#8413 <https://codeberg.org/freeipa/freeipa/issues/8413>`__
 -  sshd template must be part of client package
    `commit <https://codeberg.org/freeipa/freeipa/commit/797a64b370fad5a0a26ebeeb3e4f34c3c88c0096>`__
-   `#8400 <https://pagure.io/freeipa/issue/8400>`__
+   `#8400 <https://codeberg.org/freeipa/freeipa/issues/8400>`__
 -  Add test_dnssec to 389ds nightly tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17cf8edb4073fb1db67e5541409dd28943909750>`__
 -  ipa cert-show: fix the code setting revocation reason
    `commit <https://codeberg.org/freeipa/freeipa/commit/dcdcd1ce88a6d5ed5997f50758dc6fd025df5f41>`__
-   `#8394 <https://pagure.io/freeipa/issue/8394>`__
+   `#8394 <https://codeberg.org/freeipa/freeipa/issues/8394>`__
 -  Bump requires for selinux-policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/9858e8636ff16abaa3e1cde99953f54d6f4ee9d8>`__
 -  ipatests: fix the method adding ifp to sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3c648bd926224c53f96602ea3ec7213a3caa22d>`__
-   `#8371 <https://pagure.io/freeipa/issue/8371>`__
+   `#8371 <https://codeberg.org/freeipa/freeipa/issues/8371>`__
 -  Unify spelling of "One-Time Password" (take 2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc11b98e4a6650040731405a0e954e20be12afa6>`__
-   `#5628 <https://pagure.io/freeipa/issue/5628>`__,
-   `#8381 <https://pagure.io/freeipa/issue/8381>`__
+   `#5628 <https://codeberg.org/freeipa/freeipa/issues/5628>`__,
+   `#8381 <https://codeberg.org/freeipa/freeipa/issues/8381>`__
 -  client install: fix broken sshd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/511f5194dcf12a64fc8a6c2791edc9c6cda2d926>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipa-client-install: use sshd drop-in configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cf9979aec109e01ee470c22fbc7ca55bd8c2eb0>`__
-   `#8304 <https://pagure.io/freeipa/issue/8304>`__
+   `#8304 <https://codeberg.org/freeipa/freeipa/issues/8304>`__
 -  ipatests: Update the pki-master-f32 image version
    `commit <https://codeberg.org/freeipa/freeipa/commit/c358f8dbb5b2532f5f1e9f9ff823bd3c069b6e6e>`__
 -  ipatests: add a test for ipa-replica-install --setup-ca
    --http-cert-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/98c1017caa03cff5b73723873ef86fc1d4c0fb2a>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipa-replica-install: --setup-ca and \*-cert-file are mutually
    exclusive
    `commit <https://codeberg.org/freeipa/freeipa/commit/51cb631db39361918add4b5100d2bfaa90ab9b23>`__
-   `#8366 <https://pagure.io/freeipa/issue/8366>`__
+   `#8366 <https://codeberg.org/freeipa/freeipa/issues/8366>`__
 -  ipatests: fix the disable_dnssec_validation method
    `commit <https://codeberg.org/freeipa/freeipa/commit/14876657794949e8acfeb63e7ccaa512becde7e1>`__
-   `#8364 <https://pagure.io/freeipa/issue/8364>`__
+   `#8364 <https://codeberg.org/freeipa/freeipa/issues/8364>`__
 -  ipatests: Check if user with 'User Administrator' role can delete
    group.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dd5053cdd55adf6888ef38bfc927fc255bd7019>`__
-   `#6884 <https://pagure.io/freeipa/issue/6884>`__
+   `#6884 <https://codeberg.org/freeipa/freeipa/issues/6884>`__
 -  ipa-advise: fallback to /usr/libexec/platform-python if python3 not
    found
    `commit <https://codeberg.org/freeipa/freeipa/commit/edcfba6010c0b6a81841ca6e1e478835ce76191b>`__
-   `#8311 <https://pagure.io/freeipa/issue/8311>`__
+   `#8311 <https://codeberg.org/freeipa/freeipa/issues/8311>`__
 -  Man pages: fix syntax issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ac60a87bccb8f6e05d0eab33cab4139ddcd2d0a>`__
-   `#8273 <https://pagure.io/freeipa/issue/8273>`__
+   `#8273 <https://codeberg.org/freeipa/freeipa/issues/8273>`__
 -  ipatests: wait for SSSD to become online in backup/restore tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3753862401b8500b7498d2723ccb727b5dd6263e>`__
-   `#8228 <https://pagure.io/freeipa/issue/8228>`__
+   `#8228 <https://codeberg.org/freeipa/freeipa/issues/8228>`__
 -  xmlrpc tests: add a test for idview-apply on a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/20d601e9c389405f75c78bfb010883f3f23bbdd5>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  idviews: prevent applying to a master
    `commit <https://codeberg.org/freeipa/freeipa/commit/e08f7a9ef3df3c345b4c066f974608ad32b57571>`__
-   `#5662 <https://pagure.io/freeipa/issue/5662>`__
+   `#5662 <https://codeberg.org/freeipa/freeipa/issues/5662>`__
 -  opendnssec2.1 support: move all ods tasks to specific file
    `commit <https://codeberg.org/freeipa/freeipa/commit/682b59c8e801f06b3c6e4aa97c1ab33390c9edf8>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  DnsSecMaster migration: move the call to zonelist export later
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6865831c97bbab71c02ec12dea2280caa505c6d>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support OpenDNSSEC 2.1: new ods-signer protocol
    `commit <https://codeberg.org/freeipa/freeipa/commit/8080bf7b359ca87d62502acf1fbdf235376007f7>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  With opendnssec 2, read the zone list from file
    `commit <https://codeberg.org/freeipa/freeipa/commit/b857828180c650d7b2db17663a9413323eaef73d>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Remove the from opendnssec conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2e355ae59b8ecb862838eeeb37a33370a4874a4>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  Support opendnssec 2.1.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ae1352c72b81d656ec3d6ee44ad2b405298e58f>`__
-   `#8214 <https://pagure.io/freeipa/issue/8214>`__
+   `#8214 <https://codeberg.org/freeipa/freeipa/issues/8214>`__
 -  selinux policy: add the right context for
    org.freeipa.server.trust-enable-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fbc4e01ea5be004f7c57cb71df2d37659271d68>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: remote command fails if ipa-server-trust-ad pkg
    missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/233a18b2a24d814518a119bd3f1688a0eb361917>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: add test for ipa-adtrust-install --add-agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc4c3ac795e3af48fcfd8dd51085f5ff98047f1e>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipa-adtrust-install: run remote configuration for new agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/911992b8bf33b40f650ec406444ca8b9b847b54e>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  Privilege: add a helper checking if a principal has a given privilege
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c72e344a29e27416af428f6dbf5300c85e66e1>`__
-   `#7600 <https://pagure.io/freeipa/issue/7600>`__
+   `#7600 <https://codeberg.org/freeipa/freeipa/issues/7600>`__
 -  ipatests: fix TestSubCAkeyReplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ee8657c2a76a418e56baee50b07f6ec089e622e>`__
 -  Part2: Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/9eb1be875276c61127663c3860228f03a66ebfbd>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  ipatests: fix modify_sssd_conf()
    `commit <https://codeberg.org/freeipa/freeipa/commit/cec1ddc39ecd2163270bb00df46bfd2469c2c25a>`__
 -  ipatests: update packages for rawhide and updates-testing nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/60f746d9983b54e71f9ba98632f30e79bdead86e>`__
 -  ipatests: fix backup and restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae140ae40692154ce692c03901f6e17c0e227498>`__
-   `#8170 <https://pagure.io/freeipa/issue/8170>`__
+   `#8170 <https://codeberg.org/freeipa/freeipa/issues/8170>`__
 -  AD user without override receive InternalServerError with API
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2d69380fbae6dab244fce3fd5afe5fdc28a2663>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 -  ipa-cacert-manage man page: fix indentation
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a522bed6bd86ad7ac05ca44779145fb1aeabf3d>`__
-   `#8138 <https://pagure.io/freeipa/issue/8138>`__
+   `#8138 <https://codeberg.org/freeipa/freeipa/issues/8138>`__
 -  ipatests: fix TestMigrateDNSSECMaster teardown
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1272e48dfaa6ccf15342f1888cba556026e6cf2>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  trust upgrade: ensure that host is member of adtrust agents
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c9b212cf08e9f0e6814b2e7a0922079b3929634>`__
 -  ipatests: fix test_crlgen_manage
@@ -3074,81 +3074,81 @@ Florence Blanc-Renaud (89)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8cf4271aaeb466aa73a44f6c162ddbe9eac7fc88>`__
 -  ipatests: generic uninstall should call ipa server-del
    `commit <https://codeberg.org/freeipa/freeipa/commit/7dfc6e004be1dd1b3e2eee51786f3b9f888f3494>`__
-   `#7985 <https://pagure.io/freeipa/issue/7985>`__
+   `#7985 <https://codeberg.org/freeipa/freeipa/issues/7985>`__
 -  Nightly definition: use right template for krbtpolicy
    `commit <https://codeberg.org/freeipa/freeipa/commit/094cf629b338b78d13b15b87b4844c487c150e39>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  test_ipalib: add test for DNParam class
    `commit <https://codeberg.org/freeipa/freeipa/commit/7893fb9cb1fc7c78c78079b23756bca53268caa1>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  XMLRPCtest: add a test for add-certmapdata with multiple
    subject/issuer
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecdd7dae19e84b33c65bf6203a2cd906a9eebc4e>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  DNParam: raise Exception when multiple values provided to a 1-val
    param
    `commit <https://codeberg.org/freeipa/freeipa/commit/e08a6de6afc49aabf817b11b878f6765f662e1ff>`__
-   `#8097 <https://pagure.io/freeipa/issue/8097>`__
+   `#8097 <https://codeberg.org/freeipa/freeipa/issues/8097>`__
 -  smartcard: make the ipa-advise script compatible with
    authselect/authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/87c24ebd34d4524b73d878f1298232547cafc5ba>`__
-   `#8113 <https://pagure.io/freeipa/issue/8113>`__
+   `#8113 <https://codeberg.org/freeipa/freeipa/issues/8113>`__
 -  ipa-backup: fix python2 issue with os.mkdir
    `commit <https://codeberg.org/freeipa/freeipa/commit/921f500240fc0861e099a97a2b412e8610eaf198>`__
-   `#8099 <https://pagure.io/freeipa/issue/8099>`__
+   `#8099 <https://codeberg.org/freeipa/freeipa/issues/8099>`__
 -  ipa-server-certinstall manpage: add missing options
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fc8562b248b13a125d5bda8f0f2964d50dcc08c>`__
-   `#8086 <https://pagure.io/freeipa/issue/8086>`__
+   `#8086 <https://codeberg.org/freeipa/freeipa/issues/8086>`__
 -  ipatests: fix test_replica_promotion.py::TestHiddenReplicaPromotion
    `commit <https://codeberg.org/freeipa/freeipa/commit/121971a51e6a652f3bc0c8c481a361954bab886e>`__
-   `#8070 <https://pagure.io/freeipa/issue/8070>`__
+   `#8070 <https://codeberg.org/freeipa/freeipa/issues/8070>`__
 -  ipatests: add XMLRPC test for user-add when UPG plugin is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/387ee6e60f398efcdaf91c8097794ed24179150d>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipa user_add: do not check group if UPG is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2a2d7f4e4c63bf60c276b1fb210c72f1ebc4b9f>`__
-   `#4972 <https://pagure.io/freeipa/issue/4972>`__
+   `#4972 <https://codeberg.org/freeipa/freeipa/issues/4972>`__
 -  ipatests: fix fedora29 nightly definition
    `commit <https://codeberg.org/freeipa/freeipa/commit/6127aa0eac5bba37decc02fbffb3da891c81a9d1>`__
 -  replica install: enforce --server arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/802e54dd0e33be6015b22853767fc37a9ec02f39>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  ipatests: ensure that backup/restore restores pkcs 11 modules config
    file
    `commit <https://codeberg.org/freeipa/freeipa/commit/2919237753e031810f5b6e7d645bc126ebc8f7b5>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 -  ipa-backup: backup the PKCS module config files setup by IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/055ea253dfe0182671cba16916840a013daa8b74>`__
-   `#8073 <https://pagure.io/freeipa/issue/8073>`__
+   `#8073 <https://codeberg.org/freeipa/freeipa/issues/8073>`__
 -  ipatests: enable 389-ds audit log and collect audit file
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2313114fbbda9b1c0fdbbe564811797e7be18b1>`__
-   `#8064 <https://pagure.io/freeipa/issue/8064>`__
+   `#8064 <https://codeberg.org/freeipa/freeipa/issues/8064>`__
 -  ipatests: add nightly definition for DS integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1af6aa27c6a3c69185507fb99da172526875db3>`__
 -  config plugin: replace 'is 0' with '== 0'
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a437a3c422ee8a7b3dfee9a90abc2d9cc9e7990>`__
-   `#8057 <https://pagure.io/freeipa/issue/8057>`__
+   `#8057 <https://codeberg.org/freeipa/freeipa/issues/8057>`__
 -  ipatests: fix wrong xfail in test_domain_resolution_order
    `commit <https://codeberg.org/freeipa/freeipa/commit/b48fe19fe58f139e6c0702cd0e0eda65ae0e231d>`__
-   `#8052 <https://pagure.io/freeipa/issue/8052>`__
+   `#8052 <https://codeberg.org/freeipa/freeipa/issues/8052>`__
 -  Nightly test definition: add missing tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/41e5d4653a637bb3b97cf651382fb7668f41e226>`__
 -  xmlrpc test: add test for preserved > stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ebbb271a556ace5d1f68c404a786aef6d56ba97>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 -  user-stage: transfer all attributes from preserved to stage user
    `commit <https://codeberg.org/freeipa/freeipa/commit/27baf3501389cc3c8a12e06686da13a874d3f9da>`__
-   `#7597 <https://pagure.io/freeipa/issue/7597>`__
+   `#7597 <https://codeberg.org/freeipa/freeipa/issues/7597>`__
 -  test_xmlrpc: fix
    TestAutomemberFindOrphans.test_find_orphan_automember_rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/11e40336c5f0c5b086bbb7a98fb5cd22c80b4df3>`__
-   `#7902 <https://pagure.io/freeipa/issue/7902>`__
+   `#7902 <https://codeberg.org/freeipa/freeipa/issues/7902>`__
 -  Azure pipeline: report failure in prepare-build step
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e97e80069349d4b6a8c221f724b8f459fc3aa89>`__
-   `#8022 <https://pagure.io/freeipa/issue/8022>`__
+   `#8022 <https://codeberg.org/freeipa/freeipa/issues/8022>`__
 -  upgrade: remove ipaCert and key from /etc/httpd/alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef39e1b02a2ef965997d38fc7b72d5ee1542d44b>`__
-   `#7329 <https://pagure.io/freeipa/issue/7329>`__
+   `#7329 <https://codeberg.org/freeipa/freeipa/issues/7329>`__
 
 
 
@@ -3169,10 +3169,10 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe990128811c99f777aa04bbd39ea0bbc29611d>`__
 -  dns: allow PTR records in arbitrary zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/b153b23c75a8ddd4170c3ba47774ced219bf20aa>`__
-   `#5566 <https://pagure.io/freeipa/issue/5566>`__
+   `#5566 <https://codeberg.org/freeipa/freeipa/issues/5566>`__
 -  ipa_sam: do not modify static buffer holding fqdn
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f59118ffcce07cbd74360f9ce8047e0b35960be>`__
-   `#8501 <https://pagure.io/freeipa/issue/8501>`__
+   `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__
 -  spec: require pki-acme if pki-ca >= 10.10
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0461eb37ccf0b87b05f81380cf60dffdd26a3dc>`__
 -  install: simplify host name verification
@@ -3181,134 +3181,134 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b54d936487202a16031e5fdc23f5dfabde28af58>`__
 -  certupdate: update config after deployment becomes CA-ful
    `commit <https://codeberg.org/freeipa/freeipa/commit/53d472b490ac7a14fc78516b448d4aa312b79b7f>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  cainstance: extract function import_ra_key
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1b3b34b906808c2deb69a3838edd0cf4739b467>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  cainstance.update_ipa_conf: allow specifying ca_host
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fcc260cae4bd1186a7312c61a63144e8d656cd0>`__
-   `#7188 <https://pagure.io/freeipa/issue/7188>`__
+   `#7188 <https://codeberg.org/freeipa/freeipa/issues/7188>`__
 -  acme: delete ACME RA account on server uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f720560273e16ca6c5e646a1f4bf0a7ec354aa5>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: enable mod_md tests on Fedora
    `commit <https://codeberg.org/freeipa/freeipa/commit/525b946b75760a1ef90e1aae8e5052124fb0075c>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certbot dns-01 test
    `commit <https://codeberg.org/freeipa/freeipa/commit/678b8e682b37daa5217c0098cd6ce42c324b3955>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certbot dns script
    `commit <https://codeberg.org/freeipa/freeipa/commit/a83eaa8b6da8e5937a7f42a90310f69b8f66e6d4>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add revocation test
    `commit <https://codeberg.org/freeipa/freeipa/commit/e976dde8e1429ee023a76ddbe0e6b16a495a1ef2>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: handle alternative schema ldif location
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9f3b3b118ccb0c4052d15387d128886ec293463>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add mod_md integration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/85d0272053dbafab19c1f98cacc5ce6e1a828667>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration tests to gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb6d84903967bc6176d8a0817b602ba314129417>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration test to nightly CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab7226dcef8c8390fc9a1e939680ba9f4f5121bd>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add integration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b00035764197c0aff0c7d2de638dc174abacf9f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add ipa-acme-manage command
    `commit <https://codeberg.org/freeipa/freeipa/commit/083c6aedc6d8046c19f637ec34723812f292a0e9>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: configure engine.conf and disable by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/00a84464eae31150714f667df67774ebe34b8514>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: configure ACME service on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/d15000bed6bc5262a80aadeb5f85a476ed44799f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add certificate profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c8352f9a7f977bc994e4b5b558fb3c7db20f40e>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: add Dogtag ACL to allow ACME agents to revoke certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c309d4a4d0c19df80808b2ce9352ce2af2a30a3c>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: create ACME RA account
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3565290fefb6e14583b50d3c411a8861a4fa844>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  dogtaginstance: add ensure_group method
    `commit <https://codeberg.org/freeipa/freeipa/commit/a21823da7fcce521838764df5280295ccbdb8157>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  dogtaginstance: extract user creation to subroutine.
    `commit <https://codeberg.org/freeipa/freeipa/commit/5883cff0b7b62da3fcb3dfb7920a9f993cbcb568>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: set up ACME service when configuring CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd301a453521a177d9f34df25d3e6d203c9507ea>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  acme: ipa-pki-proxy: proxy /acme to Dogtag
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b6faa362f3ee2a63e3597f8734867d8e9d4df7d>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  certupdate: only add LWCA tracking requests on CA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4462a94433e75da622118873d300d61a8e5f53f>`__
-   `#8399 <https://pagure.io/freeipa/issue/8399>`__
+   `#8399 <https://codeberg.org/freeipa/freeipa/issues/8399>`__
 -  tests: fix cleanup for CATracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a0901f6fdf744023dc90ec5141aa9ebe4d806fd>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  ca plugin: improve doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/6da63e3be44033d7d623a574787937ab4ec9ed0a>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  ca-del: require CA to already be disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ab24ddf8a74c4c59c5c28bc79da150633530363>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  cainstance.is_crlgen_enabled: handle missing ipa-pki-proxy.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/51d5ec17570ef6911bded6381c77041f4a5c2182>`__
 -  ra.get_certificate: use REST API
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3a0b2d31fe3a02a19286d590cf1a343458fd8>`__
-   `#3473 <https://pagure.io/freeipa/issue/3473>`__,
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#3473 <https://codeberg.org/freeipa/freeipa/issues/3473>`__,
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  extract virtual operation access check subroutine
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c0061babdd9a6584ea30742648a200d6aa4d3ba>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__,
-   `#6423 <https://pagure.io/freeipa/issue/6423>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__,
+   `#6423 <https://codeberg.org/freeipa/freeipa/issues/6423>`__
 -  Define errors_by_code in ipalib.errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7766ebb940cca040d08a1dd58b92f6546ca3e9b>`__
-   `#5011 <https://pagure.io/freeipa/issue/5011>`__
+   `#5011 <https://codeberg.org/freeipa/freeipa/issues/5011>`__
 -  fix iPAddress cert issuance for >1 host/service
    `commit <https://codeberg.org/freeipa/freeipa/commit/68ada5f2040bb207a5402220fb93e360bae215fe>`__
-   `#8368 <https://pagure.io/freeipa/issue/8368>`__
+   `#8368 <https://codeberg.org/freeipa/freeipa/issues/8368>`__
 -  fix cert-find errors in CA-less deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/19544d53aeada733eb63d596be0a8576b17b9d04>`__
-   `#8369 <https://pagure.io/freeipa/issue/8369>`__
+   `#8369 <https://codeberg.org/freeipa/freeipa/issues/8369>`__
 -  upgrade: avoid stopping certmonger when fixing requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6fda6f0fbcc7dee4deb0093bf46c2fadc3068ee>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: retry request without ipa-ca.$DOMAIN dnsName on failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d9012f682a2dcff7676580fbc622771b427fcef>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  ipatests: check HTTP certificate contains ipa-ca.$DOMAIN dnsname
    `commit <https://codeberg.org/freeipa/freeipa/commit/45b5384b6ef83aaf742bf7906d846e07db874ef8>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  upgrade: add ipa-ca.$DOMAIN alias to HTTP certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf4c2c64b0bb1e4555a48bc5079aeff101fd9894>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add ipa-ca.$DOMAIN alias in initial request
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d5b5a9024c1237cb128688c7c4ac796135d50d5>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  cert-request: allow ipa-ca.$DOMAIN dNSName for IPA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7c45641fe356364175899399b51b07987b44a1b>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  httpinstance: add fqdn and ipa-ca alias to Certmonger request
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cf9c8689fc4a791eee17e0cfcb38e837a53b3f0>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: support dnsname as request search criterion
    `commit <https://codeberg.org/freeipa/freeipa/commit/18ebd1116d706d9f2a3a9c2dca16681a4f138362>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: move 'criteria' description to module docstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0fb3816f656dc4b324fc02c8d4506dadcfe544e>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  certmonger: avoid mutable default argument
    `commit <https://codeberg.org/freeipa/freeipa/commit/0711c4a0d45f9e28459596552ca751890b13c265>`__
-   `#8186 <https://pagure.io/freeipa/issue/8186>`__
+   `#8186 <https://codeberg.org/freeipa/freeipa/issues/8186>`__
 -  add resources section
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ff19cdb2c752342f81ebb93a929bf04f61f680f>`__
 -  typospotting
@@ -3434,101 +3434,101 @@ Fraser Tweedale (141)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8638e969696f4bdd11cf039bb3480c7478ee2de>`__
 -  Do not renew externally-signed CA as self-signed
    `commit <https://codeberg.org/freeipa/freeipa/commit/769180c2c60205a453f87d7d1b88c27d238728db>`__
-   `#8176 <https://pagure.io/freeipa/issue/8176>`__
+   `#8176 <https://codeberg.org/freeipa/freeipa/issues/8176>`__
 -  ipatests: add test for certinstall with notBefore in the future
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a2cc961666af1e41e127f043d571a93da800ef5>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  Fix test regressions caused by certificate validation changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4b0cf4d631d08ba217072ae5cf3b8e6317b222e>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  ipatests: assert_error: allow regexp match
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d779b492d0a78361e3566ac08781ff4a62ad40e>`__
-   `#8142 <https://pagure.io/freeipa/issue/8142>`__
+   `#8142 <https://codeberg.org/freeipa/freeipa/issues/8142>`__
 -  removed unused function export_pem_p12
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa9340cfdb5408176e8274aeb9aeba9132b5031d>`__
 -  test_integration: add tests for custom CA subject DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/e767386e7120be3515d6a34529b51ae658248038>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  upgrade: fix ipakra people entry 'description' attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ea50ff76d2ee5367b75d999c2baa2a7a480f34a>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  krainstance: set correct issuer DN in uid=ipakra entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/326d417d98b092e175623cd28e46586df00e60a2>`__
-   `#8084 <https://pagure.io/freeipa/issue/8084>`__
+   `#8084 <https://codeberg.org/freeipa/freeipa/issues/8084>`__
 -  Bump Dogtag min version to 10.7.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c7a827c0973669c55e4badcb6ab4f02993852a6>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  ipa-pki-retrieve-key: request AES encryption (with fallback)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfead9ce66fb7552f9afaea18fb72a09fbe5f1c2>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  NSSWrappedCertDB: accept optional symmetric algorithm
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fbcc3353467026e181f24cd527fe4e30f63aab4>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  IPASecStore: support extra key arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e92e65190c04cc3c4699dbba329cbd6696576f1>`__
-   `#8020 <https://pagure.io/freeipa/issue/8020>`__
+   `#8020 <https://codeberg.org/freeipa/freeipa/issues/8020>`__
 -  dsinstance: add proflie when tracking certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7ad11572d3060e64252c4366d7c8afff1bc15e9>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  ipatests: test ipa-server-upgrade in CA-less deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/65d9a9be520ea9402143d9f06878eff53647925a>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  Use RENEWAL_CA_NAME and RA_AGENT_PROFILE constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb779baadf0df3333bd853599a21e81907c8c116>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  cainstance: add profile to IPA RA tracking request
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bf008a64f15e617b0dde93555f5dca1cbdf990a>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: fix spurious certmonger re-tracking
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa5675582caef6d0708c8ae392e170b44d9daf5b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: log missing/misconfigured tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d22f568a1043b0cb0b69314d3951d39721becc7>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: update KRA tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/482866e47e20520fbe39ef05439badbb3069bef6>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: always add profile to tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f4e2f96b022a056777fed59583f204edb797a2e>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtaginstance: avoid special cases for Server-Cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/588f1ddce2f69fd5e80d3271c9c8d80d312d350f>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtag-ipa-ca-renew-agent: always use profile-based renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fb6fda01f2aca5fadc3707b7c7a3f3c9e647f85>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  certmonger: use long options when invoking dogtag-ipa-renew-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/858ef59948f5c8edd511f4db0b5fd69a1169f19b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  upgrade: add profile to Dogtag tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6f6f83dca22fb23ee2a7dd1b2925a74fe395afe>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  dogtaginstance: add profile to tracking requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c388f5a228b767dfd92bd824dfced166acda143>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  ci: add --external-ca-profile tests to gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/33f39d88bf0bb871e3868c827aeb335eb40f5ae3>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  ci: add --external-ca-profile tests to nightly
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c8352fe8536be0e630fdb910dc90831847ad119>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Collapse --external-ca-profile tests into single class
    `commit <https://codeberg.org/freeipa/freeipa/commit/80e76f094c234710ff58917e7ce4661d823c4de7>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Add more tests for --external-ca-profile handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/b15bd50e6db919279e25a8bed796df4836b845a8>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  Fix use of incorrect variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/7171142aaf91d6079798d015af9862d6e5474c8c>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__,
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__,
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  install: fix --external-ca-profile option
    `commit <https://codeberg.org/freeipa/freeipa/commit/21a9a7107a2028354c0fc15540b8f15d279e5fce>`__
-   `#5608 <https://pagure.io/freeipa/issue/5608>`__,
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#5608 <https://codeberg.org/freeipa/freeipa/issues/5608>`__,
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 -  move MSCSTemplate classes to ipalib
    `commit <https://codeberg.org/freeipa/freeipa/commit/130e1dc3433977f7a80aed139d29d21c5d30d558>`__
-   `#7548 <https://pagure.io/freeipa/issue/7548>`__
+   `#7548 <https://codeberg.org/freeipa/freeipa/issues/7548>`__
 
 
 
@@ -3560,10 +3560,10 @@ Jeremy Frasier (2)
 -  replica: Add tests to ensure the ipaapi user is allowed access to ifp
    on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ff1d6b4509e0214f8147a80a6ff80b429b680df>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 -  replica: Ensure the ipaapi user is allowed to access ifp on replicas
    `commit <https://codeberg.org/freeipa/freeipa/commit/12529d7ef184846ca3852821b813c725b22e11c6>`__
-   `#8403 <https://pagure.io/freeipa/issue/8403>`__
+   `#8403 <https://codeberg.org/freeipa/freeipa/issues/8403>`__
 
 
 
@@ -3596,12 +3596,12 @@ Kaleemullah Siddiqui (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/592f3fe65986077ec0a19158d061a371c86307c7>`__
 -  Test for check of HostKeyAlgorithms option in ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/bba41dc85c8427992b5626b5a9daaf86c3b2a812>`__
-   `#8082 <https://pagure.io/freeipa/issue/8082>`__
+   `#8082 <https://codeberg.org/freeipa/freeipa/issues/8082>`__
 -  Fix for regression from PR#3962
    `commit <https://codeberg.org/freeipa/freeipa/commit/939ee59c2716aa2abf93ac78d44df937105b430d>`__
 -  Tests for backup-restore when pkg required is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/10e8e7af039fef0c7e5d84c9bc0034f7563d3f47>`__
-   `#7630 <https://pagure.io/freeipa/issue/7630>`__
+   `#7630 <https://codeberg.org/freeipa/freeipa/issues/7630>`__
 
 
 
@@ -3645,15 +3645,15 @@ Michal Polovka (7)
 -  ipatests: add tests for ipa host-add with non-default
    maxhostnamelength
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ce0e6bf6065e8d08cee7e924eda05174d26d883>`__
-   `#2018 <https://pagure.io/freeipa/issue/2018>`__
+   `#2018 <https://codeberg.org/freeipa/freeipa/issues/2018>`__
 -  ipatests: fix topology for TestIpaNotConfigured in PR-CI nightly
    definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/253779afc4432d02aa37b44dda789c4b152568fb>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__,
-   `#8055 <https://pagure.io/freeipa/issue/8055>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__,
+   `#8055 <https://codeberg.org/freeipa/freeipa/issues/8055>`__
 -  ipatests: Test for ipa-backup with ipa not configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/a71c59c7c881ffcc76ba9b02d02ddd31a0f829b6>`__
-   `#6843 <https://pagure.io/freeipa/issue/6843>`__
+   `#6843 <https://codeberg.org/freeipa/freeipa/issues/6843>`__
 
 
 
@@ -3662,16 +3662,16 @@ Mark Reynolds (4)
 
 -  Reorder creation of the CA mapping tree and database backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c4785f042feb1fddbe579d07ff591a532e4f24d>`__
-   `#8558 <https://pagure.io/freeipa/issue/8558>`__
+   `#8558 <https://codeberg.org/freeipa/freeipa/issues/8558>`__
 -  Increase replication changelog trimming to 30 days
    `commit <https://codeberg.org/freeipa/freeipa/commit/c08c7e115682eaf5a605043c8fd10b1e080365ac>`__
-   `#8464 <https://pagure.io/freeipa/issue/8464>`__
+   `#8464 <https://codeberg.org/freeipa/freeipa/issues/8464>`__
 -  Issue 8456 - Add new aci's for the new replication changelog entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9ae7c45b8b99a3c8aefc0c962e4563c43e51e99>`__
-   `#8456 <https://pagure.io/freeipa/issue/8456>`__
+   `#8456 <https://codeberg.org/freeipa/freeipa/issues/8456>`__
 -  Issue 8407 - Support changelog integration into main database
    `commit <https://codeberg.org/freeipa/freeipa/commit/44259e8e68582e7116f8d5bee6e2c454254de69f>`__
-   `#8407 <https://pagure.io/freeipa/issue/8407>`__
+   `#8407 <https://codeberg.org/freeipa/freeipa/issues/8407>`__
 
 
 
@@ -3684,10 +3684,10 @@ Mohammad Rizwan (28)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbbfcd9b1e9bbcce864957423085d362e6d44c72>`__
 -  External-CA scenarios for ACME service
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dccf17a6c6ce023661a33fdb1f65314ef6a053f>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 -  ipatests: Check if ACME is enabled on all CA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7fd791579eca8b7a1c30b4f17bfac7c4fafe2a7>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  PEP8 fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1abeb85fbadfaff66694aedc9abfe9229cd3c5d8>`__
 -  ipatests: add --skip-overlap-check option to prepare_reverse_zone()
@@ -3704,51 +3704,51 @@ Mohammad Rizwan (28)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c02920529306aaa1a8be1fae185390e2e115859>`__
 -  webui: check if notification area doesn't intercept menu button
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b83c2a9e4afdfddc45d639eaf0c3aa7f92eb2a4>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  ipatests: Test deletion of required principal throws proper error
    `commit <https://codeberg.org/freeipa/freeipa/commit/340a50b7e78a4b63e9d2abd86766c3b6c4f47099>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  Display principal name while del required principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cadf40f2380942ffa6e9c107dc054a7ed1ecfa6>`__
-   `#7695 <https://pagure.io/freeipa/issue/7695>`__
+   `#7695 <https://codeberg.org/freeipa/freeipa/issues/7695>`__
 -  ipatests: Test to check password leak in apache error log
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c54609d73d691874ff8d5512a2d1a1284f5e77e>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  ipatests:Test if proper error thrown when AD user tries to run IPA
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/a02df530a6b4b5f5f6f9661da33aa2fb0cd47211>`__
-   `#8163 <https://pagure.io/freeipa/issue/8163>`__
+   `#8163 <https://codeberg.org/freeipa/freeipa/issues/8163>`__
 -  ipatests: Skip test using paramiko when FIPS is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/d07da417394f8d46081a3762b3ed5bf7659e69ab>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/312d00df90fc40c1c4c934945c3c73053b6ea18a>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if schema-compat-entry-attribute is set
    `commit <https://codeberg.org/freeipa/freeipa/commit/9120d65e881e582cc37ee8445fb66a54f6fb4d75>`__
-   `#8193 <https://pagure.io/freeipa/issue/8193>`__
+   `#8193 <https://codeberg.org/freeipa/freeipa/issues/8193>`__
 -  Test if getcert creates cacert file with -F option
    `commit <https://codeberg.org/freeipa/freeipa/commit/9bcc57d9e01625a122811a50f78acde247b5791d>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Move wait_for_request() method to tasks.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/6739d8722c4a3e84cdcf1e058c6fd15317ac0ca4>`__
 -  Test if server installer lock Bind9 recursion
    `commit <https://codeberg.org/freeipa/freeipa/commit/1556f3f767c3fab7634b46a9193e363887558db0>`__
-   `#8079 <https://pagure.io/freeipa/issue/8079>`__
+   `#8079 <https://codeberg.org/freeipa/freeipa/issues/8079>`__
 -  Add certmonger wait_for_request that uses run_command
    `commit <https://codeberg.org/freeipa/freeipa/commit/806795422934c3220856bcaaf8810cdebd782fd4>`__
 -  Test if certmonger reads the token in HSM
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe21094c8eca948673c6ff0aac337ee3151d4be1>`__
 -  Test AES SHA 256 and 384 Kerberos enctypes enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0d57d99e5719099ed0be0476985ab394b131cb0>`__
-   `#8110 <https://pagure.io/freeipa/issue/8110>`__
+   `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
 -  Add test to nightly yamls
    `commit <https://codeberg.org/freeipa/freeipa/commit/c77bbe7899577cb14b42625953f1b9a868e6f237>`__
 -  Installation of replica against a specific server
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2c1000e2d5481d4be377feb12588fdb09d12de0>`__
-   `#7566 <https://pagure.io/freeipa/issue/7566>`__
+   `#7566 <https://codeberg.org/freeipa/freeipa/issues/7566>`__
 -  Check file ownership and permission for dirsrv log instance
    `commit <https://codeberg.org/freeipa/freeipa/commit/7aec6f10374129d75cd99a4012980516ca535551>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 
 
 
@@ -3757,7 +3757,7 @@ ndehadra (1)
 
 -  Hidden Replica: Add a test for Automatic CRL configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/6064365aa09c9fcee01cb9be2bbe994adc361263>`__
-   `#7307 <https://pagure.io/freeipa/issue/7307>`__
+   `#7307 <https://codeberg.org/freeipa/freeipa/issues/7307>`__
 
 
 
@@ -3808,7 +3808,7 @@ Petr Voborník (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3912e8e6739058ef8fcb2964fda0edc3ee23fc1e>`__
 -  webui: hide user attributes for SMB services section if empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6707a71dcefd4b54d7909ad1ba9ba84f57c430a>`__
-   `#8336 <https://pagure.io/freeipa/issue/8336>`__
+   `#8336 <https://codeberg.org/freeipa/freeipa/issues/8336>`__
 
 
 
@@ -3825,193 +3825,193 @@ Rob Crittenden (116)
 
 -  ipatests: Test that password reset unlocks users too
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca6fc689ba92ee2db6945f37429ee7fe8d75a4b6>`__
-   `#8551 <https://pagure.io/freeipa/issue/8551>`__
+   `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
 -  On password reset also set krbLastAdminUnlock to unlock account
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ab3578b36bc7b8ce777e38ba764649d1b684ce5>`__
-   `#8551 <https://pagure.io/freeipa/issue/8551>`__
+   `#8551 <https://codeberg.org/freeipa/freeipa/issues/8551>`__
 -  Wrap libpwquality PKG_CHECK_MODULES in ENABLE_SERVER test
    `commit <https://codeberg.org/freeipa/freeipa/commit/26b9a697844c3bb66bdf83dad3a9738b3cb65361>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Catch EmptyResult exception in update_idranges
    `commit <https://codeberg.org/freeipa/freeipa/commit/69b42f0c80f392b20526b5ff8155fc1aa633dd7d>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  Test that ipapwpolicy objectclass is added on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/f86250a9a592f2549bc1446c8e3493b256618107>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  Add ipwpwdpolicy objectclass to all policies on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/b60d2d975d79856b1c149ee2136aa813342d39ed>`__
-   `#8555 <https://pagure.io/freeipa/issue/8555>`__
+   `#8555 <https://codeberg.org/freeipa/freeipa/issues/8555>`__
 -  ipatests: Add tests for requiring ipa-ca SAN when ACME is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8f13cd85503f2713c616eccfd7c37e52792c7ef>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  Change the return codes of ipa-acme-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0ff82c884356a6c9fcd0fef66580de30ec5af87>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  Require an ipa-ca SAN on 3rd party certs if ACME is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/2768b0dbaf0e07bc632a4867b13ef4c5ac875372>`__
-   `#8498 <https://pagure.io/freeipa/issue/8498>`__
+   `#8498 <https://codeberg.org/freeipa/freeipa/issues/8498>`__
 -  ipatests: Collect the let's encrypt log
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4ef64b229541200564131e927cd0b4b32662fe2>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Add a status option to ipa-acme-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ae48c8b614a23f530ec6ed33c9019e0b491e50>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Don't install ACME if full support is not available
    `commit <https://codeberg.org/freeipa/freeipa/commit/92c3ea4e293a4fca58269265b7fbf511024dab59>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Centralize enable/disable of the ACME service
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0d55ce6de5e41a98b1e37e23e8bdb339e772c0f>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Let dogtag.py be imported if the api is not initialized
    `commit <https://codeberg.org/freeipa/freeipa/commit/e13d058a066bdbd8a81b794b6f18ca8eca1f31c8>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Enable importing LDIF files not shipped by IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ef53196c6a012ad7d02aed5672d69fbcb5d0a4e>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
 -  Use a state to determine if a 389-ds upgrade is in progress
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f8eb73f588c96b391be57020ecf0b247c646d19>`__
-   `#7534 <https://pagure.io/freeipa/issue/7534>`__
+   `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
 -  ipatests: Add test_pwpolicy to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5155280bb4a92eb3dfdee5ca3f3a332f0159d568>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Requirements and design for libpwquality integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/f602da4b28fcf8822225b80df241eed6b624bf8e>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add SELinux policy so kadmind can read the crackdb dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/68aa7c05542422aca05bec4967133be09a32496e>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  ipatests: add test for password policies
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe44835970eca197543eb3c908c51a240204d846>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add a raiseonerr option to ldappasswd_user_change
    `commit <https://codeberg.org/freeipa/freeipa/commit/be2efc12d37018794200fee874f27d83e0442ea4>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Pass the user to the password policy check in the kdb driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/6da070e655c5d084a825607ed3be604c809b12f0>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add a unit test for libpwquality-based password policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/46d0096218488a961125b6d97a9210b68e5434e5>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Extend password policy to evaluate passwords using libpwpolicy
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4cca53e88e78bfe512ebe59898ede0f94ec24ff>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Require libpwolicy and configure it in the build system
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fc2eda4e15e9592132062036d70acad3bab401c>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add new pwpolicy objectclass to test_xmprpc/objectclasses.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/c03b4862b84d52ddc91c5a3fb885b0ebf753d8f2>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Extend IPA pwquality plugin to include libpwquality support
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b452e54045bb957e6f787209b4498eefc5df779>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Add LDAP schema for new libpwquality attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/41021c278ae572ff5b1b3dea828a7dd93fe1ffff>`__
-   `#2445 <https://pagure.io/freeipa/issue/2445>`__,
-   `#298 <https://pagure.io/freeipa/issue/298>`__,
-   `#5948 <https://pagure.io/freeipa/issue/5948>`__,
-   `#6964 <https://pagure.io/freeipa/issue/6964>`__
+   `#2445 <https://codeberg.org/freeipa/freeipa/issues/2445>`__,
+   `#298 <https://codeberg.org/freeipa/freeipa/issues/298>`__,
+   `#5948 <https://codeberg.org/freeipa/freeipa/issues/5948>`__,
+   `#6964 <https://codeberg.org/freeipa/freeipa/issues/6964>`__
 -  Don't restart certmonger after stopping tracking in uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/139d60d74706d2ba9855db5faefee322b23b0ba5>`__
-   `#8533 <https://pagure.io/freeipa/issue/8533>`__
+   `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__
 -  Reduce the memory requirement from 1.6 to 1.2 GB
    `commit <https://codeberg.org/freeipa/freeipa/commit/b47ddb0186eae69bca09d93035d69a24e7a03595>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Test that ccaches are cleaned up during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f9dcfe88acb27c6ac734af18dc4015e8cb5c327>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Clean up entire /run/ipa/ccaches directory not just files
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc5d9a8c9de3db863ca181348bfb01506f74302d>`__
-   `#8248 <https://pagure.io/freeipa/issue/8248>`__
+   `#8248 <https://codeberg.org/freeipa/freeipa/issues/8248>`__
 -  Require a matching server package for the selinux subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/84bbf68781715e2e574d28d7e6d2c6d75afee59e>`__
-   `#8511 <https://pagure.io/freeipa/issue/8511>`__
+   `#8511 <https://codeberg.org/freeipa/freeipa/issues/8511>`__
 -  Add index for more trust-related attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/20b55f4017ab42113f1ced829a4b4afa17839b55>`__
-   `#8491 <https://pagure.io/freeipa/issue/8491>`__
+   `#8491 <https://codeberg.org/freeipa/freeipa/issues/8491>`__
 -  ipatests: Add tests for checking available memory
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc271a55bb6c942ec5268f190dca72dbb6cb8387>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  Require at least 1.6Gb of available RAM to install the server
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfad7af35dd5a2cdd4081d1e9ac7c245f47f1dce>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  ipatests: Add test for ACI attribute and permission uniqueness
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e4431af7066ce298008973b6caddc170645c98d>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  Use ACI class set_permissions() method to set permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/2656c4687b09f8eb2fe847e5e9901df1dbb3335e>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  De-duplicate ACI attributes and permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdf830af189ceac4b0e8606fb3b538d17d90aaf6>`__
-   `#8443 <https://pagure.io/freeipa/issue/8443>`__
+   `#8443 <https://codeberg.org/freeipa/freeipa/issues/8443>`__
 -  ipatests: test that a zone name and name-from-ip will be rejected
    `commit <https://codeberg.org/freeipa/freeipa/commit/e92a4ba4aeee60b80ac361b9c4858cd54484ace8>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Don't allow both a zone name and --name-from-ip to be provided
    `commit <https://codeberg.org/freeipa/freeipa/commit/2265cb86cf71f7cbdcb969b790991c26491c753c>`__
-   `#8446 <https://pagure.io/freeipa/issue/8446>`__
+   `#8446 <https://codeberg.org/freeipa/freeipa/issues/8446>`__
 -  Set the certmonger subject with a string, not an object
    `commit <https://codeberg.org/freeipa/freeipa/commit/f249c51bf4342341378e63953386e9ac4070be54>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  ipatests: test ipa_server_certinstall with an IPA-issued cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/040d48fa61eb4902f43dfe7fa10257de1e3818b6>`__
-   `#8204 <https://pagure.io/freeipa/issue/8204>`__
+   `#8204 <https://codeberg.org/freeipa/freeipa/issues/8204>`__
 -  cli: When parsing options require name/value pairs
    `commit <https://codeberg.org/freeipa/freeipa/commit/12dfb0fc96ad6db3aa2cd5a56b6cbc8cd092751a>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 -  ipatests: Add option/arg parsing tests for the cli
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a89da5352314cad4417ee42eac2cd8ad7cdc057>`__
-   `#6115 <https://pagure.io/freeipa/issue/6115>`__
+   `#6115 <https://codeberg.org/freeipa/freeipa/issues/6115>`__
 -  ipatests: stop the CA during healthcheck expiration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/454e023ad8f0821e8a7c2400485a4d270cf4d3ea>`__
-   `#8463 <https://pagure.io/freeipa/issue/8463>`__
+   `#8463 <https://codeberg.org/freeipa/freeipa/issues/8463>`__
 -  Improve performance of ipa-server-guard
    `commit <https://codeberg.org/freeipa/freeipa/commit/18a8a4158051cf6b5b809605dd88dd8090f3485f>`__
-   `#8425 <https://pagure.io/freeipa/issue/8425>`__
+   `#8425 <https://codeberg.org/freeipa/freeipa/issues/8425>`__
 -  ipatests: Add test for is_ipa_configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/25e042d3d1e04972d4536b1fa793811e6b047559>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Use is_ipa_configured from ipalib.facts
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bdb18d56fd65e0058ee302502f68a37decc55e8>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  Fall back to old server installation detection when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8d5e6bbfe03070925c85793ac898299d543a3d4>`__
-   `#8458 <https://pagure.io/freeipa/issue/8458>`__
+   `#8458 <https://codeberg.org/freeipa/freeipa/issues/8458>`__
 -  IPA-EPN: Test that EPN can be install, uninstalled and re-installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/af5138c2aa80c85b9994eb2891d2f1ec1e2cad01>`__
 -  Added negative test case for --list-sources option
@@ -4022,28 +4022,28 @@ Rob Crittenden (116)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2bf5958efce503b7655db3c2807f0f8399d5b29>`__
 -  Address legacy pylint issues in sysrestore.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/0dc084a34fbc6d86348a3a381cb8fa4fd4af43f1>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Update check_client_configuration to use new client fact
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c3a042c06b919ff754bfce2ce6e40b9f1827e97>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Don't use the has_files() to know if client/server is configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e027134815512862ad6ae77867e74a83aee2b59>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Create a common place to retrieve facts about an IPA installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7a4756dac5140d4416312ed92270eb3249c83e3>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if IPA client configuration is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/4758db121ea0c555dab89bc1781c8752f188e414>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  Simplify determining if an IPA server installation is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa8686918f6b79d09ac8fa959fe988f6db633b2>`__
-   `#8384 <https://pagure.io/freeipa/issue/8384>`__
+   `#8384 <https://codeberg.org/freeipa/freeipa/issues/8384>`__
 -  ipatests: Check permissions of /etc/ipa/ca.crt new installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e37b45e029d33ebd865724e7d690a29b30a8ef4>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  Set mode of /etc/ipa/ca.crt to 0644 in CA-less installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec367aa4792fb14ee21ebd5a8593ed287b598229>`__
-   `#8441 <https://pagure.io/freeipa/issue/8441>`__
+   `#8441 <https://codeberg.org/freeipa/freeipa/issues/8441>`__
 -  ipatests: Test healthcheck revocation checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/61db3527e31b1d7c7cda15c034c666cc95c17775>`__
 -  ipatests: Use healthcheck namespacing in stopped server test
@@ -4062,44 +4062,44 @@ Rob Crittenden (116)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5dd566951198c3bcf0e5860deea4e76a9b8a6dc0>`__
 -  Add fips-mode-setup to ipaplatform.paths to determine FIPS status
    `commit <https://codeberg.org/freeipa/freeipa/commit/78acf0bcfcf594d56725f88426df3bf63a95fc4f>`__
-   `#8429 <https://pagure.io/freeipa/issue/8429>`__
+   `#8429 <https://codeberg.org/freeipa/freeipa/issues/8429>`__
 -  Don't delegate the TGT in ipa-join
    `commit <https://codeberg.org/freeipa/freeipa/commit/28caa22a8e5b1fd402692cdc41fa4dd4a73f6698>`__
-   `#8405 <https://pagure.io/freeipa/issue/8405>`__
+   `#8405 <https://codeberg.org/freeipa/freeipa/issues/8405>`__
 -  IPA-EPN: Don't treat givenname differently
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba7974bfd1ae1072befcbde792d8cf4a158fc3c5>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add test to validate smtp_delay value
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb205cc5e4c890df5d0344682e6c958ecb087c68>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: add smtp_delay to limit the velocity of e-mails sent
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b266d39570f447db0f571a8b8085eb6c0403509>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for --mail-test option
    `commit <https://codeberg.org/freeipa/freeipa/commit/759ab3120e09672f9b9f6c400fed79b6e2820cc7>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add mail-test option for testing sending live email
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2728c758e83c81be4ab28e5de1a76e9cbcd4799>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: test using SSL against port 465
    `commit <https://codeberg.org/freeipa/freeipa/commit/41e3d58a0b1af803926b92592cbf1d21f7e8ce14>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add test for starttls mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e621cf84f9498d6f6ff7c82609a50480dcaa78a>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Add tests for sending real mail with auth and templates
    `commit <https://codeberg.org/freeipa/freeipa/commit/1760ad48ae26e2a9ae60da0ac442b2ce9a6a4a39>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  IPA-EPN: Fixes to starttls mode, convert some log errors to
    exceptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3cbaed9fdfa3c5501974934839cd243531a1fd5>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add index for krbPasswordExpiration for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/451cbae160a1e68d01eb49ceb69adac03d5e8112>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Add a jinja2 e-mail template for EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/03caa7f965d889848675158503286cde00d635c9>`__
-   `#3687 <https://pagure.io/freeipa/issue/3687>`__
+   `#3687 <https://codeberg.org/freeipa/freeipa/issues/3687>`__
 -  Perform baseline healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/3022bb5fd200ea3b22fb1600401e95aaee2006ea>`__
 -  Test that pwpolicy only applied on Kerberos entries
@@ -4114,52 +4114,52 @@ Rob Crittenden (116)
    `commit <https://codeberg.org/freeipa/freeipa/commit/44e73428441a070f26a791ee2816f2989713ba8d>`__
 -  Fix div-by-zero when svc weight is 0 for all masters in location
    `commit <https://codeberg.org/freeipa/freeipa/commit/f589a8952c33a25794e577077bb3c0bda740667c>`__
-   `#8135 <https://pagure.io/freeipa/issue/8135>`__
+   `#8135 <https://codeberg.org/freeipa/freeipa/issues/8135>`__
 -  Don't fully quality the FQDN in ssbrowser.html for Chrome
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4966f9c3f9566603be24e09f4803b3183898272>`__
-   `#8201 <https://pagure.io/freeipa/issue/8201>`__
+   `#8201 <https://codeberg.org/freeipa/freeipa/issues/8201>`__
 -  Add tests for ipa-cacert-manage delete command
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e71605c54c31dfa5c9ed9fc0dd640047fa96bf6>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  ipa-certupdate removes all CA certs from db before adding new ones
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cb4f4bd50fe25f6ad66a4da1cec9dedfb281f12>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Add delete option to ipa-cacert-manage to remove CA certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/acfb6191a1b2b35f85201ae013eaccb9474e0c7d>`__
-   `#8124 <https://pagure.io/freeipa/issue/8124>`__
+   `#8124 <https://codeberg.org/freeipa/freeipa/issues/8124>`__
 -  Allow an empty cookie in dogtag-ipa-ca-renew-agent-submit
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5b9efeb57c010443c33c6f14f831abdbd804e78>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  CVE-2019-10195: Don't log passwords embedded in commands in calls
    using batch
    `commit <https://codeberg.org/freeipa/freeipa/commit/02ce407f5e10e670d4788778037892b58f80adc0>`__
 -  Add integration test for Kerberos ticket policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/c02cc93c146bca429f69bf5536a3f6c15b02876e>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  Conditionally restart certmonger after client installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3593e5362206fd9287e97fe2cee229a1117811ff>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Add conditional restart (try-restart) capability to services
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e3de172696a98914f77e50fd64bc8b63360cd27>`__
-   `#8105 <https://pagure.io/freeipa/issue/8105>`__
+   `#8105 <https://codeberg.org/freeipa/freeipa/issues/8105>`__
 -  Enable AES SHA 256 and 384-bit enctypes in Kerberos
    `commit <https://codeberg.org/freeipa/freeipa/commit/09d5b938c128d8bb01ae40b5d736a266c6075b39>`__
-   `#8110 <https://pagure.io/freeipa/issue/8110>`__
+   `#8110 <https://codeberg.org/freeipa/freeipa/issues/8110>`__
 -  Disable dogtag cert publishing
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8b0d1d6a036d55f4e3bcac996c14371614105d8>`__
-   `#7522 <https://pagure.io/freeipa/issue/7522>`__
+   `#7522 <https://codeberg.org/freeipa/freeipa/issues/7522>`__
 -  ipa-restore: Restore ownership and perms on 389-ds log directory
    `commit <https://codeberg.org/freeipa/freeipa/commit/8da0e2e9774ead01d5c0fa53b1498f15b1818b79>`__
-   `#7725 <https://pagure.io/freeipa/issue/7725>`__
+   `#7725 <https://codeberg.org/freeipa/freeipa/issues/7725>`__
 -  Report if a certmonger CA is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b28c458b91c545d089da6271da0927e7c91ccdd>`__
-   `#7870 <https://pagure.io/freeipa/issue/7870>`__
+   `#7870 <https://codeberg.org/freeipa/freeipa/issues/7870>`__
 -  Re-order tasks.restore_pkcs11_modules() to run earlier
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffb4b624fc8bfd870958976ec25b74677e740841>`__
-   `#8034 <https://pagure.io/freeipa/issue/8034>`__
+   `#8034 <https://codeberg.org/freeipa/freeipa/issues/8034>`__
 -  Don't log host passwords when they are set/modified
    `commit <https://codeberg.org/freeipa/freeipa/commit/48a3f4af46517c7dbaddad7e2c5d4e82a6ef2f33>`__
-   `#8017 <https://pagure.io/freeipa/issue/8017>`__
+   `#8017 <https://codeberg.org/freeipa/freeipa/issues/8017>`__
 -  Skip lock and fork in ipa-server-guard on unsupported ops
    `commit <https://codeberg.org/freeipa/freeipa/commit/65d38af9e27f894ec8260b9d8d7bcbdcb79b5c0f>`__
 -  Defer initializing the API in dogtag-ipa-ca-renew-agent-submit
@@ -4168,26 +4168,26 @@ Rob Crittenden (116)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5db48f151ba4aef2baebc40a4d357403a922d362>`__
 -  Log dogtag auth timeout in install, provide hint to increase it
    `commit <https://codeberg.org/freeipa/freeipa/commit/adf2eab26309fb3ce0c2e2dbb0593f64bcd3d475>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Log the replication wait timeout for debugging purposes
    `commit <https://codeberg.org/freeipa/freeipa/commit/54035982e5850ec59611798a9e172a044969106f>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Replace replication_wait_timeout with certmonger_wait_timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/faf34fcdfd78208726e3e8586186f34e7c44d732>`__
-   `#7971 <https://pagure.io/freeipa/issue/7971>`__
+   `#7971 <https://codeberg.org/freeipa/freeipa/issues/7971>`__
 -  Use tasks to configure automount nsswitch settings
    `commit <https://codeberg.org/freeipa/freeipa/commit/41ef8fba31ddbb32e2e5b7cccdc9b582a0809111>`__
 -  Move ipachangeconf from ipaclient.install to ipapython
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5af8c19a9e40fb3b96c56ace081f79980437fc2>`__
 -  Don't return SSH keys with ipa host-find --pkey-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/73c32dbfeb9a67a476243540dc724784b1a007aa>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  httpinstance: add pinfile when tracking certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5822e3a25c0b1b35678ba3d8bcca6cbc16bff5b>`__
-   `#7991 <https://pagure.io/freeipa/issue/7991>`__
+   `#7991 <https://codeberg.org/freeipa/freeipa/issues/7991>`__
 -  Remove posixAccount from service_find search filter
    `commit <https://codeberg.org/freeipa/freeipa/commit/e771fa59ff65545ff1e84f1cd30e06556fabcee3>`__
-   `#8013 <https://pagure.io/freeipa/issue/8013>`__
+   `#8013 <https://codeberg.org/freeipa/freeipa/issues/8013>`__
 
 
 
@@ -4198,7 +4198,7 @@ Robbie Harwood (16)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e382cdd02807ed5f145b79bb68a4ba279126a8a>`__
 -  ipa-kdb: implement AS-REQ lifetime jitter
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d67180f7d2d0c6b5856db7061c44521f6a13c23>`__
-   `#8010 <https://pagure.io/freeipa/issue/8010>`__
+   `#8010 <https://codeberg.org/freeipa/freeipa/issues/8010>`__
 -  Update kdcpolicy design doc for jitter implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/249097c62414abc99256af9dc622c284745081e4>`__
 -  Drop support for DAL version 5.0
@@ -4253,7 +4253,7 @@ Rafael Guterres Jeffman (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc53544c6f4db00ea11fdf9fa7fb0c421ca63496>`__
 -  Re-add function façades removed by commit 2da9088.
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c20641f5c8e9d4f813d0ba3e80b7ccc9df0ed15>`__
-   `#8062 <https://pagure.io/freeipa/issue/8062>`__
+   `#8062 <https://codeberg.org/freeipa/freeipa/issues/8062>`__
 
 
 
@@ -4278,7 +4278,7 @@ Sam Morris (1)
 
 -  Debian: write out only one CA certificate per file
    `commit <https://codeberg.org/freeipa/freeipa/commit/3985183d73ffa4be0f1a29a846d0de04d838f62a>`__
-   `#8106 <https://pagure.io/freeipa/issue/8106>`__
+   `#8106 <https://codeberg.org/freeipa/freeipa/issues/8106>`__
 
 
 
@@ -4287,10 +4287,10 @@ Sumit Bose (2)
 
 -  ipa-kdb: Remove keys if password auth is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0d12b7f1b06af8ad369041b64dc763441a1a44a>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__
 -  extdom: unify error code handling especially LDAP_NO_SUCH_OBJECT
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fe984fed7a7091bd1366be95fdfa2f56f777bb8>`__
-   `#8044 <https://pagure.io/freeipa/issue/8044>`__
+   `#8044 <https://codeberg.org/freeipa/freeipa/issues/8044>`__
 
 
 
@@ -4309,15 +4309,15 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/82e69008ad43b993a2d3664b3ea35d9f84f2679a>`__
 -  EPN: Allow authentication by SMTP client's certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/17f430efc4cf438b6c052465b8252688bc5822f9>`__
-   `#8580 <https://pagure.io/freeipa/issue/8580>`__
+   `#8580 <https://codeberg.org/freeipa/freeipa/issues/8580>`__
 -  EPN: Enable certificate validation and hostname checking
    `commit <https://codeberg.org/freeipa/freeipa/commit/32aa1540f0f25864816eced0b2f569a6cdfd3973>`__
-   `#8579 <https://pagure.io/freeipa/issue/8579>`__
+   `#8579 <https://codeberg.org/freeipa/freeipa/issues/8579>`__
 -  test_epn: Standardize EPN configs for deduplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/977063a56ef8f11c75a4cdd836f8692155337c7b>`__
 -  EPN: Don't downgrade security
    `commit <https://codeberg.org/freeipa/freeipa/commit/94adee3c73f039fc2d985afd1681cd64ece55116>`__
-   `#8578 <https://pagure.io/freeipa/issue/8578>`__
+   `#8578 <https://codeberg.org/freeipa/freeipa/issues/8578>`__
 -  ipatests: Respect platform's openssl dir
    `commit <https://codeberg.org/freeipa/freeipa/commit/be006ad6c4e36fd53212a5e573524d1c96dfab39>`__
 -  dns: Make use of \`resolve_address\` of a current resolver instead of
@@ -4325,17 +4325,17 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b450c9bd324a3c89ea03d898592cfed832184802>`__
 -  dnspython: Add compatibility shim
    `commit <https://codeberg.org/freeipa/freeipa/commit/49e643783d22ded7a44d84599020af4e8a3d4d5a>`__
-   `#8383 <https://pagure.io/freeipa/issue/8383>`__
+   `#8383 <https://codeberg.org/freeipa/freeipa/issues/8383>`__
 -  tox: Don't expand symlinks
    `commit <https://codeberg.org/freeipa/freeipa/commit/fdb227e55ab976fb26ef417df1e4a842d3280f5c>`__
-   `#8475 <https://pagure.io/freeipa/issue/8475>`__
+   `#8475 <https://codeberg.org/freeipa/freeipa/issues/8475>`__
 -  Azure: Increase verbosity for Tox task
    `commit <https://codeberg.org/freeipa/freeipa/commit/30cf59d0ae39e83f3590152aec19e466dbc3623a>`__
 -  deps: Require \`nss-tools\` for make's fasttest target
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3d10871300498150c41f3acc154688f1ee48ceb>`__
 -  nss: Raise exception earlier on unsupported DB type
    `commit <https://codeberg.org/freeipa/freeipa/commit/a102cfe5faf28b801d2ad3570477ef9dd5c0d5f1>`__
-   `#8474 <https://pagure.io/freeipa/issue/8474>`__
+   `#8474 <https://codeberg.org/freeipa/freeipa/issues/8474>`__
 -  Azure: base: Collect both install and uninstall logs
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5b23287aeddd32b129d4c97e6354900c8b931ec>`__
 -  Azure: Drop dependency on UsePythonVersion task
@@ -4344,129 +4344,129 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d326a9097c6fe5f1eb6d30340aedbe9200c3d37>`__
 -  ipa-dnskeysyncd: Raise loglevel to DEBUG
    `commit <https://codeberg.org/freeipa/freeipa/commit/92157bc880600be137c634d5def788c1bf8c5e8a>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Include crypto policy in openssl config
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2030b8cad9eaf8760ec107f370be3b71ffbe2f4>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Don't override custom command line options for named
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecfaf897b937e2333296d32960b2cc13843048f9>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  service: Allow service to clean up its state
    `commit <https://codeberg.org/freeipa/freeipa/commit/8716881fc41909d0ab5a32d2db79313d7b81ee49>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  spec: Bump required openssl-pkcs11 and softhsm
    `commit <https://codeberg.org/freeipa/freeipa/commit/53b341f94b2ba5f39696995e4ad772ffe757e495>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Make use of 'pkcs11' OpenSSL engine for BIND on Fedora31
    `commit <https://codeberg.org/freeipa/freeipa/commit/721435cf7f2ed41fe807c34022fed31c792b4497>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  upgrade: Handle migration of BIND OpenSSL engine
    `commit <https://codeberg.org/freeipa/freeipa/commit/85ed106d78b0393aac7929cd2713f1097fb8a67d>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  DNSKeySyncInstance: Populate named/ods uid/gid on instantiation
    `commit <https://codeberg.org/freeipa/freeipa/commit/bed09b7f85a2abf73e2dfec58ea8a094ae847d29>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Allow using of a custom OpenSSL engine for BIND
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c907e34ae4496482151cd9c8271d9931ac4056d>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  named: Remove no longer used paths
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9334ce5e5fbedfb22a5779ce90e367c13979747>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  spec: Require ldns-utils
    `commit <https://codeberg.org/freeipa/freeipa/commit/173cd9b91b1048e852dca9c39dbbd38304367dd1>`__
-   `#8094 <https://pagure.io/freeipa/issue/8094>`__
+   `#8094 <https://codeberg.org/freeipa/freeipa/issues/8094>`__
 -  pylint: Ignore \`raise-missing-from\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/8831b9b6498b834c77dce2e0b96854be105810f9>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Ignore \`super-with-arguments\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec6369ca009139af69aa4214e82fc411184b428f>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Fix warning W0612(unused-variable)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e85872528251ba34a45c9639beb0ccda2ac82f1>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  pylint: Teach pylint about more RRs types
    `commit <https://codeberg.org/freeipa/freeipa/commit/de105aa8fc8281c28c359d607c2b43154103a399>`__
-   `#8468 <https://pagure.io/freeipa/issue/8468>`__
+   `#8468 <https://codeberg.org/freeipa/freeipa/issues/8468>`__
 -  spec: Move ipa-cldap plugin out to freeipa-server-trust-ad package
    `commit <https://codeberg.org/freeipa/freeipa/commit/03a5e5f35ff09b34474d28b5ec3704a2aa0b31b8>`__
 -  uninstall: Clean up no longer used flag
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c1e44830048f5b13656349c63b5319a536e3a8d>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  uninstall: Don't fail on missing /var/lib/samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/89d86dac0a13063a11deaa8ef31f9fb2fcbc1ff7>`__
-   `#8461 <https://pagure.io/freeipa/issue/8461>`__
+   `#8461 <https://codeberg.org/freeipa/freeipa/issues/8461>`__
 -  rpm-spec: Don't fail on missing /etc/ssh/ssh_config
    `commit <https://codeberg.org/freeipa/freeipa/commit/777147e051d71ebfbac23269cf78fcb23a3b1f43>`__
-   `#8459 <https://pagure.io/freeipa/issue/8459>`__
+   `#8459 <https://codeberg.org/freeipa/freeipa/issues/8459>`__
 -  ipatests: Skip keyring tests on containerized platforms
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5c09675f3c7c2ecb105df4c4ecf846a2d3ffdc4>`__
 -  Azure: Switch to dockerhub provider
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b85bfb03052b56591b06abe62c71e36170dc9a0>`__
 -  ipatests: Add compatibility against python-cryptography 3.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a344a5d932db148b1921c03906d2843b3622cb>`__
-   `#8428 <https://pagure.io/freeipa/issue/8428>`__
+   `#8428 <https://codeberg.org/freeipa/freeipa/issues/8428>`__
 -  pylint: Fix warning and error
    `commit <https://codeberg.org/freeipa/freeipa/commit/c81cac70acd304f34f875af5096c407a44f1395b>`__
-   `#8442 <https://pagure.io/freeipa/issue/8442>`__
+   `#8442 <https://codeberg.org/freeipa/freeipa/issues/8442>`__
 -  ipatests: Don't turn Pytest IPA deprecation warnings into errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/55b7787ef5e71200632bcd2751f228b57312fcb0>`__
-   `#8435 <https://pagure.io/freeipa/issue/8435>`__
+   `#8435 <https://codeberg.org/freeipa/freeipa/issues/8435>`__
 -  Azure: Make dnf repos consistent
    `commit <https://codeberg.org/freeipa/freeipa/commit/26f96595b010396f055c7d11a645be57fc637863>`__
-   `#8330 <https://pagure.io/freeipa/issue/8330>`__
+   `#8330 <https://codeberg.org/freeipa/freeipa/issues/8330>`__
 -  Azure: Always update apt cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6fbee53bcdbbdcf630f1594123ca01fa9a4ca27>`__
 -  Azure: Allow chronyd to sync time
    `commit <https://codeberg.org/freeipa/freeipa/commit/8882fc49d07dad75368a6f0e39d77ede3cc06b83>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Add custom seccomp profile
    `commit <https://codeberg.org/freeipa/freeipa/commit/958e2458133c13219d8cd0d7618eba2b70b4be89>`__
-   `#8316 <https://pagure.io/freeipa/issue/8316>`__
+   `#8316 <https://codeberg.org/freeipa/freeipa/issues/8316>`__
 -  Azure: Increase memory limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/87408ee7557cff04c1dd9c5de052e49f22c34f0f>`__
-   `#8264 <https://pagure.io/freeipa/issue/8264>`__
+   `#8264 <https://codeberg.org/freeipa/freeipa/issues/8264>`__
 -  ipatests: Collect all logs on all Unix hosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/63747bc0c041382536e2cad121bb591e42df3a2f>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Pretty print multihost config
    `commit <https://codeberg.org/freeipa/freeipa/commit/5da309ee11f2aaba687d12a8c517f64070e22ae8>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Cleanup 'collect_logs' decorator
    `commit <https://codeberg.org/freeipa/freeipa/commit/43ac2d9ab36518e510d621813ed73fb40e7cd2de>`__
-   `#8265 <https://pagure.io/freeipa/issue/8265>`__
+   `#8265 <https://codeberg.org/freeipa/freeipa/issues/8265>`__
 -  ipatests: Specify shell implementation
    `commit <https://codeberg.org/freeipa/freeipa/commit/974395704ad3a0c992324a080e96e1160f324153>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Specify Pytest XML report schema
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d8d1670365e466c6e285d1b09494d11aa7be64a>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'skip' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/18500a3d01c9e902342cdaaf12b42484c11fa62c>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'capture' compatibility
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6b088effdcb47e7a9ee2c2505a950b07eff13bf>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove no longer needed 'get_marker'
    `commit <https://codeberg.org/freeipa/freeipa/commit/be6ac7d4c999c6fdd184c6cac9bd6330ed6261bb>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Remove deprecated yield_fixture
    `commit <https://codeberg.org/freeipa/freeipa/commit/d67846fa36b64fb692b406158fb04869c5c3e27a>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Bump required Pytest
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffb1db5616cec6ceb49b7948e9c8e5e6284c7b02>`__
-   `#8101 <https://pagure.io/freeipa/issue/8101>`__
+   `#8101 <https://codeberg.org/freeipa/freeipa/issues/8101>`__
 -  ipatests: Mark firewalld commands as no-op on non-firewalld distros
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba162b9b47004da633a2c140409982725f5e0960>`__
-   `#8261 <https://pagure.io/freeipa/issue/8261>`__
+   `#8261 <https://codeberg.org/freeipa/freeipa/issues/8261>`__
 -  Azure: Gather coredumps
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1b53ded8b566f8ca4ed191a76efe7076263ed5f>`__
-   `#8251 <https://pagure.io/freeipa/issue/8251>`__
+   `#8251 <https://codeberg.org/freeipa/freeipa/issues/8251>`__
 -  Azure: Allow distros to install Python they want
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa5a3336a80b381a4a49ad61accdde2f984203cb>`__
-   `#8254 <https://pagure.io/freeipa/issue/8254>`__
+   `#8254 <https://codeberg.org/freeipa/freeipa/issues/8254>`__
 -  pki-proxy: Don't rely on running apache until it's configured
    `commit <https://codeberg.org/freeipa/freeipa/commit/14c9cf99889fec73c46b33f94b0dc483c4542044>`__
-   `#8233 <https://pagure.io/freeipa/issue/8233>`__
+   `#8233 <https://codeberg.org/freeipa/freeipa/issues/8233>`__
 -  spec: Take the ownership over '/usr/libexec/ipa/custodia'
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c9c6a70632cdb8f55b65a50c9a808007523666b>`__
 -  Azure: Report elapsed time
@@ -4483,81 +4483,81 @@ Stanislav Levin (91)
    `commit <https://codeberg.org/freeipa/freeipa/commit/6daf4d2e10007b5c22a9e491e5372d25fd74fc88>`__
 -  pylint: Run Pylint over Azure Python scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/e280a2f06ae1e7e78bc86122fbb6d6ceded9e34c>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Add support for testing multi IPA environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/31d05650fbd784cf87e9dd325d2220c69d6f43ef>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Don't collect twice systemd_journal.log
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3f1b9b43d55aafb59945ff9635abb4786e0b51a>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  yamllint: Lint all the YAML files
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa104daf77902172f087c7026052fd9a59b4861a>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Make it possible to configure distro-specific stuff
    `commit <https://codeberg.org/freeipa/freeipa/commit/b82515562a9b33c2e0fe345a0cc0bdd8c3cc1688>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to run integration tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/879855ce705770834d0be8182818ae672bc72063>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow SSH for Docker environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/157fa59e7ce29ea3d7f254a102f7af1bfd77e237>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  Azure: Allow to not provide tests to be ignored
    `commit <https://codeberg.org/freeipa/freeipa/commit/ecc398c409e41ff4d1014e6e88bb5c82d6c19f75>`__
-   `#8202 <https://pagure.io/freeipa/issue/8202>`__
+   `#8202 <https://codeberg.org/freeipa/freeipa/issues/8202>`__
 -  ipatests: Allow zero-length arguments
    `commit <https://codeberg.org/freeipa/freeipa/commit/902821e8aa47936acac713023bff9a4009d8dfb7>`__
-   `#8173 <https://pagure.io/freeipa/issue/8173>`__
+   `#8173 <https://codeberg.org/freeipa/freeipa/issues/8173>`__
 -  lint: Make Pylint-2.4 happy again
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba12165eaf76e6fee30b05b0fe939e13854d70dc>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Clean up comment
    `commit <https://codeberg.org/freeipa/freeipa/commit/a309de6c08987b1cf9645111414d1c52b4525190>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Synchronize pylint plugin to ipatests code
    `commit <https://codeberg.org/freeipa/freeipa/commit/e128e7d691d0102460a54359dc8855fb7fcd7f35>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  pylint: Teach Pylint how to handle request.context
    `commit <https://codeberg.org/freeipa/freeipa/commit/92b440a0baf590fcb3082dfe2ca673813e1e5b7c>`__
-   `#8116 <https://pagure.io/freeipa/issue/8116>`__
+   `#8116 <https://codeberg.org/freeipa/freeipa/issues/8116>`__
 -  ipatests: Properly kill gpg-agent
    `commit <https://codeberg.org/freeipa/freeipa/commit/19462788f162491e0aedaaf42528cae7104b8068>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Warn about unittest/nose/xunit tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c7447fd42548d28df6200e354afdc03355b94b6>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate unittest/nose to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/fec66942d469188fcd1ccfbd6e14f4e8334056b4>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  pytest: Migrate xunit-style setups to Pytest fixtures
    `commit <https://codeberg.org/freeipa/freeipa/commit/292d686c0b7935dd219559b10de3a393b712a990>`__
-   `#7989 <https://pagure.io/freeipa/issue/7989>`__
+   `#7989 <https://codeberg.org/freeipa/freeipa/issues/7989>`__
 -  Fix errors found by Pylint-2.4.3
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6769ad12f79c9430ecf7c1a97be8b865a059e23>`__
-   `#8102 <https://pagure.io/freeipa/issue/8102>`__
+   `#8102 <https://codeberg.org/freeipa/freeipa/issues/8102>`__
 -  Install language packs for tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ed7dd4bf14c8cfb80aa5f59549821feaf9c3f26>`__
 -  Restore running of 'test_ipaserver' tests on Azure
    `commit <https://codeberg.org/freeipa/freeipa/commit/16149831daf12826c1c39d4109a0014b86fbb072>`__
 -  Setup DNS for AP Docker container
    `commit <https://codeberg.org/freeipa/freeipa/commit/feae9de73ec9f084d8662690a61f5afefc9a1d6c>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 -  Fixed errors newly exposed by pylint 2.4.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0b420f6dd9d5cb8019691866f6131117a12b713>`__
-   `#8077 <https://pagure.io/freeipa/issue/8077>`__
+   `#8077 <https://codeberg.org/freeipa/freeipa/issues/8077>`__
 -  Avoid use of '/tmp' for pip operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7500220c443c6051178211eadd64392ca7bd08a>`__
-   `#8009 <https://pagure.io/freeipa/issue/8009>`__
+   `#8009 <https://codeberg.org/freeipa/freeipa/issues/8009>`__
 -  Make use of Azure Pipeline slicing
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2d4e2a61f46cf6337786b2cb031e3a9f394a708>`__
-   `#8008 <https://pagure.io/freeipa/issue/8008>`__
+   `#8008 <https://codeberg.org/freeipa/freeipa/issues/8008>`__
 -  Simplify ipa-run-tests script
    `commit <https://codeberg.org/freeipa/freeipa/commit/2312b38a678d30b73c08dae19db7f8b74361a957>`__
-   `#8007 <https://pagure.io/freeipa/issue/8007>`__
+   `#8007 <https://codeberg.org/freeipa/freeipa/issues/8007>`__
 -  Fix \`test_webui.test_selinuxusermap\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac1ea0ec6710f40adffc3f04b39422f3043c6554>`__
-   `#7996 <https://pagure.io/freeipa/issue/7996>`__,
-   `#8005 <https://pagure.io/freeipa/issue/8005>`__
+   `#7996 <https://codeberg.org/freeipa/freeipa/issues/7996>`__,
+   `#8005 <https://codeberg.org/freeipa/freeipa/issues/8005>`__
 
 
 
@@ -4599,7 +4599,7 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e44fc80b8e0ca09a57fad854fb70e616b1c41d2>`__
 -  ipatests: provide AD admin password when trying to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/aae30eb708b04c54807bc226b93ca14e09561b87>`__
-   `#7895 <https://pagure.io/freeipa/issue/7895>`__
+   `#7895 <https://codeberg.org/freeipa/freeipa/issues/7895>`__
 -  ipatests: remove test_ordering
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e47799cc7c761cba54dbbadb29c07f05de34674>`__
 -  ipatests: add test for SSSD updating expired cache items
@@ -4608,40 +4608,40 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c059c81ce61d70ec3c855881902a8ca1f08eeed>`__
 -  ipatests: remove invalid parameter from sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e01e7fe6c64ef0d75c7256cc4fa631b0c296edd2>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: use remote_sssd_config to modify sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dd679b31dcdab1447b9d19c94019aaf7a0db071>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: replace utility for editing sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/9450aef75f2ac064ea182c942d39400287a38bab>`__
-   `#8219 <https://pagure.io/freeipa/issue/8219>`__
+   `#8219 <https://codeberg.org/freeipa/freeipa/issues/8219>`__
 -  ipatests: update docstring to reflect changes in FileBackup.restore()
    `commit <https://codeberg.org/freeipa/freeipa/commit/888c7ba938686a5fbc1c359e43a8e79989dee850>`__
 -  ipatests: add test_trust suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/001de6eed70d96a3e1e12554e8320d8f18ebf5a6>`__
 -  ipatests: add check for output contents of ipa-client-samba
    `commit <https://codeberg.org/freeipa/freeipa/commit/15fd36612ea451cec2e1302a462fa440663fcc74>`__
-   `#8149 <https://pagure.io/freeipa/issue/8149>`__
+   `#8149 <https://codeberg.org/freeipa/freeipa/issues/8149>`__
 -  ipatests: add test_winsyncmigrate suite to nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ad4f4c86ab780771c0419e939fb618b982db3df>`__
 -  ipatests: add check that ipa-adtrust-install generates sane smb.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/e87357749e17a79cd0c5fc2aad995a1ce66d7727>`__
-   `#6951 <https://pagure.io/freeipa/issue/6951>`__
+   `#6951 <https://codeberg.org/freeipa/freeipa/issues/6951>`__
 -  ipatests: enable test_smb.py in gating.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/f58fb573d18808343e30a59304c5d3862b4e7e42>`__
 -  ipatests: replace ad hoc backup with FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2b230ce64bb7a29572cbfabbd23dd0900c7fce3>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: refactor FileBackup helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/72540c42337cacab1dcbf0a4b2b03d59512e7956>`__
-   `#8115 <https://pagure.io/freeipa/issue/8115>`__
+   `#8115 <https://codeberg.org/freeipa/freeipa/issues/8115>`__
 -  ipatests: in DNS zone file add A record for name server
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16c08b7d68c8b6dc9871077ca057871ff54a795>`__
 -  ipatests: strip newline character when getting name of temp file
    `commit <https://codeberg.org/freeipa/freeipa/commit/b10e43c3eab01c4c2ec7c9a803ef67477f97bedd>`__
 -  ipatests: add test to check that only TLS 1.2 is enabled in Apache
    `commit <https://codeberg.org/freeipa/freeipa/commit/14be2715334e16a2d3f07a6b64bcd6d068ce89c1>`__
-   `#7995 <https://pagure.io/freeipa/issue/7995>`__
+   `#7995 <https://codeberg.org/freeipa/freeipa/issues/7995>`__
 -  ipatests: fix DNS forwarders setup for AD trust tests with non-root
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d7f89c5a0e6dc0d1dc567ab50111c9bcdb8b708>`__
@@ -4654,7 +4654,7 @@ Sergey Orlov (45)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7dde3a422067c82b67eab197a0da3d6f149c1b3c>`__
 -  ipatests: refactor and extend tests for IPA-Samba integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d033b040d8cc96d7c6dfa0786fc09505b3a9acf>`__
-   `#3999 <https://pagure.io/freeipa/issue/3999>`__
+   `#3999 <https://codeberg.org/freeipa/freeipa/issues/3999>`__
 -  ipatests: modify run_command to allow specify successful return codes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fe69f352b28c7bbf218c9d3ece4b45eac6ddad6>`__
 -  ipatests: add utility functions related to using and managing user
@@ -4685,17 +4685,17 @@ Sumedh Sidhaye (6)
 -  Test to check if Certmonger tracks certs in between
    reboots/interruptions and while in "CA_WORKING" state
    `commit <https://codeberg.org/freeipa/freeipa/commit/58ad7b74eb4136ff8cd10ad6caf463df7403f5b3>`__
-   `#8164 <https://pagure.io/freeipa/issue/8164>`__
+   `#8164 <https://codeberg.org/freeipa/freeipa/issues/8164>`__
 -  Added a test to check if ipa host-find --pkey-only does not return
    SSH public key
    `commit <https://codeberg.org/freeipa/freeipa/commit/f0f2c2645ef5aa0a065e2b5a2063d57d85f74d56>`__
-   `#8029 <https://pagure.io/freeipa/issue/8029>`__
+   `#8029 <https://codeberg.org/freeipa/freeipa/issues/8029>`__
 -  Test: Test to check whether ssh from ipa client to ipa master is
    successful after adding ldap_deref_threshold=0 in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/de1fa7cc745fbd9127d00697e248d39e8c541e45>`__
 -  Test: To check ipa replica-manage del does not fail
    `commit <https://codeberg.org/freeipa/freeipa/commit/b52d40b0c1242eb49b21834ef83d810b687ca657>`__
-   `#7929 <https://pagure.io/freeipa/issue/7929>`__
+   `#7929 <https://codeberg.org/freeipa/freeipa/issues/7929>`__
 
 
 
@@ -4721,94 +4721,94 @@ Serhii Tsymbaliuk (28)
 -  WebUI tests: Add simple test to check topology graph page is
    available
    `commit <https://codeberg.org/freeipa/freeipa/commit/69368fccdb8786fca63341a780f9c48a91c84f5e>`__
-   `#8523 <https://pagure.io/freeipa/issue/8523>`__
+   `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__
 -  WebUI: Fix topology graph navigation crash
    `commit <https://codeberg.org/freeipa/freeipa/commit/1512acc7de5b6c2ea3f9edbe661d6d1e2bdc5889>`__
-   `#8523 <https://pagure.io/freeipa/issue/8523>`__
+   `#8523 <https://codeberg.org/freeipa/freeipa/issues/8523>`__
 -  WebUI: Fix jQuery DOM manipulation issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/29b41aef0a49d5460631a8543f0f6620d4696790>`__
-   `#8507 <https://pagure.io/freeipa/issue/8507>`__
+   `#8507 <https://codeberg.org/freeipa/freeipa/issues/8507>`__
 -  WebUI tests: Add test case to cover user ID override feature
    `commit <https://codeberg.org/freeipa/freeipa/commit/bcae2094048609a6cfaecf73d9b611d3d90af44b>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI: Fix error "unknown command 'idoverrideuser_add_member'"
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d9d6348c17f683bf2bda986d2ca0d785a3def17>`__
-   `#8416 <https://pagure.io/freeipa/issue/8416>`__
+   `#8416 <https://codeberg.org/freeipa/freeipa/issues/8416>`__
 -  WebUI tests: Change navigation tests to find menu items using
    data-name instead of href
    `commit <https://codeberg.org/freeipa/freeipa/commit/d452e45ff0e4293aa835e57c3d4dce82956e4baa>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix issue with opening links in new tab/window
    `commit <https://codeberg.org/freeipa/freeipa/commit/b25bccc59a99255bf8b67c6843b120923d2a89e5>`__
-   `#7137 <https://pagure.io/freeipa/issue/7137>`__
+   `#7137 <https://codeberg.org/freeipa/freeipa/issues/7137>`__
 -  WebUI: Fix "IPA Error 3007: RequirmentError" while adding
    idoverrideuser association
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2ba333b9681d008d9c528a79dbdd76ce11a3ecd>`__
-   `#8335 <https://pagure.io/freeipa/issue/8335>`__
+   `#8335 <https://codeberg.org/freeipa/freeipa/issues/8335>`__
 -  WebUI: Apply jQuery patch to fix htmlPrefilter issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc9f3e0557c6a0a5901fff956f9cb1362085375f>`__
-   `#8325 <https://pagure.io/freeipa/issue/8325>`__
+   `#8325 <https://codeberg.org/freeipa/freeipa/issues/8325>`__
 -  WebUI tests: Test all available fields on "Kerberos Ticket Policy"
    page
    `commit <https://codeberg.org/freeipa/freeipa/commit/e668b61fd2843edc4863d39f9707fd7993571b2e>`__
-   `#8207 <https://pagure.io/freeipa/issue/8207>`__
+   `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__
 -  WebUI: Add authentication indicator specific fields to "Kerberos
    Ticket Policy" page
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bef36de644a055ac6b0844ae17aa6526a87bc61>`__
-   `#8207 <https://pagure.io/freeipa/issue/8207>`__
+   `#8207 <https://codeberg.org/freeipa/freeipa/issues/8207>`__
 -  WebUI tests: Add confirmation step after changing default group in
    automember tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3645854c11b0489215a27077a633755638f00268>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI: Add confirmation dialog for changing default user/host group
    `commit <https://codeberg.org/freeipa/freeipa/commit/33ca0745585ae3fcd466631a069e244bea74be88>`__
-   `#8322 <https://pagure.io/freeipa/issue/8322>`__
+   `#8322 <https://codeberg.org/freeipa/freeipa/issues/8322>`__
 -  WebUI tests: cover membership management with UI tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4892d42af68c472639b73cdaf0bc5550229bf9d>`__
-   `#8298 <https://pagure.io/freeipa/issue/8298>`__
+   `#8298 <https://codeberg.org/freeipa/freeipa/issues/8298>`__
 -  Web UI: Upgrade jQuery version 2.0.3 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0494bc3f39e1a26f52b430e4b8f07b28accbf72>`__
-   `#8284 <https://pagure.io/freeipa/issue/8284>`__
+   `#8284 <https://codeberg.org/freeipa/freeipa/issues/8284>`__
 -  Web UI: Upgrade Dojo version 1.13.0 -> 1.16.2
    `commit <https://codeberg.org/freeipa/freeipa/commit/10aaef031bf5f6845f7d5ea053b9620147745c99>`__
-   `#8222 <https://pagure.io/freeipa/issue/8222>`__
+   `#8222 <https://codeberg.org/freeipa/freeipa/issues/8222>`__
 -  Web UI: Upgrade Bootstrap version 3.3.7 -> 3.4.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/99a62f29b2b77961ea8e642e172ea774bc8882a9>`__
-   `#8239 <https://pagure.io/freeipa/issue/8239>`__
+   `#8239 <https://codeberg.org/freeipa/freeipa/issues/8239>`__
 -  WebUI tests: Fix broken reference to parent facet in table record
    check
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4634a59c98ae922708f9211786b67505dada736>`__
-   `#8157 <https://pagure.io/freeipa/issue/8157>`__
+   `#8157 <https://codeberg.org/freeipa/freeipa/issues/8157>`__
 -  WebUI tests: Fix 'Button is not displayed' exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/9418042ee700b8c82f289ce649ab2b80c60d7822>`__
-   `#8169 <https://pagure.io/freeipa/issue/8169>`__
+   `#8169 <https://codeberg.org/freeipa/freeipa/issues/8169>`__
 -  WebUI: Fix notification area layout
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f6b1c99f00c519a5b2186fcb310d23ed2c8e71d>`__
-   `#8120 <https://pagure.io/freeipa/issue/8120>`__
+   `#8120 <https://codeberg.org/freeipa/freeipa/issues/8120>`__
 -  WebUI: Fix adding member manager for groups and host groups
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0b0c6b4b598acd7a867594d91b7f7cff47d2e5e>`__
-   `#8123 <https://pagure.io/freeipa/issue/8123>`__
+   `#8123 <https://codeberg.org/freeipa/freeipa/issues/8123>`__
 -  WebUI: Fix new test initialization on "HBAC Test" page
    `commit <https://codeberg.org/freeipa/freeipa/commit/4dbc6926b16b44146eef36d2f56403e2347f12c8>`__
-   `#8031 <https://pagure.io/freeipa/issue/8031>`__
+   `#8031 <https://codeberg.org/freeipa/freeipa/issues/8031>`__
 -  WebUI: Fix changing category on HBAC/Sudo/etc Rule pages
    `commit <https://codeberg.org/freeipa/freeipa/commit/755154318ac6b6a57eee2bdec76debd25e97fd45>`__
-   `#7961 <https://pagure.io/freeipa/issue/7961>`__
+   `#7961 <https://codeberg.org/freeipa/freeipa/issues/7961>`__
 -  WebUI: Make 'Unlock' option is available only on locked user page
    `commit <https://codeberg.org/freeipa/freeipa/commit/123c93f92c575eeb4344f918b86112937b8cb4e8>`__
-   `#5062 <https://pagure.io/freeipa/issue/5062>`__
+   `#5062 <https://codeberg.org/freeipa/freeipa/issues/5062>`__
 -  WebUI tests: Fix login screen loading issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/b20ae34b48d7715024b94d46f03875497df3c9a4>`__
-   `#8053 <https://pagure.io/freeipa/issue/8053>`__
+   `#8053 <https://codeberg.org/freeipa/freeipa/issues/8053>`__
 -  WebUI tests: Fix request timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16ea8e652a3a3b555087646b9887bc77934d175>`__
-   `#8024 <https://pagure.io/freeipa/issue/8024>`__
+   `#8024 <https://codeberg.org/freeipa/freeipa/issues/8024>`__
 -  WebUI: Add PKINIT status field to 'Configuration' page
    `commit <https://codeberg.org/freeipa/freeipa/commit/6af723c0c36bc1d7b4c4357b466a285254e0e176>`__
-   `#7305 <https://pagure.io/freeipa/issue/7305>`__
+   `#7305 <https://codeberg.org/freeipa/freeipa/issues/7305>`__
 -  WebUI tests: Fix timeout issues for reset password tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/6316a006327426af9365f865633cf6767ff699a9>`__
-   `#8012 <https://pagure.io/freeipa/issue/8012>`__
+   `#8012 <https://codeberg.org/freeipa/freeipa/issues/8012>`__
 
 
 
@@ -4822,10 +4822,10 @@ Sudhir Menon (32)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7be1a2470c220da30154305e869149d808c0ec2>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_riplugincheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b1230e5b083084eecf3aeb027223d5501a45924>`__
-   `#8563 <https://pagure.io/freeipa/issue/8563>`__
+   `#8563 <https://codeberg.org/freeipa/freeipa/issues/8563>`__
 -  ipatests: Fix for test_ipahealthcheck_ds_encryption
    `commit <https://codeberg.org/freeipa/freeipa/commit/43ea80ae913d7213ec6595b46b2b532bb04dbb64>`__
-   `#8560 <https://pagure.io/freeipa/issue/8560>`__
+   `#8560 <https://codeberg.org/freeipa/freeipa/issues/8560>`__
 -  ipatests: ipa-healthcheck test for DS RIPluginCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/686414d2017b8122df04b04493909a12db8ccd66>`__
 -  ipatests: ipa-healthcheck test for EncryptionCheck
@@ -4871,7 +4871,7 @@ Sudhir Menon (32)
 -  ipatests: Added testcase to check that ipa-adtrust-install command
    runs successfully with locale set as LANG=en_IN.UTF-8
    `commit <https://codeberg.org/freeipa/freeipa/commit/555f8a038dae139ad161c5dab51e2378f8894b81>`__
-   `#8066 <https://pagure.io/freeipa/issue/8066>`__
+   `#8066 <https://codeberg.org/freeipa/freeipa/issues/8066>`__
 -  ipatests: Test for ipahealthcheck tool for IPADomainCheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba213aa448a9b568da4ba9920a4b513406bd3964>`__
 -  ipatests: Test for ipahealthcheck.ds.ruv check
@@ -4891,7 +4891,7 @@ Sudhir Menon (32)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5c8efa33c9460337d9ae92fd1ec8215074667a5>`__
 -  Added testcase to check capitalization fix while running ipa user-mod
    `commit <https://codeberg.org/freeipa/freeipa/commit/b24359cafae6bcc37b6281b7fb431eae47e0c9cf>`__
-   `#5879 <https://pagure.io/freeipa/issue/5879>`__
+   `#5879 <https://codeberg.org/freeipa/freeipa/issues/5879>`__
 
 
 
@@ -4900,17 +4900,17 @@ Tibor Dudlák (5)
 
 -  Add container environment check to replicainstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1e20b45c5deeb25989c87a2d717bda5a31bb084>`__
-   `#6210 <https://pagure.io/freeipa/issue/6210>`__
+   `#6210 <https://codeberg.org/freeipa/freeipa/issues/6210>`__
 -  Increase ntp_options test timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b7fae30b15d5507da95f91f453b1d816eff6d7b>`__
 -  ipatests: refactor TestNTPoptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0efb9ea48a96168c73f15a297b3b7da7b6e87e0>`__
 -  ipatests: Add tests for interactive chronyd config
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bc7fb7fd0b0dec3b7fd8d25b4a30aa453537dfd>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 -  ipatests: Update test tasks for client to be interactive
    `commit <https://codeberg.org/freeipa/freeipa/commit/44bcf0990fd5ed64c9997420b19db161b3b407fe>`__
-   `#7908 <https://pagure.io/freeipa/issue/7908>`__
+   `#7908 <https://codeberg.org/freeipa/freeipa/issues/7908>`__
 
 
 
@@ -4980,7 +4980,7 @@ Thomas Woerner (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/51fcca535236e309dc6431ad68bad36bf8f56823>`__
 -  DNS install check: Fix overlapping DNS zone from the master itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/f80a6548ad8d0d21219ce26d3e819f7ad5f3663e>`__
-   `#8150 <https://pagure.io/freeipa/issue/8150>`__
+   `#8150 <https://codeberg.org/freeipa/freeipa/issues/8150>`__
 -  Enable TestInstallMasterDNSRepeatedly in prci_definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2820bbbc3789cde2ecb9ea3eae91c1bd6f248ee>`__
 -  Test repeated installation of the primary with DNS enabled and domain
@@ -4994,7 +4994,7 @@ Viktor Ashirov (1)
 
 -  Update ACIs with the correct syntax
    `commit <https://codeberg.org/freeipa/freeipa/commit/273ed1535d54a4ab213cca6cee1e39497b9ad75b>`__
-   `#8301 <https://pagure.io/freeipa/issue/8301>`__
+   `#8301 <https://codeberg.org/freeipa/freeipa/issues/8301>`__
 
 
 
@@ -5003,7 +5003,7 @@ Vit Mojzis (4)
 
 -  selinux: disable ipa_custodia when installing custom policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/3aad16a75ef06d20d111773268df30ee04274db7>`__
-   `#6891 <https://pagure.io/freeipa/issue/6891>`__
+   `#6891 <https://codeberg.org/freeipa/freeipa/issues/6891>`__
 -  selinux: Remove obsolete memcached access
    `commit <https://codeberg.org/freeipa/freeipa/commit/473f9baf26761cc70a0c36fe5d94446213509eb5>`__
 -  selinux: move BUILD_SELINUX_POLICY definition
@@ -5044,6 +5044,6 @@ Zdenek Pytela (2)
 
 -  Add ipa_pki_retrieve_key_exec() interface
    `commit <https://codeberg.org/freeipa/freeipa/commit/7651d335b3fe7c644ae9b8de2590b315303375cf>`__
-   `#8488 <https://pagure.io/freeipa/issue/8488>`__
+   `#8488 <https://codeberg.org/freeipa/freeipa/issues/8488>`__
 -  Allow ipa-adtrust-install restart sssd and dirsrv services
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e75623ef8cbde78e9b57d3aa56e935a97a06f80>`__

--- a/src/page/Releases/4.9.0rc2.rst
+++ b/src/page/Releases/4.9.0rc2.rst
@@ -43,51 +43,51 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#3299 <https://pagure.io/freeipa/issue/3299>`__ [RFE] Switch the
+-  `#3299 <https://codeberg.org/freeipa/freeipa/issues/3299>`__ [RFE] Switch the
    client to JSON RPC
--  `#7534 <https://pagure.io/freeipa/issue/7534>`__
+-  `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
    (`rhbz#1569011 <https://bugzilla.redhat.com/show_bug.cgi?id=1569011>`__)
    Investigate failures to restore 389-ds attriubtes on upgrade failure
--  `#7676 <https://pagure.io/freeipa/issue/7676>`__
+-  `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
    (`rhbz#1544379 <https://bugzilla.redhat.com/show_bug.cgi?id=1544379>`__)
    ipa-client-install changes system wide ssh configuration
--  `#7975 <https://pagure.io/freeipa/issue/7975>`__ Accept 389-ds JSON
+-  `#7975 <https://codeberg.org/freeipa/freeipa/issues/7975>`__ Accept 389-ds JSON
    replication status messages
--  `#8424 <https://pagure.io/freeipa/issue/8424>`__ Add ipa.p11-kit to
+-  `#8424 <https://codeberg.org/freeipa/freeipa/issues/8424>`__ Add ipa.p11-kit to
    ipa-client-install man page files list
--  `#8514 <https://pagure.io/freeipa/issue/8514>`__
+-  `#8514 <https://codeberg.org/freeipa/freeipa/issues/8514>`__
    (`rhbz#1885126 <https://bugzilla.redhat.com/show_bug.cgi?id=1885126>`__)
    Nightly failure (enforcing mode) in
    test_acme.py::TestACME::test_mod_md
--  `#8524 <https://pagure.io/freeipa/issue/8524>`__
+-  `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Deploy & manage the ACME service topology wide from a single system
--  `#8531 <https://pagure.io/freeipa/issue/8531>`__ RFE: Use host keytab
+-  `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__ RFE: Use host keytab
    to obtain ticket for ipa-certupdate
--  `#8545 <https://pagure.io/freeipa/issue/8545>`__
+-  `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
    (`rhbz#1869605 <https://bugzilla.redhat.com/show_bug.cgi?id=1869605>`__)
    KRA Transport and Storage Certificates do not renew
--  `#8554 <https://pagure.io/freeipa/issue/8554>`__
+-  `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
    (`rhbz#1891056 <https://bugzilla.redhat.com/show_bug.cgi?id=1891056>`__)
    ipa-kdb: support subordinate/superior UPN suffixes
--  `#8581 <https://pagure.io/freeipa/issue/8581>`__ Nightly test failure
+-  `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__ Nightly test failure
    in test_acme.py::TestACME::test_third_party_certs (updates-testing)
--  `#8587 <https://pagure.io/freeipa/issue/8587>`__ client-only build
+-  `#8587 <https://codeberg.org/freeipa/freeipa/issues/8587>`__ client-only build
    fails due to unconditional use of pwquality features
--  `#8589 <https://pagure.io/freeipa/issue/8589>`__
+-  `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
    (`rhbz#1812871 <https://bugzilla.redhat.com/show_bug.cgi?id=1812871>`__)
    Intermittent IdM Client Registration Failures
--  `#8590 <https://pagure.io/freeipa/issue/8590>`__ Nightly test failure
+-  `#8590 <https://codeberg.org/freeipa/freeipa/issues/8590>`__ Nightly test failure
    in
    test_integration/test_krbtpolicy.py::TestPWPolicy::test_krbtpolicy_default::setup
--  `#8595 <https://pagure.io/freeipa/issue/8595>`__ Allow ipa-ca as a
+-  `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__ Allow ipa-ca as a
    name for an IPA server
--  `#8597 <https://pagure.io/freeipa/issue/8597>`__
+-  `#8597 <https://codeberg.org/freeipa/freeipa/issues/8597>`__
    (`rhbz#1901068 <https://bugzilla.redhat.com/show_bug.cgi?id=1901068>`__)
    Traceback while doing ipa-backup
--  `#8601 <https://pagure.io/freeipa/issue/8601>`__ Nightly test failure
+-  `#8601 <https://codeberg.org/freeipa/freeipa/issues/8601>`__ Nightly test failure
    in test_trust.py::TestTrust::test_subordinate_suffix
--  `#8603 <https://pagure.io/freeipa/issue/8603>`__
+-  `#8603 <https://codeberg.org/freeipa/freeipa/issues/8603>`__
    (`rhbz#1902727 <https://bugzilla.redhat.com/show_bug.cgi?id=1902727>`__)
    ipa-acme-manage enable fails after upgrade
 
@@ -117,10 +117,10 @@ Alexander Bokovoy (5)
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b56a4cbaa3bb71260ffbc35f304ddf5ee31baed>`__
 -  ad trust: accept subordinate domains of the forest trust root
    `commit <https://codeberg.org/freeipa/freeipa/commit/381cc5e8eae1b7437fc15cb699983887d398f498>`__
-   `#8554 <https://pagure.io/freeipa/issue/8554>`__
+   `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
 -  util: Fix client-only build
    `commit <https://codeberg.org/freeipa/freeipa/commit/244704cc156dba0731671c55661d82073f970c9b>`__
-   `#8587 <https://pagure.io/freeipa/issue/8587>`__
+   `#8587 <https://codeberg.org/freeipa/freeipa/issues/8587>`__
 
 
 
@@ -129,7 +129,7 @@ Antonio Torres Moríñigo (1)
 
 -  ipa-client-install manpage: add ipa.p11-kit to list of files created
    `commit <https://codeberg.org/freeipa/freeipa/commit/08bbd0a2d712a5a7f1a02999390c4be2a9df3f0e>`__
-   `#8424 <https://pagure.io/freeipa/issue/8424>`__
+   `#8424 <https://codeberg.org/freeipa/freeipa/issues/8424>`__
 
 
 
@@ -138,10 +138,10 @@ Florence Blanc-Renaud (2)
 
 -  ipatests: fix TestTrust::test_subordinate_suffix
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf1d652ff946e448a5b97a12df926ae4a7d9db01>`__
-   `#8601 <https://pagure.io/freeipa/issue/8601>`__
+   `#8601 <https://codeberg.org/freeipa/freeipa/issues/8601>`__
 -  Always define the path DNSSEC_OPENSSL_CONF
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a7db1838ad9b9ebbe565dbbde126968f9c296f>`__
-   `#8597 <https://pagure.io/freeipa/issue/8597>`__
+   `#8597 <https://codeberg.org/freeipa/freeipa/issues/8597>`__
 
 
 
@@ -150,7 +150,7 @@ Mark Reynolds (1)
 
 -  Accept 389-ds JSON replication status messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/826dccc9cb99f4bce8bd24b47c531f918f19d8d6>`__
-   `#7975 <https://pagure.io/freeipa/issue/7975>`__
+   `#7975 <https://codeberg.org/freeipa/freeipa/issues/7975>`__
 
 
 
@@ -159,7 +159,7 @@ Mohammad Rizwan (1)
 
 -  ipatests: Test certmonger IPA responder switched to JSONRPC
    `commit <https://codeberg.org/freeipa/freeipa/commit/25eebb21a2f85817691ce65c431d6b5de3bebe3b>`__
-   `#3299 <https://pagure.io/freeipa/issue/3299>`__
+   `#3299 <https://codeberg.org/freeipa/freeipa/issues/3299>`__
 
 
 
@@ -168,78 +168,78 @@ Rob Crittenden (25)
 
 -  Skip the ACME mod_md test when the client is in enforcing mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d576d5b4b1e9e0c43aafde7636c6a25b5ca294f>`__
-   `#8514 <https://pagure.io/freeipa/issue/8514>`__
+   `#8514 <https://codeberg.org/freeipa/freeipa/issues/8514>`__
 -  Increase timeout for krbtpolicy to 4800
    `commit <https://codeberg.org/freeipa/freeipa/commit/28ed75ca0251724e34a447174ae775edca9763e2>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Enable the ccache sweep systemd timer
    `commit <https://codeberg.org/freeipa/freeipa/commit/068d08577d97258267917f81363a1a033a681803>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  ipatests: test that stale caches are removed using the sweeper
    `commit <https://codeberg.org/freeipa/freeipa/commit/22fa1a7e5c49a677b55f71d95d47cc58e0f29c57>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Generate a unique cache for each connection
    `commit <https://codeberg.org/freeipa/freeipa/commit/51b186b6033bafaa39a2b0544b5cdc9c0298208c>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  Convert reset_to_default_policy into a pytest fixture
    `commit <https://codeberg.org/freeipa/freeipa/commit/848dffb59273493ef3abde2a86864e85c8d19eff>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 -  VERSION: back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e1cbcb7783704ef5d6c883e55003acac4ee1553>`__
 -  ipatests: Test that ipa-ca.$domain can retrieve CRLs without redirect
    `commit <https://codeberg.org/freeipa/freeipa/commit/b478bf99d9f158dabae145169f242b2b5d26404c>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__
 -  Allow Apache to answer to ipa-ca requests without a redirect
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ba6a0371b6d12adf46a654356468e52bf3ee33f>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__
 -  Move where the restore state is marked during IPA server upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/20055ddaf169787c041f0baf0bd0cdca1f5fe7b5>`__
-   `#7534 <https://pagure.io/freeipa/issue/7534>`__
+   `#7534 <https://codeberg.org/freeipa/freeipa/issues/7534>`__
 -  Reorder when ACME is enabled to fix failure on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea67962d5d2b4812234bb6c22c85b7716951b2f9>`__
-   `#8603 <https://pagure.io/freeipa/issue/8603>`__
+   `#8603 <https://codeberg.org/freeipa/freeipa/issues/8603>`__
 -  Remove test for minimum ACME support and rely on package deps
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d6caf5d0eae315797b36abfe8444827bdd71fb7>`__
 -  Require PKI 10.10+ for KRA profile and ACME support
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e530e93c37ee71a560714e26285cd85e71557c9>`__
-   `#8524 <https://pagure.io/freeipa/issue/8524>`__,
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__,
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  Test that the KRA profiles can renewal its three certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd4771d75f8549fe1790540764f23d47bf3d187c>`__
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  Change KRA profiles in certmonger tracking so they can renew
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9e1c014f601a567f4aa5135d02883c498835268>`__
-   `#8545 <https://pagure.io/freeipa/issue/8545>`__
+   `#8545 <https://codeberg.org/freeipa/freeipa/issues/8545>`__
 -  ipatests: Increase timeout for ACME in gating.yaml
    `commit <https://codeberg.org/freeipa/freeipa/commit/17f293e9da0375bac4871c0100c6146a8c2f8e55>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: honor class inheritance in TestACMEwithExternalCA
    `commit <https://codeberg.org/freeipa/freeipa/commit/75ad5757528491616f7f4e596bb9f6b152944d99>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: configure MDStoreDir for mod_md ACME test
    `commit <https://codeberg.org/freeipa/freeipa/commit/b474b263ed0161ba8411cc84014e4d08a44ac15f>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Clean up existing ACME registration and certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d286e79515c8a6c856a5acde6300271422acfac>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Configure a replica in TestACMEwithExternalCA
    `commit <https://codeberg.org/freeipa/freeipa/commit/de5baf8516cde060f1606070b2a8824f71178f16>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: call the CALess install method to generate the CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cd6b81a68be98ae9f60da67d2bc640831f0cf0c>`__
-   `#8581 <https://pagure.io/freeipa/issue/8581>`__
+   `#8581 <https://codeberg.org/freeipa/freeipa/issues/8581>`__
 -  ipatests: Test that Match ProxyCommand masks on no shell exec
    `commit <https://codeberg.org/freeipa/freeipa/commit/d89e3abf2714092baae1607afd83da1c944d6c9f>`__
-   `#7676 <https://pagure.io/freeipa/issue/7676>`__
+   `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
 -  Create IPA ssh client configuration and move ProxyCommand
    `commit <https://codeberg.org/freeipa/freeipa/commit/a525b2ebf01ffff83d0a5925035f4be0fc5c700c>`__
-   `#7676 <https://pagure.io/freeipa/issue/7676>`__
+   `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
 -  ipatests: Test that ipa-certupdate can run without credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/4941d3d4b1ba10ccddf5429463debcefac6fbd9f>`__
-   `#8531 <https://pagure.io/freeipa/issue/8531>`__
+   `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__
 -  Use host keytab to obtain credentials needed for ipa-certupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a09ce9f3fa503eeefe394856be538892652accf>`__
-   `#8531 <https://pagure.io/freeipa/issue/8531>`__
+   `#8531 <https://codeberg.org/freeipa/freeipa/issues/8531>`__
 
 
 
@@ -248,7 +248,7 @@ Robbie Harwood (1)
 
 -  Fix krbtpolicy tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/17a4198a666453dbec55409d4e2acc37a37b57ac>`__
-   `#8590 <https://pagure.io/freeipa/issue/8590>`__
+   `#8590 <https://codeberg.org/freeipa/freeipa/issues/8590>`__
 
 
 

--- a/src/page/Releases/4.9.0rc3.rst
+++ b/src/page/Releases/4.9.0rc3.rst
@@ -42,19 +42,19 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#8595 <https://pagure.io/freeipa/issue/8595>`__ Allow ipa-ca as a
+-  `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__ Allow ipa-ca as a
    name for an IPA server
--  `#8596 <https://pagure.io/freeipa/issue/8596>`__
+-  `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
    (`rhbz#1895197 <https://bugzilla.redhat.com/show_bug.cgi?id=1895197>`__)
    improve IPA PKI susbsystem detection by other means than a directory
    presence, use pki-server subsystem-find
--  `#8613 <https://pagure.io/freeipa/issue/8613>`__ mod_auth_gssapi
+-  `#8613 <https://codeberg.org/freeipa/freeipa/issues/8613>`__ mod_auth_gssapi
    cannot create unique ccache as it runs under apache and not ipaapi
--  `#8615 <https://pagure.io/freeipa/issue/8615>`__ ipa-rewrite.conf
+-  `#8615 <https://codeberg.org/freeipa/freeipa/issues/8615>`__ ipa-rewrite.conf
    upgrade is failing due to missing variable definition
--  `#8616 <https://pagure.io/freeipa/issue/8616>`__ xmlrpc tests
+-  `#8616 <https://codeberg.org/freeipa/freeipa/issues/8616>`__ xmlrpc tests
    test_user_plugin failure
--  `#8617 <https://pagure.io/freeipa/issue/8617>`__ systemd: enforce
+-  `#8617 <https://codeberg.org/freeipa/freeipa/issues/8617>`__ systemd: enforce
    en_US.UTF-8 locale in systemd units
 
 
@@ -71,15 +71,15 @@ Alexander Bokovoy (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/502d29107a458717b4ae1b3f7b17fb1159e3a135>`__
 -  systemd: enforce en_US.UTF-8 locale in systemd units
    `commit <https://codeberg.org/freeipa/freeipa/commit/184997e85d03c30a34fbe268d1e9f39206178a1e>`__
-   `#8617 <https://pagure.io/freeipa/issue/8617>`__
+   `#8617 <https://codeberg.org/freeipa/freeipa/issues/8617>`__
 -  upgrade: provide DOMAIN to the server upgrade dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc51feb106d6dee655c55adb802b3cfdac778fca>`__
-   `#8595 <https://pagure.io/freeipa/issue/8595>`__,
-   `#8615 <https://pagure.io/freeipa/issue/8615>`__
+   `#8595 <https://codeberg.org/freeipa/freeipa/issues/8595>`__,
+   `#8615 <https://codeberg.org/freeipa/freeipa/issues/8615>`__
 -  Allow mod_auth_gssapi to create and access ccaches in
    /run/ipa/ccaches
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a6886538360fb340eb4423660d11ee4af7e39>`__
-   `#8613 <https://pagure.io/freeipa/issue/8613>`__
+   `#8613 <https://codeberg.org/freeipa/freeipa/issues/8613>`__
 -  Correct SELinux policy requirements
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cb8f065ac7bcf814c4991aeca3be8b590c7b5f6>`__
 -  Back to git snapshots
@@ -92,10 +92,10 @@ Florence Blanc-Renaud (3)
 
 -  ipatests: add test for PKI subsystem detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/24f6a36b82d2a8bd8f2283457fcb415e5898a1b1>`__
-   `#8596 <https://pagure.io/freeipa/issue/8596>`__
+   `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
 -  Improve PKI subsystem detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf30cc3f63fbce2a3ff9c53ae4cd177a3bf4e527>`__
-   `#8596 <https://pagure.io/freeipa/issue/8596>`__
+   `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
 -  xmlrpctests: remove harcoded expiration date from test_user_plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2bc3f1c5baff68e4c8d5f1e5c38b5647eac4cf4>`__
-   `#8616 <https://pagure.io/freeipa/issue/8616>`__
+   `#8616 <https://codeberg.org/freeipa/freeipa/issues/8616>`__

--- a/src/page/Releases/4.9.1.rst
+++ b/src/page/Releases/4.9.1.rst
@@ -135,96 +135,96 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#3226 <https://pagure.io/freeipa/issue/3226>`__
+-  `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
    (`rhbz#871208 <https://bugzilla.redhat.com/show_bug.cgi?id=871208>`__)
    [RFE] ipa sudorule-add-user should accept more types of characters
--  `#7599 <https://pagure.io/freeipa/issue/7599>`__
+-  `#7599 <https://codeberg.org/freeipa/freeipa/issues/7599>`__
    (`rhbz#1593745 <https://bugzilla.redhat.com/show_bug.cgi?id=1593745>`__)
    Leading / trailing white spaces in password are disallowed
--  `#7676 <https://pagure.io/freeipa/issue/7676>`__
+-  `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
    (`rhbz#1544379 <https://bugzilla.redhat.com/show_bug.cgi?id=1544379>`__)
    ipa-client-install changes system wide ssh configuration
--  `#8501 <https://pagure.io/freeipa/issue/8501>`__ Unify how FreeIPA
+-  `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__ Unify how FreeIPA
    gets FQDN of current host
--  `#8508 <https://pagure.io/freeipa/issue/8508>`__ Nightly failure
+-  `#8508 <https://codeberg.org/freeipa/freeipa/issues/8508>`__ Nightly failure
    (ipa-4-8/master, enforcing mode) in ipa trust-add
--  `#8519 <https://pagure.io/freeipa/issue/8519>`__ Fedora container
+-  `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__ Fedora container
    platform is incomplete
--  `#8524 <https://pagure.io/freeipa/issue/8524>`__
+-  `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Deploy & manage the ACME service topology wide from a single system
--  `#8528 <https://pagure.io/freeipa/issue/8528>`__ Use separate logs
+-  `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__ Use separate logs
    for AD Trust and DNS installer
--  `#8576 <https://pagure.io/freeipa/issue/8576>`__
+-  `#8576 <https://codeberg.org/freeipa/freeipa/issues/8576>`__
    (`rhbz#1728015 <https://bugzilla.redhat.com/show_bug.cgi?id=1728015>`__)
    ipasam: derive parent domain for subdomains automatically
--  `#8584 <https://pagure.io/freeipa/issue/8584>`__ ACME communication
+-  `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__ ACME communication
    with dogtag REST endpoints should be using the cookie it creates
--  `#8589 <https://pagure.io/freeipa/issue/8589>`__
+-  `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
    (`rhbz#1812871 <https://bugzilla.redhat.com/show_bug.cgi?id=1812871>`__)
    Intermittent IdM Client Registration Failures
--  `#8596 <https://pagure.io/freeipa/issue/8596>`__
+-  `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__
    (`rhbz#1895197 <https://bugzilla.redhat.com/show_bug.cgi?id=1895197>`__)
    improve IPA PKI susbsystem detection by other means than a directory
    presence, use pki-server subsystem-find
--  `#8602 <https://pagure.io/freeipa/issue/8602>`__ Nightly failure in
+-  `#8602 <https://codeberg.org/freeipa/freeipa/issues/8602>`__ Nightly failure in
    test_acme.py::TestACME::test_certbot_certonly_standalone: An
    unexpected error occurred:
--  `#8614 <https://pagure.io/freeipa/issue/8614>`__ Remove ca.crt from
+-  `#8614 <https://codeberg.org/freeipa/freeipa/issues/8614>`__ Remove ca.crt from
    the system-wide store on uninstall
--  `#8618 <https://pagure.io/freeipa/issue/8618>`__
+-  `#8618 <https://codeberg.org/freeipa/freeipa/issues/8618>`__
    (`rhbz#1780782 <https://bugzilla.redhat.com/show_bug.cgi?id=1780782>`__)
    ipa-cert-fix tool fails when the Dogtag CA SSL CSR is missing from
    CS.cfg
--  `#8631 <https://pagure.io/freeipa/issue/8631>`__ Nightly failure
+-  `#8631 <https://codeberg.org/freeipa/freeipa/issues/8631>`__ Nightly failure
    (389ds master branch) in
    test_commands.py::TestIPACommand::test_ipa_nis_manage_enable_incorrect_password
--  `#8634 <https://pagure.io/freeipa/issue/8634>`__
+-  `#8634 <https://codeberg.org/freeipa/freeipa/issues/8634>`__
    (`rhbz#1913089 <https://bugzilla.redhat.com/show_bug.cgi?id=1913089>`__)
    Install of CA fails on CentOS 8 Stream with pki-core 10.9
--  `#8635 <https://pagure.io/freeipa/issue/8635>`__ Memory availability
+-  `#8635 <https://codeberg.org/freeipa/freeipa/issues/8635>`__ Memory availability
    detection does not work with cgroupsv2 environment
--  `#8644 <https://pagure.io/freeipa/issue/8644>`__
+-  `#8644 <https://codeberg.org/freeipa/freeipa/issues/8644>`__
    (`rhbz#1912845 <https://bugzilla.redhat.com/show_bug.cgi?id=1912845>`__)
    ipa-certupdate drops profile from the caSigningCert tracking
--  `#8646 <https://pagure.io/freeipa/issue/8646>`__ permission-mod
+-  `#8646 <https://codeberg.org/freeipa/freeipa/issues/8646>`__ permission-mod
    attrs, includedattrs and excludedattrs issues
--  `#8650 <https://pagure.io/freeipa/issue/8650>`__ Updated
+-  `#8650 <https://codeberg.org/freeipa/freeipa/issues/8650>`__ Updated
    dnspython-2.1.0 causes a test failure
--  `#8653 <https://pagure.io/freeipa/issue/8653>`__ Nightly test failure
+-  `#8653 <https://codeberg.org/freeipa/freeipa/issues/8653>`__ Nightly test failure
    in
    test_integration/test_upgrade.py::TestUpgrade::()::test_kra_detection
--  `#8655 <https://pagure.io/freeipa/issue/8655>`__
+-  `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__
    (`rhbz#1860129 <https://bugzilla.redhat.com/show_bug.cgi?id=1860129>`__)
    Allow to establish trust to Active Directory in FIPS mode
--  `#8656 <https://pagure.io/freeipa/issue/8656>`__ Use client keytab
+-  `#8656 <https://codeberg.org/freeipa/freeipa/issues/8656>`__ Use client keytab
    for 389ds
--  `#8658 <https://pagure.io/freeipa/issue/8658>`__ Value stored to
+-  `#8658 <https://codeberg.org/freeipa/freeipa/issues/8658>`__ Value stored to
    'krberr' is never read in ipa-rmkeytab.c
--  `#8659 <https://pagure.io/freeipa/issue/8659>`__ ipa-kdb: provide
+-  `#8659 <https://codeberg.org/freeipa/freeipa/issues/8659>`__ ipa-kdb: provide
    correct logon time in MS-PAC from authentication time
--  `#8660 <https://pagure.io/freeipa/issue/8660>`__ ipasam: implement
+-  `#8660 <https://codeberg.org/freeipa/freeipa/issues/8660>`__ ipasam: implement
    PASSDB getgrnam call
--  `#8661 <https://pagure.io/freeipa/issue/8661>`__ ipasam: allow search
+-  `#8661 <https://codeberg.org/freeipa/freeipa/issues/8661>`__ ipasam: allow search
    of users by user principal name (UPN)
--  `#8662 <https://pagure.io/freeipa/issue/8662>`__ Nightly test failure
+-  `#8662 <https://codeberg.org/freeipa/freeipa/issues/8662>`__ Nightly test failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheckFileCheck::test_ipa_filecheck_bad_owner
--  `#8664 <https://pagure.io/freeipa/issue/8664>`__ Nightly test failure
+-  `#8664 <https://codeberg.org/freeipa/freeipa/issues/8664>`__ Nightly test failure
    (fed33, rawhide) in ipa trust-add --external=True
--  `#8668 <https://pagure.io/freeipa/issue/8668>`__
+-  `#8668 <https://codeberg.org/freeipa/freeipa/issues/8668>`__
    (`rhbz#1915471 <https://bugzilla.redhat.com/show_bug.cgi?id=1915471>`__)
    Nightly failure in (f33+updates-testing)
    test_trust.py::TestTrust::test_ipa_commands_run_as_aduser
--  `#8670 <https://pagure.io/freeipa/issue/8670>`__ Nightly failure
+-  `#8670 <https://codeberg.org/freeipa/freeipa/issues/8670>`__ Nightly failure
    (fed33) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_encryption
--  `#8674 <https://pagure.io/freeipa/issue/8674>`__ test_ipahealthcheck
+-  `#8674 <https://codeberg.org/freeipa/freeipa/issues/8674>`__ test_ipahealthcheck
    divides KiB by 1000
--  `#8678 <https://pagure.io/freeipa/issue/8678>`__ Nightly failure
+-  `#8678 <https://codeberg.org/freeipa/freeipa/issues/8678>`__ Nightly failure
    (master) in
    test_trust.py::TestTrust::test_establish_forest_trust_with_shared_secret
--  `#8682 <https://pagure.io/freeipa/issue/8682>`__ [ipatests]
+-  `#8682 <https://codeberg.org/freeipa/freeipa/issues/8682>`__ [ipatests]
    TestIPACommand.test_login_wrong_password time to time fails
 
 
@@ -260,72 +260,72 @@ Alexander Bokovoy (30)
 -  baseldap: allow rejecting unknown objects instead of adding to an
    external attr
    `commit <https://codeberg.org/freeipa/freeipa/commit/51ca38772f41d3a26a4253a732338d09a69f9647>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  ipatests: when talking to AD DCs, use FQDN credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/64b70be65698b12927795a7a8b79ef7aada010b8>`__
-   `#8678 <https://pagure.io/freeipa/issue/8678>`__
+   `#8678 <https://codeberg.org/freeipa/freeipa/issues/8678>`__
 -  test_trust: add tests for using AD users and groups in SUDO rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7c56fde7727bfad3f885cf50e21182cdc46024e>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  ipatests: fix test_sudorule_plugin's wrong argument use
    `commit <https://codeberg.org/freeipa/freeipa/commit/f4d3c91e7f80659268e006dffa5f064b29b45c98>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  sudorule runAs: allow to add users and groups from trusted domains
    directly
    `commit <https://codeberg.org/freeipa/freeipa/commit/78043bfb5e2a3b1fc0fae6d55ba605ba469ce5ae>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  sudorule-add-user: allow to reference users and groups from trusted
    domains directly
    `commit <https://codeberg.org/freeipa/freeipa/commit/054a068f4705cd715789ceda75fa709404d5f884>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  idviews: add extended validator for users from trusted domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3563d1c35fbe9e6e96199ead211ec3b4ff1d2d2>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  baseldap: when adding external objects, differentiate between them
    and failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffc2edf61efccbcbd4294fbc8a8613decea299a3>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  baseldap: refactor validator support in add_external_pre_callback
    `commit <https://codeberg.org/freeipa/freeipa/commit/132d7fb0ed21e2e7cc69366e2141ae69e7864afb>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  Add design document for using AD users/groups in SUDO rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/16b30cbe5e4f1fd8965ed27ba2ca9b4b7b295e9c>`__
-   `#3226 <https://pagure.io/freeipa/issue/3226>`__
+   `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__
 -  use a constant instead of /var/lib/sss/keytabs
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f63afb4408e308c2ee972a72875525afefa5d54>`__
 -  trust-fetch-domains: use custom krb5.conf overlay for all trust
    operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/c842d4b5c2404d263d56aa0c4ba33fe32b2ca61e>`__
-   `#8655 <https://pagure.io/freeipa/issue/8655>`__,
-   `#8664 <https://pagure.io/freeipa/issue/8664>`__
+   `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__,
+   `#8664 <https://codeberg.org/freeipa/freeipa/issues/8664>`__
 -  ipaserver/dcerpc: store forest topology as a blob in ipasam
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d706b6f57309ec394df617cecb9a73d021fc2f7>`__
-   `#8576 <https://pagure.io/freeipa/issue/8576>`__
+   `#8576 <https://codeberg.org/freeipa/freeipa/issues/8576>`__
 -  ipasam: derive parent domain for subdomains automatically
    `commit <https://codeberg.org/freeipa/freeipa/commit/f103172954c259443f0c5b4ac89474e66cf3a1d6>`__
-   `#8576 <https://pagure.io/freeipa/issue/8576>`__
+   `#8576 <https://codeberg.org/freeipa/freeipa/issues/8576>`__
 -  ipasam: free trusted domain context on failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8f927db7da00d1671f871d3b2e89429aec3beb9>`__
-   `#8576 <https://pagure.io/freeipa/issue/8576>`__
+   `#8576 <https://codeberg.org/freeipa/freeipa/issues/8576>`__
 -  ipasam: allow search of users by user principal name (UPN)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e8eb0f5fe82be58be88fa0d9b07ee7af69d8829>`__
-   `#8661 <https://pagure.io/freeipa/issue/8661>`__
+   `#8661 <https://codeberg.org/freeipa/freeipa/issues/8661>`__
 -  ipasam: implement PASSDB getgrnam call
    `commit <https://codeberg.org/freeipa/freeipa/commit/962052a0567b6878843272b1882d0a0b3b2debd1>`__
-   `#8660 <https://pagure.io/freeipa/issue/8660>`__
+   `#8660 <https://codeberg.org/freeipa/freeipa/issues/8660>`__
 -  ipa-kdb: provide correct logon time in MS-PAC from authentication
    time
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8bf37422b7c49a4a39b4704b18158b37ee9ef80>`__
-   `#8659 <https://pagure.io/freeipa/issue/8659>`__
+   `#8659 <https://codeberg.org/freeipa/freeipa/issues/8659>`__
 -  ipaserver/dcerpc.py: enforce SMB encryption on LSA pipe if available
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fa07a108030265dc89921a37216a1184e1e7516>`__
-   `#8655 <https://pagure.io/freeipa/issue/8655>`__
+   `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__
 -  ipaserver/dcerpc.py: use Kerberos authentication for discovery
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ab9bf68a4d12c8763c1669d0c14b7771a3289da>`__
-   `#8655 <https://pagure.io/freeipa/issue/8655>`__
+   `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__
 -  ipaserver/dcerpc: use Samba-provided trust helper to establish trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/753246f4e82af5697ee51bdc7f667959e1824be1>`__
-   `#8655 <https://pagure.io/freeipa/issue/8655>`__
+   `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__
 -  ipatests: fix race condition in finalizer of encrypted backup test
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fe573b3d953913bc94fd06c230703dac70f0e8d>`__
 -  ipaplatform: add constant for systemd-run binary
@@ -340,10 +340,10 @@ Antonio Torres (2)
 
 -  Check that IPA cert is added to trust store after server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/2715fbd4a73115949264298858ed0835fe982164>`__
-   `#8614 <https://pagure.io/freeipa/issue/8614>`__
+   `#8614 <https://codeberg.org/freeipa/freeipa/issues/8614>`__
 -  Test that IPA certs are removed on server uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a86a93e560e1d9ade2f78b0cf82d93b8833eb39>`__
-   `#8614 <https://pagure.io/freeipa/issue/8614>`__
+   `#8614 <https://codeberg.org/freeipa/freeipa/issues/8614>`__
 
 
 
@@ -355,7 +355,7 @@ Antonio Torres Moríñigo (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f3762ef92a809059f196e5553f1c31e9f1180e7>`__
 -  Allow leading/trailing whitespaces in passwords
    `commit <https://codeberg.org/freeipa/freeipa/commit/89eba7d38db2f510554b3365f9d099190ce80c51>`__
-   `#7599 <https://pagure.io/freeipa/issue/7599>`__
+   `#7599 <https://codeberg.org/freeipa/freeipa/issues/7599>`__
 
 
 
@@ -364,7 +364,7 @@ Christian Heimes (1)
 
 -  Add ccache sweeper files to gitignore
    `commit <https://codeberg.org/freeipa/freeipa/commit/56b84973b9f02e74f2518bd58694b673f88f8d5e>`__
-   `#8589 <https://pagure.io/freeipa/issue/8589>`__
+   `#8589 <https://codeberg.org/freeipa/freeipa/issues/8589>`__
 
 
 
@@ -373,7 +373,7 @@ François Cami (1)
 
 -  ipatests: test_ipahealthcheck: fix units
    `commit <https://codeberg.org/freeipa/freeipa/commit/34add4a2e091dc7bc6031f8fc6cc80904b1bea20>`__
-   `#8674 <https://pagure.io/freeipa/issue/8674>`__
+   `#8674 <https://codeberg.org/freeipa/freeipa/issues/8674>`__
 
 
 
@@ -384,38 +384,38 @@ Florence Blanc-Renaud (12)
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb78693405aab603203e60a174b04cd3264e1855>`__
 -  ipatests: fix expected output for ipahealthcheck.ipa.files
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc2a52abe256d2de09eafe8a07898b0cbea3404b>`__
-   `#8662 <https://pagure.io/freeipa/issue/8662>`__
+   `#8662 <https://codeberg.org/freeipa/freeipa/issues/8662>`__
 -  ipatests: fix healthcheck test for ipahealthcheck.ds.encryption
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a207918521b474a39c1689837db146800624af8>`__
-   `#8670 <https://pagure.io/freeipa/issue/8670>`__
+   `#8670 <https://codeberg.org/freeipa/freeipa/issues/8670>`__
 -  ipatests: fix expected errmsg in
    TestTrust::test_ipa_commands_run_as_aduser
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd3bad88ee4d4535416ad5fc5f97b55a939534ef>`__
-   `#8668 <https://pagure.io/freeipa/issue/8668>`__
+   `#8668 <https://codeberg.org/freeipa/freeipa/issues/8668>`__
 -  ipatest: fix test_upgrade.py::TestUpgrade::()::test_kra_detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/0db289695c8225cad5c17c6a5846ff0a373c3ce6>`__
-   `#8596 <https://pagure.io/freeipa/issue/8596>`__,
-   `#8653 <https://pagure.io/freeipa/issue/8653>`__
+   `#8596 <https://codeberg.org/freeipa/freeipa/issues/8596>`__,
+   `#8653 <https://codeberg.org/freeipa/freeipa/issues/8653>`__
 -  selinux: modify policy to allow one-way trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/952b6bdcceda9f460e17075404084f1f3ddb5eaa>`__
-   `#8508 <https://pagure.io/freeipa/issue/8508>`__
+   `#8508 <https://codeberg.org/freeipa/freeipa/issues/8508>`__
 -  ipatests: add test_ipa_cert_fix to the nightly definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f2be8a45a1d4baff0074cf4d8c446e3d08db795>`__
-   `#8618 <https://pagure.io/freeipa/issue/8618>`__
+   `#8618 <https://codeberg.org/freeipa/freeipa/issues/8618>`__
 -  ipa-cert-fix: do not fail when CSR is missing from CS.cfg
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb711f781322657b0b3d77332f2462ecfb27db95>`__
-   `#8618 <https://pagure.io/freeipa/issue/8618>`__
+   `#8618 <https://codeberg.org/freeipa/freeipa/issues/8618>`__
 -  ipatests: add a test for ipa-cert-fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/f36e518b5704b02b81a4b80a1b84c429594cf5ce>`__
-   `#8618 <https://pagure.io/freeipa/issue/8618>`__
+   `#8618 <https://codeberg.org/freeipa/freeipa/issues/8618>`__
 -  ipatests: clear initgroups cache in clear_sssd_cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/286d0680a6d4ae53b79596e545f9291791e36aa5>`__
 -  ipatests: remove test_acme from gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd1b596b5711aefd87fd6ec340c3713ee5932425>`__
-   `#8602 <https://pagure.io/freeipa/issue/8602>`__
+   `#8602 <https://codeberg.org/freeipa/freeipa/issues/8602>`__
 -  ipatests: fix expected error message in test_commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/8bc341868f9154a625b7aae2604a7aa7b6cd0696>`__
-   `#8631 <https://pagure.io/freeipa/issue/8631>`__
+   `#8631 <https://codeberg.org/freeipa/freeipa/issues/8631>`__
 
 
 
@@ -432,16 +432,16 @@ Rob Crittenden (16)
 
 -  ipatests: test the cgroup v2 memory restrictions
    `commit <https://codeberg.org/freeipa/freeipa/commit/85d944cea13725511973fa00c9db6a1ebeb90efa>`__
-   `#8635 <https://pagure.io/freeipa/issue/8635>`__
+   `#8635 <https://codeberg.org/freeipa/freeipa/issues/8635>`__
 -  Add support for cgroup v2 to the installer memory checker
    `commit <https://codeberg.org/freeipa/freeipa/commit/1dd4501a9fe1e83964b1f008b91d20b4afe5051a>`__
-   `#8635 <https://pagure.io/freeipa/issue/8635>`__
+   `#8635 <https://codeberg.org/freeipa/freeipa/issues/8635>`__
 -  ipa-rmkeytab: Check return value of krb5_kt_(start|end)_seq_get
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b380969241b7f28b2aa275ff1a71fdf78912580>`__
-   `#8658 <https://pagure.io/freeipa/issue/8658>`__
+   `#8658 <https://codeberg.org/freeipa/freeipa/issues/8658>`__
 -  ipa-rmkeytab: convert numeric return values to #defines
    `commit <https://codeberg.org/freeipa/freeipa/commit/06ffc7aae7f37bbd03dbd145e30c13f2234ed071>`__
-   `#8658 <https://pagure.io/freeipa/issue/8658>`__
+   `#8658 <https://codeberg.org/freeipa/freeipa/issues/8658>`__
 -  ipa_pwd: Remove unnecessary conditional
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6cfbffc8f2e45d0e8e6057e6ead6d35e99bf48a>`__
 -  ipa_kdb: Fix memory leak
@@ -455,25 +455,25 @@ Rob Crittenden (16)
 -  Revert "Remove test for minimum ACME support and rely on package
    deps"
    `commit <https://codeberg.org/freeipa/freeipa/commit/3aeb9b8e40cc526fd5c5162158b9cc5755670f66>`__
-   `#8634 <https://pagure.io/freeipa/issue/8634>`__
+   `#8634 <https://codeberg.org/freeipa/freeipa/issues/8634>`__
 -  ipatests: See if nologin supports -c before asserting message
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca9f8d1c9feda6fd58220f1424970dcca5b730e0>`__
-   `#7676 <https://pagure.io/freeipa/issue/7676>`__
+   `#7676 <https://codeberg.org/freeipa/freeipa/issues/7676>`__
 -  ipatests: test that modifying a permission attrs handles failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdc383a1a906f97c06b2bfa281a4b290fb4b04b3>`__
-   `#8646 <https://pagure.io/freeipa/issue/8646>`__
+   `#8646 <https://codeberg.org/freeipa/freeipa/issues/8646>`__
 -  Remove virtual attributes before rolling back a permission
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ae744254dd845f9a459601cb8a1468aeaad028a>`__
-   `#8646 <https://pagure.io/freeipa/issue/8646>`__
+   `#8646 <https://codeberg.org/freeipa/freeipa/issues/8646>`__
 -  Remove invalid test case for DNS SRV priority
    `commit <https://codeberg.org/freeipa/freeipa/commit/071b71290601d4a5f6a65adf2b55c34d3865172d>`__
-   `#8650 <https://pagure.io/freeipa/issue/8650>`__
+   `#8650 <https://codeberg.org/freeipa/freeipa/issues/8650>`__
 -  ipatests: test that no errors are reported after ipa-certupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/ad1764a1fff885e1c386b0a9f50517b2e0725e03>`__
-   `#8644 <https://pagure.io/freeipa/issue/8644>`__
+   `#8644 <https://codeberg.org/freeipa/freeipa/issues/8644>`__
 -  Don't change the CA profile when modifying request in ipa_certupdate
    `commit <https://codeberg.org/freeipa/freeipa/commit/10ba43ad35acecdd1c4b7981db31a90cce1b9fab>`__
-   `#8644 <https://pagure.io/freeipa/issue/8644>`__
+   `#8644 <https://codeberg.org/freeipa/freeipa/issues/8644>`__
 
 
 
@@ -482,7 +482,7 @@ Robbie Harwood (1)
 
 -  Set client keytab location for 389ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/df411f00a3d1db2fcb0d122a54b9e13a57e35f3f>`__
-   `#8656 <https://pagure.io/freeipa/issue/8656>`__
+   `#8656 <https://codeberg.org/freeipa/freeipa/issues/8656>`__
 
 
 
@@ -491,7 +491,7 @@ Stanislav Levin (2)
 
 -  ipatests: Don't assume sshd flush its logs immediately
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbe7d2258d6c900b2e02b2373e720275d9917316>`__
-   `#8682 <https://pagure.io/freeipa/issue/8682>`__
+   `#8682 <https://codeberg.org/freeipa/freeipa/issues/8682>`__
 -  ipatests: Raise log level of 389-ds replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/41a9cc637b4ea8794fc17f9fc06c6cf8d3a31caa>`__
 

--- a/src/page/Releases/4.9.10.rst
+++ b/src/page/Releases/4.9.10.rst
@@ -112,85 +112,85 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#1539 <https://pagure.io/freeipa/issue/1539>`__
+-  `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
    (`rhbz#782917 <https://bugzilla.redhat.com/show_bug.cgi?id=782917>`__)
    [RFE] Add code to check password expiration on ldap bind
--  `#8582 <https://pagure.io/freeipa/issue/8582>`__ Nightly test failure
+-  `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__ Nightly test failure
    in
    test_replica_promotion.py::TestHiddenReplicaPromotion::test_ipahealthcheck_hidden_replica
    - ClonesConnectivyAndDataCheck
--  `#8803 <https://pagure.io/freeipa/issue/8803>`__ Add support for
+-  `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__ Add support for
    managing IdP references
--  `#8804 <https://pagure.io/freeipa/issue/8804>`__ Extend supported
+-  `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__ Extend supported
    user authentication methods in IPA to allow IdP auth
--  `#8805 <https://pagure.io/freeipa/issue/8805>`__ Extend \`ipa-otpd\`
+-  `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__ Extend \`ipa-otpd\`
    daemon to recognize IdP references
--  `#8977 <https://pagure.io/freeipa/issue/8977>`__
+-  `#8977 <https://codeberg.org/freeipa/freeipa/issues/8977>`__
    (`rhbz#2000947 <https://bugzilla.redhat.com/show_bug.cgi?id=2000947>`__)
    subid: subid-match displays the DN of the owner, not its UID.
--  `#9121 <https://pagure.io/freeipa/issue/9121>`__
+-  `#9121 <https://codeberg.org/freeipa/freeipa/issues/9121>`__
    (`rhbz#2056508 <https://bugzilla.redhat.com/show_bug.cgi?id=2056508>`__)
    Ipa server ignores max ticket lifetime when using spake preauth,
    issues ticket with 24h lifetime
--  `#9128 <https://pagure.io/freeipa/issue/9128>`__
+-  `#9128 <https://codeberg.org/freeipa/freeipa/issues/9128>`__
    (`rhbz#2059396 <https://bugzilla.redhat.com/show_bug.cgi?id=2059396>`__)
    Turn down debug from ipa-dnskeysyncd
--  `#9136 <https://pagure.io/freeipa/issue/9136>`__
+-  `#9136 <https://codeberg.org/freeipa/freeipa/issues/9136>`__
    (`rhbz#1872467 <https://bugzilla.redhat.com/show_bug.cgi?id=1872467>`__)
    Add tests for ipa-healthcheck setting command-line options in
    configuration
--  `#9140 <https://pagure.io/freeipa/issue/9140>`__ Test
+-  `#9140 <https://codeberg.org/freeipa/freeipa/issues/9140>`__ Test
    test_rekey_keytype_DSA should be disabled
--  `#9145 <https://pagure.io/freeipa/issue/9145>`__ Configure email
+-  `#9145 <https://codeberg.org/freeipa/freeipa/issues/9145>`__ Configure email
    subject line for IPA EPN
--  `#9146 <https://pagure.io/freeipa/issue/9146>`__ Nightly test failure
+-  `#9146 <https://codeberg.org/freeipa/freeipa/issues/9146>`__ Nightly test failure
    in \`test_epn.py::TestEPN::test_EPN_config_file\`
--  `#9147 <https://pagure.io/freeipa/issue/9147>`__
+-  `#9147 <https://codeberg.org/freeipa/freeipa/issues/9147>`__
    (`rhbz#1958777 <https://bugzilla.redhat.com/show_bug.cgi?id=1958777>`__)
    ipa-server-install --uninstall fails on Fedora 33, returned non-zero
    exit status 2: Unable to disable feature: No such file or directory
--  `#9148 <https://pagure.io/freeipa/issue/9148>`__ documentation build
+-  `#9148 <https://codeberg.org/freeipa/freeipa/issues/9148>`__ documentation build
    fails in readthedocs
--  `#9150 <https://pagure.io/freeipa/issue/9150>`__
+-  `#9150 <https://codeberg.org/freeipa/freeipa/issues/9150>`__
    (`rhbz#2063155 <https://bugzilla.redhat.com/show_bug.cgi?id=2063155>`__)
    Remove 'Remove' button from subid page
--  `#9151 <https://pagure.io/freeipa/issue/9151>`__
+-  `#9151 <https://codeberg.org/freeipa/freeipa/issues/9151>`__
    (`rhbz#2012911 <https://bugzilla.redhat.com/show_bug.cgi?id=2012911>`__)
    Disable DNSSEC in ipa-healthcheck tests
--  `#9152 <https://pagure.io/freeipa/issue/9152>`__ Regression in
+-  `#9152 <https://codeberg.org/freeipa/freeipa/issues/9152>`__ Regression in
    TestIpaHealthCheckWithoutDNS
--  `#9155 <https://pagure.io/freeipa/issue/9155>`__ Depend on sssd-idp
+-  `#9155 <https://codeberg.org/freeipa/freeipa/issues/9155>`__ Depend on sssd-idp
    directly to help RHEL BaseOS/AppStream repository split
--  `#9157 <https://pagure.io/freeipa/issue/9157>`__ implement support
+-  `#9157 <https://codeberg.org/freeipa/freeipa/issues/9157>`__ implement support
    for bind 9.18+
--  `#9159 <https://pagure.io/freeipa/issue/9159>`__
+-  `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
    (`rhbz#2068088 <https://bugzilla.redhat.com/show_bug.cgi?id=2068088>`__)
    [RFE] ipa-client-install should provide option to enable subid: sss
    in /etc/nsswitch.conf
--  `#9162 <https://pagure.io/freeipa/issue/9162>`__
+-  `#9162 <https://codeberg.org/freeipa/freeipa/issues/9162>`__
    (`rhbz#2004646 <https://bugzilla.redhat.com/show_bug.cgi?id=2004646>`__)
    RFE: Improve error message with more detail for ipa-replica-install
    command
--  `#9165 <https://pagure.io/freeipa/issue/9165>`__ Nightly test failure
+-  `#9165 <https://codeberg.org/freeipa/freeipa/issues/9165>`__ Nightly test failure
    (rawhide) in test_krbtpolicy.py::TestPWPolicy::test_krbtpolicy_otp
--  `#9167 <https://pagure.io/freeipa/issue/9167>`__ Nightly test failure
+-  `#9167 <https://codeberg.org/freeipa/freeipa/issues/9167>`__ Nightly test failure
    in test_graceperiod_not_replicated
--  `#9171 <https://pagure.io/freeipa/issue/9171>`__ Boolean value not
+-  `#9171 <https://codeberg.org/freeipa/freeipa/issues/9171>`__ Boolean value not
    mapped on WebUI checkbox
--  `#9173 <https://pagure.io/freeipa/issue/9173>`__ Inconsistent ACI
+-  `#9173 <https://codeberg.org/freeipa/freeipa/issues/9173>`__ Inconsistent ACI
    before/after running ipa-server-upgrade
--  `#9174 <https://pagure.io/freeipa/issue/9174>`__ Update Suse support
+-  `#9174 <https://codeberg.org/freeipa/freeipa/issues/9174>`__ Update Suse support
    in freeipa
--  `#9175 <https://pagure.io/freeipa/issue/9175>`__ ipatests: need to
+-  `#9175 <https://codeberg.org/freeipa/freeipa/issues/9175>`__ ipatests: need to
    update expected output for ipa-healthcheck's
    DogtagCertsConnectivityCheck
--  `#9176 <https://pagure.io/freeipa/issue/9176>`__
+-  `#9176 <https://codeberg.org/freeipa/freeipa/issues/9176>`__
    (`rhbz#2092015 <https://bugzilla.redhat.com/show_bug.cgi?id=2092015>`__)
    secret in ipa-pki-proxy.conf is not changed if new requiredSecret
    value is present in /etc/pki/pki-tomcat/server.xml
--  `#9178 <https://pagure.io/freeipa/issue/9178>`__ idviews: use cached
+-  `#9178 <https://codeberg.org/freeipa/freeipa/issues/9178>`__ idviews: use cached
    ipaOriginalUid value when resolving ID override anchor
--  `#9180 <https://pagure.io/freeipa/issue/9180>`__ Add new config
+-  `#9180 <https://codeberg.org/freeipa/freeipa/issues/9180>`__ Add new config
    option for LDAP cache debugging
 
 
@@ -216,33 +216,33 @@ Alexander Bokovoy (29)
 -  idviews: use cached ipaOriginalUid value when resolving ID override
    anchor
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfca49c469e822199cbdccd05d4c4a4cbf281448>`__
-   `#9178 <https://pagure.io/freeipa/issue/9178>`__
+   `#9178 <https://codeberg.org/freeipa/freeipa/issues/9178>`__
 -  ipaldap: fix conversion from boolean OID to Python
    `commit <https://codeberg.org/freeipa/freeipa/commit/faeb656c77adf27a49ccaceb57fc1ba44e11cc1d>`__
-   `#9171 <https://pagure.io/freeipa/issue/9171>`__
+   `#9171 <https://codeberg.org/freeipa/freeipa/issues/9171>`__
 -  ipa-kdb: avoid additional checks for a well-known anonymous principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c6fc7db61d83e01a4913d22dfb178af43d30d8b>`__
-   `#9165 <https://pagure.io/freeipa/issue/9165>`__
+   `#9165 <https://codeberg.org/freeipa/freeipa/issues/9165>`__
 -  Ignore dnssec-enable-related named-checkonf errors in test
    `commit <https://codeberg.org/freeipa/freeipa/commit/35c720cab0d91e730e94d95abfdd54d7882987d0>`__
-   `#9157 <https://pagure.io/freeipa/issue/9157>`__
+   `#9157 <https://codeberg.org/freeipa/freeipa/issues/9157>`__
 -  Support dnssec utils from bind 9.17.2+
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c6bdf97598984e74318061449f7906e487cd034>`__
-   `#9157 <https://pagure.io/freeipa/issue/9157>`__
+   `#9157 <https://codeberg.org/freeipa/freeipa/issues/9157>`__
 -  ipa-kdb: apply per-indicator settings from inherited ticket policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a2baae42f8cff025521df19eed793f8184ce5974>`__
-   `#9121 <https://pagure.io/freeipa/issue/9121>`__
+   `#9121 <https://codeberg.org/freeipa/freeipa/issues/9121>`__
 -  freeipa.spec.in: Depend on sssd-idp directly to help RHEL
    BaseOS/AppStream repository split
    `commit <https://codeberg.org/freeipa/freeipa/commit/979163bff2e689c46ff67d6976f7927f0d81f9cd>`__
-   `#9155 <https://pagure.io/freeipa/issue/9155>`__
+   `#9155 <https://codeberg.org/freeipa/freeipa/issues/9155>`__
 -  docs: tune RTD to display lists with disc and left margin
    `commit <https://codeberg.org/freeipa/freeipa/commit/40a257f1e682616c66c77c86be14437dbcad8a8c>`__
 -  workshop: add chapter 12: External IdP support
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f9e0d3ff3bd80b75bc9f5de97e7e086ba0a31e3>`__
 -  freeipa.spec.in: use SSSD 2.7.0 to add IdP pre-auth mechanism
    `commit <https://codeberg.org/freeipa/freeipa/commit/d49aa7103bacba60bae28f32bd76d9d35853626b>`__
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 -  doc/workshop: document use of pam_sss_gss PAM module
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0eab8fe7609fea0b46ea863db1822eca1daac63>`__
 -  External IdP: initial SELinux policy
@@ -251,27 +251,27 @@ Alexander Bokovoy (29)
    `commit <https://codeberg.org/freeipa/freeipa/commit/51a4e42dd777661addd4f2fed1654ee978e8a4d7>`__
 -  KDB: support external IdP configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/673478b1cf9950aed755a6a9ae8f81cb323932b3>`__
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__
 -  ipa-otpd: add support for SSSD OIDC helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/bf8e2bb99f1c09ced820bd4bf6e9d7832db2caea>`__
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 -  external-idp: add XMLRPC tests for External IdP objects and idp
    indicator
    `commit <https://codeberg.org/freeipa/freeipa/commit/b77015b7a3b627282560253cf2cd579c89f02923>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__
 -  external-idp: add support to manage external IdP objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/2136bd5d00f7aed5ae722ff8253c2b74ba444972>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__
 -  external-idp: add LDAP schema, indices and other LDAP objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/1df7b82ac188650775703dc95530017c969d0bff>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__
 -  doc/designs: add External IdP support design documents
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d81338cb94a2d850f53629ebba98a1f1ec90d1e>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__,
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__,
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 -  js tests: use latest grunt
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea0275f6113854feb02715265a5a85904023816d>`__
 -  Azure CI: don't force non-existing OpenSSL configuration anymore
@@ -283,21 +283,21 @@ Alexander Bokovoy (29)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e882144bb5c5661906eeaefa6ce6f511005bfb2>`__
 -  web ui: do not provide Remove button in subid page
    `commit <https://codeberg.org/freeipa/freeipa/commit/59cf9017a009bb5eb4f6ef0ed07aa21e60614ab3>`__
-   `#9150 <https://pagure.io/freeipa/issue/9150>`__
+   `#9150 <https://codeberg.org/freeipa/freeipa/issues/9150>`__
 -  docs: force sphinx version above 3.0 to avoid caching in RTD
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ea1866f1bdea4e20894906e7dbdbde27f9715cd>`__
 -  docs: update Sphinx requirements in ipasphinx package
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffd8f14af2a1d2d1bce9011473449706902d884d>`__
-   `#9148 <https://pagure.io/freeipa/issue/9148>`__
+   `#9148 <https://codeberg.org/freeipa/freeipa/issues/9148>`__
 -  docs: add the readthedocs configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/68c20846cf80eb2d46a05e0f8879ddfbd19fbbec>`__
-   `#9148 <https://pagure.io/freeipa/issue/9148>`__
+   `#9148 <https://codeberg.org/freeipa/freeipa/issues/9148>`__
 -  docs: add plantuml and use virtual environment to generate docs
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ddef72fbbf779da32660d54389d68a7c3b35a1a>`__
-   `#9148 <https://pagure.io/freeipa/issue/9148>`__
+   `#9148 <https://codeberg.org/freeipa/freeipa/issues/9148>`__
 -  doc: migrate to m2r2 and newer sphinx, add plantuml to venv
    `commit <https://codeberg.org/freeipa/freeipa/commit/de918aea190401183da4742fc9d56101a13f1b17>`__
-   `#9148 <https://pagure.io/freeipa/issue/9148>`__
+   `#9148 <https://codeberg.org/freeipa/freeipa/issues/9148>`__
 
 
 
@@ -308,9 +308,9 @@ Anuja More (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b39f9336fa12e7f28ce0a5c51677983bc9b72621>`__
 -  ipatests: Add integration tests for External IdP support
    `commit <https://codeberg.org/freeipa/freeipa/commit/b979dd91f149fd1f4fc1f48466a26f575eae0ae4>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__,
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__,
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 
 
 
@@ -327,7 +327,7 @@ Matthew Davis (1)
 
 -  Create missing SSSD_PUBCONF_KRB5_INCLUDE_D_DIR
    `commit <https://codeberg.org/freeipa/freeipa/commit/70d23b225d11a6c8c16bd94faa8891100b83c1ac>`__
-   `#9174 <https://pagure.io/freeipa/issue/9174>`__
+   `#9174 <https://codeberg.org/freeipa/freeipa/issues/9174>`__
 
 
 
@@ -336,41 +336,41 @@ Florence Blanc-Renaud (12)
 
 -  ACI: define "Read DNS entries from a zone" aci during install
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b8b032ed5dd33662032e82ba4e296e7b0700c17>`__
-   `#9173 <https://pagure.io/freeipa/issue/9173>`__
+   `#9173 <https://codeberg.org/freeipa/freeipa/issues/9173>`__
 -  ipatests: update expected output for boolean attribute
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6bc8fd4c80d7ab9cd369ffce521d52c0eabe4cb>`__
-   `#9171 <https://pagure.io/freeipa/issue/9171>`__
+   `#9171 <https://codeberg.org/freeipa/freeipa/issues/9171>`__
 -  ipa-replica-install: nsds5replicaUpdateInProgress is a Boolean
    `commit <https://codeberg.org/freeipa/freeipa/commit/23d56bb95229756054df72de4d50fead8fc6116e>`__
-   `#9171 <https://pagure.io/freeipa/issue/9171>`__
+   `#9171 <https://codeberg.org/freeipa/freeipa/issues/9171>`__
 -  ipatest: update expected out for ipa-healthcheck's
    DogtagCertsConnectivityCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/6147f877a57dab33cccea08cc57fcb7b82d4a602>`__
-   `#9175 <https://pagure.io/freeipa/issue/9175>`__
+   `#9175 <https://codeberg.org/freeipa/freeipa/issues/9175>`__
 -  ipatests: add new test with --subid installer option
    `commit <https://codeberg.org/freeipa/freeipa/commit/0193498f682eb3efa9cbdf82af215eaa854f466a>`__
-   `#9159 <https://pagure.io/freeipa/issue/9159>`__
+   `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
 -  man pages: document the --subid installer option
    `commit <https://codeberg.org/freeipa/freeipa/commit/e10f3385d0bbb4100a8220ce372dc2748f8b329e>`__
-   `#9159 <https://pagure.io/freeipa/issue/9159>`__
+   `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
 -  Installer: add --subid option to select the sssd profile with-subid
    `commit <https://codeberg.org/freeipa/freeipa/commit/74b2fd06d978d56137ccfde310f9c64187e0a5a3>`__
-   `#9159 <https://pagure.io/freeipa/issue/9159>`__
+   `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
 -  client uninstall: handle uninstall with authconfig
    `commit <https://codeberg.org/freeipa/freeipa/commit/d39e232e9ee28da5d4488135d264d2d1b9e671ba>`__
-   `#9147 <https://pagure.io/freeipa/issue/9147>`__
+   `#9147 <https://codeberg.org/freeipa/freeipa/issues/9147>`__
 -  ipatests: --no-dnssec-validation requires --setup-dns
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f814d9f54207a53c99155e542cc5b210707d0fd>`__
-   `#9152 <https://pagure.io/freeipa/issue/9152>`__
+   `#9152 <https://codeberg.org/freeipa/freeipa/issues/9152>`__
 -  ipatests: remove test_rekey_keytype_DSA
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3093d9c3990f8e899487087965f008607a519c6>`__
-   `#9140 <https://pagure.io/freeipa/issue/9140>`__
+   `#9140 <https://codeberg.org/freeipa/freeipa/issues/9140>`__
 -  ipatests: update the expected sha256sum of epn.conf file
    `commit <https://codeberg.org/freeipa/freeipa/commit/5877c4e17a92c73aa68b8ba3c7a47555e32a13ca>`__
-   `#9146 <https://pagure.io/freeipa/issue/9146>`__
+   `#9146 <https://codeberg.org/freeipa/freeipa/issues/9146>`__
 -  EPN: document missing option msg_subject
    `commit <https://codeberg.org/freeipa/freeipa/commit/d37d1f717ec725726d770ea73b4ab2e418c485e2>`__
-   `#9145 <https://pagure.io/freeipa/issue/9145>`__
+   `#9145 <https://codeberg.org/freeipa/freeipa/issues/9145>`__
 
 
 
@@ -381,7 +381,7 @@ Francisco Trivino (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8abc0a22a8866e82776afbd7c3bc5e3195c43115>`__
 -  Update ipa-replica-install replication agreement error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/c03a8c3c06562c128aac6be506274995cea74948>`__
-   `#9162 <https://pagure.io/freeipa/issue/9162>`__
+   `#9162 <https://codeberg.org/freeipa/freeipa/issues/9162>`__
 -  ipatests: Bump PR-CI latest templates to Fedora 36
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ae6ef549fe51457a6f505f3c0ea6a7804e9bcd2>`__
 
@@ -392,7 +392,7 @@ Matthew Davis (1)
 
 -  Suse compatibility fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe048d83cb88593e490af8b95c12917071683b4c>`__
-   `#9174 <https://pagure.io/freeipa/issue/9174>`__
+   `#9174 <https://codeberg.org/freeipa/freeipa/issues/9174>`__
 
 
 
@@ -402,15 +402,15 @@ Michal Polovka (4)
 -  ipatests: xfail for test_ipahealthcheck_hidden_replica to respect pki
    version
    `commit <https://codeberg.org/freeipa/freeipa/commit/60739ce483e897cbd85575304dfb7562066189e4>`__
-   `#8582 <https://pagure.io/freeipa/issue/8582>`__
+   `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__
 -  ipatests: tasks: add ipactl start, stop and restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/58ddcffc412f7dd5cc762bd6f80faa07fcedf7ec>`__
 -  ipatests: RFE: Improve ipa-replica-install error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/352b9dfb49bdf1c70a8de9ed7287387417580c86>`__
-   `#9162 <https://pagure.io/freeipa/issue/9162>`__
+   `#9162 <https://codeberg.org/freeipa/freeipa/issues/9162>`__
 -  ipatests: test_subids: test subid-match shows UID of the owner
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab0e67d1f51c2db620de002d5f61425e0a65c9aa>`__
-   `#8977 <https://pagure.io/freeipa/issue/8977>`__
+   `#8977 <https://codeberg.org/freeipa/freeipa/issues/8977>`__
 
 
 
@@ -419,46 +419,46 @@ Rob Crittenden (14)
 
 -  Add switch for LDAP cache debug output
    `commit <https://codeberg.org/freeipa/freeipa/commit/d062dc9da891cbb3b0ab04291d89afddf140c560>`__
-   `#9180 <https://pagure.io/freeipa/issue/9180>`__
+   `#9180 <https://codeberg.org/freeipa/freeipa/issues/9180>`__
 -  Remove extraneous AJP secret from server.xml on upgrades
    `commit <https://codeberg.org/freeipa/freeipa/commit/deaaaaf1492410269c1f66f8d4bb57e41b99d87c>`__
-   `#9176 <https://pagure.io/freeipa/issue/9176>`__
+   `#9176 <https://codeberg.org/freeipa/freeipa/issues/9176>`__
 -  graceperiod: ignore case when checking for missing objectclass
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6cc41094b2bc526e9f8e87229e8f83a74cfc263>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  Set default LDAP password grace period to -1
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b0fbdc37b92981d541a4152fdfeb0964692878f>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  doc: Design document for LDAP graceperiod
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2b296454c57ab639b8e023050dabc193693c42f>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  Don't duplicate the LDAP gracelimit set in the previous test
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b2edd5b4e13cb7a8b9b9eec4a0e194b4e6ca71b>`__
-   `#9167 <https://pagure.io/freeipa/issue/9167>`__
+   `#9167 <https://codeberg.org/freeipa/freeipa/issues/9167>`__
 -  Configure and enable the graceperiod plugin on upgrades
    `commit <https://codeberg.org/freeipa/freeipa/commit/62bafcc53d4f45b28eb9a541e5385c2f1e7a3f97>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  dnssec daemons: read the dns context config file for debug state
    `commit <https://codeberg.org/freeipa/freeipa/commit/c00286462196026337600113119eb5522b96141a>`__
-   `#9128 <https://pagure.io/freeipa/issue/9128>`__
+   `#9128 <https://codeberg.org/freeipa/freeipa/issues/9128>`__
 -  healthcheck: add tests for setting cli options in config file
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e8350e0dd8219fd8245f57e0ebc9a096e9be84f>`__
-   `#9136 <https://pagure.io/freeipa/issue/9136>`__
+   `#9136 <https://codeberg.org/freeipa/freeipa/issues/9136>`__
 -  Exclude passwordgraceusertime from replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/87fe3fbba6d2b5bf2a7e9a0fca91c4e588641c9c>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  Remove the replicated attribute constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b3ab98b90686bb41a901af6b1cf5da99b99a148>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  Implement LDAP bind grace period 389-ds plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fcbf2ded2563ff5151edee9384d793ad38f6dae>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  If the password auth type is enabled also enable the hardened policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/300f1301bbbe8a62183819f4350f47e3f182b7f1>`__
-   `#9121 <https://pagure.io/freeipa/issue/9121>`__
+   `#9121 <https://codeberg.org/freeipa/freeipa/issues/9121>`__
 -  kdb: The jitter offset should always be positive
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed1447ab612e5445a76e979fb059825bab84d1df>`__
-   `#9121 <https://pagure.io/freeipa/issue/9121>`__
+   `#9121 <https://codeberg.org/freeipa/freeipa/issues/9121>`__
 
 
 
@@ -470,7 +470,7 @@ Sudhir Menon (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3488276649861563471398b3747224ca54875861>`__
 -  ipatests: Adding --no-dnssec-validation option for healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/f11b7b3bf50f7ccf4689b1b0f80894b0b1247983>`__
-   `#9151 <https://pagure.io/freeipa/issue/9151>`__
+   `#9151 <https://codeberg.org/freeipa/freeipa/issues/9151>`__
 
 
 

--- a/src/page/Releases/4.9.11.rst
+++ b/src/page/Releases/4.9.11.rst
@@ -60,121 +60,121 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#8946 <https://pagure.io/freeipa/issue/8946>`__ RFE: Add label name
+-  `#8946 <https://codeberg.org/freeipa/freeipa/issues/8946>`__ RFE: Add label name
    to Certificates section in WebUI to enable testing
--  `#8951 <https://pagure.io/freeipa/issue/8951>`__ Test for RFE
+-  `#8951 <https://codeberg.org/freeipa/freeipa/issues/8951>`__ Test for RFE
    ipa-healthcheck tool can include check to see if the system is FIPS
    enabled or not
--  `#9062 <https://pagure.io/freeipa/issue/9062>`__ [ipatests] SID
+-  `#9062 <https://codeberg.org/freeipa/freeipa/issues/9062>`__ [ipatests] SID
    generation and test_xmlrpc/test_user_plugin.py
--  `#9083 <https://pagure.io/freeipa/issue/9083>`__ Support MIT Kerberos
+-  `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__ Support MIT Kerberos
    KDB version 9
--  `#9158 <https://pagure.io/freeipa/issue/9158>`__ Internal error when
+-  `#9158 <https://codeberg.org/freeipa/freeipa/issues/9158>`__ Internal error when
    setting dnsconfig or dnsforwardzone forwarders.
--  `#9160 <https://pagure.io/freeipa/issue/9160>`__
+-  `#9160 <https://codeberg.org/freeipa/freeipa/issues/9160>`__
    cryptography.utils.register_interface is scheduled for removal
--  `#9161 <https://pagure.io/freeipa/issue/9161>`__ Nightly test failure
+-  `#9161 <https://codeberg.org/freeipa/freeipa/issues/9161>`__ Nightly test failure
    in test_selinuxusermap.py::test_selinuxusermap::test_misc
--  `#9183 <https://pagure.io/freeipa/issue/9183>`__ Timeout issue in
+-  `#9183 <https://codeberg.org/freeipa/freeipa/issues/9183>`__ Timeout issue in
    test_installation.py when using interactive mode
--  `#9185 <https://pagure.io/freeipa/issue/9185>`__ Fix missing
+-  `#9185 <https://codeberg.org/freeipa/freeipa/issues/9185>`__ Fix missing
    parameter for Suse ipaplatform task
--  `#9187 <https://pagure.io/freeipa/issue/9187>`__
+-  `#9187 <https://codeberg.org/freeipa/freeipa/issues/9187>`__
    (`rhbz#2022028 <https://bugzilla.redhat.com/show_bug.cgi?id=2022028>`__)
    [UX] Preserving a user account produces output saying it was deleted
--  `#9188 <https://pagure.io/freeipa/issue/9188>`__
+-  `#9188 <https://codeberg.org/freeipa/freeipa/issues/9188>`__
    (`rhbz#2098187 <https://bugzilla.redhat.com/show_bug.cgi?id=2098187>`__)
    Add warning for empty targetattr when creating ACI with RBAC
--  `#9189 <https://pagure.io/freeipa/issue/9189>`__ ipatests: Fix
+-  `#9189 <https://codeberg.org/freeipa/freeipa/issues/9189>`__ ipatests: Fix
    test_idp.py for downstream idm-ci
--  `#9190 <https://pagure.io/freeipa/issue/9190>`__
+-  `#9190 <https://codeberg.org/freeipa/freeipa/issues/9190>`__
    ipatests.test_ipaserver.test_secure_ajp_connector failing with python
    3.6.8 with: TypeError: a bytes-like object is required, not 'str'
--  `#9192 <https://pagure.io/freeipa/issue/9192>`__
+-  `#9192 <https://codeberg.org/freeipa/freeipa/issues/9192>`__
    (`rhbz#2094672 <https://bugzilla.redhat.com/show_bug.cgi?id=2094672>`__)
    IdM WebUI Pagination Size should not allow empty value
--  `#9198 <https://pagure.io/freeipa/issue/9198>`__ [Tracker] nightly
+-  `#9198 <https://codeberg.org/freeipa/freeipa/issues/9198>`__ [Tracker] nightly
    failure: after ipa trust-add, cred cache contains
    cifs/master.ipa.test@IPA.TEST instead of admin principal
--  `#9204 <https://pagure.io/freeipa/issue/9204>`__ [Tracker] In
+-  `#9204 <https://codeberg.org/freeipa/freeipa/issues/9204>`__ [Tracker] In
    ipa-server-upgrade ca_upgrade_schema() results in unnecessary pki
    restarts
--  `#9206 <https://pagure.io/freeipa/issue/9206>`__
+-  `#9206 <https://codeberg.org/freeipa/freeipa/issues/9206>`__
    (`rhbz#2109236 <https://bugzilla.redhat.com/show_bug.cgi?id=2109236>`__)
    ldap bind occurs when admin user changes password with gracelimit=0
--  `#9207 <https://pagure.io/freeipa/issue/9207>`__ Failure in
+-  `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__ Failure in
    AzurePipeline.freeipa (GATING InstallDNSSECFirst_1_to_5)
--  `#9208 <https://pagure.io/freeipa/issue/9208>`__ ap: Doc build fails
+-  `#9208 <https://codeberg.org/freeipa/freeipa/issues/9208>`__ ap: Doc build fails
    against Sphinx 5.1.0
--  `#9211 <https://pagure.io/freeipa/issue/9211>`__
+-  `#9211 <https://codeberg.org/freeipa/freeipa/issues/9211>`__
    (`rhbz#2109243 <https://bugzilla.redhat.com/show_bug.cgi?id=2109243>`__)
    RFE: Allow grace login limit to be set in IPA WebUI.
--  `#9212 <https://pagure.io/freeipa/issue/9212>`__
+-  `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
    (`rhbz#2115475 <https://bugzilla.redhat.com/show_bug.cgi?id=2115475>`__)
    Nightly test failure in
    test_user.py::test_user::test_password_expiration_notification
--  `#9214 <https://pagure.io/freeipa/issue/9214>`__ Nightly failure in
+-  `#9214 <https://codeberg.org/freeipa/freeipa/issues/9214>`__ Nightly failure in
    webui test
    test_subid.py::test_subid::test_subid_range_deletion_not_allowed
--  `#9218 <https://pagure.io/freeipa/issue/9218>`__
+-  `#9218 <https://codeberg.org/freeipa/freeipa/issues/9218>`__
    (`rhbz#2116966 <https://bugzilla.redhat.com/show_bug.cgi?id=2116966>`__)
    Random failure in test-winsyncmigrate
--  `#9225 <https://pagure.io/freeipa/issue/9225>`__ pytest library
+-  `#9225 <https://codeberg.org/freeipa/freeipa/issues/9225>`__ pytest library
    module rename from quarkus to keycloak
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9228 <https://pagure.io/freeipa/issue/9228>`__
+-  `#9228 <https://codeberg.org/freeipa/freeipa/issues/9228>`__
    (`rhbz#2148258 <https://bugzilla.redhat.com/show_bug.cgi?id=2148258>`__)
    ipa-client-install does not maintain server affinity during
    installation
--  `#9230 <https://pagure.io/freeipa/issue/9230>`__ build failure
+-  `#9230 <https://codeberg.org/freeipa/freeipa/issues/9230>`__ build failure
    against gcc < 11
--  `#9231 <https://pagure.io/freeipa/issue/9231>`__ /run/ipa/ccaches
+-  `#9231 <https://codeberg.org/freeipa/freeipa/issues/9231>`__ /run/ipa/ccaches
    uses all available tmpfs space
--  `#9237 <https://pagure.io/freeipa/issue/9237>`__ Show order in sudo
+-  `#9237 <https://codeberg.org/freeipa/freeipa/issues/9237>`__ Show order in sudo
    rule list in web interface
--  `#9243 <https://pagure.io/freeipa/issue/9243>`__
+-  `#9243 <https://codeberg.org/freeipa/freeipa/issues/9243>`__
    (`rhbz#2127833 <https://bugzilla.redhat.com/show_bug.cgi?id=2127833>`__)
    Password Policy Grace login limit allows invalid maximum value
--  `#9245 <https://pagure.io/freeipa/issue/9245>`__
+-  `#9245 <https://codeberg.org/freeipa/freeipa/issues/9245>`__
    (`rhbz#2117167 <https://bugzilla.redhat.com/show_bug.cgi?id=2117167>`__)
    \`extdom\` plugin can return object from a wrong domain.
--  `#9246 <https://pagure.io/freeipa/issue/9246>`__ Nightly test failure
+-  `#9246 <https://codeberg.org/freeipa/freeipa/issues/9246>`__ Nightly test failure
    in test_user_permissions.TestInstallClientNoAdmin
--  `#9248 <https://pagure.io/freeipa/issue/9248>`__
+-  `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
    (`rhbz#2124369 <https://bugzilla.redhat.com/show_bug.cgi?id=2124369>`__)
    OTP token sync always returns OK even with random numbers
--  `#9249 <https://pagure.io/freeipa/issue/9249>`__
+-  `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
    (`rhbz#2108630 <https://bugzilla.redhat.com/show_bug.cgi?id=2108630>`__)
    Deprecated feature idnssoaserial in IdM appears when creating reverse
    dns zones
--  `#9252 <https://pagure.io/freeipa/issue/9252>`__
+-  `#9252 <https://codeberg.org/freeipa/freeipa/issues/9252>`__
    (`rhbz#2129895 <https://bugzilla.redhat.com/show_bug.cgi?id=2129895>`__)
    [DDF] The Examples in the RHEL ipa(1) man page show "ipa help
    commands" with content for "ipa halp topics" and "ipa hel
--  `#9254 <https://pagure.io/freeipa/issue/9254>`__ Exclude installed
+-  `#9254 <https://codeberg.org/freeipa/freeipa/issues/9254>`__ Exclude installed
    policy module file from RPM verification
--  `#9255 <https://pagure.io/freeipa/issue/9255>`__ ipapython.dn_ctypes
+-  `#9255 <https://codeberg.org/freeipa/freeipa/issues/9255>`__ ipapython.dn_ctypes
    is not compatible with libldap 2.6
--  `#9257 <https://pagure.io/freeipa/issue/9257>`__
+-  `#9257 <https://codeberg.org/freeipa/freeipa/issues/9257>`__
    (`rhbz#2104185 <https://bugzilla.redhat.com/show_bug.cgi?id=2104185>`__)
    Introduction of URI records for kerberos breaks location
    functionality
--  `#9258 <https://pagure.io/freeipa/issue/9258>`__
+-  `#9258 <https://codeberg.org/freeipa/freeipa/issues/9258>`__
    (`rhbz#2094673 <https://bugzilla.redhat.com/show_bug.cgi?id=2094673>`__)
    Do not add TLS CA configuration to ldap.conf anymore
--  `#9259 <https://pagure.io/freeipa/issue/9259>`__
+-  `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
    (`rhbz#2144737 <https://bugzilla.redhat.com/show_bug.cgi?id=2144737>`__)
    vault interoperability with older RHEL systems is broken
--  `#9269 <https://pagure.io/freeipa/issue/9269>`__
+-  `#9269 <https://codeberg.org/freeipa/freeipa/issues/9269>`__
    (`rhbz#2143224 <https://bugzilla.redhat.com/show_bug.cgi?id=2143224>`__,
    `rhbz#2075452 <https://bugzilla.redhat.com/show_bug.cgi?id=2075452>`__)
    ipa-certupdate does not restart/reload KDC on servers
--  `#9271 <https://pagure.io/freeipa/issue/9271>`__
+-  `#9271 <https://codeberg.org/freeipa/freeipa/issues/9271>`__
    (`rhbz#2143224 <https://bugzilla.redhat.com/show_bug.cgi?id=2143224>`__)
    Support PKINIT with ipa-client-install
--  `#9274 <https://pagure.io/freeipa/issue/9274>`__ ipa-join: pass the
+-  `#9274 <https://codeberg.org/freeipa/freeipa/issues/9274>`__ ipa-join: pass the
    curl write function by name, not address
 
 
@@ -189,7 +189,7 @@ Armando Neto (1)
 
 -  webui: Do not allow empty pagination size
    `commit <https://codeberg.org/freeipa/freeipa/commit/991849cf58fa990ad4540a61214b5ab4fcd4baa1>`__
-   `#9192 <https://pagure.io/freeipa/issue/9192>`__
+   `#9192 <https://codeberg.org/freeipa/freeipa/issues/9192>`__
 
 
 
@@ -199,33 +199,33 @@ Alexander Bokovoy (10)
 -  ipa-kdb: for delegation check, use different error codes before and
    after krb5 1.20
    `commit <https://codeberg.org/freeipa/freeipa/commit/e12aa8bb782e1f3722ae93d63632cd93df06faab>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: fix comment to make sure we talk about krb5 1.20 or later
    `commit <https://codeberg.org/freeipa/freeipa/commit/a35cac3d6fa80d259240b0eb1d4952c321be9e92>`__
 -  ipa-kdb: fix PAC requester check
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e504647dd00202c02cd203ca3474a332d1e413e>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: handle empty S4U proxy in allowed_to_delegate
    `commit <https://codeberg.org/freeipa/freeipa/commit/4755bd42c0f4c8fcda6131ee89b6fa8308d8a75c>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: handle cross-realm TGT entries when generating PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/0dd3315afb1056e3ca5bfd6af161793b5a5b8d86>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: add krb5 1.20 support
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0d840347b453bda141691ac587bc2ec851f15a5>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipa-kdb: refactor MS-PAC processing to prepare for krb5 1.20
    `commit <https://codeberg.org/freeipa/freeipa/commit/9efa8fe49c08fc584189b9d9ab24dfa8560db824>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  ipaclient: do not set TLS CA options in ldap.conf anymore
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9a56b51bbb350219d0f5cb0ea6b3cc00230d437>`__
-   `#9258 <https://pagure.io/freeipa/issue/9258>`__
+   `#9258 <https://codeberg.org/freeipa/freeipa/issues/9258>`__
 -  fix canonicalization issue in Web UI
    `commit <https://codeberg.org/freeipa/freeipa/commit/109cd579e3b089b7fad4c92bf25594eba1af8a21>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 -  ipa-otpd: initialize local pointers and handle gcc 10
    `commit <https://codeberg.org/freeipa/freeipa/commit/9290aa5500f752d0eedabdfc92c9fe6c0ee743b8>`__
-   `#9230 <https://pagure.io/freeipa/issue/9230>`__
+   `#9230 <https://codeberg.org/freeipa/freeipa/issues/9230>`__
 
 
 
@@ -234,17 +234,17 @@ Anuja More (4)
 
 -  ipatests : Test query to AD specific attributes is successful.
    `commit <https://codeberg.org/freeipa/freeipa/commit/21cb86a8e571ac7aa0304c57961881ca9c4aeacb>`__
-   `#9127 <https://pagure.io/freeipa/issue/9127>`__
+   `#9127 <https://codeberg.org/freeipa/freeipa/issues/9127>`__
 -  ipatests: Fix install_master for test_idp.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/15f454f6f8d25275c9570e2cc3a97c4e030fc581>`__
-   `#9189 <https://pagure.io/freeipa/issue/9189>`__
+   `#9189 <https://codeberg.org/freeipa/freeipa/issues/9189>`__
 -  ipatests: update prci definitions for test_idp.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/50b4d9ab3fcb2e63edc8d20346e4a8a79f15692d>`__
 -  Add end to end integration tests for external IdP
    `commit <https://codeberg.org/freeipa/freeipa/commit/857713c5a9c8e0b62c06dd92e69c09eeb34b2e99>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__,
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__,
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 
 
 
@@ -272,7 +272,7 @@ Alexey Tikhonov (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a07cece0c006b3a89fc467284244f979d39f0209>`__
 -  extdom: make sure result doesn't miss domain part
    `commit <https://codeberg.org/freeipa/freeipa/commit/3de618f75416afd6c087c243fe35755739d229a4>`__
-   `#9245 <https://pagure.io/freeipa/issue/9245>`__
+   `#9245 <https://codeberg.org/freeipa/freeipa/issues/9245>`__
 -  extdom: internal functions should be static
    `commit <https://codeberg.org/freeipa/freeipa/commit/666357649f4dfb8254cb3707e97e12c69e6714f7>`__
 
@@ -283,31 +283,31 @@ Carla Martinez (9)
 
 -  webui: Add name to 'Certificates' table
    `commit <https://codeberg.org/freeipa/freeipa/commit/76c8b47e4fb249db0b7c6185afcc0d11b78c5824>`__
-   `#8946 <https://pagure.io/freeipa/issue/8946>`__
+   `#8946 <https://codeberg.org/freeipa/freeipa/issues/8946>`__
 -  webui: Add label name to 'Certificates' section
    `commit <https://codeberg.org/freeipa/freeipa/commit/98eda97648fb0d9a7ae9aac32938d4f889f8a213>`__
-   `#8946 <https://pagure.io/freeipa/issue/8946>`__
+   `#8946 <https://codeberg.org/freeipa/freeipa/issues/8946>`__
 -  Update API and VERSION
    `commit <https://codeberg.org/freeipa/freeipa/commit/856edcc8d3c9fe64eff532db669536a0a78ba70d>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  webui: Set 'SOA serial' field as read-only
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f8c9a4d96877bab1cb474615d77aca2fa586ece>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  ipatest: Remove warning message for 'idnssoaserial'
    `commit <https://codeberg.org/freeipa/freeipa/commit/76604df09d8b62795f4e2d1fbc99af9ed55ec5cd>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  Set 'idnssoaserial' to deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/e9048daac53e24759a33e2031c8b4224a80a0e54>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  webui: Show 'Sudo order' column
    `commit <https://codeberg.org/freeipa/freeipa/commit/0513a83a4fcd5626168cb45132af8cd1b4a9ee03>`__
-   `#9237 <https://pagure.io/freeipa/issue/9237>`__
+   `#9237 <https://codeberg.org/freeipa/freeipa/issues/9237>`__
 -  Set pkeys in test_selinuxusermap.py::test_misc::delete_record
    `commit <https://codeberg.org/freeipa/freeipa/commit/cefa8f1e5f5b01e6863d07e9f3849dfd4c485f22>`__
-   `#9161 <https://pagure.io/freeipa/issue/9161>`__
+   `#9161 <https://codeberg.org/freeipa/freeipa/issues/9161>`__
 -  webui: Allow grace login limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/ade5093b08f92b279c200f341e96972a74f644d8>`__
-   `#9211 <https://pagure.io/freeipa/issue/9211>`__
+   `#9211 <https://codeberg.org/freeipa/freeipa/issues/9211>`__
 
 
 
@@ -316,8 +316,8 @@ Christian Heimes (1)
 
 -  Add PKINIT support to ipa-client-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/80da53eaada1b5ad61b8cff2f9ed1217fea600c9>`__
-   `#9269 <https://pagure.io/freeipa/issue/9269>`__,
-   `#9271 <https://pagure.io/freeipa/issue/9271>`__
+   `#9269 <https://codeberg.org/freeipa/freeipa/issues/9269>`__,
+   `#9271 <https://codeberg.org/freeipa/freeipa/issues/9271>`__
 
 
 
@@ -382,13 +382,13 @@ Erik Belko (3)
 
 -  ipatests: Add test for grace login limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd92757fc4a20eb73ebe08573c3e7ac5fb5c6ae2>`__
-   `#9211 <https://pagure.io/freeipa/issue/9211>`__
+   `#9211 <https://codeberg.org/freeipa/freeipa/issues/9211>`__
 -  ipatests: test for root using admin password in webUI
    `commit <https://codeberg.org/freeipa/freeipa/commit/80b18b08e8cf3aaa9f75769e703c2aab569b599e>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 -  ipatests: healthcheck: test if system is FIPS enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/f962a0c2832619100046c923d15f21e8c10fce96>`__
-   `#8951 <https://pagure.io/freeipa/issue/8951>`__
+   `#8951 <https://codeberg.org/freeipa/freeipa/issues/8951>`__
 
 
 
@@ -399,44 +399,44 @@ Florence Blanc-Renaud (15)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e725e9954737367fd6b2e5e3566d4f19ddd36295>`__
 -  API reference: update dnszone_add generated doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/0caa26daf2cf8f770b0111a22d89e31c763a1e89>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  API reference: update vault doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d6eabd3caf629a14c801ced4ad50dd9faa8147e>`__
-   `#9259 <https://pagure.io/freeipa/issue/9259>`__
+   `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
 -  ipatests: update vagrant boxes
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca486d1507a2eb0a05576f835354d8d42c178810>`__
 -  Spec file: bump the selinux-policy version
    `commit <https://codeberg.org/freeipa/freeipa/commit/58ad9f2eec0afe494c57015c4449ae39748117e4>`__
-   `#9198 <https://pagure.io/freeipa/issue/9198>`__
+   `#9198 <https://codeberg.org/freeipa/freeipa/issues/9198>`__
 -  webui tests: fix test_subid suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/58e12bd93a9b7b1c9a39981ee0c6a724040e164f>`__
-   `#9214 <https://pagure.io/freeipa/issue/9214>`__
+   `#9214 <https://codeberg.org/freeipa/freeipa/issues/9214>`__
 -  ipa man page: format the EXAMPLES section
    `commit <https://codeberg.org/freeipa/freeipa/commit/64ef2b9c07ec0b1b316555739ff9f98229258838>`__
-   `#9252 <https://pagure.io/freeipa/issue/9252>`__
+   `#9252 <https://codeberg.org/freeipa/freeipa/issues/9252>`__
 -  ipatests: add negative test for otptoken-sync
    `commit <https://codeberg.org/freeipa/freeipa/commit/895a800e90a34f55f5d2789ece6e7bc8e6f5c0a6>`__
-   `#9248 <https://pagure.io/freeipa/issue/9248>`__
+   `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
 -  ipa otptoken-sync: return error when sync fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cc94cd3b929ee1878767d23f98ad5e755583c6b>`__
-   `#9248 <https://pagure.io/freeipa/issue/9248>`__
+   `#9248 <https://codeberg.org/freeipa/freeipa/issues/9248>`__
 -  gitignore: add install/oddjob/org.freeipa.server.config-enable-sid
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7369944d8b68032eddcc4577b0cc5f9f603cda9>`__
 -  ipatests: Fix expected object classes
    `commit <https://codeberg.org/freeipa/freeipa/commit/2385d1d90aa91d34c4b36842a17e72aa2399a733>`__
-   `#9062 <https://pagure.io/freeipa/issue/9062>`__
+   `#9062 <https://codeberg.org/freeipa/freeipa/issues/9062>`__
 -  check_repl_update: in progress is a boolean
    `commit <https://codeberg.org/freeipa/freeipa/commit/05a298f56485222583cb7dd4f6a3a4c5c77fc8cf>`__
-   `#9218 <https://pagure.io/freeipa/issue/9218>`__
+   `#9218 <https://codeberg.org/freeipa/freeipa/issues/9218>`__
 -  azure tests: disable TestInstallDNSSECFirst
    `commit <https://codeberg.org/freeipa/freeipa/commit/d40fd287836dc8440f69314d77ccb461c7e6ccea>`__
-   `#9216 <https://pagure.io/freeipa/issue/9216>`__
+   `#9216 <https://codeberg.org/freeipa/freeipa/issues/9216>`__
 -  xmlrpc tests: updated expected output for preserved user
    `commit <https://codeberg.org/freeipa/freeipa/commit/4984ff210a169129e4e56b10e54e9c795520855c>`__
-   `#9187 <https://pagure.io/freeipa/issue/9187>`__
+   `#9187 <https://codeberg.org/freeipa/freeipa/issues/9187>`__
 -  Preserve user: fix the confusing summary
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff4152539b96d309dcceaf854a3e0a49f435acff>`__
-   `#9187 <https://pagure.io/freeipa/issue/9187>`__
+   `#9187 <https://codeberg.org/freeipa/freeipa/issues/9187>`__
 
 
 
@@ -445,7 +445,7 @@ Francisco Trivino (1)
 
 -  Vault: fix interoperability issues with older RHEL systems
    `commit <https://codeberg.org/freeipa/freeipa/commit/c643e56e4c45b7cb61aa53989657143627c23e04>`__
-   `#9259 <https://pagure.io/freeipa/issue/9259>`__
+   `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
 
 
 
@@ -454,10 +454,10 @@ Fraser Tweedale (2)
 
 -  install: suggest --skip-mem-check when mem check fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbf2614d8acc11a1b41558a45dac8ec98b032732>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  man: add --skip-mem-check to man pages
    `commit <https://codeberg.org/freeipa/freeipa/commit/585cebb1a9673e2fc083dd3c9545a6c080e171e3>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 
 
 
@@ -466,7 +466,7 @@ Matthew Davis (1)
 
 -  Add missing parameter to Suse modify_nsswitch_pam_stack
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f15804270590fdf0f339fc53ed63bf440361b7b>`__
-   `#9185 <https://pagure.io/freeipa/issue/9185>`__
+   `#9185 <https://codeberg.org/freeipa/freeipa/issues/9185>`__
 
 
 
@@ -475,7 +475,7 @@ Jesse Sandberg (1)
 
 -  Fix ipa-ccache-sweeper activation timer and clean up service file
    `commit <https://codeberg.org/freeipa/freeipa/commit/358924455d87b67db6cd743f3cfe15522b4c0d91>`__
-   `#9231 <https://pagure.io/freeipa/issue/9231>`__
+   `#9231 <https://codeberg.org/freeipa/freeipa/issues/9231>`__
 
 
 
@@ -484,7 +484,7 @@ Julien Rische (1)
 
 -  Generate CNAMEs for TXT+URI location krb records
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0652f5dc8efc4580d8039e70c0e762638d3871d>`__
-   `#9257 <https://pagure.io/freeipa/issue/9257>`__
+   `#9257 <https://codeberg.org/freeipa/freeipa/issues/9257>`__
 
 
 
@@ -498,7 +498,7 @@ Michal Polovka (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/206e08d811c43ba8295816e609d4cb7148a774a3>`__
 -  ipatests: Increase expect timeout for interactive mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6a6781284658e77f36c07cb7fd35b43240946a2>`__
-   `#9183 <https://pagure.io/freeipa/issue/9183>`__
+   `#9183 <https://codeberg.org/freeipa/freeipa/issues/9183>`__
 
 
 
@@ -523,7 +523,7 @@ Nikola Knazekova (1)
 
 -  Exclude installed policy module file from RPM verification
    `commit <https://codeberg.org/freeipa/freeipa/commit/c977cefa101e145b13b5c19ae5369e5ca7ef1ef8>`__
-   `#9254 <https://pagure.io/freeipa/issue/9254>`__
+   `#9254 <https://codeberg.org/freeipa/freeipa/issues/9254>`__
 
 
 
@@ -532,9 +532,9 @@ Pavel Březina (1)
 
 -  docs: add security section to idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/170155b648084846111bf0c65459aba94a8e980d>`__
-   `#8803 <https://pagure.io/freeipa/issue/8803>`__,
-   `#8804 <https://pagure.io/freeipa/issue/8804>`__,
-   `#8805 <https://pagure.io/freeipa/issue/8805>`__
+   `#8803 <https://codeberg.org/freeipa/freeipa/issues/8803>`__,
+   `#8804 <https://codeberg.org/freeipa/freeipa/issues/8804>`__,
+   `#8805 <https://codeberg.org/freeipa/freeipa/issues/8805>`__
 
 
 
@@ -563,40 +563,40 @@ Rob Crittenden (12)
 
 -  Pass the curl write callback by name instead of address
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d184a295b1b581f1d5e189ee810c6b08bc0550b>`__
-   `#9274 <https://pagure.io/freeipa/issue/9274>`__
+   `#9274 <https://codeberg.org/freeipa/freeipa/issues/9274>`__
 -  Move client certificate request after krb5.conf is created
    `commit <https://codeberg.org/freeipa/freeipa/commit/762d786bf7a3043fd56877949f02bccd077e2711>`__
-   `#9246 <https://pagure.io/freeipa/issue/9246>`__
+   `#9246 <https://codeberg.org/freeipa/freeipa/issues/9246>`__
 -  Defer creating the final krb5.conf on clients
    `commit <https://codeberg.org/freeipa/freeipa/commit/69413325158a3ea06d1491acd77ee6e0955ee89a>`__
-   `#9228 <https://pagure.io/freeipa/issue/9228>`__
+   `#9228 <https://codeberg.org/freeipa/freeipa/issues/9228>`__
 -  Fix upper bound of password policy grace limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/91a02174a0a9694fd5611c071913ad4720be5ac9>`__
-   `#9243 <https://pagure.io/freeipa/issue/9243>`__
+   `#9243 <https://codeberg.org/freeipa/freeipa/issues/9243>`__
 -  Set default on group pwpolicy with no grace limit in upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4ddaaf3048c4e8d78a1807af7266ee40ab3a30b>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  Set default gracelimit on group password policies to -1
    `commit <https://codeberg.org/freeipa/freeipa/commit/497a57e7a6872fa30d1855a1d91a455bfdbf9300>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  doc: Update LDAP grace period design with default values
    `commit <https://codeberg.org/freeipa/freeipa/commit/434620ee342ac4767beccec647a318bfa7743dfa>`__
-   `#9212 <https://pagure.io/freeipa/issue/9212>`__
+   `#9212 <https://codeberg.org/freeipa/freeipa/issues/9212>`__
 -  upgrades: Don't restart the CA on ACME and profile schema change
    `commit <https://codeberg.org/freeipa/freeipa/commit/aaf57185a2701b34948105e8b54075afe048ff18>`__
-   `#9204 <https://pagure.io/freeipa/issue/9204>`__
+   `#9204 <https://codeberg.org/freeipa/freeipa/issues/9204>`__
 -  Disabling gracelimit does not prevent LDAP binds
    `commit <https://codeberg.org/freeipa/freeipa/commit/1316cd8b2252c2543cf2ef2186956a8833037b1e>`__
-   `#9206 <https://pagure.io/freeipa/issue/9206>`__
+   `#9206 <https://codeberg.org/freeipa/freeipa/issues/9206>`__
 -  Warn for permissions with read/write/search/compare and no attrs
    `commit <https://codeberg.org/freeipa/freeipa/commit/b31631ad69f72fb42b5091375df8021580f8139a>`__
-   `#9188 <https://pagure.io/freeipa/issue/9188>`__
+   `#9188 <https://codeberg.org/freeipa/freeipa/issues/9188>`__
 -  Only calculate LDAP password grace when the password is expired
    `commit <https://codeberg.org/freeipa/freeipa/commit/3675bd1d7aca443832bb9bb2f521cc4d3a088aec>`__
-   `#1539 <https://pagure.io/freeipa/issue/1539>`__
+   `#1539 <https://codeberg.org/freeipa/freeipa/issues/1539>`__
 -  Fix test_secure_ajp_connector.py failing with Python 3.6.8
    `commit <https://codeberg.org/freeipa/freeipa/commit/de64d6724e028a1882c3a8be31c2752bebdd41fd>`__
-   `#9190 <https://pagure.io/freeipa/issue/9190>`__
+   `#9190 <https://codeberg.org/freeipa/freeipa/issues/9190>`__
 
 
 
@@ -721,22 +721,22 @@ Stanislav Levin (6)
 
 -  ipapython: Support openldap 2.6
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e93f46c589ba0a68c039d65ea3c0872644a0eb0>`__
-   `#9255 <https://pagure.io/freeipa/issue/9255>`__
+   `#9255 <https://codeberg.org/freeipa/freeipa/issues/9255>`__
 -  x509: Replace removed register_interface with subclassing
    `commit <https://codeberg.org/freeipa/freeipa/commit/89fe83b03ac3b046685389ee1059ca75c73e53b0>`__
-   `#9160 <https://pagure.io/freeipa/issue/9160>`__
+   `#9160 <https://codeberg.org/freeipa/freeipa/issues/9160>`__
 -  ap: Constrain supported docutils
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ada42e3bce58a729e689377b1a41b6cfa90b508>`__
-   `#9208 <https://pagure.io/freeipa/issue/9208>`__
+   `#9208 <https://codeberg.org/freeipa/freeipa/issues/9208>`__
 -  ap: Rearrange overloaded jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/b59baf31bc097821ff7787ecd75affb27ea2a7c3>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 -  ap: Disable azure's security daemon
    `commit <https://codeberg.org/freeipa/freeipa/commit/98c6e96e8db3d5bdc0315094b8a7bf81d196479b>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 -  ap: Raise dbus timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/e77b0b08d78d4d5ae7632ef23aebc577848ea507>`__
-   `#9207 <https://pagure.io/freeipa/issue/9207>`__
+   `#9207 <https://codeberg.org/freeipa/freeipa/issues/9207>`__
 
 
 
@@ -745,7 +745,7 @@ Scott Poore (1)
 
 -  ipatests: Rename create_quarkus to create_keycloak
    `commit <https://codeberg.org/freeipa/freeipa/commit/88ea19b9a53d9c209105af049a1df100d07e081a>`__
-   `#9225 <https://pagure.io/freeipa/issue/9225>`__
+   `#9225 <https://codeberg.org/freeipa/freeipa/issues/9225>`__
 
 
 
@@ -754,10 +754,10 @@ Sudhir Menon (2)
 
 -  ipatests: WebUI: do not allow subid range deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/58b026716c973f422b1b98e27eb9536e59919d82>`__
-   `#9150 <https://pagure.io/freeipa/issue/9150>`__
+   `#9150 <https://codeberg.org/freeipa/freeipa/issues/9150>`__
 -  ipatests: ipa-client-install --subid adds entry in nsswitch.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5762621ef3ed1e699306a8d2eef634bc927a6fc>`__
-   `#9159 <https://pagure.io/freeipa/issue/9159>`__
+   `#9159 <https://codeberg.org/freeipa/freeipa/issues/9159>`__
 
 
 
@@ -776,7 +776,7 @@ Thomas Woerner (1)
 
 -  DNSResolver: Fix use of nameservers with ports
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e2e4664aec641886923c2bec61ce25b96edb62a>`__
-   `#9158 <https://pagure.io/freeipa/issue/9158>`__
+   `#9158 <https://codeberg.org/freeipa/freeipa/issues/9158>`__
 
 
 

--- a/src/page/Releases/4.9.12.rst
+++ b/src/page/Releases/4.9.12.rst
@@ -60,82 +60,82 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#5130 <https://pagure.io/freeipa/issue/5130>`__
+-  `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
    (`rhbz#1243261 <https://bugzilla.redhat.com/show_bug.cgi?id=1243261>`__)
    non-admin users cannot search hbac rules
--  `#6044 <https://pagure.io/freeipa/issue/6044>`__
+-  `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
    (`rhbz#1353899 <https://bugzilla.redhat.com/show_bug.cgi?id=1353899>`__)
    ipa-advise: object of type 'type' has no len()
--  `#9195 <https://pagure.io/freeipa/issue/9195>`__
+-  `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
    (`rhbz#2158775 <https://bugzilla.redhat.com/show_bug.cgi?id=2158775>`__)
    Hiding a server does not completely clean up DNS records
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9238 <https://pagure.io/freeipa/issue/9238>`__ Nightly test failure
+-  `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__ Nightly test failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ds_configcheck_passwordstorage
--  `#9279 <https://pagure.io/freeipa/issue/9279>`__ ipa-otpd@.service:
+-  `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__ ipa-otpd@.service:
    deprecated syslog setting
--  `#9282 <https://pagure.io/freeipa/issue/9282>`__ Nightly test failure
+-  `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__ Nightly test failure
    in
    test_webui/test_subid.py/test_subid/test_subid_range_deletion_not_allowed
--  `#9285 <https://pagure.io/freeipa/issue/9285>`__ ipa-certupdate
+-  `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__ ipa-certupdate
    restarts HTTPd too early
--  `#9286 <https://pagure.io/freeipa/issue/9286>`__
+-  `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
    (`rhbz#2056009 <https://bugzilla.redhat.com/show_bug.cgi?id=2056009>`__)
    memberManager ACIs aren't allowing group-based manager access due to
    missing upgrade code
--  `#9287 <https://pagure.io/freeipa/issue/9287>`__ [RFE] makeapi should
+-  `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__ [RFE] makeapi should
    validate the generated API doc vs stored doc
--  `#9290 <https://pagure.io/freeipa/issue/9290>`__
+-  `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
    (`rhbz#2149889 <https://bugzilla.redhat.com/show_bug.cgi?id=2149889>`__)
    idm:client is missing dependency on krb5-pkinit.
--  `#9291 <https://pagure.io/freeipa/issue/9291>`__ Nightly test failure
+-  `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__ Nightly test failure
    (rawhide) in test_ipa_dns_systemrecords_check
--  `#9306 <https://pagure.io/freeipa/issue/9306>`__
+-  `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
    (`rhbz#2160389 <https://bugzilla.redhat.com/show_bug.cgi?id=2160389>`__)
    'ERROR Could not remove /tmp/tmpbkw6hawo.ipabkp' can be seen prior to
    'ipa-client-install' command was successful.
--  `#9310 <https://pagure.io/freeipa/issue/9310>`__
+-  `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
    (`rhbz#2162335 <https://bugzilla.redhat.com/show_bug.cgi?id=2162335>`__)
    ipa-trust-add with --range-type=ipa-ad-trust-posix fails while
    creating an ID range
--  `#9314 <https://pagure.io/freeipa/issue/9314>`__ Redundant build
+-  `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__ Redundant build
    dependency on python3-paste (if with lint)
--  `#9315 <https://pagure.io/freeipa/issue/9315>`__ [tests]
+-  `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__ [tests]
    test_ipa_healthcheck_fips_enabled fails on system without
    fips-mode-setup
--  `#9316 <https://pagure.io/freeipa/issue/9316>`__
+-  `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
    (`rhbz#2166324 <https://bugzilla.redhat.com/show_bug.cgi?id=2166324>`__)
    Passwordless (GSSAPI) SSH login with AD user
--  `#9318 <https://pagure.io/freeipa/issue/9318>`__ Incomplete fast
+-  `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__ Incomplete fast
    lint/codestyle check if both Python template files and Python modules
    were changed
--  `#9319 <https://pagure.io/freeipa/issue/9319>`__ [tests]
+-  `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__ [tests]
    TestDNSResolver failures on systems without or empty /etc/resolv.conf
--  `#9320 <https://pagure.io/freeipa/issue/9320>`__
+-  `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
    (`rhbz#2018198 <https://bugzilla.redhat.com/show_bug.cgi?id=2018198>`__)
    RFE - Add a warning note about possible performance impact of the
    Auto Member rebuild task.
--  `#9324 <https://pagure.io/freeipa/issue/9324>`__ ipatests: Frequent
+-  `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__ ipatests: Frequent
    timeout of test_acme
--  `#9326 <https://pagure.io/freeipa/issue/9326>`__ ipatests: timeout of
+-  `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__ ipatests: timeout of
    test_trust
--  `#9329 <https://pagure.io/freeipa/issue/9329>`__ Azure test:
+-  `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__ Azure test:
    WebUI_Unit_Tests are failing
--  `#9333 <https://pagure.io/freeipa/issue/9333>`__ ipa-client-install
+-  `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__ ipa-client-install
    --pkinit-identity can block in unattended mode
--  `#9338 <https://pagure.io/freeipa/issue/9338>`__ Update 'Auth
+-  `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__ Update 'Auth
    indicators' doc string to show 'ipd' usage
--  `#9339 <https://pagure.io/freeipa/issue/9339>`__ Broken support for
+-  `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__ Broken support for
    dnspython < 2
--  `#9349 <https://pagure.io/freeipa/issue/9349>`__
+-  `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
    (`rhbz#2180914 <https://bugzilla.redhat.com/show_bug.cgi?id=2180914>`__)
    Sequence processing failures for group_add using server context
--  `#9355 <https://pagure.io/freeipa/issue/9355>`__ support python
+-  `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__ support python
    cryptography 40.0
--  `#9358 <https://pagure.io/freeipa/issue/9358>`__
+-  `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
    update_dna_shared_config sometimes blocks installation for 2 minutes
 
 
@@ -151,24 +151,24 @@ Alexander Bokovoy (6)
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
    `commit <https://codeberg.org/freeipa/freeipa/commit/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
-   `#9355 <https://pagure.io/freeipa/issue/9355>`__
+   `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__
 -  Fix tox in Azure CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/53ac81765aaad71ef18e720017454c33df0ab27c>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Use system-wide chromium for webui tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Don't fail if optional RPM macros file is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/801308af209167ef84351987cd894c5721e3d853>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
    `commit <https://codeberg.org/freeipa/freeipa/commit/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -177,16 +177,16 @@ Anuja More (4)
 
 -  ipatests: Test that non admin user can search hbac rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
-   `#5130 <https://pagure.io/freeipa/issue/5130>`__
+   `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
-   `#6044 <https://pagure.io/freeipa/issue/6044>`__
+   `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
    `commit <https://codeberg.org/freeipa/freeipa/commit/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  Add test for SSH with GSSAPI auth.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 
 
 
@@ -199,14 +199,14 @@ Antonio Torres (8)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
    `commit <https://codeberg.org/freeipa/freeipa/commit/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
 -  API doc: add note about ipa show-mappings to usage guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
 -  API doc: validate generated reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
-   `#9287 <https://pagure.io/freeipa/issue/9287>`__
+   `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__
 -  API doc: add basic user management guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/84c4449e93d57f5236f978388cf6561a4866686a>`__
 -  Back to git snapshots
@@ -219,7 +219,7 @@ Carla Martinez (1)
 
 -  Update 'Auth indicators' doc string
    `commit <https://codeberg.org/freeipa/freeipa/commit/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
-   `#9338 <https://pagure.io/freeipa/issue/9338>`__
+   `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__
 
 
 
@@ -228,13 +228,13 @@ Christian Heimes (3)
 
 -  Speed up installer by restarting DS after DNA plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
-   `#9358 <https://pagure.io/freeipa/issue/9358>`__
+   `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
 -  Don't block when kinit_pkinit() fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
-   `#9333 <https://pagure.io/freeipa/issue/9333>`__
+   `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3052c17599c7318c385b27795678b368906fd26>`__
-   `#9285 <https://pagure.io/freeipa/issue/9285>`__
+   `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__
 
 
 
@@ -262,7 +262,7 @@ Erik Belko (1)
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -271,31 +271,31 @@ Florence Blanc-Renaud (16)
 
 -  ipatests: increase timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: remove wrong job definition TestACMEPrune
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdd115239adeae9f84b016207552b60985d65854>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  ipatests: increase timeout for test_acme
    `commit <https://codeberg.org/freeipa/freeipa/commit/67131ae7f93e6ceab9be06d29151c37d74024699>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
    `commit <https://codeberg.org/freeipa/freeipa/commit/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
-   `#9310 <https://pagure.io/freeipa/issue/9310>`__
+   `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
 -  Tests: force key type in ACME tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
-   `#9298 <https://pagure.io/freeipa/issue/9298>`__
+   `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__
 -  server install: remove error log about missing bkup file
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
-   `#9306 <https://pagure.io/freeipa/issue/9306>`__
+   `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
 -  ipatests: mark test_smb as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
-   `#9135 <https://pagure.io/freeipa/issue/9135>`__
+   `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b4d019881232833e915fedba48537548d2ef60>`__
 -  FIPS setup: fix typo filtering camellia encryption
@@ -304,13 +304,13 @@ Florence Blanc-Renaud (16)
    `commit <https://codeberg.org/freeipa/freeipa/commit/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
 -  ipatests: update the fake fips mode expected message
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
-   `#9002 <https://pagure.io/freeipa/issue/9002>`__
+   `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
-   `#9290 <https://pagure.io/freeipa/issue/9290>`__
+   `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
 -  webui tests: fix assertion in test_subid.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/3801d0c1c8a3dbec54dead29666137de2649e109>`__
-   `#9282 <https://pagure.io/freeipa/issue/9282>`__
+   `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__
 -  PRCI: update memory reqs for each topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
 
@@ -321,16 +321,16 @@ mbhalodi (4)
 
 -  ipatests: Test for sequence processing failures with server context
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  ipatests: add missing automember-cli tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff50fe5f038be52207bb770179becc31fbc74e17>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 
 
 
@@ -339,7 +339,7 @@ Michal Polovka (1)
 
 -  ipatest: loginscreen: do not use hardcoded password
    `commit <https://codeberg.org/freeipa/freeipa/commit/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 
 
 
@@ -348,13 +348,13 @@ Rob Crittenden (3)
 
 -  Wipe the ipa-ca DNS record when updating system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9387280543b86444cf4c258a7b720f492357baf>`__
-   `#9195 <https://pagure.io/freeipa/issue/9195>`__
+   `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 
 
 
@@ -363,31 +363,31 @@ Stanislav Levin (9)
 
 -  fastlint: Correct concatenation of file lists
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8418ce63de206967bea5918615ee4471183cd06>`__
-   `#9318 <https://pagure.io/freeipa/issue/9318>`__
+   `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__
 -  dns: Fix support for dnspython 1.1x
    `commit <https://codeberg.org/freeipa/freeipa/commit/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
-   `#9339 <https://pagure.io/freeipa/issue/9339>`__
+   `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__
 -  tests: webui: Update vendored qunit
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  AP: webui: List installed nodejs packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Load qunit only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/958a3958b4835fc2454e8bd71797638dcef9c460>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Allow file access from files in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
-   `#9319 <https://pagure.io/freeipa/issue/9319>`__
+   `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__
 -  spec: Drop no longer used build dependency on paste
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebd4096f039964cfd1d95467630c10559d051e13>`__
-   `#9314 <https://pagure.io/freeipa/issue/9314>`__
+   `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
-   `#9315 <https://pagure.io/freeipa/issue/9315>`__
+   `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__
 
 
 
@@ -397,7 +397,7 @@ Sumedh Sidhaye (1)
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8ef2c2f226704ce510525f07675107179124a95>`__
-   `#9238 <https://pagure.io/freeipa/issue/9238>`__
+   `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__
 
 
 
@@ -406,7 +406,7 @@ Sudhir Menon (1)
 
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
-   `#9279 <https://pagure.io/freeipa/issue/9279>`__
+   `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__
 
 
 

--- a/src/page/Releases/4.9.2.rst
+++ b/src/page/Releases/4.9.2.rst
@@ -33,61 +33,61 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#6739 <https://pagure.io/freeipa/issue/6739>`__ Cannot login to
+-  `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__ Cannot login to
    replica's WebUI
--  `#8404 <https://pagure.io/freeipa/issue/8404>`__ Detect and fail if
+-  `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__ Detect and fail if
    not enough memory is available for installation
--  `#8452 <https://pagure.io/freeipa/issue/8452>`__ update samba
+-  `#8452 <https://codeberg.org/freeipa/freeipa/issues/8452>`__ update samba
    configuration on IPA master to explicitly use 'server role' setting
--  `#8506 <https://pagure.io/freeipa/issue/8506>`__ Nightly failure in
+-  `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__ Nightly failure in
    ipa-server-install --uninstall: org.freedesktop.DBus.Error.NoReply
--  `#8533 <https://pagure.io/freeipa/issue/8533>`__ Nightly failure in
+-  `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__ Nightly failure in
    ipa-replica-install configuring renewals: DBusException:
    org.freedesktop.DBus.Error.NoReply
--  `#8550 <https://pagure.io/freeipa/issue/8550>`__
+-  `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
    (`rhbz#1902173 <https://bugzilla.redhat.com/show_bug.cgi?id=1902173>`__)
    Uninstallation of server with KRA diplays error but proceeds
    successfully (unable to access security domain)
--  `#8554 <https://pagure.io/freeipa/issue/8554>`__
+-  `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
    (`rhbz#1891056 <https://bugzilla.redhat.com/show_bug.cgi?id=1891056>`__)
    ipa-kdb: support subordinate/superior UPN suffixes
--  `#8588 <https://pagure.io/freeipa/issue/8588>`__ The 'ipactl status'
+-  `#8588 <https://codeberg.org/freeipa/freeipa/issues/8588>`__ The 'ipactl status'
    command exit code does not fail on a partial error
--  `#8630 <https://pagure.io/freeipa/issue/8630>`__
+-  `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
    (`rhbz#1909876 <https://bugzilla.redhat.com/show_bug.cgi?id=1909876>`__)
    Do not resolve user/group UID/GID in the service constructors
--  `#8636 <https://pagure.io/freeipa/issue/8636>`__
+-  `#8636 <https://codeberg.org/freeipa/freeipa/issues/8636>`__
    (`rhbz#1923900 <https://bugzilla.redhat.com/show_bug.cgi?id=1923900>`__)
    Samba on IdM member failure
--  `#8647 <https://pagure.io/freeipa/issue/8647>`__
+-  `#8647 <https://codeberg.org/freeipa/freeipa/issues/8647>`__
    (`rhbz#1912556 <https://bugzilla.redhat.com/show_bug.cgi?id=1912556>`__)
    Incorrect DNSKEY created when DNSSEC enabled for zone
--  `#8658 <https://pagure.io/freeipa/issue/8658>`__
+-  `#8658 <https://codeberg.org/freeipa/freeipa/issues/8658>`__
    (`rhbz#1924501 <https://bugzilla.redhat.com/show_bug.cgi?id=1924501>`__)
    Value stored to 'krberr' is never read in ipa-rmkeytab.c
--  `#8669 <https://pagure.io/freeipa/issue/8669>`__ Reduce difference
+-  `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__ Reduce difference
    between upstream and downstream releases
--  `#8675 <https://pagure.io/freeipa/issue/8675>`__ Update failed: NSS
+-  `#8675 <https://codeberg.org/freeipa/freeipa/issues/8675>`__ Update failed: NSS
    is built without support of the legacy database(DBM)
--  `#8683 <https://pagure.io/freeipa/issue/8683>`__ [ipatests]
+-  `#8683 <https://codeberg.org/freeipa/freeipa/issues/8683>`__ [ipatests]
    \`test_ipa_dns_systemrecords_check\` and
    \`test_ipa_healthcheck_no_errors\` fail in Azure Pipelines
--  `#8685 <https://pagure.io/freeipa/issue/8685>`__ KDC cert has no SAN
+-  `#8685 <https://codeberg.org/freeipa/freeipa/issues/8685>`__ KDC cert has no SAN
    DNSname
--  `#8686 <https://pagure.io/freeipa/issue/8686>`__
+-  `#8686 <https://codeberg.org/freeipa/freeipa/issues/8686>`__
    (`rhbz#1922955 <https://bugzilla.redhat.com/show_bug.cgi?id=1922955>`__)
    Resubmitting KDC cert fails with internal server error
--  `#8689 <https://pagure.io/freeipa/issue/8689>`__ Add centos platform
+-  `#8689 <https://codeberg.org/freeipa/freeipa/issues/8689>`__ Add centos platform
    module
--  `#8690 <https://pagure.io/freeipa/issue/8690>`__ Add a tool to
+-  `#8690 <https://codeberg.org/freeipa/freeipa/issues/8690>`__ Add a tool to
    control interactive programs on remote hosts in IPA tests
--  `#8699 <https://pagure.io/freeipa/issue/8699>`__
+-  `#8699 <https://codeberg.org/freeipa/freeipa/issues/8699>`__
    (`rhbz#1926699 <https://bugzilla.redhat.com/show_bug.cgi?id=1926699>`__)
    avc denial for gpg-agent with systemd-run
--  `#8704 <https://pagure.io/freeipa/issue/8704>`__
+-  `#8704 <https://codeberg.org/freeipa/freeipa/issues/8704>`__
    (`rhbz#1926910 <https://bugzilla.redhat.com/show_bug.cgi?id=1926910>`__)
    ipa cert-remove-hold returns an incorrect error message
--  `#8712 <https://pagure.io/freeipa/issue/8712>`__ Support new baseURL
+-  `#8712 <https://codeberg.org/freeipa/freeipa/issues/8712>`__ Support new baseURL
    config option for ACME
 
 
@@ -110,7 +110,7 @@ Alexander Bokovoy (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1313a595d63ced25b2df029029ef501e88ea596>`__
 -  test_installutils: run gpg-agent under a specific SELinux context
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ca2797eaca963fe94f7396353569f7f8ed6d09d>`__
-   `#8699 <https://pagure.io/freeipa/issue/8699>`__
+   `#8699 <https://codeberg.org/freeipa/freeipa/issues/8699>`__
 -  Force-update translation after FreeIPA to IPA change: po/fr.po
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc9652107e4424f0567bc5a010cad15047db7212>`__
 -  Force-update translation after FreeIPA to IPA change: po/es.po
@@ -125,10 +125,10 @@ Alexander Bokovoy (14)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d00ad4b767eb17e218e03544aa53881c9333330>`__
 -  client: synchronize ignored return codes with ipa-rmkeytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a1ad476e04859e68809435a8098beef1d38c76d>`__
-   `#8658 <https://pagure.io/freeipa/issue/8658>`__
+   `#8658 <https://codeberg.org/freeipa/freeipa/issues/8658>`__
 -  ipa-sam: return NetBIOS domain name instead of DNS one
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a4cf2187a6298a46b52ba12ff04648b73f8dd56>`__
-   `#8636 <https://pagure.io/freeipa/issue/8636>`__
+   `#8636 <https://codeberg.org/freeipa/freeipa/issues/8636>`__
 -  Back to git commits
    `commit <https://codeberg.org/freeipa/freeipa/commit/9690659ddf57e32a9255d8eed8d27b3ffa8a90cf>`__
 
@@ -143,11 +143,11 @@ Antonio Torres (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/602a4fa321560c69407d1c6d0a04f190a5350038>`__
 -  WebUI: change FreeIPA naming to IPA in About dialog
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f63dc994522243fde1cb932f6a8b5a26a171933>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Update samba configuration on IPA master to explicitly use 'server
    role' setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b64a4e8ad5563030650f6d293d4b0537d72cd2c>`__
-   `#8452 <https://pagure.io/freeipa/issue/8452>`__
+   `#8452 <https://codeberg.org/freeipa/freeipa/issues/8452>`__
 
 
 
@@ -156,17 +156,17 @@ Christian Heimes (4)
 
 -  configure: ipaplatform falls back to ID_LIKE
    `commit <https://codeberg.org/freeipa/freeipa/commit/55180f6e9141bca391a7e2c9d9727948624c307f>`__
-   `#8689 <https://pagure.io/freeipa/issue/8689>`__
+   `#8689 <https://codeberg.org/freeipa/freeipa/issues/8689>`__
 -  Don't install csrgen extra dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/de3510211537f116a097d1212d2586f4b0726467>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Ensure that KDC cert has SAN DNS entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ab290a048d34b03821716b1606f9a33f62964d9>`__
-   `#8685 <https://pagure.io/freeipa/issue/8685>`__
+   `#8685 <https://codeberg.org/freeipa/freeipa/issues/8685>`__
 -  Fix cert_request for KDC cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c48897ed1700725d3cd07a4a106e40f62d76c47>`__
-   `#6739 <https://pagure.io/freeipa/issue/6739>`__,
-   `#8686 <https://pagure.io/freeipa/issue/8686>`__
+   `#6739 <https://codeberg.org/freeipa/freeipa/issues/6739>`__,
+   `#8686 <https://codeberg.org/freeipa/freeipa/issues/8686>`__
 
 
 
@@ -175,26 +175,26 @@ Florence Blanc-Renaud (8)
 
 -  ipatests: update expected error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/9854c399da83a30259ccec9cf9277ffd97f7cd67>`__
-   `#8704 <https://pagure.io/freeipa/issue/8704>`__
+   `#8704 <https://codeberg.org/freeipa/freeipa/issues/8704>`__
 -  xmlrpc tests: add a test for cert-remove-hold
    `commit <https://codeberg.org/freeipa/freeipa/commit/55c7e2121ea78eec102560d176ccb2c74146caf7>`__
-   `#8704 <https://pagure.io/freeipa/issue/8704>`__
+   `#8704 <https://codeberg.org/freeipa/freeipa/issues/8704>`__
 -  cert plugin: propagate the error for non-existent cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/45d7d15c1186bc563393ae0bf131ccf94b1d12c4>`__
-   `#8704 <https://pagure.io/freeipa/issue/8704>`__
+   `#8704 <https://codeberg.org/freeipa/freeipa/issues/8704>`__
 -  ipatests: ipactl status now exits with 3 when a service is stopped
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d30629801a88a8f03c94f2274ed93a1ff0a38be>`__
-   `#8588 <https://pagure.io/freeipa/issue/8588>`__
+   `#8588 <https://codeberg.org/freeipa/freeipa/issues/8588>`__
 -  ipatests: fix ipahealthcheck fixture \_modify_permission
    `commit <https://codeberg.org/freeipa/freeipa/commit/b784e1f8d4e393e31616430f74ccc3d158418619>`__
 -  OpenDNSSEC: fix timezone in key creation date
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a51892ab9688b6bc5282098a426003932462549>`__
 -  ipatests: add a test for ZSK/KSK keytype in DNSKEY record
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd21d068cb4500b0d8a8af14b0371f95cc40c974>`__
-   `#8647 <https://pagure.io/freeipa/issue/8647>`__
+   `#8647 <https://codeberg.org/freeipa/freeipa/issues/8647>`__
 -  dnssec: fix the key type with OpenDNSSEC 2.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/44762369fb05b67855a8dc81d647c8880d642902>`__
-   `#8647 <https://pagure.io/freeipa/issue/8647>`__
+   `#8647 <https://codeberg.org/freeipa/freeipa/issues/8647>`__
 
 
 
@@ -203,7 +203,7 @@ Mohammad Rizwan (1)
 
 -  ipatests: Test if server setup without dns uninstall properly
    `commit <https://codeberg.org/freeipa/freeipa/commit/85674f16a18a6d4917dcf56330dc122902b53475>`__
-   `#8630 <https://pagure.io/freeipa/issue/8630>`__
+   `#8630 <https://codeberg.org/freeipa/freeipa/issues/8630>`__
 
 
 
@@ -212,62 +212,62 @@ Rob Crittenden (20)
 
 -  Remove the option stop_certmonger from stop_tracking\_\*
    `commit <https://codeberg.org/freeipa/freeipa/commit/9872610f7df6576813715f5de239957042ca2c9d>`__
-   `#8506 <https://pagure.io/freeipa/issue/8506>`__,
-   `#8533 <https://pagure.io/freeipa/issue/8533>`__
+   `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__,
+   `#8533 <https://codeberg.org/freeipa/freeipa/issues/8533>`__
 -  Add some logging around initial ACME deployment
    `commit <https://codeberg.org/freeipa/freeipa/commit/6526ab48a36b068de1970a2685dcedcf4b278bd3>`__
-   `#8712 <https://pagure.io/freeipa/issue/8712>`__
+   `#8712 <https://codeberg.org/freeipa/freeipa/issues/8712>`__
 -  Add versions to the ACME config templates and update on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/31061c60af065d7251a7aaf6d5c93e86434d12f2>`__
-   `#8712 <https://pagure.io/freeipa/issue/8712>`__
+   `#8712 <https://codeberg.org/freeipa/freeipa/issues/8712>`__
 -  Set the ACME baseURL in order to pin a client to a single IPA server
    `commit <https://codeberg.org/freeipa/freeipa/commit/a16dc59447bceab9df7d0597e81af2f1a525ce4c>`__
-   `#8712 <https://pagure.io/freeipa/issue/8712>`__
+   `#8712 <https://codeberg.org/freeipa/freeipa/issues/8712>`__
 -  Add RHEL 9 UI branding patch reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/dffe69573e1ee5a14af12d83c9c86084cfa3a58d>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Force-update translation after FreeIPA to IPA change: po/ipa.pot
    `commit <https://codeberg.org/freeipa/freeipa/commit/936f98e93e43f1e30d3109d37009654db349a241>`__
 -  Remove references to rjsmin in UI compile.sh
    `commit <https://codeberg.org/freeipa/freeipa/commit/1478db894844ca4527e0017a7204d4d6f5695752>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Remove support for csrgen
    `commit <https://codeberg.org/freeipa/freeipa/commit/e35bec9a5214a836d938eae6c577a4f33fe5e4f9>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Change FreeIPA references to IPA and Identity Management
    `commit <https://codeberg.org/freeipa/freeipa/commit/f05ee29d10f2be294d707bd34bfc8399c06b63c5>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  ipatests: Handle non-zero return code in test_ipactl_scenario_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/00226adaa68935fbc1d85508eadafa420027edb5>`__
-   `#8550 <https://pagure.io/freeipa/issue/8550>`__
+   `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
 -  Add exit status to the ipactl man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/302f9377e5c760bcf38be2b0503915ccadef8b67>`__
-   `#8550 <https://pagure.io/freeipa/issue/8550>`__
+   `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
 -  Ensure IPA is running (ideally) before uninstalling the KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/87ede26cc2bcbe543cb970a5e55cf1901791a100>`__
-   `#8550 <https://pagure.io/freeipa/issue/8550>`__
+   `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
 -  ipactl: support script status 3, program is not running
    `commit <https://codeberg.org/freeipa/freeipa/commit/ddb5414d56f57fdd18ad66fbc6a53410725dd9cd>`__
-   `#8588 <https://pagure.io/freeipa/issue/8588>`__
+   `#8588 <https://codeberg.org/freeipa/freeipa/issues/8588>`__
 -  Use the new API introduced in PKI 10.8
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d26ce5061c5b7f9383286a108fc48b19b5bc65a>`__
 -  Change CA profile migration message from info to debug
    `commit <https://codeberg.org/freeipa/freeipa/commit/b99bc2d8b1e5226f61a7c980cfb7576dac222466>`__
 -  Only build the UI with uglifyjs on RHEL 8
    `commit <https://codeberg.org/freeipa/freeipa/commit/5fb0cc43eab329e8cb0020ca96f70a05fa9bb4bd>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Provide more detailed logging around memory detection
    `commit <https://codeberg.org/freeipa/freeipa/commit/6eff5b9527d5d187922eed6f569d3e63d67e094d>`__
-   `#8404 <https://pagure.io/freeipa/issue/8404>`__
+   `#8404 <https://codeberg.org/freeipa/freeipa/issues/8404>`__
 -  ipatests: Update NSSDatabase DBM test on non-DBM-capable installs
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f1849e74a7c81213ec658058aec97033c84e038>`__
-   `#8675 <https://pagure.io/freeipa/issue/8675>`__
+   `#8675 <https://codeberg.org/freeipa/freeipa/issues/8675>`__
 -  Ignore database errors when trying to extract ipaCert on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/348d4eef6f974c75cb546fc690bb3a20a789de28>`__
-   `#8675 <https://pagure.io/freeipa/issue/8675>`__
+   `#8675 <https://codeberg.org/freeipa/freeipa/issues/8675>`__
 -  Report the NSS database directory if it cannot be opened
    `commit <https://codeberg.org/freeipa/freeipa/commit/b71c0c678430c38cbd22663cbf48229a23f19c8e>`__
-   `#8675 <https://pagure.io/freeipa/issue/8675>`__
+   `#8675 <https://codeberg.org/freeipa/freeipa/issues/8675>`__
 
 
 
@@ -278,10 +278,10 @@ Stanislav Levin (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b11a7ce5542fae4d3d2ab0584d3dfe0f67ef617>`__
 -  ipatests: Handle AAAA records in test_ipa_dns_systemrecords_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/151fa5040af0f044fe7bf0154c2dcfc58506a499>`__
-   `#8683 <https://pagure.io/freeipa/issue/8683>`__
+   `#8683 <https://codeberg.org/freeipa/freeipa/issues/8683>`__
 -  Azure: Populate containers with self-AAAA records
    `commit <https://codeberg.org/freeipa/freeipa/commit/63b14839aff23db7977decbeb742949bd05a8219>`__
-   `#8683 <https://pagure.io/freeipa/issue/8683>`__
+   `#8683 <https://codeberg.org/freeipa/freeipa/issues/8683>`__
 
 
 
@@ -291,16 +291,16 @@ Sergey Orlov (5)
 -  ipatests: use pexpect to control inetractive session of
    ipa-adtrust-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/34d72d16ee3ac4e3979eed5be7ddf31997a485b8>`__
-   `#8690 <https://pagure.io/freeipa/issue/8690>`__
+   `#8690 <https://codeberg.org/freeipa/freeipa/issues/8690>`__
 -  ipatests: use pexpect to invoke ktutil
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c15447e1345a3c93932e70dea1177f6a42fb2d4>`__
-   `#8690 <https://pagure.io/freeipa/issue/8690>`__
+   `#8690 <https://codeberg.org/freeipa/freeipa/issues/8690>`__
 -  ipatests: add a tests-oriented wrapper for pexpect module
    `commit <https://codeberg.org/freeipa/freeipa/commit/29377901f7bc74baceda1bf42617dd69dacf10a2>`__
-   `#8690 <https://pagure.io/freeipa/issue/8690>`__
+   `#8690 <https://codeberg.org/freeipa/freeipa/issues/8690>`__
 -  ipatests: rewrite test for requests routing to subordinate suffixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d9f988f5eb5f07965582b84f1b3ac812125b63f>`__
-   `#8554 <https://pagure.io/freeipa/issue/8554>`__
+   `#8554 <https://codeberg.org/freeipa/freeipa/issues/8554>`__
 -  fix collecting log files which are symlinks
    `commit <https://codeberg.org/freeipa/freeipa/commit/5517aa691805cccfa4d19a28a6dbf3319845c4a6>`__
 

--- a/src/page/Releases/4.9.3.rst
+++ b/src/page/Releases/4.9.3.rst
@@ -38,94 +38,94 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7885 <https://pagure.io/freeipa/issue/7885>`__
+-  `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
    (`rhbz#1690191 <https://bugzilla.redhat.com/show_bug.cgi?id=1690191>`__)
    RFE: wrapper for Dogtag cert-fix command
--  `#8155 <https://pagure.io/freeipa/issue/8155>`__ Enhance error
+-  `#8155 <https://codeberg.org/freeipa/freeipa/issues/8155>`__ Enhance error
    message for adding non-posix groups with a GID
--  `#8244 <https://pagure.io/freeipa/issue/8244>`__ The help for the
+-  `#8244 <https://codeberg.org/freeipa/freeipa/issues/8244>`__ The help for the
    --otp flag in "ipa passwd" could be clearer
--  `#8423 <https://pagure.io/freeipa/issue/8423>`__ Multiple permitopen
+-  `#8423 <https://codeberg.org/freeipa/freeipa/issues/8423>`__ Multiple permitopen
    in SSH-key
--  `#8496 <https://pagure.io/freeipa/issue/8496>`__ [Tracker] Multiple
+-  `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__ [Tracker] Multiple
    nightly test failures in test_dnssec, test_backup_and_restore and
    test_dns_locations
--  `#8506 <https://pagure.io/freeipa/issue/8506>`__
+-  `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
    (`rhbz#1930038 <https://bugzilla.redhat.com/show_bug.cgi?id=1930038>`__)
    Nightly failure in ipa-server-install --uninstall:
    org.freedesktop.DBus.Error.NoReply
--  `#8530 <https://pagure.io/freeipa/issue/8530>`__
+-  `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
    (`rhbz#1859185 <https://bugzilla.redhat.com/show_bug.cgi?id=1859185>`__)
    Running ipa-server-install fails on machine where libsss_sudo is not
    installed
--  `#8550 <https://pagure.io/freeipa/issue/8550>`__
+-  `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
    (`rhbz#1902173 <https://bugzilla.redhat.com/show_bug.cgi?id=1902173>`__)
    Uninstallation of server with KRA diplays error but proceeds
    successfully (unable to access security domain)
--  `#8553 <https://pagure.io/freeipa/issue/8553>`__ Random failure in
+-  `#8553 <https://codeberg.org/freeipa/freeipa/issues/8553>`__ Random failure in
    test_backup_and_restore.py::TestBackupRoles::test_rolecheck_Trust
--  `#8565 <https://pagure.io/freeipa/issue/8565>`__ Remove duplication
+-  `#8565 <https://codeberg.org/freeipa/freeipa/issues/8565>`__ Remove duplication
    in pkispawn exception output
--  `#8600 <https://pagure.io/freeipa/issue/8600>`__ ipa-cert-fix unable
+-  `#8600 <https://codeberg.org/freeipa/freeipa/issues/8600>`__ ipa-cert-fix unable
    to fix certs no named 'Server-cert'
--  `#8605 <https://pagure.io/freeipa/issue/8605>`__
+-  `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
    (`rhbz#1903250 <https://bugzilla.redhat.com/show_bug.cgi?id=1903250>`__)
    backtrace using ipa-replica-manage
--  `#8636 <https://pagure.io/freeipa/issue/8636>`__
+-  `#8636 <https://codeberg.org/freeipa/freeipa/issues/8636>`__
    (`rhbz#1923900 <https://bugzilla.redhat.com/show_bug.cgi?id=1923900>`__)
    Samba on IdM member failure
--  `#8654 <https://pagure.io/freeipa/issue/8654>`__ DNSSEC key
+-  `#8654 <https://codeberg.org/freeipa/freeipa/issues/8654>`__ DNSSEC key
    synchronization issues
--  `#8669 <https://pagure.io/freeipa/issue/8669>`__ Reduce difference
+-  `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__ Reduce difference
    between upstream and downstream releases
--  `#8681 <https://pagure.io/freeipa/issue/8681>`__ krb5kdc dumped core
--  `#8695 <https://pagure.io/freeipa/issue/8695>`__ Nightly failure in
+-  `#8681 <https://codeberg.org/freeipa/freeipa/issues/8681>`__ krb5kdc dumped core
+-  `#8695 <https://codeberg.org/freeipa/freeipa/issues/8695>`__ Nightly failure in
    test_dnssec.py::TestInstallDNSSECFirst::test_resolvconf (fed33)
--  `#8703 <https://pagure.io/freeipa/issue/8703>`__ DNS resolvers issues
+-  `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__ DNS resolvers issues
    in IPA tests
--  `#8705 <https://pagure.io/freeipa/issue/8705>`__ server installation
+-  `#8705 <https://codeberg.org/freeipa/freeipa/issues/8705>`__ server installation
    fails against 389-ds 1.4.3.19
--  `#8715 <https://pagure.io/freeipa/issue/8715>`__
+-  `#8715 <https://codeberg.org/freeipa/freeipa/issues/8715>`__
    (`rhbz#1924707 <https://bugzilla.redhat.com/show_bug.cgi?id=1924707>`__)
    Establishing trust with AD domain using shared secret fails in FIPS
    mode
--  `#8718 <https://pagure.io/freeipa/issue/8718>`__
+-  `#8718 <https://codeberg.org/freeipa/freeipa/issues/8718>`__
    (`rhbz#1928854 <https://bugzilla.redhat.com/show_bug.cgi?id=1928854>`__)
    ipa-server-install ignores --zonemgr parameter
--  `#8720 <https://pagure.io/freeipa/issue/8720>`__ New pylint failures
+-  `#8720 <https://codeberg.org/freeipa/freeipa/issues/8720>`__ New pylint failures
    reported for inconsistent-return-statements
--  `#8721 <https://pagure.io/freeipa/issue/8721>`__
+-  `#8721 <https://codeberg.org/freeipa/freeipa/issues/8721>`__
    (`rhbz#1779984 <https://bugzilla.redhat.com/show_bug.cgi?id=1779984>`__)
    The ipa-cert-fix command failed. [Errno 2] No such file or directory:
    '/etc/pki/pki-tomcat/certs/27-renewed.crt'
--  `#8725 <https://pagure.io/freeipa/issue/8725>`__ Nightly test failure
+-  `#8725 <https://codeberg.org/freeipa/freeipa/issues/8725>`__ Nightly test failure
    in test_cert
--  `#8728 <https://pagure.io/freeipa/issue/8728>`__ Random nightly test
+-  `#8728 <https://codeberg.org/freeipa/freeipa/issues/8728>`__ Random nightly test
    failure in test_commands.py::TestIPACommand::test_ssh_key_connection
--  `#8735 <https://pagure.io/freeipa/issue/8735>`__ ccache-sweeper
+-  `#8735 <https://codeberg.org/freeipa/freeipa/issues/8735>`__ ccache-sweeper
    removes valid ccaches
--  `#8737 <https://pagure.io/freeipa/issue/8737>`__ [ipatests]
+-  `#8737 <https://codeberg.org/freeipa/freeipa/issues/8737>`__ [ipatests]
    \`test_source_ipahealthcheck_ipa_host_check_ipahostkeytab\` fails
    against krb5 1.19.1
--  `#8743 <https://pagure.io/freeipa/issue/8743>`__
+-  `#8743 <https://codeberg.org/freeipa/freeipa/issues/8743>`__
    (`rhbz#1922781 <https://bugzilla.redhat.com/show_bug.cgi?id=1922781>`__)
    Inconsistent nsaccountlock field type in api response
--  `#8747 <https://pagure.io/freeipa/issue/8747>`__ Nightly failure in
+-  `#8747 <https://codeberg.org/freeipa/freeipa/issues/8747>`__ Nightly failure in
    test_sssd.py::TestSSSDWithAdTrust::test_is_user_filtered
--  `#8753 <https://pagure.io/freeipa/issue/8753>`__ Adopt redhat
+-  `#8753 <https://codeberg.org/freeipa/freeipa/issues/8753>`__ Adopt redhat
    ipaplatform to RHEL 9/ELN and RHEL 7/8 split
--  `#8759 <https://pagure.io/freeipa/issue/8759>`__ RFE: Extend logging
+-  `#8759 <https://codeberg.org/freeipa/freeipa/issues/8759>`__ RFE: Extend logging
    to include execution time
--  `#8768 <https://pagure.io/freeipa/issue/8768>`__ rpmlint should be
+-  `#8768 <https://codeberg.org/freeipa/freeipa/issues/8768>`__ rpmlint should be
    optional for fastcheck, devcheck and lint make targets
--  `#8772 <https://pagure.io/freeipa/issue/8772>`__ pylint 2.7.0-2.7.2
+-  `#8772 <https://codeberg.org/freeipa/freeipa/issues/8772>`__ pylint 2.7.0-2.7.2
    introduces new warnings
--  `#8779 <https://pagure.io/freeipa/issue/8779>`__ Nightly test failure
+-  `#8779 <https://codeberg.org/freeipa/freeipa/issues/8779>`__ Nightly test failure
    (updates-testing) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_ds_riplugincheck
--  `#8780 <https://pagure.io/freeipa/issue/8780>`__ RFE: Reduce number
+-  `#8780 <https://codeberg.org/freeipa/freeipa/issues/8780>`__ RFE: Reduce number
    of LDAP operations during sudorule-mod
--  `#8781 <https://pagure.io/freeipa/issue/8781>`__
+-  `#8781 <https://codeberg.org/freeipa/freeipa/issues/8781>`__
    test_ipaserver/test_jsplugins.py::test_jsplugins::test_jsplugins
    fails in server-less environments
 
@@ -155,7 +155,7 @@ Alexander Bokovoy (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef4a2f30b458db9487ebf724bdd3ba1f4e7f9d99>`__
 -  freeipa.spec: synchronize with Fedora for 389-ds and PKI versions
    `commit <https://codeberg.org/freeipa/freeipa/commit/a63c6e0252ba82233839ad33ca9331be2b7aba95>`__
-   `#8705 <https://pagure.io/freeipa/issue/8705>`__
+   `#8705 <https://codeberg.org/freeipa/freeipa/issues/8705>`__
 -  ipa-kdb: mark test functions as static
    `commit <https://codeberg.org/freeipa/freeipa/commit/2968609fd9f8f91b704dc8167d39ecc67beb8ddd>`__
 -  ipa-kdb: reformat ipa_kdb_certauth
@@ -166,7 +166,7 @@ Alexander Bokovoy (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0da9de495ca41a1bf0926aef7c9c75c3e53dcd63>`__
 -  ipa-kdb: do not use OpenLDAP functions with NULL LDAP context
    `commit <https://codeberg.org/freeipa/freeipa/commit/2832810891acfaca68142df7271d6f0a50a588eb>`__
-   `#8681 <https://pagure.io/freeipa/issue/8681>`__
+   `#8681 <https://codeberg.org/freeipa/freeipa/issues/8681>`__
 -  Back to git commits
    `commit <https://codeberg.org/freeipa/freeipa/commit/811d130c66880208a244741b90a5e6de2429004a>`__
 
@@ -177,35 +177,35 @@ Antonio Torres (11)
 
 -  sudorule: reduce number of LDAP searches during modification
    `commit <https://codeberg.org/freeipa/freeipa/commit/8552faba077f5ef7ef3c6f9b2281564df553dbc7>`__
-   `#8780 <https://pagure.io/freeipa/issue/8780>`__
+   `#8780 <https://codeberg.org/freeipa/freeipa/issues/8780>`__
 -  ipa passwd: make help for \`--otp\` option clearer
    `commit <https://codeberg.org/freeipa/freeipa/commit/74638edb4387b570b545f0c0e3067a3fc10c703b>`__
-   `#8244 <https://pagure.io/freeipa/issue/8244>`__
+   `#8244 <https://codeberg.org/freeipa/freeipa/issues/8244>`__
 -  ipatests: add test for multiple permitopen entries in SSH keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc799a5f9602099be048abda319023cda9d466c7>`__
 -  Allow multiple permitopen/permitlisten in SSH keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dc58965fa7ba6080ba0c281567ac6d9b211953e>`__
-   `#8423 <https://pagure.io/freeipa/issue/8423>`__
+   `#8423 <https://codeberg.org/freeipa/freeipa/issues/8423>`__
 -  ipatests: add test for group creation with GID and nonposix option
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8bc3e401ea83d845ce11b19d9b14e28676a9a33>`__
 -  Enhance error message when adding non-posix group with a GID
    `commit <https://codeberg.org/freeipa/freeipa/commit/28d310d5b0f84d5769c2ccada7ab48c6138b14de>`__
-   `#8155 <https://pagure.io/freeipa/issue/8155>`__
+   `#8155 <https://codeberg.org/freeipa/freeipa/issues/8155>`__
 -  ipatests: expect boolean type for nsaccountlock in user module
    `commit <https://codeberg.org/freeipa/freeipa/commit/cfff1f6710e1c0a857e913c8545b9a4b0a0e05f9>`__
-   `#8743 <https://pagure.io/freeipa/issue/8743>`__
+   `#8743 <https://codeberg.org/freeipa/freeipa/issues/8743>`__
 -  Return nsaccountlock in user-add as boolean
    `commit <https://codeberg.org/freeipa/freeipa/commit/39153f9b8a9af7537cd594e5d708abecef9217c8>`__
-   `#8743 <https://pagure.io/freeipa/issue/8743>`__
+   `#8743 <https://codeberg.org/freeipa/freeipa/issues/8743>`__
 -  Extend logging to include execution time
    `commit <https://codeberg.org/freeipa/freeipa/commit/e880d38beb95cd15311d49c8a1e748d5dfe45ca6>`__
-   `#8759 <https://pagure.io/freeipa/issue/8759>`__
+   `#8759 <https://codeberg.org/freeipa/freeipa/issues/8759>`__
 -  ipatests: check that zonemgr is set correctly during server install
    `commit <https://codeberg.org/freeipa/freeipa/commit/82043e1fd052618608d3b7786473a632478795ee>`__
-   `#8718 <https://pagure.io/freeipa/issue/8718>`__
+   `#8718 <https://codeberg.org/freeipa/freeipa/issues/8718>`__
 -  ipaserver: don't ignore zonemgr option on install
    `commit <https://codeberg.org/freeipa/freeipa/commit/20bb855a57080145d0d5555294381c890ef605bb>`__
-   `#8718 <https://pagure.io/freeipa/issue/8718>`__
+   `#8718 <https://codeberg.org/freeipa/freeipa/issues/8718>`__
 
 
 
@@ -222,32 +222,32 @@ François Cami (10)
 
 -  ipatests: check for the "no sudo present" string absence
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b917833fdd62cce2fd72809fd5c963194efba3e>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  ipa-client-install: output a warning if sudo is not present (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/061e0b63ef3a72ba3261b42ec5f2ce290070c613>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  ipa-csreplica-manage, ipa-replica-manage: refactor
    `commit <https://codeberg.org/freeipa/freeipa/commit/25cbae4d0248fd289fb9cc6dbe55ca8fd88b5513>`__
-   `#8605 <https://pagure.io/freeipa/issue/8605>`__
+   `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
 -  ipalib/util.py: add print_replication_status
    `commit <https://codeberg.org/freeipa/freeipa/commit/5f2f97a698fc8278b3bc908e9bfc0d452575afa5>`__
 -  ipa-replica-manage: handle missing attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/85484d312cf0e9da563ea97166ea24dfd6833702>`__
-   `#8605 <https://pagure.io/freeipa/issue/8605>`__
+   `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
 -  ipa-replica-manage: always display nsds5replicalastinitstatus
    `commit <https://codeberg.org/freeipa/freeipa/commit/f6204b0d5e6f82827249e09ff2e4598ea4e7f69e>`__
-   `#8605 <https://pagure.io/freeipa/issue/8605>`__
+   `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
 -  freeipa.spec: client: depend on libsss_sudo and sudo
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee0ba2df41cf545b82d3d26e7e7e42447bb0f63e>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  ipa-client-install: output a warning if sudo is not present
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe157ca349e3146a53884e90e6e588efb4e97eeb>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 -  ipatests: tasks: handle uninstalling packages with nodeps
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c2741af9f353d2fbb21a5768e6433c0e99da0e9>`__
 -  ipatests: add TestInstallWithoutSudo
    `commit <https://codeberg.org/freeipa/freeipa/commit/b590dcef10680b4ea3181ae1caec183e5967562b>`__
-   `#8530 <https://pagure.io/freeipa/issue/8530>`__
+   `#8530 <https://codeberg.org/freeipa/freeipa/issues/8530>`__
 
 
 
@@ -256,36 +256,36 @@ Florence Blanc-Renaud (11)
 
 -  ipatests: update expected message
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9ed627288a5319719b94dc9b8c0fea692a827b4>`__
-   `#8779 <https://pagure.io/freeipa/issue/8779>`__
+   `#8779 <https://codeberg.org/freeipa/freeipa/issues/8779>`__
 -  Adapt redhat ipaplatform to RHEL9/ELN
    `commit <https://codeberg.org/freeipa/freeipa/commit/8272da74041330b500425847b8f4dc84aba01b56>`__
-   `#8753 <https://pagure.io/freeipa/issue/8753>`__
+   `#8753 <https://codeberg.org/freeipa/freeipa/issues/8753>`__
 -  ipatests: fix TestInstalDNSSECFirst::test_resolvconf logic
    `commit <https://codeberg.org/freeipa/freeipa/commit/5af574326bd60c52ddcaf7f7cfe73f4e810bc04a>`__
-   `#8695 <https://pagure.io/freeipa/issue/8695>`__
+   `#8695 <https://codeberg.org/freeipa/freeipa/issues/8695>`__
 -  ipatests: re-add test_dnssec.py::TestInstallDNSSECFirst in gating
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab23ecdad53d2095d9534a4c941dab7e205f286c>`__
-   `#8496 <https://pagure.io/freeipa/issue/8496>`__
+   `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__
 -  ipatests: filter_users belongs to nss section
    `commit <https://codeberg.org/freeipa/freeipa/commit/5221f4c2a08094e15f516bbef8a722c0869ba53a>`__
-   `#8747 <https://pagure.io/freeipa/issue/8747>`__
+   `#8747 <https://codeberg.org/freeipa/freeipa/issues/8747>`__
 -  dnssec: concurrency issue when disabling old replica key
    `commit <https://codeberg.org/freeipa/freeipa/commit/7616f1dad2b478c5e4f850587da1bd4e52108fa1>`__
-   `#8654 <https://pagure.io/freeipa/issue/8654>`__
+   `#8654 <https://codeberg.org/freeipa/freeipa/issues/8654>`__
 -  dnssec: fix ipa-ods-exporter crash when master key missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cfcbc67e12c2ce6e98d3ed1645bc592a573199e>`__
-   `#8654 <https://pagure.io/freeipa/issue/8654>`__
+   `#8654 <https://codeberg.org/freeipa/freeipa/issues/8654>`__
 -  ipatests: use whole date when calling journalctl --since
    `commit <https://codeberg.org/freeipa/freeipa/commit/caf748860860293e010e695d72f6b3b3d8509f8a>`__
-   `#8728 <https://pagure.io/freeipa/issue/8728>`__
+   `#8728 <https://codeberg.org/freeipa/freeipa/issues/8728>`__
 -  freeipa.spec: bump the required version of 389ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c1c469fc94b3c6b26a73173bfba7698108ec69c>`__
-   `#8496 <https://pagure.io/freeipa/issue/8496>`__
+   `#8496 <https://codeberg.org/freeipa/freeipa/issues/8496>`__
 -  ipatests: Update PRCI templates for ipa-4-9
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bcacd800a4fdba3899bf1358bc532e717ad335c>`__
 -  pylint: fix inconsistent-return-statements
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fae28f974ccdbcf021cb506b31761cf04547c64>`__
-   `#8720 <https://pagure.io/freeipa/issue/8720>`__
+   `#8720 <https://codeberg.org/freeipa/freeipa/issues/8720>`__
 
 
 
@@ -294,7 +294,7 @@ Fraser Tweedale (1)
 
 -  ipa-cert-fix: improve handling of 'pki-server cert-fix' failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b1b5b07c1b7e813ee5dbe342ff24ebbc939bb9>`__
-   `#8721 <https://pagure.io/freeipa/issue/8721>`__
+   `#8721 <https://codeberg.org/freeipa/freeipa/issues/8721>`__
 
 
 
@@ -311,7 +311,7 @@ Kaleemullah Siddiqui (1)
 
 -  ipatests: error message check in uninstall log for KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b25cd3241a5609b4d903d5697b8947fab403c90>`__
-   `#8550 <https://pagure.io/freeipa/issue/8550>`__
+   `#8550 <https://codeberg.org/freeipa/freeipa/issues/8550>`__
 
 
 
@@ -320,23 +320,23 @@ Mohammad Rizwan (7)
 
 -  ipatests: Don't rely on certmonger's assigned request id
    `commit <https://codeberg.org/freeipa/freeipa/commit/8defcb0cee32eedda28a0adb6d7745c6fbdbf355>`__
-   `#8725 <https://pagure.io/freeipa/issue/8725>`__
+   `#8725 <https://codeberg.org/freeipa/freeipa/issues/8725>`__
 -  ipatests: Enable certbot test on rhel
    `commit <https://codeberg.org/freeipa/freeipa/commit/339152c1ca5e0d3b7f11a03390003a57328d0d6d>`__
 -  ipatests: introduce wait_for_replication in test_rolecheck_Trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b8de48f1cce81277e63c104adc6c5f485e70418>`__
-   `#8553 <https://pagure.io/freeipa/issue/8553>`__
+   `#8553 <https://codeberg.org/freeipa/freeipa/issues/8553>`__
 -  ipatests: update nightly definition for ipa_cert_fix suite
    `commit <https://codeberg.org/freeipa/freeipa/commit/260fbcb03297ef1ed5418b16c0df0587d2989b22>`__
 -  ipatests: Test if ipa-cert-fix renews expired certs with kra
    installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/c84e0547e1a693ba0e9edbfeea7bafdb2fb2b4a2>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 -  Move fixture outside the class and add setup_kra capability
    `commit <https://codeberg.org/freeipa/freeipa/commit/36a60dbb35cb4429f00528f79bec8b7982a30c74>`__
 -  ipatests: Test if ipa-cert-fix renews expired certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f30ddb1b7e30c22f9b7d14d2658b58a0ea6b459>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 
 
 
@@ -345,34 +345,34 @@ Rob Crittenden (11)
 
 -  Increase timeout for TestIpaHealthCheck to 5400s
    `commit <https://codeberg.org/freeipa/freeipa/commit/d15e577bc1b6f9d98b1ac424d1c0df4ef9839c91>`__
-   `#8506 <https://pagure.io/freeipa/issue/8506>`__
+   `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
 -  Uninstall without starting the CA in cert expiration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/b70e30dbf011fd918c4f2955dda0fc2bc12a35ea>`__
-   `#8506 <https://pagure.io/freeipa/issue/8506>`__
+   `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
 -  ipatests: Test secure_ajp_connector works with multiple connectors
    `commit <https://codeberg.org/freeipa/freeipa/commit/16fbe095ff54e4b560a81c0cc0453c939f2c58a8>`__
 -  Allow overriding is_newer_tomcat_version()
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3e4bd9ec450c6ea5285c76fee60a7c6601b58f3>`__
 -  Don't renew non-IPA issued certs in ipa-cert-fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3463728f2196589d36e14cedccb26c03730a7c0>`__
-   `#8600 <https://pagure.io/freeipa/issue/8600>`__
+   `#8600 <https://codeberg.org/freeipa/freeipa/issues/8600>`__
 -  Set pki-core dependency to 10.3.3 for pki-server cert-fix bug
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cb6f0ba0df928eea60b20892a6fc85373627946>`__
 -  ipatests: test third-party 389-ds cert with ipa-cert-fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/660507fda2394b17d709c47a05ce5df548a47990>`__
-   `#8600 <https://pagure.io/freeipa/issue/8600>`__
+   `#8600 <https://codeberg.org/freeipa/freeipa/issues/8600>`__
 -  ipa-cert-fix: Don't hardcode the NSS certificate nickname
    `commit <https://codeberg.org/freeipa/freeipa/commit/a0626e09b3eaf5d030982e2ff03e95841ad1b4b9>`__
-   `#8600 <https://pagure.io/freeipa/issue/8600>`__
+   `#8600 <https://codeberg.org/freeipa/freeipa/issues/8600>`__
 -  Remove a remaining file used with csrgen
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe4b1545b6f288f10aa11f4dd8ff32b14d337fc1>`__
-   `#8669 <https://pagure.io/freeipa/issue/8669>`__
+   `#8669 <https://codeberg.org/freeipa/freeipa/issues/8669>`__
 -  Don't double-report any errors from pki-spawn failures
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1e12c75f12a739599c07ffe88aea82df635fabd>`__
-   `#8565 <https://pagure.io/freeipa/issue/8565>`__
+   `#8565 <https://codeberg.org/freeipa/freeipa/issues/8565>`__
 -  Suppress error message if the CRL directory doesn't exist
    `commit <https://codeberg.org/freeipa/freeipa/commit/584151d1277f60e1db116992fbd98f3421391254>`__
-   `#8565 <https://pagure.io/freeipa/issue/8565>`__
+   `#8565 <https://codeberg.org/freeipa/freeipa/issues/8565>`__
 
 
 
@@ -381,13 +381,13 @@ Stanislav Levin (16)
 
 -  ipatests: Skip test_jsplugins in server less environments
    `commit <https://codeberg.org/freeipa/freeipa/commit/3eb8b304c612500218806c04486efd79b2495ba2>`__
-   `#8781 <https://pagure.io/freeipa/issue/8781>`__
+   `#8781 <https://codeberg.org/freeipa/freeipa/issues/8781>`__
 -  Azure: Run Lint task as separate job
    `commit <https://codeberg.org/freeipa/freeipa/commit/188a279c5bf14b7cbd7cc0d65cc294fc6862b8d3>`__
-   `#8772 <https://pagure.io/freeipa/issue/8772>`__
+   `#8772 <https://codeberg.org/freeipa/freeipa/issues/8772>`__
 -  pylint: Fix several warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/2bec09aa038d2ef8f3819f11e67ba81d70cb5fe4>`__
-   `#8772 <https://pagure.io/freeipa/issue/8772>`__
+   `#8772 <https://codeberg.org/freeipa/freeipa/issues/8772>`__
 -  Azure: Don't install pypi's docker
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c1dc1b226254003dda882f7856c4e3b3e5b3767>`__
 -  Azure: Disable AppArmor profile for chrony
@@ -406,18 +406,18 @@ Stanislav Levin (16)
    `commit <https://codeberg.org/freeipa/freeipa/commit/380336d6d26228c237c1ef7e7e61ed472fd66e0d>`__
 -  Azure: Run rpmlint on Fedora
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c38c57f77a455d6e5c257d4397011157f4f33e3>`__
-   `#8768 <https://pagure.io/freeipa/issue/8768>`__
+   `#8768 <https://codeberg.org/freeipa/freeipa/issues/8768>`__
 -  configure: Make rpmlint optional
    `commit <https://codeberg.org/freeipa/freeipa/commit/c441397b33fad0b5d03561763851efb6bcff4643>`__
-   `#8768 <https://pagure.io/freeipa/issue/8768>`__
+   `#8768 <https://codeberg.org/freeipa/freeipa/issues/8768>`__
 -  ipatests: Fix expectation about GSS error in test for healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbbfce1151b6c7dd95dea1a2438cd11c1b22e7b7>`__
-   `#8737 <https://pagure.io/freeipa/issue/8737>`__
+   `#8737 <https://codeberg.org/freeipa/freeipa/issues/8737>`__
 -  cleanup: Drop never used path for httpd's ccache
    `commit <https://codeberg.org/freeipa/freeipa/commit/99a65e3e720d0de94abfcbfa1c2619a709d3c8db>`__
 -  ccache_sweeper: Add gssproxy service
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf80bb33baa79ba93987ee7e63109ece4b37bbd0>`__
-   `#8735 <https://pagure.io/freeipa/issue/8735>`__
+   `#8735 <https://codeberg.org/freeipa/freeipa/issues/8735>`__
 
 
 
@@ -440,35 +440,35 @@ Sergey Orlov (16)
 -  ipatests: do not configure nameserver when installing client and
    replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ca7cb6585828312864eae6f5264e313be697bbf>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: always try to create A records for hosts in IPA domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0ee8e00aaad8d89baf3a751dd0f55f405d66394>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: mock resolver factory
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3abb2c696afeccd1f6eb8d3235d999cee53dfca>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: disable systemd-resolved cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/28af45425ba2612cc0e2e612768b74bc0314d242>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: do not manually modify /etc/resolv.conf in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5d7f85b9280e6a0fae942e25e47db5e16ae49e4>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: setup resolvers during replica and client installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/64f2a408ef5bc408c7c99a224c596dcf68037dd7>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: add utility for managing domain name resolvers
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a394c6a016b21c5427fce9bad81f4c718ddeb45>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: collect config files for NetworkManager and
    systemd-resolved
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c5b70643d5408fbe5aae1135392842824b1e49d>`__
-   `#8703 <https://pagure.io/freeipa/issue/8703>`__
+   `#8703 <https://codeberg.org/freeipa/freeipa/issues/8703>`__
 -  ipatests: test Samba mount with NTLM authentication
    `commit <https://codeberg.org/freeipa/freeipa/commit/80ccac79b9d123e158a5ba60f9853611d0854188>`__
-   `#8636 <https://pagure.io/freeipa/issue/8636>`__
+   `#8636 <https://codeberg.org/freeipa/freeipa/issues/8636>`__
 -  ipatests: skip tests for AD trust with shared secret in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d7b2d7d1b4711255ea72d62d27b5c5f4ec7c6e1>`__
-   `#8715 <https://pagure.io/freeipa/issue/8715>`__
+   `#8715 <https://codeberg.org/freeipa/freeipa/issues/8715>`__
 
 
 

--- a/src/page/Releases/4.9.4.rst
+++ b/src/page/Releases/4.9.4.rst
@@ -60,119 +60,119 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#2575 <https://pagure.io/freeipa/issue/2575>`__
+-  `#2575 <https://codeberg.org/freeipa/freeipa/issues/2575>`__
    (`rhbz#952756 <https://bugzilla.redhat.com/show_bug.cgi?id=952756>`__)
    [RFE] Installer wizard should prompt for DNS
--  `#2692 <https://pagure.io/freeipa/issue/2692>`__
+-  `#2692 <https://codeberg.org/freeipa/freeipa/issues/2692>`__
    (`rhbz#817071 <https://bugzilla.redhat.com/show_bug.cgi?id=817071>`__)
    ipa-server-install ignores --hostname
--  `#4011 <https://pagure.io/freeipa/issue/4011>`__
+-  `#4011 <https://codeberg.org/freeipa/freeipa/issues/4011>`__
    (`rhbz#1026434 <https://bugzilla.redhat.com/show_bug.cgi?id=1026434>`__)
    ipa-server-install crashes when AD subpackage is not installed
--  `#4166 <https://pagure.io/freeipa/issue/4166>`__
+-  `#4166 <https://codeberg.org/freeipa/freeipa/issues/4166>`__
    (`rhbz#1059135 <https://bugzilla.redhat.com/show_bug.cgi?id=1059135>`__)
    Backup CS.cfg before modifying it
--  `#4751 <https://pagure.io/freeipa/issue/4751>`__
+-  `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
    (`rhbz#1851835 <https://bugzilla.redhat.com/show_bug.cgi?id=1851835>`__)
    Implement ACME certificate enrolment
--  `#6587 <https://pagure.io/freeipa/issue/6587>`__ ipa-otpd: systemctl
+-  `#6587 <https://codeberg.org/freeipa/freeipa/issues/6587>`__ ipa-otpd: systemctl
    reports "degraded" for "is-system-running" after todays CentOS
    updates
--  `#7397 <https://pagure.io/freeipa/issue/7397>`__ ipa host-add
+-  `#7397 <https://codeberg.org/freeipa/freeipa/issues/7397>`__ ipa host-add
    --ip-address... returns Internal error when forward-policy=none is
    defined
--  `#7835 <https://pagure.io/freeipa/issue/7835>`__
+-  `#7835 <https://codeberg.org/freeipa/freeipa/issues/7835>`__
    (`rhbz#1658280 <https://bugzilla.redhat.com/show_bug.cgi?id=1658280>`__)
    Cert revocation for services and hosts is inefficient
--  `#8203 <https://pagure.io/freeipa/issue/8203>`__
+-  `#8203 <https://codeberg.org/freeipa/freeipa/issues/8203>`__
    (`rhbz#1835853 <https://bugzilla.redhat.com/show_bug.cgi?id=1835853>`__)
    User page on WebUi only has half the information in CA-less install
--  `#8361 <https://pagure.io/freeipa/issue/8361>`__ Add support for
+-  `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__ Add support for
    managing subuids and subgids in FreeIPA
--  `#8534 <https://pagure.io/freeipa/issue/8534>`__ Nightly test failure
+-  `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__ Nightly test failure
    in
    test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion::test_hidden_replica_promote
--  `#8582 <https://pagure.io/freeipa/issue/8582>`__ Nightly test failure
+-  `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__ Nightly test failure
    in
    test_replica_promotion.py::TestHiddenReplicaPromotion::test_ipahealthcheck_hidden_replica
    - ClonesConnectivyAndDataCheck
--  `#8632 <https://pagure.io/freeipa/issue/8632>`__ [CA-less] user fails
+-  `#8632 <https://codeberg.org/freeipa/freeipa/issues/8632>`__ [CA-less] user fails
    to login via WebUI in case of \`--no-pkinit\`
--  `#8641 <https://pagure.io/freeipa/issue/8641>`__ Random failure in
+-  `#8641 <https://codeberg.org/freeipa/freeipa/issues/8641>`__ Random failure in
    test_webui/test_user.py::TestLifeCycles::test_life_cycles
--  `#8676 <https://pagure.io/freeipa/issue/8676>`__
+-  `#8676 <https://codeberg.org/freeipa/freeipa/issues/8676>`__
    (`rhbz#1955440 <https://bugzilla.redhat.com/show_bug.cgi?id=1955440>`__)
    [Tracker] Multiple nightly test failure in
    test_integration/test_ntp_options/TestNTPoptions
--  `#8738 <https://pagure.io/freeipa/issue/8738>`__
+-  `#8738 <https://codeberg.org/freeipa/freeipa/issues/8738>`__
    (`rhbz#1934991 <https://bugzilla.redhat.com/show_bug.cgi?id=1934991>`__)
    ACME fails to generate a cert on migrated RHEL8.4 server
--  `#8767 <https://pagure.io/freeipa/issue/8767>`__
+-  `#8767 <https://codeberg.org/freeipa/freeipa/issues/8767>`__
    (`rhbz#1943151 <https://bugzilla.redhat.com/show_bug.cgi?id=1943151>`__)
    ipa-server-install displays debug output when --debug output is not
    specified.
--  `#8784 <https://pagure.io/freeipa/issue/8784>`__ RFE: Reduce number
+-  `#8784 <https://codeberg.org/freeipa/freeipa/issues/8784>`__ RFE: Reduce number
    of LDAP operations during hbacrule-del
--  `#8785 <https://pagure.io/freeipa/issue/8785>`__ Nightly test failure
+-  `#8785 <https://codeberg.org/freeipa/freeipa/issues/8785>`__ Nightly test failure
    in
    test_integration/test_commands.py/TestIPACommand/test_proxycommand_invalid_shell
--  `#8787 <https://pagure.io/freeipa/issue/8787>`__ Add pkey_only to the
+-  `#8787 <https://codeberg.org/freeipa/freeipa/issues/8787>`__ Add pkey_only to the
    service_find calls in the host plugin
--  `#8792 <https://pagure.io/freeipa/issue/8792>`__ Random nightly test
+-  `#8792 <https://codeberg.org/freeipa/freeipa/issues/8792>`__ Random nightly test
    failure in
    test_replica_promotion.py::TestRenewalMaster::test_automatic_renewal_master_transfer_ondelete
--  `#8793 <https://pagure.io/freeipa/issue/8793>`__ [Tracker] Nightly
+-  `#8793 <https://codeberg.org/freeipa/freeipa/issues/8793>`__ [Tracker] Nightly
    failure (rawhide/f34) in
    test_dnssec.py::TestInstallDNSSECFirst::test_chain_of_trust
--  `#8794 <https://pagure.io/freeipa/issue/8794>`__
+-  `#8794 <https://codeberg.org/freeipa/freeipa/issues/8794>`__
    (`rhbz#1948034 <https://bugzilla.redhat.com/show_bug.cgi?id=1948034>`__)
    Failure to deploy FreeIPA domain controller in Rawhide with
    systemd-resolved 248-1.fc35
--  `#8797 <https://pagure.io/freeipa/issue/8797>`__ Cache the value of
+-  `#8797 <https://codeberg.org/freeipa/freeipa/issues/8797>`__ Cache the value of
    ca_is_enabled in the request context
--  `#8798 <https://pagure.io/freeipa/issue/8798>`__
+-  `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
    (`rhbz#1953656 <https://bugzilla.redhat.com/show_bug.cgi?id=1953656>`__)
    RFE: Cache LDAP data within a request
--  `#8799 <https://pagure.io/freeipa/issue/8799>`__ Remove DS
+-  `#8799 <https://codeberg.org/freeipa/freeipa/issues/8799>`__ Remove DS
    problematic code
--  `#8801 <https://pagure.io/freeipa/issue/8801>`__ user-mod requires
+-  `#8801 <https://codeberg.org/freeipa/freeipa/issues/8801>`__ user-mod requires
    two searches for a user entry
--  `#8802 <https://pagure.io/freeipa/issue/8802>`__ IPA test failing
+-  `#8802 <https://codeberg.org/freeipa/freeipa/issues/8802>`__ IPA test failing
    with long serial numbers
--  `#8807 <https://pagure.io/freeipa/issue/8807>`__
+-  `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
    (`rhbz#1688267 <https://bugzilla.redhat.com/show_bug.cgi?id=1688267>`__)
    [RFE] IPA to allow setting a new range type.
--  `#8809 <https://pagure.io/freeipa/issue/8809>`__ RFE: A tool to
+-  `#8809 <https://codeberg.org/freeipa/freeipa/issues/8809>`__ RFE: A tool to
    collect and analyze etimes from IPA logs
--  `#8814 <https://pagure.io/freeipa/issue/8814>`__ Use Dogtag's
+-  `#8814 <https://codeberg.org/freeipa/freeipa/issues/8814>`__ Use Dogtag's
    CryptographyCryptoProvider instead of NSSCryptoProvider for
    KRAClient()
--  `#8818 <https://pagure.io/freeipa/issue/8818>`__ new pylint 2.8 and
+-  `#8818 <https://codeberg.org/freeipa/freeipa/issues/8818>`__ new pylint 2.8 and
    astroid 2.5.5
--  `#8830 <https://pagure.io/freeipa/issue/8830>`__ [azure] performance
+-  `#8830 <https://codeberg.org/freeipa/freeipa/issues/8830>`__ [azure] performance
    instability
--  `#8831 <https://pagure.io/freeipa/issue/8831>`__
+-  `#8831 <https://codeberg.org/freeipa/freeipa/issues/8831>`__
    update_dna_shared_config may not update all entries
--  `#8832 <https://pagure.io/freeipa/issue/8832>`__
+-  `#8832 <https://codeberg.org/freeipa/freeipa/issues/8832>`__
    (`rhbz#1957768 <https://bugzilla.redhat.com/show_bug.cgi?id=1957768>`__)
    ipa-server-upgrade is failing while upgrading rhel8.3 to rhel8.4
--  `#8837 <https://pagure.io/freeipa/issue/8837>`__ Add support of
+-  `#8837 <https://codeberg.org/freeipa/freeipa/issues/8837>`__ Add support of
    'ipaautoprivategroups' LDAP attribute on 'ID ranges' page
--  `#8844 <https://pagure.io/freeipa/issue/8844>`__ [Tracker] Nightly
+-  `#8844 <https://codeberg.org/freeipa/freeipa/issues/8844>`__ [Tracker] Nightly
    test failure (sssd 2.5.0-1) in test_smb and test_sudo
--  `#8847 <https://pagure.io/freeipa/issue/8847>`__ [F34] JS linter
--  `#8848 <https://pagure.io/freeipa/issue/8848>`__ F32 is going to be
+-  `#8847 <https://codeberg.org/freeipa/freeipa/issues/8847>`__ [F34] JS linter
+-  `#8848 <https://codeberg.org/freeipa/freeipa/issues/8848>`__ F32 is going to be
    EOL
--  `#8851 <https://pagure.io/freeipa/issue/8851>`__ pkispawn: use
+-  `#8851 <https://codeberg.org/freeipa/freeipa/issues/8851>`__ pkispawn: use
    loopback IP address instead of localhost4/localhost6 for AJP
--  `#8856 <https://pagure.io/freeipa/issue/8856>`__
+-  `#8856 <https://codeberg.org/freeipa/freeipa/issues/8856>`__
    (`rhbz#1951511 <https://bugzilla.redhat.com/show_bug.cgi?id=1951511>`__)
    Allow specifying permanent logging settings for BIND
--  `#8872 <https://pagure.io/freeipa/issue/8872>`__ FreeIPA 4.9.3 Web UI
+-  `#8872 <https://codeberg.org/freeipa/freeipa/issues/8872>`__ FreeIPA 4.9.3 Web UI
    reports "Internal Server Error" on Fedora 34 Server after reboot
--  `#8873 <https://pagure.io/freeipa/issue/8873>`__ Missing credential
+-  `#8873 <https://codeberg.org/freeipa/freeipa/issues/8873>`__ Missing credential
    cache can raise 500 when authenticating instead of 401
--  `#8874 <https://pagure.io/freeipa/issue/8874>`__
+-  `#8874 <https://codeberg.org/freeipa/freeipa/issues/8874>`__
    (`rhbz#1962570 <https://bugzilla.redhat.com/show_bug.cgi?id=1962570>`__)
    depend on system-logos-ipa instead of redhat-logos-ipa
 
@@ -206,10 +206,10 @@ Alexander Bokovoy (37)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1157c5b14f994bce1a2f31fc0e0c7da139dd14fe>`__
 -  Depend on system-logos-ipa on RHEL/CentOS Stream
    `commit <https://codeberg.org/freeipa/freeipa/commit/3dd8c4d5134f7997ee75b18b282b83ff56ae5bbc>`__
-   `#8874 <https://pagure.io/freeipa/issue/8874>`__
+   `#8874 <https://codeberg.org/freeipa/freeipa/issues/8874>`__
 -  service: enforce keytab user when retrieving the keytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7f3c1ff4cbfc7840ca7c3015ca13eaeceee18ca>`__
-   `#8872 <https://pagure.io/freeipa/issue/8872>`__
+   `#8872 <https://codeberg.org/freeipa/freeipa/issues/8872>`__
 -  po/zh_CN.po: Update translations to FreeIPA ipa-4-9 state
    `commit <https://codeberg.org/freeipa/freeipa/commit/94831c341962d20c5a3ba9d5a293db9b69b7e331>`__
 -  po/tr.po: Update translations to FreeIPA ipa-4-9 state
@@ -260,18 +260,18 @@ Alexander Bokovoy (37)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d933123eda92b7259ce8d67c6d95fa00c8f683bd>`__
 -  ds: Support renaming of a replication plugin in 389-ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/04a6583ce3c1304907d092b19e5c7cc915f6952a>`__
-   `#8799 <https://pagure.io/freeipa/issue/8799>`__
+   `#8799 <https://codeberg.org/freeipa/freeipa/issues/8799>`__
 -  Update IRC links to point to Libera.chat
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab5aba2b78caace61079c229f30dd81e501446ef>`__
 -  freeipa.spec: do not use jsl for linting on Fedora 34+
    `commit <https://codeberg.org/freeipa/freeipa/commit/18563bc87b07fd7aca6f9d3af534fdc2c42bb8aa>`__
-   `#8847 <https://pagure.io/freeipa/issue/8847>`__
+   `#8847 <https://codeberg.org/freeipa/freeipa/issues/8847>`__
 -  ipa-otpd: handle LDAP timeout in a better way
    `commit <https://codeberg.org/freeipa/freeipa/commit/33404a62c01053c6a25b21445bb2731249064618>`__
-   `#6587 <https://pagure.io/freeipa/issue/6587>`__
+   `#6587 <https://codeberg.org/freeipa/freeipa/issues/6587>`__
 -  ipaserver/install/dns: handle SERVFAIL when checking reverse zone
    `commit <https://codeberg.org/freeipa/freeipa/commit/aea2c9fb02e07935524c7998ff265a22057eceb5>`__
-   `#8794 <https://pagure.io/freeipa/issue/8794>`__
+   `#8794 <https://codeberg.org/freeipa/freeipa/issues/8794>`__
 -  Back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/50d986b98196c540d38916b0410910e5450f4871>`__
 
@@ -282,7 +282,7 @@ Antonio Torres (1)
 
 -  hbacrule: reduce number of LDAP searches during deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/046012ecfa9731bc98ef2103645ad99cfd0baa32>`__
-   `#8784 <https://pagure.io/freeipa/issue/8784>`__
+   `#8784 <https://codeberg.org/freeipa/freeipa/issues/8784>`__
 
 
 
@@ -301,17 +301,17 @@ Christian Heimes (7)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e9407d9d6c3d09263c70f805f360c6894a72262>`__
 -  Fix update_dna_shared_config to wait for both entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/74889cf3ffa39e7988ebf7fc9c4480c3a0346a20>`__
-   `#8831 <https://pagure.io/freeipa/issue/8831>`__
+   `#8831 <https://codeberg.org/freeipa/freeipa/issues/8831>`__
 -  Constrain pylint to supported versions
    `commit <https://codeberg.org/freeipa/freeipa/commit/35198bedf42f7142df3986b3ddef1d22029fbcab>`__
-   `#8818 <https://pagure.io/freeipa/issue/8818>`__
+   `#8818 <https://codeberg.org/freeipa/freeipa/issues/8818>`__
 -  Add max/min safe integer
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c3a2dbfeaa73db868bacd4042de02a20b714d05>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__,
-   `#8802 <https://pagure.io/freeipa/issue/8802>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__,
+   `#8802 <https://codeberg.org/freeipa/freeipa/issues/8802>`__
 -  Use PyCA crypto provider for KRAClient
    `commit <https://codeberg.org/freeipa/freeipa/commit/0244a060f2a521548bae0f8fb1287bbed14b8653>`__
-   `#8814 <https://pagure.io/freeipa/issue/8814>`__
+   `#8814 <https://codeberg.org/freeipa/freeipa/issues/8814>`__
 -  Improve wsgi app loading
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7700b9c5e2cf156fbecb15201ab26d562302b3b>`__
 -  Better mod_wsgi configuration
@@ -324,26 +324,26 @@ François Cami (7)
 
 -  ipatests: mark test_ipahealthcheck_hidden_replica as expected failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ffaf29a370d42d62ae4701fe7c1f5f885a7df2c>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__,
-   `#8582 <https://pagure.io/freeipa/issue/8582>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__,
+   `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__
 -  ipatests: hidden replica: misc fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/45fa10434e1ee4c36ef0e3a0c3f88d447c71ba35>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 -  ipatests: hidden replica: use dns_update_system_records
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1fef6b80a2102b2a28ab33e84e1bb827fddeeac>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 -  ipatests: use wait_for_replication for hidden replica checks
    `commit <https://codeberg.org/freeipa/freeipa/commit/834adfc2b1cfcdb3486da2eabf0e9a1ee1ad96cc>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 -  ipatests: hiddenreplica: use wait_for_ipa_to_start after restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ad9c38ee00e46444e54c73b7ec5da16c66d4b93>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 -  ipatests: tasks.py: add dns_update_system_records
    `commit <https://codeberg.org/freeipa/freeipa/commit/18b03506d3f1f85656219699a0e9dda305b6885b>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 -  ipatests: tasks.py: add wait_for_ipa_to_start
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f598c8d8306f847c0c9ded165d33b8c6435d759>`__
-   `#8534 <https://pagure.io/freeipa/issue/8534>`__
+   `#8534 <https://codeberg.org/freeipa/freeipa/issues/8534>`__
 
 
 
@@ -352,36 +352,36 @@ Florence Blanc-Renaud (12)
 
 -  pkispawn: override AJP connector address
    `commit <https://codeberg.org/freeipa/freeipa/commit/986e2d7d78d0026f01269b192770a45dc5f1b772>`__
-   `#8851 <https://pagure.io/freeipa/issue/8851>`__
+   `#8851 <https://codeberg.org/freeipa/freeipa/issues/8851>`__
 -  Spec file: bump augeas-libs version
    `commit <https://codeberg.org/freeipa/freeipa/commit/4dd9d079fbc190ebcce54c427898c67d83066d1e>`__
-   `#8676 <https://pagure.io/freeipa/issue/8676>`__
+   `#8676 <https://codeberg.org/freeipa/freeipa/issues/8676>`__
 -  xmlrpc tests: add test for idrange auto-private-groups option
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ddc191491f9d06ebe28688fe9fb2d1dd80b711e>`__
-   `#8807 <https://pagure.io/freeipa/issue/8807>`__
+   `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
 -  Trust: add auto private groups option
    `commit <https://codeberg.org/freeipa/freeipa/commit/cada918c7849dfff61eeef0c6ef1de420288bff0>`__
-   `#8807 <https://pagure.io/freeipa/issue/8807>`__
+   `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
 -  LDAP schema: new attribute ipaautoprivategroups
    `commit <https://codeberg.org/freeipa/freeipa/commit/42b8fa60cfbf1551e916816b6d738b44fdff509a>`__
-   `#8807 <https://pagure.io/freeipa/issue/8807>`__
+   `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
 -  Design doc for idrange option "auto-private-groups"
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d3414287068189be896c280f9ea1a6c8bc9d32d>`__
-   `#8807 <https://pagure.io/freeipa/issue/8807>`__
+   `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
 -  ipatests: check that the output of sudo -V is not displayed
    `commit <https://codeberg.org/freeipa/freeipa/commit/3499fdeec2391b9d2d06a6c073ac0cc2b5f02989>`__
-   `#8767 <https://pagure.io/freeipa/issue/8767>`__
+   `#8767 <https://codeberg.org/freeipa/freeipa/issues/8767>`__
 -  client install: do not capture sudo -V stdout
    `commit <https://codeberg.org/freeipa/freeipa/commit/7fa80acf5fda9ba06c81bed97f1a0c33346574a6>`__
-   `#8767 <https://pagure.io/freeipa/issue/8767>`__
+   `#8767 <https://codeberg.org/freeipa/freeipa/issues/8767>`__
 -  Bumps openssl requires
    `commit <https://codeberg.org/freeipa/freeipa/commit/de5fffd3c34560bd51d78deabcdf35529ca90a32>`__
-   `#8632 <https://pagure.io/freeipa/issue/8632>`__
+   `#8632 <https://codeberg.org/freeipa/freeipa/issues/8632>`__
 -  ipatests: TestIpaHealthCheck now needs 1 client
    `commit <https://codeberg.org/freeipa/freeipa/commit/03dfd01ee78c495c0ee21c6ea9fcef1148eb1053>`__
 -  ipatests: call server-del before replica uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7271ea2ba40a4d0ff0d4d0b9bac9a237b747ef0>`__
-   `#8792 <https://pagure.io/freeipa/issue/8792>`__
+   `#8792 <https://codeberg.org/freeipa/freeipa/issues/8792>`__
 -  ipatests: collect PKI config files and NSSDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/4334438136dbc3dfcfb07f60f50dfb5a63c0618e>`__
 
@@ -415,16 +415,16 @@ Michal Polovka (3)
 
 -  ipatests: test_installation: add install test scenarios
    `commit <https://codeberg.org/freeipa/freeipa/commit/a21311095d3b918fcb0f5fe28669e385103c31eb>`__
-   `#2575 <https://pagure.io/freeipa/issue/2575>`__,
-   `#2692 <https://pagure.io/freeipa/issue/2692>`__,
-   `#4011 <https://pagure.io/freeipa/issue/4011>`__,
-   `#4166 <https://pagure.io/freeipa/issue/4166>`__
+   `#2575 <https://codeberg.org/freeipa/freeipa/issues/2575>`__,
+   `#2692 <https://codeberg.org/freeipa/freeipa/issues/2692>`__,
+   `#4011 <https://codeberg.org/freeipa/freeipa/issues/4011>`__,
+   `#4166 <https://codeberg.org/freeipa/freeipa/issues/4166>`__
 -  WebUI: Handle assertion if multiple notifications are present
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd2a14a2e8d36735d5c2051a06fb62f3f1c6c682>`__
-   `#8641 <https://pagure.io/freeipa/issue/8641>`__
+   `#8641 <https://codeberg.org/freeipa/freeipa/issues/8641>`__
 -  WebUI: test_user: test if user is enabled by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/b3488b21319ad6ec800796313fdb7cd23ae17c23>`__
-   `#8203 <https://pagure.io/freeipa/issue/8203>`__
+   `#8203 <https://codeberg.org/freeipa/freeipa/issues/8203>`__
 
 
 
@@ -433,7 +433,7 @@ Mohammad Rizwan (1)
 
 -  ipatests: Test if ACME renews the issued cert with cerbot
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7ff4089437ee20bbce7fc55d43a7702dd7540a7>`__
-   `#4751 <https://pagure.io/freeipa/issue/4751>`__
+   `#4751 <https://codeberg.org/freeipa/freeipa/issues/4751>`__
 
 
 
@@ -442,49 +442,49 @@ Rob Crittenden (15)
 
 -  Catch ValueError when trying to retrieve existing credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/63d20c44760849a7ef65b234e7e231f9a073f61f>`__
-   `#8873 <https://pagure.io/freeipa/issue/8873>`__
+   `#8873 <https://codeberg.org/freeipa/freeipa/issues/8873>`__
 -  ipatests: kinit on server for test_proxycommand_invalid_shell
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfd7b6e00d00efea637f0f575570ac7abd6c5fbc>`__
-   `#8785 <https://pagure.io/freeipa/issue/8785>`__
+   `#8785 <https://codeberg.org/freeipa/freeipa/issues/8785>`__
 -  Add ability to search on certificate revocation status
    `commit <https://codeberg.org/freeipa/freeipa/commit/6031b8a2109ab1963d395a63541ddb3a8799fd9f>`__
-   `#7835 <https://pagure.io/freeipa/issue/7835>`__
+   `#7835 <https://codeberg.org/freeipa/freeipa/issues/7835>`__
 -  Load dogtag RA plugin in installers so profiles can be loaded
    `commit <https://codeberg.org/freeipa/freeipa/commit/7239864be38f13b5d6968552ea565a8dfedcf0dd>`__
-   `#8738 <https://pagure.io/freeipa/issue/8738>`__
+   `#8738 <https://codeberg.org/freeipa/freeipa/issues/8738>`__
 -  Parse the debugging cache log to determine the read savings
    `commit <https://codeberg.org/freeipa/freeipa/commit/0307d222acb8a6c675b985463f56f1071a4e5364>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Add a unit test for the LDAP cache layer
    `commit <https://codeberg.org/freeipa/freeipa/commit/951720d4e66d313c537b003200efc3b33fe4b045>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Add LDAP cache options to the default.conf man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/00c99cceb43d97a5331e0407337e845c710a51d4>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Implement simple LDAP cache layer
    `commit <https://codeberg.org/freeipa/freeipa/commit/b37d679f1dad9fc93f2a8431b4aa62b25f48bcb7>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Unify installer context to be 'installer'
    `commit <https://codeberg.org/freeipa/freeipa/commit/63767ec067a63811bf73a7314786123b2e89d5ff>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Call the LDAPClient layer when modifying values
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6637b2feb2008b4a9538518d5d08a0de79c5a68>`__
-   `#8798 <https://pagure.io/freeipa/issue/8798>`__
+   `#8798 <https://codeberg.org/freeipa/freeipa/issues/8798>`__
 -  Only attempt to upgrade ACME configuration files if deployed
    `commit <https://codeberg.org/freeipa/freeipa/commit/1aa3f7a7fd24c651aafde150351328148fd517be>`__
-   `#8832 <https://pagure.io/freeipa/issue/8832>`__
+   `#8832 <https://codeberg.org/freeipa/freeipa/issues/8832>`__
 -  Parse Apache log etime and display average per command
    `commit <https://codeberg.org/freeipa/freeipa/commit/bae02a7edad6cb291d7610fae3465119a3b72b65>`__
-   `#8809 <https://pagure.io/freeipa/issue/8809>`__
+   `#8809 <https://codeberg.org/freeipa/freeipa/issues/8809>`__
 -  Retrieve the user objectclasses when checking for existence
    `commit <https://codeberg.org/freeipa/freeipa/commit/58c73a71ba296380e10ffc28a2c360ef8341d53d>`__
-   `#8801 <https://pagure.io/freeipa/issue/8801>`__
+   `#8801 <https://codeberg.org/freeipa/freeipa/issues/8801>`__
 -  Cache the value of ca_is_enabled in the request context
    `commit <https://codeberg.org/freeipa/freeipa/commit/74130f863f76c11b6705cde886804a60ea11f64f>`__
-   `#8797 <https://pagure.io/freeipa/issue/8797>`__
+   `#8797 <https://codeberg.org/freeipa/freeipa/issues/8797>`__
 -  Add pkey_only to the service_find calls in host del and disable
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e0626a922f63779836026f5aa7872177be08eef>`__
-   `#8787 <https://pagure.io/freeipa/issue/8787>`__
+   `#8787 <https://codeberg.org/freeipa/freeipa/issues/8787>`__
 
 
 
@@ -493,7 +493,7 @@ Stanislav Levin (27)
 
 -  ipatests: Fetch sudo rules without time offset
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e05170f82c00d7873564cd6e811430a9fdc32da>`__
-   `#8844 <https://pagure.io/freeipa/issue/8844>`__
+   `#8844 <https://codeberg.org/freeipa/freeipa/issues/8844>`__
 -  azure: Make it possible to adjust Docker resources per test env
    `commit <https://codeberg.org/freeipa/freeipa/commit/391ca8b90b6610b16023602a30b451bdcb5a1e6f>`__
 -  azure: coredump: Wait for systemd fully booted
@@ -505,7 +505,7 @@ Stanislav Levin (27)
 -  ipatests: dnssec: Add alternative approach for checking chain of
    trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ada2d983fa136016c94cf827f3c3ef1d65a8323>`__
-   `#8793 <https://pagure.io/freeipa/issue/8793>`__
+   `#8793 <https://codeberg.org/freeipa/freeipa/issues/8793>`__
 -  azure: Collect installed packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/3049b9587f0ded768ba3a61ec0e98368a6316a0a>`__
 -  ipatests: Suppress list trust or certificates
@@ -516,7 +516,7 @@ Stanislav Levin (27)
    `commit <https://codeberg.org/freeipa/freeipa/commit/645f90a835d8ba8080ffdd9a7a3f98f40a3ac550>`__
 -  dns: get_reverse_zone: Ignore resolver's timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e1531180336083fe1b873045a06647ae9074633>`__
-   `#7397 <https://pagure.io/freeipa/issue/7397>`__
+   `#7397 <https://codeberg.org/freeipa/freeipa/issues/7397>`__
 -  dnsutil: Improvements for IPA DNS Resolver
    `commit <https://codeberg.org/freeipa/freeipa/commit/b487629262671714b5e36c74c8dbc193b008ce7d>`__
 -  ipatests: Handle network-isolated mode
@@ -527,7 +527,7 @@ Stanislav Levin (27)
    `commit <https://codeberg.org/freeipa/freeipa/commit/64c0f900306295d1e9832ed58844bb9b2338a339>`__
 -  BIND: Setup logging
    `commit <https://codeberg.org/freeipa/freeipa/commit/0932c9217ff343d788b13ee1845fecb9666cbea8>`__
-   `#8856 <https://pagure.io/freeipa/issue/8856>`__
+   `#8856 <https://codeberg.org/freeipa/freeipa/issues/8856>`__
 -  azure: Warn about memory issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/6164bfb56ad6d3acce9ea778cebf6694a15dd3d8>`__
 -  azure: Add workaround for PhantomJS against OpenSSL 1.1.1
@@ -546,13 +546,13 @@ Stanislav Levin (27)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c711292bcf5a0cb2ce02cd470be6a37b67200b25>`__
 -  azure: bump F32->F34
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9fd47a7ae58085be49bcf6772d688779b492748>`__
-   `#8848 <https://pagure.io/freeipa/issue/8848>`__
+   `#8848 <https://codeberg.org/freeipa/freeipa/issues/8848>`__
 -  pkispawn: Make timeout consistent with IPA's startup_timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/5afe830e541296aad3d43598898bf335be8f6dd9>`__
-   `#8830 <https://pagure.io/freeipa/issue/8830>`__
+   `#8830 <https://codeberg.org/freeipa/freeipa/issues/8830>`__
 -  pylint: Adapt to new Pylint 2.8
    `commit <https://codeberg.org/freeipa/freeipa/commit/eefbe8558b25ca9e9da10b391ec41e2987b8bd2d>`__
-   `#8818 <https://pagure.io/freeipa/issue/8818>`__
+   `#8818 <https://codeberg.org/freeipa/freeipa/issues/8818>`__
 
 
 
@@ -570,11 +570,11 @@ Serhii Tsymbaliuk (2)
 -  WebUI tests: Add test for 'ipaautoprivategroups' field on 'ID Ranges'
    page
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfbafafc3e38fd5b07fc3843c28fa019900a0ee7>`__
-   `#8837 <https://pagure.io/freeipa/issue/8837>`__
+   `#8837 <https://codeberg.org/freeipa/freeipa/issues/8837>`__
 -  WebUI: Add support of 'ipaautoprivategroups' LDAP attribute on 'ID
    Ranges' page
    `commit <https://codeberg.org/freeipa/freeipa/commit/15b47c8b0c7bb484240726f29a126411a2483393>`__
-   `#8837 <https://pagure.io/freeipa/issue/8837>`__
+   `#8837 <https://codeberg.org/freeipa/freeipa/issues/8837>`__
 
 
 

--- a/src/page/Releases/4.9.5.rst
+++ b/src/page/Releases/4.9.5.rst
@@ -38,21 +38,21 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#8691 <https://pagure.io/freeipa/issue/8691>`__ [Tracker] Nightly
+-  `#8691 <https://codeberg.org/freeipa/freeipa/issues/8691>`__ [Tracker] Nightly
    failure (fc33) in test_winsyncmigrate.py: ipa-replica-manage connect
    --winsync error
--  `#8702 <https://pagure.io/freeipa/issue/8702>`__
+-  `#8702 <https://codeberg.org/freeipa/freeipa/issues/8702>`__
    (`rhbz#1780317 <https://bugzilla.redhat.com/show_bug.cgi?id=1780317>`__)
    ipa-cert-fix: False Positive Status for cert renewal.
--  `#8756 <https://pagure.io/freeipa/issue/8756>`__ [Tracker] 389ds
+-  `#8756 <https://codeberg.org/freeipa/freeipa/issues/8756>`__ [Tracker] 389ds
    coredump in test_caless.py::TestReplicaInstall::test_wildcard_http
--  `#8868 <https://pagure.io/freeipa/issue/8868>`__ Nightly test failure
+-  `#8868 <https://codeberg.org/freeipa/freeipa/issues/8868>`__ Nightly test failure
    in test_integration/test_fips.py::TestInstallFIPS
--  `#8873 <https://pagure.io/freeipa/issue/8873>`__ Missing credential
+-  `#8873 <https://codeberg.org/freeipa/freeipa/issues/8873>`__ Missing credential
    cache can raise 500 when authenticating instead of 401
--  `#8876 <https://pagure.io/freeipa/issue/8876>`__ Nightly failure in
+-  `#8876 <https://codeberg.org/freeipa/freeipa/issues/8876>`__ Nightly failure in
    test_installation.py::TestInstallWithCA1::test_install_with_bad_ldap_conf
--  `#8877 <https://pagure.io/freeipa/issue/8877>`__ Nightly test failure
+-  `#8877 <https://codeberg.org/freeipa/freeipa/issues/8877>`__ Nightly test failure
    in test_nfs.py: runner VM runs out of disk space due to huge sssd log
    file
 
@@ -78,7 +78,7 @@ Alexander Bokovoy (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e045f118c87346bfab5b5634fd23f3054f082f7f>`__
 -  get_credentials: return ValueError for missing creds
    `commit <https://codeberg.org/freeipa/freeipa/commit/5238651da06547bb004de2434ae7d357422ba735>`__
-   `#8873 <https://pagure.io/freeipa/issue/8873>`__
+   `#8873 <https://codeberg.org/freeipa/freeipa/issues/8873>`__
 -  Back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/b25f5bd9109b87916e097dd8353ea5f0dc49e398>`__
 
@@ -89,17 +89,17 @@ Florence Blanc-Renaud (4)
 
 -  ipa-cert-fix man page: add note about certmonger renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a445aff10c1ab84e8784ab41b0a838e500e617>`__
-   `#8702 <https://pagure.io/freeipa/issue/8702>`__
+   `#8702 <https://codeberg.org/freeipa/freeipa/issues/8702>`__
 -  freeipa.spec: bump 389-ds version
    `commit <https://codeberg.org/freeipa/freeipa/commit/6eb535334d33f8f375b856e3a2d0b8853b318b4d>`__
-   `#8691 <https://pagure.io/freeipa/issue/8691>`__,
-   `#8756 <https://pagure.io/freeipa/issue/8756>`__
+   `#8691 <https://codeberg.org/freeipa/freeipa/issues/8691>`__,
+   `#8756 <https://codeberg.org/freeipa/freeipa/issues/8756>`__
 -  ipatests: delete the replica before uninstallation
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b22450dfdc1657b463683b09b9c69816f9152d9>`__
-   `#8876 <https://pagure.io/freeipa/issue/8876>`__
+   `#8876 <https://codeberg.org/freeipa/freeipa/issues/8876>`__
 -  ipatests: set selinux context for fips mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/13b257d7a05fd255df472144712edb34604dbe06>`__
-   `#8868 <https://pagure.io/freeipa/issue/8868>`__
+   `#8868 <https://codeberg.org/freeipa/freeipa/issues/8868>`__
 
 
 
@@ -110,7 +110,7 @@ Stanislav Levin (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fd06f33b83aec19a88c594d3750bc476157ab83>`__
 -  krb_utils: Simplify get_credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/700be74975cad998e7dbcc4fb437e6b0bbd77305>`__
-   `#8873 <https://pagure.io/freeipa/issue/8873>`__
+   `#8873 <https://codeberg.org/freeipa/freeipa/issues/8873>`__
 
 
 
@@ -119,8 +119,8 @@ Sergey Orlov (2)
 
 -  ipatests: disable test_nfs.py::TestNFS in nightly runs on Fedora 33
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9f5acc0d281f1a27471091648c36f94528c5a29>`__
-   `#8877 <https://pagure.io/freeipa/issue/8877>`__
+   `#8877 <https://codeberg.org/freeipa/freeipa/issues/8877>`__
 -  ipatests: temporary disable execution of test_nfs.py::TestNFS in
    nightly runs
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ee14f513711ae9be799cfa2bd009f13c5248932>`__
-   `#8877 <https://pagure.io/freeipa/issue/8877>`__
+   `#8877 <https://codeberg.org/freeipa/freeipa/issues/8877>`__

--- a/src/page/Releases/4.9.6.rst
+++ b/src/page/Releases/4.9.6.rst
@@ -59,43 +59,43 @@ or #freeipa channel on Freenode.
 Resolved tickets
 ----------------
 
--  `#7752 <https://pagure.io/freeipa/issue/7752>`__ ipa client throws
+-  `#7752 <https://codeberg.org/freeipa/freeipa/issues/7752>`__ ipa client throws
    http.client.ResponseNotReady error
--  `#8402 <https://pagure.io/freeipa/issue/8402>`__
+-  `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__
    (`rhbz#1854557 <https://bugzilla.redhat.com/show_bug.cgi?id=1854557>`__)
    [RFE] ipa-client-install forces nsupdate to bind with gssapi
--  `#8532 <https://pagure.io/freeipa/issue/8532>`__
+-  `#8532 <https://codeberg.org/freeipa/freeipa/issues/8532>`__
    (`rhbz#1886837 <https://bugzilla.redhat.com/show_bug.cgi?id=1886837>`__)
    Revise PKINIT upgrade code
--  `#8726 <https://pagure.io/freeipa/issue/8726>`__ Provide a better
+-  `#8726 <https://codeberg.org/freeipa/freeipa/issues/8726>`__ Provide a better
    error message with updatedns and FQDN Is not provided
--  `#8754 <https://pagure.io/freeipa/issue/8754>`__
+-  `#8754 <https://codeberg.org/freeipa/freeipa/issues/8754>`__
    (`rhbz#1919384 <https://bugzilla.redhat.com/show_bug.cgi?id=1919384>`__)
    Certificate Serial Number issue
--  `#8817 <https://pagure.io/freeipa/issue/8817>`__ Running
+-  `#8817 <https://codeberg.org/freeipa/freeipa/issues/8817>`__ Running
    ipa-server-certinstall with v1 certificate fails with Attempted
    "__iter__" operation on ASN.1 schema object
--  `#8880 <https://pagure.io/freeipa/issue/8880>`__
+-  `#8880 <https://codeberg.org/freeipa/freeipa/issues/8880>`__
    (`rhbz#1973023 <https://bugzilla.redhat.com/show_bug.cgi?id=1973023>`__)
    CA_less ipa-server-install fails if CA cert subject contains non
    ascii chars
--  `#8882 <https://pagure.io/freeipa/issue/8882>`__ Directly integrate
+-  `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__ Directly integrate
    custodia
--  `#8884 <https://pagure.io/freeipa/issue/8884>`__
+-  `#8884 <https://codeberg.org/freeipa/freeipa/issues/8884>`__
    (`rhbz#1967325 <https://bugzilla.redhat.com/show_bug.cgi?id=1967325>`__)
    API returns the misleading error "Insufficient Access" if run as
    non-admin
--  `#8885 <https://pagure.io/freeipa/issue/8885>`__
+-  `#8885 <https://codeberg.org/freeipa/freeipa/issues/8885>`__
    (`rhbz#1975139 <https://bugzilla.redhat.com/show_bug.cgi?id=1975139>`__)
    Upgrade error: Add failure missing required attribute "objectclass"
--  `#8889 <https://pagure.io/freeipa/issue/8889>`__ [tests] healthcheck
+-  `#8889 <https://codeberg.org/freeipa/freeipa/issues/8889>`__ [tests] healthcheck
    0.9
--  `#8897 <https://pagure.io/freeipa/issue/8897>`__
+-  `#8897 <https://codeberg.org/freeipa/freeipa/issues/8897>`__
    (`rhbz#1976286 <https://bugzilla.redhat.com/show_bug.cgi?id=1976286>`__)
    ansible-freeipa automember test fails with
    \`automember_add_condition: testgroup: 'objectclass'\` due to ldap
    cache
--  `#8898 <https://pagure.io/freeipa/issue/8898>`__ plugin \`plugins\`
+-  `#8898 <https://codeberg.org/freeipa/freeipa/issues/8898>`__ plugin \`plugins\`
    doesn't work
 
 
@@ -120,16 +120,16 @@ Antonio Torres (3)
 
 -  ipatests: test host update using shortname
    `commit <https://codeberg.org/freeipa/freeipa/commit/27a65a1a352b50304fa6765a535443993b445044>`__
-   `#8726 <https://pagure.io/freeipa/issue/8726>`__,
-   `#8884 <https://pagure.io/freeipa/issue/8884>`__
+   `#8726 <https://codeberg.org/freeipa/freeipa/issues/8726>`__,
+   `#8884 <https://codeberg.org/freeipa/freeipa/issues/8884>`__
 -  host: try to resolve FQDN before command execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/48370cb3e8fa928dcc51406a4a5e7dbe5bf8243f>`__
-   `#8726 <https://pagure.io/freeipa/issue/8726>`__,
-   `#8884 <https://pagure.io/freeipa/issue/8884>`__
+   `#8726 <https://codeberg.org/freeipa/freeipa/issues/8726>`__,
+   `#8884 <https://codeberg.org/freeipa/freeipa/issues/8884>`__
 -  Allow PKINIT to be enabled when updating from a pre-PKINIT IPA CA
    server
    `commit <https://codeberg.org/freeipa/freeipa/commit/7bed7e4b06e70b04e16410878ad269564291eec4>`__
-   `#8532 <https://pagure.io/freeipa/issue/8532>`__
+   `#8532 <https://codeberg.org/freeipa/freeipa/issues/8532>`__
 
 
 
@@ -138,24 +138,24 @@ Christian Heimes (7)
 
 -  Also drop Custodia client and forwarder
    `commit <https://codeberg.org/freeipa/freeipa/commit/62647ff3217331339e66170a0665b529e204be2e>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 -  Add Custodia tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/cde5e2d4d7c36fadad492a7a753547297ffbaf60>`__
 -  Remove more unused Custodia code
    `commit <https://codeberg.org/freeipa/freeipa/commit/7cb2c89d5900dc02df1e587dd87d7f820404cd92>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 -  Fix Custodia pylint issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ec775fcfa15f1da20841111484e1e25d9f13d38>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 -  Fix Custodia imports
    `commit <https://codeberg.org/freeipa/freeipa/commit/02ece292ada0da25864bc71ed4f2f16d01933df5>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 -  Remove unused Custodia modules
    `commit <https://codeberg.org/freeipa/freeipa/commit/d804f1feeddd31957bc3d88dfb79e9bd119813cb>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 -  Add Custodia 0.6.0 to ipaserver package
    `commit <https://codeberg.org/freeipa/freeipa/commit/1be15d2024f327bc846e5fe324dc24fb2a96a828>`__
-   `#8882 <https://pagure.io/freeipa/issue/8882>`__
+   `#8882 <https://codeberg.org/freeipa/freeipa/issues/8882>`__
 
 
 
@@ -164,13 +164,13 @@ François Cami (3)
 
 -  ipa-client-install: update sssd.conf if nsupdate requires -g
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cbd24dd04ece7ab24c5cbd3448a46aeb02363f8>`__
-   `#8402 <https://pagure.io/freeipa/issue/8402>`__
+   `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__
 -  ipa-client-install: invoke nsupdate twice (GSS-TSIG, plain)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8588c5006a61855cb178643916a02513df3fa31>`__
-   `#8402 <https://pagure.io/freeipa/issue/8402>`__
+   `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__
 -  ipa-client-install: remove fsync in do_nsupdate()
    `commit <https://codeberg.org/freeipa/freeipa/commit/e82f2538326af62802a587dbd66ff1a06514af60>`__
-   `#8402 <https://pagure.io/freeipa/issue/8402>`__
+   `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__
 
 
 
@@ -179,10 +179,10 @@ Florence Blanc-Renaud (2)
 
 -  ipatests: use non-ascii chars in CA-less install
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b040e10d3fac2cfb5ce057718e537ecbe8e2ac1>`__
-   `#8880 <https://pagure.io/freeipa/issue/8880>`__
+   `#8880 <https://codeberg.org/freeipa/freeipa/issues/8880>`__
 -  CA-less install: non-ASCII chars in CA cert subject
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b278b63b417edea74ca9344688e02b70e64b8bf>`__
-   `#8880 <https://pagure.io/freeipa/issue/8880>`__
+   `#8880 <https://codeberg.org/freeipa/freeipa/issues/8880>`__
 
 
 
@@ -191,13 +191,13 @@ Rob Crittenden (3)
 
 -  Return a copy of cached entries, only with requested attributes
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae4478de1f0e9e35098d1bbbfae1b3506bcf3672>`__
-   `#8897 <https://pagure.io/freeipa/issue/8897>`__
+   `#8897 <https://codeberg.org/freeipa/freeipa/issues/8897>`__
 -  Use get_replication_plugin_name in LDAP updater
    `commit <https://codeberg.org/freeipa/freeipa/commit/45d8118e6c94f25c0971fe2fe07d8f6eb7eb6f7c>`__
-   `#8885 <https://pagure.io/freeipa/issue/8885>`__
+   `#8885 <https://codeberg.org/freeipa/freeipa/issues/8885>`__
 -  When loading certificates verify that it is X.509 v3
    `commit <https://codeberg.org/freeipa/freeipa/commit/22f0d8c50ab4618b05d0263380f594b23153724b>`__
-   `#8817 <https://pagure.io/freeipa/issue/8817>`__
+   `#8817 <https://codeberg.org/freeipa/freeipa/issues/8817>`__
 
 
 
@@ -208,13 +208,13 @@ Stanislav Levin (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/0abae79183207a4bdc7a6147eb143319806ad567>`__
 -  ipatests: Add tests for \`plugins\` plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/15d710247d389e992844637fdb8a35610b595ba2>`__
-   `#8898 <https://pagure.io/freeipa/issue/8898>`__
+   `#8898 <https://codeberg.org/freeipa/freeipa/issues/8898>`__
 -  plugins: Don't treat keys of api as bytes
    `commit <https://codeberg.org/freeipa/freeipa/commit/32eb409cf6c4bf03d4ae3451001c81d175310a7c>`__
-   `#8898 <https://pagure.io/freeipa/issue/8898>`__
+   `#8898 <https://codeberg.org/freeipa/freeipa/issues/8898>`__
 -  ipatests: healthcheck: Update IPAHostKeytab assumptions
    `commit <https://codeberg.org/freeipa/freeipa/commit/d744ff3caef509af8d3c25393aac6c2d83fdb78c>`__
-   `#8889 <https://pagure.io/freeipa/issue/8889>`__
+   `#8889 <https://codeberg.org/freeipa/freeipa/issues/8889>`__
 
 
 
@@ -223,7 +223,7 @@ Serhii Tsymbaliuk (1)
 
 -  WebUI: Fix certificate serial number representation
    `commit <https://codeberg.org/freeipa/freeipa/commit/52e60889ff85b0129503d086214419fc2f9700d8>`__
-   `#8754 <https://pagure.io/freeipa/issue/8754>`__
+   `#8754 <https://codeberg.org/freeipa/freeipa/issues/8754>`__
 
 
 
@@ -235,4 +235,4 @@ Sudhir Menon (2)
 -  ipatests: Test to check that ResponseNotReady error is not displayed
    when user session cache is deleted
    `commit <https://codeberg.org/freeipa/freeipa/commit/2aa77992090499b2706ca077cc8ca980f47abbc0>`__
-   `#7752 <https://pagure.io/freeipa/issue/7752>`__
+   `#7752 <https://codeberg.org/freeipa/freeipa/issues/7752>`__

--- a/src/page/Releases/4.9.7.rst
+++ b/src/page/Releases/4.9.7.rst
@@ -69,120 +69,120 @@ or #freeipa channel on libra.chat.
 Resolved tickets
 ----------------
 
--  `#3226 <https://pagure.io/freeipa/issue/3226>`__ [RFE] ipa
+-  `#3226 <https://codeberg.org/freeipa/freeipa/issues/3226>`__ [RFE] ipa
    sudorule-add-user should accept more types of characters
--  `#6587 <https://pagure.io/freeipa/issue/6587>`__ ipa-otpd: systemctl
+-  `#6587 <https://codeberg.org/freeipa/freeipa/issues/6587>`__ ipa-otpd: systemctl
    reports "degraded" for "is-system-running" after todays CentOS
    updates
--  `#7814 <https://pagure.io/freeipa/issue/7814>`__ fix
+-  `#7814 <https://codeberg.org/freeipa/freeipa/issues/7814>`__ fix
    automountlocation-tofiles output
--  `#8206 <https://pagure.io/freeipa/issue/8206>`__ Add checks to
+-  `#8206 <https://codeberg.org/freeipa/freeipa/issues/8206>`__ Add checks to
    prevent assigning authentication indicators to internal IPA services
--  `#8227 <https://pagure.io/freeipa/issue/8227>`__ dnszone-add: ignores
+-  `#8227 <https://codeberg.org/freeipa/freeipa/issues/8227>`__ dnszone-add: ignores
    given SOA serial
--  `#8245 <https://pagure.io/freeipa/issue/8245>`__ ipa-kra-install
+-  `#8245 <https://codeberg.org/freeipa/freeipa/issues/8245>`__ ipa-kra-install
    should exit if ca_host is overriden.
--  `#8257 <https://pagure.io/freeipa/issue/8257>`__ ipa-certupdate sets
+-  `#8257 <https://codeberg.org/freeipa/freeipa/issues/8257>`__ ipa-certupdate sets
    temporary ccache in the wrong place
--  `#8361 <https://pagure.io/freeipa/issue/8361>`__ Add support for
+-  `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__ Add support for
    managing subuids and subgids in FreeIPA
--  `#8397 <https://pagure.io/freeipa/issue/8397>`__ Cannot remove First
+-  `#8397 <https://codeberg.org/freeipa/freeipa/issues/8397>`__ Cannot remove First
    master server with KRA after the server hard disk failed (
    destructed)
--  `#8402 <https://pagure.io/freeipa/issue/8402>`__ [RFE]
+-  `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__ [RFE]
    ipa-client-install forces nsupdate to bind with gssapi
--  `#8415 <https://pagure.io/freeipa/issue/8415>`__ Ignore case when
+-  `#8415 <https://codeberg.org/freeipa/freeipa/issues/8415>`__ Ignore case when
    evaluating attributes and objectclasses in config plugin
--  `#8452 <https://pagure.io/freeipa/issue/8452>`__ update samba
+-  `#8452 <https://codeberg.org/freeipa/freeipa/issues/8452>`__ update samba
    configuration on IPA master to explicitly use 'server role' setting
--  `#8478 <https://pagure.io/freeipa/issue/8478>`__ Do SRV discovery in
+-  `#8478 <https://codeberg.org/freeipa/freeipa/issues/8478>`__ Do SRV discovery in
    ipa-getkeytab if -s and -H aren't provided
--  `#8501 <https://pagure.io/freeipa/issue/8501>`__ Unify how FreeIPA
+-  `#8501 <https://codeberg.org/freeipa/freeipa/issues/8501>`__ Unify how FreeIPA
    gets FQDN of current host
--  `#8519 <https://pagure.io/freeipa/issue/8519>`__ Fedora container
+-  `#8519 <https://codeberg.org/freeipa/freeipa/issues/8519>`__ Fedora container
    platform is incomplete
--  `#8524 <https://pagure.io/freeipa/issue/8524>`__ Deploy & manage the
+-  `#8524 <https://codeberg.org/freeipa/freeipa/issues/8524>`__ Deploy & manage the
    ACME service topology wide from a single system
--  `#8528 <https://pagure.io/freeipa/issue/8528>`__ Use separate logs
+-  `#8528 <https://codeberg.org/freeipa/freeipa/issues/8528>`__ Use separate logs
    for AD Trust and DNS installer
--  `#8584 <https://pagure.io/freeipa/issue/8584>`__ ACME communication
+-  `#8584 <https://codeberg.org/freeipa/freeipa/issues/8584>`__ ACME communication
    with dogtag REST endpoints should be using the cookie it creates
--  `#8647 <https://pagure.io/freeipa/issue/8647>`__ Incorrect DNSKEY
+-  `#8647 <https://codeberg.org/freeipa/freeipa/issues/8647>`__ Incorrect DNSKEY
    created when DNSSEC enabled for zone
--  `#8655 <https://pagure.io/freeipa/issue/8655>`__ Allow to establish
+-  `#8655 <https://codeberg.org/freeipa/freeipa/issues/8655>`__ Allow to establish
    trust to Active Directory in FIPS mode
--  `#8676 <https://pagure.io/freeipa/issue/8676>`__ [Tracker] Multiple
+-  `#8676 <https://codeberg.org/freeipa/freeipa/issues/8676>`__ [Tracker] Multiple
    nightly test failure in
    test_integration/test_ntp_options/TestNTPoptions
--  `#8795 <https://pagure.io/freeipa/issue/8795>`__ Remove dependency
+-  `#8795 <https://codeberg.org/freeipa/freeipa/issues/8795>`__ Remove dependency
    from tests on ipaserver package/modules
--  `#8810 <https://pagure.io/freeipa/issue/8810>`__ Nightly test failure
+-  `#8810 <https://codeberg.org/freeipa/freeipa/issues/8810>`__ Nightly test failure
    (rawhide/f34) in test_ipahealthcheck.py::TestIpaHealthCheck: missing
    AAAA record for ipa-ca
--  `#8832 <https://pagure.io/freeipa/issue/8832>`__ ipa-server-upgrade
+-  `#8832 <https://codeberg.org/freeipa/freeipa/issues/8832>`__ ipa-server-upgrade
    is failing while upgrading rhel8.3 to rhel8.4
--  `#8864 <https://pagure.io/freeipa/issue/8864>`__ azure: dnf sometimes
+-  `#8864 <https://codeberg.org/freeipa/freeipa/issues/8864>`__ azure: dnf sometimes
    fails
--  `#8889 <https://pagure.io/freeipa/issue/8889>`__ [tests] healthcheck
+-  `#8889 <https://codeberg.org/freeipa/freeipa/issues/8889>`__ [tests] healthcheck
    0.9
--  `#8890 <https://pagure.io/freeipa/issue/8890>`__ Nightly test failure
+-  `#8890 <https://codeberg.org/freeipa/freeipa/issues/8890>`__ Nightly test failure
    (rawhide) in
    test_ipa_cert_fix.py::TestIpaCertFix::test_missing_startup
--  `#8891 <https://pagure.io/freeipa/issue/8891>`__ FreeIPA server in
+-  `#8891 <https://codeberg.org/freeipa/freeipa/issues/8891>`__ FreeIPA server in
    debug mode fails to run because time.perf_counter_ns is Python 3.7+
--  `#8892 <https://pagure.io/freeipa/issue/8892>`__ [RFE] When IPA
+-  `#8892 <https://codeberg.org/freeipa/freeipa/issues/8892>`__ [RFE] When IPA
    system is healthy, ipa-healthcheck --failures-only should display
    proper message instead of empty list
--  `#8905 <https://pagure.io/freeipa/issue/8905>`__ Package
+-  `#8905 <https://codeberg.org/freeipa/freeipa/issues/8905>`__ Package
    python3-ipatests (from CRB repo) Requires python3-coverage
--  `#8906 <https://pagure.io/freeipa/issue/8906>`__ support for
+-  `#8906 <https://codeberg.org/freeipa/freeipa/issues/8906>`__ support for
    SHA384withRSA signing algo missing
--  `#8909 <https://pagure.io/freeipa/issue/8909>`__ Unable to set
+-  `#8909 <https://codeberg.org/freeipa/freeipa/issues/8909>`__ Unable to set
    ipaUserAuthType with stageuser-add
--  `#8911 <https://pagure.io/freeipa/issue/8911>`__ Nightly test failure
+-  `#8911 <https://codeberg.org/freeipa/freeipa/issues/8911>`__ Nightly test failure
    in pki-fedora/test_webui_cert.
--  `#8913 <https://pagure.io/freeipa/issue/8913>`__ [man page]
+-  `#8913 <https://codeberg.org/freeipa/freeipa/issues/8913>`__ [man page]
    contradiction in ipa-server-upgrade command's man page and usage
--  `#8918 <https://pagure.io/freeipa/issue/8918>`__ Nightly failure in
+-  `#8918 <https://codeberg.org/freeipa/freeipa/issues/8918>`__ Nightly failure in
    test_external_ca.py::TestSelfExternalSelf::test_switch_back_to_self_signed
--  `#8919 <https://pagure.io/freeipa/issue/8919>`__ Nightly test failure
+-  `#8919 <https://codeberg.org/freeipa/freeipa/issues/8919>`__ Nightly test failure
    in test_webui/test_range.py::test_range::test_crud
--  `#8920 <https://pagure.io/freeipa/issue/8920>`__ ipa-healthcheck
+-  `#8920 <https://codeberg.org/freeipa/freeipa/issues/8920>`__ ipa-healthcheck
    reports RIPluginCheck CRITICAL error for DSRILE0002
--  `#8923 <https://pagure.io/freeipa/issue/8923>`__ Trust controller
+-  `#8923 <https://codeberg.org/freeipa/freeipa/issues/8923>`__ Trust controller
    role should pull sssd-winbind-idmap package
--  `#8925 <https://pagure.io/freeipa/issue/8925>`__ ipatests:
+-  `#8925 <https://codeberg.org/freeipa/freeipa/issues/8925>`__ ipatests:
    NAMED_CRYPTO_POLICY_FILE not defined for RHEL
--  `#8926 <https://pagure.io/freeipa/issue/8926>`__ Nightly test failure
+-  `#8926 <https://codeberg.org/freeipa/freeipa/issues/8926>`__ Nightly test failure
    (rawhide) in test_smb
--  `#8929 <https://pagure.io/freeipa/issue/8929>`__ Nightly test failure
+-  `#8929 <https://codeberg.org/freeipa/freeipa/issues/8929>`__ Nightly test failure
    in test_integration//test_acme.py/TestACMERenew/test_renew - kinit
    admin: Password change failed while getting initial credentials
--  `#8930 <https://pagure.io/freeipa/issue/8930>`__ IdM should call into
+-  `#8930 <https://codeberg.org/freeipa/freeipa/issues/8930>`__ IdM should call into
    Dogtag to dynamically update the security domain info
--  `#8931 <https://pagure.io/freeipa/issue/8931>`__ flake8 report for
+-  `#8931 <https://codeberg.org/freeipa/freeipa/issues/8931>`__ flake8 report for
    tasks.py
--  `#8934 <https://pagure.io/freeipa/issue/8934>`__ ipa-advise
+-  `#8934 <https://codeberg.org/freeipa/freeipa/issues/8934>`__ ipa-advise
    unconditionally uses modutil to load opensc module
--  `#8935 <https://pagure.io/freeipa/issue/8935>`__ [tracker] Update
+-  `#8935 <https://codeberg.org/freeipa/freeipa/issues/8935>`__ [tracker] Update
    boxes for PR-CI nightly runs
--  `#8936 <https://pagure.io/freeipa/issue/8936>`__ ipa-server install
+-  `#8936 <https://codeberg.org/freeipa/freeipa/issues/8936>`__ ipa-server install
    failure without DNS
--  `#8937 <https://pagure.io/freeipa/issue/8937>`__ Multiple issues in
+-  `#8937 <https://codeberg.org/freeipa/freeipa/issues/8937>`__ Multiple issues in
    tasks's install/uninstall helpers
--  `#8938 <https://pagure.io/freeipa/issue/8938>`__ Remove
+-  `#8938 <https://codeberg.org/freeipa/freeipa/issues/8938>`__ Remove
    python3-pexpect as dependency for ipatests pkg
--  `#8939 <https://pagure.io/freeipa/issue/8939>`__ Add index for
+-  `#8939 <https://codeberg.org/freeipa/freeipa/issues/8939>`__ Add index for
    sudoorder
--  `#8942 <https://pagure.io/freeipa/issue/8942>`__ TestAJPSecretUpgrade
+-  `#8942 <https://codeberg.org/freeipa/freeipa/issues/8942>`__ TestAJPSecretUpgrade
    tests fail on system without pkiuser
--  `#8944 <https://pagure.io/freeipa/issue/8944>`__
+-  `#8944 <https://codeberg.org/freeipa/freeipa/issues/8944>`__
    TestIpaAdTrustInstall::test_ipa_user_s4u2self_pac failed at
    create_active_user
--  `#8949 <https://pagure.io/freeipa/issue/8949>`__ Test for RFE
+-  `#8949 <https://codeberg.org/freeipa/freeipa/issues/8949>`__ Test for RFE
    ipa-healthcheck should verify owner/perms for important logs in
    "/var/log" in the ipahealthcheck.ipa.files source
--  `#8956 <https://pagure.io/freeipa/issue/8956>`__ Nightly failure in
+-  `#8956 <https://codeberg.org/freeipa/freeipa/issues/8956>`__ Nightly failure in
    test_caless.py::TestIPACommands::test_invoke_upgrader
 
 
@@ -197,7 +197,7 @@ Armando Neto (1)
 
 -  ipatests: bump prci boxes + move gating to f34
    `commit <https://codeberg.org/freeipa/freeipa/commit/02447762a3f62383313f0b8cd7c5d129dc2c6213>`__
-   `#8935 <https://pagure.io/freeipa/issue/8935>`__
+   `#8935 <https://codeberg.org/freeipa/freeipa/issues/8935>`__
 
 
 
@@ -206,7 +206,7 @@ Alexander Bokovoy (2)
 
 -  rhel platform: add a named crypto-policy support
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a5159b216455070eb51b6a11ceaf0033fc8ce4c>`__
-   `#8925 <https://pagure.io/freeipa/issue/8925>`__
+   `#8925 <https://codeberg.org/freeipa/freeipa/issues/8925>`__
 -  Back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b7e8841824b44fc41581717c51ccd4b0fc553ff>`__
 
@@ -217,17 +217,17 @@ Anuja More (5)
 
 -  ipatests: Test unsecure nsupdate.
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fdab0c94c4e17e42e5f38a0e671bea39bcc9b74>`__
-   `#8402 <https://pagure.io/freeipa/issue/8402>`__
+   `#8402 <https://codeberg.org/freeipa/freeipa/issues/8402>`__
 -  ipatests: Refactor test_check_otpd_after_idle_timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/eac03d6828d0bac1925c897090fc77e250eaee04>`__
-   `#6587 <https://pagure.io/freeipa/issue/6587>`__
+   `#6587 <https://codeberg.org/freeipa/freeipa/issues/6587>`__
 -  ipatests: skip test_basesearch_compat_tree on fedora.
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4062e407d242a72b9d4e32f4fdd6aed086ce005>`__
 -  ipatests: Test ldapsearch with base scope works with compat tree.
    `commit <https://codeberg.org/freeipa/freeipa/commit/a3d71eb72a6125a80a9d7b698f34dcb95dc25184>`__
 -  ipatests: Test for OTP when the LDAP connection timed out.
    `commit <https://codeberg.org/freeipa/freeipa/commit/25a4acf3ad5964eacddbcb83ddf9f84432968918>`__
-   `#6587 <https://pagure.io/freeipa/issue/6587>`__
+   `#6587 <https://codeberg.org/freeipa/freeipa/issues/6587>`__
 
 
 
@@ -236,23 +236,23 @@ Antonio Torres (6)
 
 -  ipatests: expect SOA serial option deprecation warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d7512495d3e7f933d95707f74a6b6f0aeecd00f>`__
-   `#8227 <https://pagure.io/freeipa/issue/8227>`__
+   `#8227 <https://codeberg.org/freeipa/freeipa/issues/8227>`__
 -  dnszone: deprecate option for setting SOA serial
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c0dcabd6e2163dfa80a4d2a18064824934274fa>`__
-   `#8227 <https://pagure.io/freeipa/issue/8227>`__
+   `#8227 <https://codeberg.org/freeipa/freeipa/issues/8227>`__
 -  ipatests: test if KRA install fails when ca_host is overriden
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4e13a33247fb14145c632fb53b4480fc5fb10ea>`__
-   `#8245 <https://pagure.io/freeipa/issue/8245>`__
+   `#8245 <https://codeberg.org/freeipa/freeipa/issues/8245>`__
 -  ipa-kra-install: exit if ca_host is overriden
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab4720d9c2bae059e8f622cd4a331510fefe27ae>`__
-   `#8245 <https://pagure.io/freeipa/issue/8245>`__
+   `#8245 <https://codeberg.org/freeipa/freeipa/issues/8245>`__
 -  ipatests: ensure auth indicators can't be added to internal IPA
    services
    `commit <https://codeberg.org/freeipa/freeipa/commit/28484c3dee225662e41acc691bfe6b1c1cee99c8>`__
-   `#8206 <https://pagure.io/freeipa/issue/8206>`__
+   `#8206 <https://codeberg.org/freeipa/freeipa/issues/8206>`__
 -  Add checks to prevent adding auth indicators to internal IPA services
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5d2857297cfcf87ed8973df96e89ebcef22850d>`__
-   `#8206 <https://pagure.io/freeipa/issue/8206>`__
+   `#8206 <https://codeberg.org/freeipa/freeipa/issues/8206>`__
 
 
 
@@ -261,10 +261,10 @@ Christian Heimes (8)
 
 -  Fix string check in uninstall helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5b5bc9099fc26b863d7c964e47dbdcd0ff008c8>`__
-   `#8937 <https://pagure.io/freeipa/issue/8937>`__
+   `#8937 <https://codeberg.org/freeipa/freeipa/issues/8937>`__
 -  Fix ldapupdate.get_sub_dict() for missing named user
    `commit <https://codeberg.org/freeipa/freeipa/commit/a1eb13cdbc109da8c028bb886a1207ea2cc23cee>`__
-   `#8936 <https://pagure.io/freeipa/issue/8936>`__
+   `#8936 <https://codeberg.org/freeipa/freeipa/issues/8936>`__
 -  Test DNA plugin configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/b53a52a1fafa94e0129e6e3e55fddd59909f0f0a>`__
 -  Fix oid of ipaUserDefaultSubordinateId
@@ -277,7 +277,7 @@ Christian Heimes (8)
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d4fe06663c3e66b1da73c01ce022790634a3e3b>`__
 -  Add basic support for subordinate user/group ids
    `commit <https://codeberg.org/freeipa/freeipa/commit/3540986a11d4f3401ba4918f25229a79283d9dbd>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__
 
 
 
@@ -298,38 +298,38 @@ François Cami (13)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cb6b5c801b04922c3a23070e79aab20399d033b>`__
 -  ipatests: use krb5_trace in TestIpaAdTrustInstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ae23e1257478bfee04b08b54f36dda7f5850348>`__
-   `#8944 <https://pagure.io/freeipa/issue/8944>`__
+   `#8944 <https://codeberg.org/freeipa/freeipa/issues/8944>`__
 -  freeipa.spec.in: remove python3-pexpect from Requires
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0e1d6f94dd16c8066be8ce3c75ef306890a3e2b>`__
-   `#8938 <https://pagure.io/freeipa/issue/8938>`__
+   `#8938 <https://codeberg.org/freeipa/freeipa/issues/8938>`__
 -  gating.yaml: Fix TestInstallMaster timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/33c561dcd30dc346ccbaa00933bcd1cac5e994b6>`__
 -  Azure: temporarily disable problematic tests, #2
    `commit <https://codeberg.org/freeipa/freeipa/commit/18ccaea7cb36b3d1069f0d12a15b06357b3f94f0>`__
-   `#8864 <https://pagure.io/freeipa/issue/8864>`__
+   `#8864 <https://codeberg.org/freeipa/freeipa/issues/8864>`__
 -  Azure: temporarily disable problematic tests, #1
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb1d509fd5271d39cc899838b57e5398683401f7>`__
-   `#8864 <https://pagure.io/freeipa/issue/8864>`__
+   `#8864 <https://codeberg.org/freeipa/freeipa/issues/8864>`__
 -  tasks.py: fix flake8-reported issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b826ab3582566b15a618f57cb2e002a9c16ef64>`__
-   `#8931 <https://pagure.io/freeipa/issue/8931>`__
+   `#8931 <https://codeberg.org/freeipa/freeipa/issues/8931>`__
 -  test_acme: make password renewal more robust
    `commit <https://codeberg.org/freeipa/freeipa/commit/701adb9185c77194ba1ad0c5fd2f13484417ef6f>`__
-   `#8929 <https://pagure.io/freeipa/issue/8929>`__
+   `#8929 <https://codeberg.org/freeipa/freeipa/issues/8929>`__
 -  test_acme: refactor with tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/86869364a30f071ee79974b301ff68e80c0950ba>`__
 -  ipatests: smbclient "-k" => "--use-kerberos=desired"
    `commit <https://codeberg.org/freeipa/freeipa/commit/161d5844eb1214e60c636bdb73713c6a43f1e75c>`__
-   `#8926 <https://pagure.io/freeipa/issue/8926>`__
+   `#8926 <https://codeberg.org/freeipa/freeipa/issues/8926>`__
 -  rpcserver.py: perf_counter_ns is Python 3.7+
    `commit <https://codeberg.org/freeipa/freeipa/commit/1539c7383116647ad9c5b125b343f972e9c9653b>`__
-   `#8891 <https://pagure.io/freeipa/issue/8891>`__
+   `#8891 <https://codeberg.org/freeipa/freeipa/issues/8891>`__
 -  ipatests: smoke test for server debug mode.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee4be290e1583834a573c3896ee1d97b3fbb6c24>`__
-   `#8891 <https://pagure.io/freeipa/issue/8891>`__
+   `#8891 <https://codeberg.org/freeipa/freeipa/issues/8891>`__
 -  paths: add IPA_SERVER_CONF
    `commit <https://codeberg.org/freeipa/freeipa/commit/e713c227bb420a841ce3ae146bca55a84a1b0dbf>`__
-   `#8891 <https://pagure.io/freeipa/issue/8891>`__
+   `#8891 <https://codeberg.org/freeipa/freeipa/issues/8891>`__
 
 
 
@@ -338,41 +338,41 @@ Florence Blanc-Renaud (12)
 
 -  webui tests: fix algo for finding available idrange
    `commit <https://codeberg.org/freeipa/freeipa/commit/f7997ed0b7d5b915c0184bf8e8864ff935cd6232>`__
-   `#8919 <https://pagure.io/freeipa/issue/8919>`__
+   `#8919 <https://codeberg.org/freeipa/freeipa/issues/8919>`__
 -  Index: Fix definition for memberOf
    `commit <https://codeberg.org/freeipa/freeipa/commit/b132956e42a88ab39bb8d6a854e7c5d28d544a11>`__
-   `#8920 <https://pagure.io/freeipa/issue/8920>`__
+   `#8920 <https://codeberg.org/freeipa/freeipa/issues/8920>`__
 -  spec file: Trust controller role should pull sssd-winbind-idmap
    package
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a4f459b81bc77cdf233b65f41d0f76dbb5f2fce>`__
-   `#8923 <https://pagure.io/freeipa/issue/8923>`__
+   `#8923 <https://codeberg.org/freeipa/freeipa/issues/8923>`__
 -  webui tests: close notification when revoking cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/40e4ccf1ea943aba4d10e8126ffa49feddd2e683>`__
-   `#8911 <https://pagure.io/freeipa/issue/8911>`__
+   `#8911 <https://codeberg.org/freeipa/freeipa/issues/8911>`__
 -  pr-ci definitions: add subid-related jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/d456649feb40d462f73321a4a220b4aff7adb443>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__
 -  ipatests: use whole date when calling journalctl --since
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2e6292337c6f7f68ac383db8aa54a1abfa3f6b4>`__
-   `#8918 <https://pagure.io/freeipa/issue/8918>`__
+   `#8918 <https://codeberg.org/freeipa/freeipa/issues/8918>`__
 -  Server install: do not use unchecked ip addr for ipa-ca record
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c0a123e99d943f115cc726e391f5d79b5bfb70e>`__
-   `#8810 <https://pagure.io/freeipa/issue/8810>`__
+   `#8810 <https://codeberg.org/freeipa/freeipa/issues/8810>`__
 -  man page: update ipa-server-upgrade.1
    `commit <https://codeberg.org/freeipa/freeipa/commit/195035cef51a132b2b80df57ed50f2fe620244e6>`__
-   `#8913 <https://pagure.io/freeipa/issue/8913>`__
+   `#8913 <https://codeberg.org/freeipa/freeipa/issues/8913>`__
 -  augeas: bump version for rhel9
    `commit <https://codeberg.org/freeipa/freeipa/commit/076e499f6f1223458cb896f1e90296e511c922d7>`__
-   `#8676 <https://pagure.io/freeipa/issue/8676>`__
+   `#8676 <https://codeberg.org/freeipa/freeipa/issues/8676>`__
 -  XMLRPC test: add a test for stageuser-add --user-auth-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a5a0fe7d25209a41a2eadd159f7f4c771e5d7fc>`__
-   `#8909 <https://pagure.io/freeipa/issue/8909>`__
+   `#8909 <https://codeberg.org/freeipa/freeipa/issues/8909>`__
 -  stageuser: add ipauserauthtypeclass when required
    `commit <https://codeberg.org/freeipa/freeipa/commit/06468b2f604c56b02231904072cb57412966a701>`__
-   `#8909 <https://pagure.io/freeipa/issue/8909>`__
+   `#8909 <https://codeberg.org/freeipa/freeipa/issues/8909>`__
 -  Remove unneeded dependency on python-coverage
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cfae2623420356fd99e09bf8559b11da66e2ccd>`__
-   `#8905 <https://pagure.io/freeipa/issue/8905>`__
+   `#8905 <https://codeberg.org/freeipa/freeipa/issues/8905>`__
 
 
 
@@ -381,15 +381,15 @@ Michal Polovka (3)
 
 -  ipatests: test_ipahealthcheck: Verify permissions for /var/log/ files
    `commit <https://codeberg.org/freeipa/freeipa/commit/488ac7e3ba9f36d6b187687d120920d2d80d8b7f>`__
-   `#8949 <https://pagure.io/freeipa/issue/8949>`__
+   `#8949 <https://codeberg.org/freeipa/freeipa/issues/8949>`__
 -  ipatests: test_installation: move tracking_reqs dependency to ipalib
    constants ipaserver: krainstance: utilize moved tracking_reqs
    dependency
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5df4dc4884f1a66ccbca79b9a0d83874c996d1d>`__
-   `#8795 <https://pagure.io/freeipa/issue/8795>`__
+   `#8795 <https://codeberg.org/freeipa/freeipa/issues/8795>`__
 -  ipatests: test_ipahealthcheck: print a message if a system is healthy
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f910eb2dda8595da435b4aed6e759a2916df813>`__
-   `#8892 <https://pagure.io/freeipa/issue/8892>`__
+   `#8892 <https://codeberg.org/freeipa/freeipa/issues/8892>`__
 
 
 
@@ -398,11 +398,11 @@ Mohammad Rizwan (2)
 
 -  ipatests: Look for warning into stderr instead of stdout
    `commit <https://codeberg.org/freeipa/freeipa/commit/96dd8ac1cd2e7fb8177d83e7ba5c6d79f4216ea3>`__
-   `#8890 <https://pagure.io/freeipa/issue/8890>`__
+   `#8890 <https://codeberg.org/freeipa/freeipa/issues/8890>`__
 -  ipatests: Test ipa-cert-fix warns when startup directive is missing
    from CS.cfg
    `commit <https://codeberg.org/freeipa/freeipa/commit/02c0da3ef74948579106aab4b669f6e64dd60b24>`__
-   `#8890 <https://pagure.io/freeipa/issue/8890>`__
+   `#8890 <https://codeberg.org/freeipa/freeipa/issues/8890>`__
 
 
 
@@ -411,66 +411,66 @@ Rob Crittenden (21)
 
 -  Only call add_agent_to_security_domain_admins() when CA is installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/da1d543c2bfa9e4acb6fde170e66c88e521ac232>`__
-   `#8956 <https://pagure.io/freeipa/issue/8956>`__
+   `#8956 <https://codeberg.org/freeipa/freeipa/issues/8956>`__
 -  ipatests: Verify that securitydomain is updated on server-del
    `commit <https://codeberg.org/freeipa/freeipa/commit/a417810df5500b5780396ab88d53eaea74f74ccc>`__
-   `#8930 <https://pagure.io/freeipa/issue/8930>`__
+   `#8930 <https://codeberg.org/freeipa/freeipa/issues/8930>`__
 -  Clean up the PKI securitydomain when removing a server
    `commit <https://codeberg.org/freeipa/freeipa/commit/be3a0f3201bbb060a9d53fb65cbbccf6c7bf9bb4>`__
-   `#8930 <https://pagure.io/freeipa/issue/8930>`__
+   `#8930 <https://codeberg.org/freeipa/freeipa/issues/8930>`__
 -  pr-ci definitions: add custom plugin-related jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/78c48199782743e619463cefa7411817f4fe4a14>`__
-   `#8415 <https://pagure.io/freeipa/issue/8415>`__
+   `#8415 <https://codeberg.org/freeipa/freeipa/issues/8415>`__
 -  ipatests: add suite for testing custom plugins
    `commit <https://codeberg.org/freeipa/freeipa/commit/e28e45402c7edb007e356a59cf09ed8e10cd14d9>`__
-   `#8415 <https://pagure.io/freeipa/issue/8415>`__
+   `#8415 <https://codeberg.org/freeipa/freeipa/issues/8415>`__
 -  Don't assume that plugin attributes and objectclasses are lowercase
    `commit <https://codeberg.org/freeipa/freeipa/commit/97a2a925348d3bd732e582108feb02d644ba011a>`__
-   `#8415 <https://pagure.io/freeipa/issue/8415>`__
+   `#8415 <https://codeberg.org/freeipa/freeipa/issues/8415>`__
 -  Add index for sudoorder
    `commit <https://codeberg.org/freeipa/freeipa/commit/0526174971017aebfb9d9fcb29c6dde6e67438fe>`__
-   `#8939 <https://pagure.io/freeipa/issue/8939>`__
+   `#8939 <https://codeberg.org/freeipa/freeipa/issues/8939>`__
 -  ipatests: verify that getcert output includes the issued date
    `commit <https://codeberg.org/freeipa/freeipa/commit/826b5825bd644fc69a9bee17626d71fe03cc0190>`__
 -  ipa-advise: Define the domain used when looking up ipa-ca
    `commit <https://codeberg.org/freeipa/freeipa/commit/9a4a6cdd27781573351595e38d38eeadc8ab090d>`__
-   `#8934 <https://pagure.io/freeipa/issue/8934>`__
+   `#8934 <https://codeberg.org/freeipa/freeipa/issues/8934>`__
 -  ipa-advise: if p11-kit provides opensc, don't add to NSS db
    `commit <https://codeberg.org/freeipa/freeipa/commit/018ee09ccbe7fc0a5b0909592eadd168224b2409>`__
-   `#8934 <https://pagure.io/freeipa/issue/8934>`__
+   `#8934 <https://codeberg.org/freeipa/freeipa/issues/8934>`__
 -  ipatests: test ipa-getkeytab server option
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a13200fd8b92dd90ebc4b6416ef25659df8aa71>`__
-   `#8478 <https://pagure.io/freeipa/issue/8478>`__
+   `#8478 <https://codeberg.org/freeipa/freeipa/issues/8478>`__
 -  ipa-getkeytab: fix compiler warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/0114d24ea160676b784ef7010c19bbacc67ceea0>`__
-   `#8478 <https://pagure.io/freeipa/issue/8478>`__
+   `#8478 <https://codeberg.org/freeipa/freeipa/issues/8478>`__
 -  ipa-getkeytab: add option to discover servers using DNS SRV
    `commit <https://codeberg.org/freeipa/freeipa/commit/42206df69adc9c1eefa3ee576891b2ae3ac269e0>`__
-   `#8478 <https://pagure.io/freeipa/issue/8478>`__
+   `#8478 <https://codeberg.org/freeipa/freeipa/issues/8478>`__
 -  Provide more information in ipa-certupdate on ccache failure
    `commit <https://codeberg.org/freeipa/freeipa/commit/fbbff3edc0fcc8bf2624283ccd88848eedaac8d7>`__
-   `#8257 <https://pagure.io/freeipa/issue/8257>`__
+   `#8257 <https://codeberg.org/freeipa/freeipa/issues/8257>`__
 -  Fix automountlocation-tofiles expected output in xmlrpc test
    `commit <https://codeberg.org/freeipa/freeipa/commit/ded3cd3fc8490561e44310e8f89efc3e13e82884>`__
-   `#7814 <https://pagure.io/freeipa/issue/7814>`__
+   `#7814 <https://codeberg.org/freeipa/freeipa/issues/7814>`__
 -  ipatests: Add test for ipa automountlocation-tofiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbe4159e27d44550085cb3ce0629d1e525c9b30e>`__
-   `#7814 <https://pagure.io/freeipa/issue/7814>`__
+   `#7814 <https://codeberg.org/freeipa/freeipa/issues/7814>`__
 -  Display all orphaned keys in automountlocation-tofiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/89ca5c8836333aece9caf2ac433ccab1140f909a>`__
-   `#7814 <https://pagure.io/freeipa/issue/7814>`__
+   `#7814 <https://codeberg.org/freeipa/freeipa/issues/7814>`__
 -  ipatests: test removing last KRA when it is not running
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ea8f8b68b5a7217518f68065a5fc1df16126314>`__
-   `#8397 <https://pagure.io/freeipa/issue/8397>`__
+   `#8397 <https://codeberg.org/freeipa/freeipa/issues/8397>`__
 -  Use new method in check to prevent removal of last KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b9adf1d8d5efb48e734650e4101e8816b01e1d3>`__
-   `#8397 <https://pagure.io/freeipa/issue/8397>`__
+   `#8397 <https://codeberg.org/freeipa/freeipa/issues/8397>`__
 -  Fall back to krbprincipalname when validating host auth indicators
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ad535b618d60fa016061212ff85d0ad28ccae59>`__
-   `#8206 <https://pagure.io/freeipa/issue/8206>`__
+   `#8206 <https://codeberg.org/freeipa/freeipa/issues/8206>`__
 -  Add SHA384withRSA as a certificate signing algorithm
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca8c7010e8aa0f87bde11c36947fefd549bae8fd>`__
-   `#8906 <https://pagure.io/freeipa/issue/8906>`__
+   `#8906 <https://codeberg.org/freeipa/freeipa/issues/8906>`__
 
 
 
@@ -479,7 +479,7 @@ Stanislav Levin (1)
 
 -  ipatests: Fix TestAJPSecretUpgrade tests on systems without pkiuser
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9bc471e063f2865d6423e4f1c9b81e73a45e43f>`__
-   `#8942 <https://pagure.io/freeipa/issue/8942>`__
+   `#8942 <https://codeberg.org/freeipa/freeipa/issues/8942>`__
 
 
 
@@ -488,7 +488,7 @@ Serhii Tsymbaliuk (1)
 
 -  WebUI: Improve subordinate ids user workflow
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f4b8982cd06011df8daac480a726637fc52649e>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__
 
 
 
@@ -498,4 +498,4 @@ Sudhir Menon (1)
 -  ipatests: Fix for
    test_source_ipahealthcheck_ipa_host_check_ipahostkeytab
    `commit <https://codeberg.org/freeipa/freeipa/commit/26be7ffdba87e0e6294ea035ab3dc9bd933fba43>`__
-   `#8889 <https://pagure.io/freeipa/issue/8889>`__
+   `#8889 <https://codeberg.org/freeipa/freeipa/issues/8889>`__

--- a/src/page/Releases/4.9.8.rst
+++ b/src/page/Releases/4.9.8.rst
@@ -198,117 +198,117 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#7885 <https://pagure.io/freeipa/issue/7885>`__
+-  `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
    (`rhbz#1690191 <https://bugzilla.redhat.com/show_bug.cgi?id=1690191>`__)
    RFE: wrapper for Dogtag cert-fix command
--  `#8353 <https://pagure.io/freeipa/issue/8353>`__ Sporadic: Nightly
+-  `#8353 <https://codeberg.org/freeipa/freeipa/issues/8353>`__ Sporadic: Nightly
    test failure in
    test_adtrust_install.py::TestIpaAdTrustInstall::test_add_agent_not_allowed
    - kinit: Password has expired while getting initial credentials
--  `#8397 <https://pagure.io/freeipa/issue/8397>`__
+-  `#8397 <https://codeberg.org/freeipa/freeipa/issues/8397>`__
    (`rhbz#1985069 <https://bugzilla.redhat.com/show_bug.cgi?id=1985069>`__)
    Cannot remove First master server with KRA after the server hard disk
    failed ( destructed)
--  `#8492 <https://pagure.io/freeipa/issue/8492>`__ RFE: Include the
+-  `#8492 <https://codeberg.org/freeipa/freeipa/issues/8492>`__ RFE: Include the
    server schema version in communication with the client
--  `#8687 <https://pagure.io/freeipa/issue/8687>`__
+-  `#8687 <https://codeberg.org/freeipa/freeipa/issues/8687>`__
    (`rhbz#1980356 <https://bugzilla.redhat.com/show_bug.cgi?id=1980356>`__)
    Nightly failure (rawhide/f34) reinstalling samba client: winbindd
    coredump
--  `#8700 <https://pagure.io/freeipa/issue/8700>`__ ipa-server-install
+-  `#8700 <https://codeberg.org/freeipa/freeipa/issues/8700>`__ ipa-server-install
    --auto-reverse does not create reverse DNS zone in Fedora 33
--  `#8755 <https://pagure.io/freeipa/issue/8755>`__
+-  `#8755 <https://codeberg.org/freeipa/freeipa/issues/8755>`__
    (`rhbz#1921007 <https://bugzilla.redhat.com/show_bug.cgi?id=1921007>`__)
    ipa-server-install : No such file or directory:
    '/etc/authselect/user-nsswitch.conf'
--  `#8815 <https://pagure.io/freeipa/issue/8815>`__ Nightly test failure
+-  `#8815 <https://codeberg.org/freeipa/freeipa/issues/8815>`__ Nightly test failure
    in new test test_ipa_cert_fix.py::TestCertFixReplica
--  `#8846 <https://pagure.io/freeipa/issue/8846>`__ Nightly test failure
+-  `#8846 <https://codeberg.org/freeipa/freeipa/issues/8846>`__ Nightly test failure
    in
    test_webui_policy::test_selinuxusermap::test_undo_refresh_reset_update_cancel
--  `#8932 <https://pagure.io/freeipa/issue/8932>`__ ipatests: move_date
+-  `#8932 <https://codeberg.org/freeipa/freeipa/issues/8932>`__ ipatests: move_date
    is defined twice
--  `#8953 <https://pagure.io/freeipa/issue/8953>`__
+-  `#8953 <https://codeberg.org/freeipa/freeipa/issues/8953>`__
    test_certmonger_ipa_responder_jsonrpc random failure
--  `#8954 <https://pagure.io/freeipa/issue/8954>`__ Issues in commands
+-  `#8954 <https://codeberg.org/freeipa/freeipa/issues/8954>`__ Issues in commands
    of \`schema\` plugin
--  `#8955 <https://pagure.io/freeipa/issue/8955>`__ Unstable
+-  `#8955 <https://codeberg.org/freeipa/freeipa/issues/8955>`__ Unstable
    fingerprints for the same API schema
--  `#8961 <https://pagure.io/freeipa/issue/8961>`__ [azure] inconsistent
+-  `#8961 <https://codeberg.org/freeipa/freeipa/issues/8961>`__ [azure] inconsistent
    results for \`Quick code style check\` and \`Lint\` tasks
--  `#8962 <https://pagure.io/freeipa/issue/8962>`__
+-  `#8962 <https://codeberg.org/freeipa/freeipa/issues/8962>`__
    (`rhbz#1966289 <https://bugzilla.redhat.com/show_bug.cgi?id=1966289>`__)
    Info about searchrecordslimit set search limit to 10,000 after
    upgrade
--  `#8965 <https://pagure.io/freeipa/issue/8965>`__
+-  `#8965 <https://codeberg.org/freeipa/freeipa/issues/8965>`__
    (`rhbz#2000261 <https://bugzilla.redhat.com/show_bug.cgi?id=2000261>`__)
    extdom: LDAP_INVALID_SYNTAX returned instead of LDAP_NO_SUCH_OBJECT
--  `#8966 <https://pagure.io/freeipa/issue/8966>`__ Invoke pkispawn with
+-  `#8966 <https://codeberg.org/freeipa/freeipa/issues/8966>`__ Invoke pkispawn with
    --log-file
--  `#8968 <https://pagure.io/freeipa/issue/8968>`__ Add URI records for
+-  `#8968 <https://codeberg.org/freeipa/freeipa/issues/8968>`__ Add URI records for
    KDC
--  `#8972 <https://pagure.io/freeipa/issue/8972>`__
+-  `#8972 <https://codeberg.org/freeipa/freeipa/issues/8972>`__
    (`rhbz#1998129 <https://bugzilla.redhat.com/show_bug.cgi?id=1998129>`__)
    AVC denied { read } comm="ipa-custodia" on aarch64 during
    installation of ipa-server
--  `#8974 <https://pagure.io/freeipa/issue/8974>`__
+-  `#8974 <https://codeberg.org/freeipa/freeipa/issues/8974>`__
    (`rhbz#1999142 <https://bugzilla.redhat.com/show_bug.cgi?id=1999142>`__)
    RHEL 8.5 IPA Replica setup fails against a RHEL 7.9 IPA server
--  `#8975 <https://pagure.io/freeipa/issue/8975>`__ Nightly test failure
+-  `#8975 <https://codeberg.org/freeipa/freeipa/issues/8975>`__ Nightly test failure
    in
    test_integration/test_commands.py/TestIPACommand/test_reset_password_unlock
--  `#8979 <https://pagure.io/freeipa/issue/8979>`__ Nightly test failure
+-  `#8979 <https://codeberg.org/freeipa/freeipa/issues/8979>`__ Nightly test failure
    (rawhide) in
    test_trust.py::TestTrust::test_establish_forest_trust_with_shared_secret
--  `#8980 <https://pagure.io/freeipa/issue/8980>`__ Nightly test failure
+-  `#8980 <https://codeberg.org/freeipa/freeipa/issues/8980>`__ Nightly test failure
    in pki-fedora/test_integration/test_backup_and_restore
--  `#8983 <https://pagure.io/freeipa/issue/8983>`__ [azure] tar
+-  `#8983 <https://codeberg.org/freeipa/freeipa/issues/8983>`__ [azure] tar
    sometimes fails on changed in process files
--  `#8984 <https://pagure.io/freeipa/issue/8984>`__
+-  `#8984 <https://codeberg.org/freeipa/freeipa/issues/8984>`__
    (`rhbz#1999992 <https://bugzilla.redhat.com/show_bug.cgi?id=1999992>`__)
    ipa migrate-ds command fails to warn when compat plugin is enabled
--  `#8985 <https://pagure.io/freeipa/issue/8985>`__ [azure] docs build
+-  `#8985 <https://codeberg.org/freeipa/freeipa/issues/8985>`__ [azure] docs build
    fails with Pygments 2.8.0+
--  `#8986 <https://pagure.io/freeipa/issue/8986>`__
+-  `#8986 <https://codeberg.org/freeipa/freeipa/issues/8986>`__
    (`rhbz#1999893 <https://bugzilla.redhat.com/show_bug.cgi?id=1999893>`__)
    ipa cert-request replaces user certificate instead of adding
--  `#8987 <https://pagure.io/freeipa/issue/8987>`__ Nightly test failure
+-  `#8987 <https://codeberg.org/freeipa/freeipa/issues/8987>`__ Nightly test failure
    in test_integration/test_trust.py/TestTrust/test_extdom_plugin
--  `#8989 <https://pagure.io/freeipa/issue/8989>`__ Nightly failure
+-  `#8989 <https://codeberg.org/freeipa/freeipa/issues/8989>`__ Nightly failure
    (rawhide) in tasks.run_ssh_cmd
--  `#8995 <https://pagure.io/freeipa/issue/8995>`__ Integrate SID
+-  `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__ Integrate SID
    configuration into base IPA installers
--  `#8999 <https://pagure.io/freeipa/issue/8999>`__ Nightly failure
+-  `#8999 <https://codeberg.org/freeipa/freeipa/issues/8999>`__ Nightly failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA::test_ipahealthcheck_ipaopensslchainvalidation
--  `#9000 <https://pagure.io/freeipa/issue/9000>`__ Nightly failure
+-  `#9000 <https://codeberg.org/freeipa/freeipa/issues/9000>`__ Nightly failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_sosreport_includes_healthcheck
--  `#9006 <https://pagure.io/freeipa/issue/9006>`__ Nightly failure in
+-  `#9006 <https://codeberg.org/freeipa/freeipa/issues/9006>`__ Nightly failure in
    test_commands.py::TestIPACommand::test_cacert_manage
--  `#9008 <https://pagure.io/freeipa/issue/9008>`__ [azure] clone3 and
+-  `#9008 <https://codeberg.org/freeipa/freeipa/issues/9008>`__ [azure] clone3 and
    glibc 2.34 in container
--  `#9009 <https://pagure.io/freeipa/issue/9009>`__ Nightly failure
+-  `#9009 <https://codeberg.org/freeipa/freeipa/issues/9009>`__ Nightly failure
    (rawhide) in webui_tests: yaml.load() now requires Loader
--  `#9011 <https://pagure.io/freeipa/issue/9011>`__ [azure] pip's
+-  `#9011 <https://codeberg.org/freeipa/freeipa/issues/9011>`__ [azure] pip's
    builddir
--  `#9013 <https://pagure.io/freeipa/issue/9013>`__ [ipatests]
+-  `#9013 <https://codeberg.org/freeipa/freeipa/issues/9013>`__ [ipatests]
    test_external_ca.py::TestMultipleExternalCA::test_master_install_ca1
    fails
--  `#9026 <https://pagure.io/freeipa/issue/9026>`__
+-  `#9026 <https://codeberg.org/freeipa/freeipa/issues/9026>`__
    (`rhbz#2020207 <https://bugzilla.redhat.com/show_bug.cgi?id=2020207>`__)
    Missing bind-pkcs11-utils causing failures in OpenDNSSec
--  `#9029 <https://pagure.io/freeipa/issue/9029>`__ Nightly webui test
+-  `#9029 <https://codeberg.org/freeipa/freeipa/issues/9029>`__ Nightly webui test
    failure (rawhide): selenium issue
--  `#9031 <https://pagure.io/freeipa/issue/9031>`__ Harden FreeIPA KDC
+-  `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__ Harden FreeIPA KDC
    processing of PAC buffers
--  `#9036 <https://pagure.io/freeipa/issue/9036>`__
+-  `#9036 <https://codeberg.org/freeipa/freeipa/issues/9036>`__
    (`rhbz#2009114 <https://bugzilla.redhat.com/show_bug.cgi?id=2009114>`__)
    Invalid PTR records created when navigated from host details page
--  `#9038 <https://pagure.io/freeipa/issue/9038>`__
+-  `#9038 <https://codeberg.org/freeipa/freeipa/issues/9038>`__
    (`rhbz#1825010 <https://bugzilla.redhat.com/show_bug.cgi?id=1825010>`__)
    Concerns regarding 'ipa pwpolicy-mod --minlife 24 --maxlife 1'
--  `#9046 <https://pagure.io/freeipa/issue/9046>`__ Stacktrace when
+-  `#9046 <https://codeberg.org/freeipa/freeipa/issues/9046>`__ Stacktrace when
    using 'ipa server-del' in non-English locale
 
 
@@ -323,7 +323,7 @@ Armando Neto (2)
 
 -  ipatests: Fix UI_driver method after Selenium upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb5ef716070cb564b3455ddf7a6656de5e228d0e>`__
-   `#9029 <https://pagure.io/freeipa/issue/9029>`__
+   `#9029 <https://codeberg.org/freeipa/freeipa/issues/9029>`__
 -  ipatests: Bump PR-CI latest templates to Fedora 35
    `commit <https://codeberg.org/freeipa/freeipa/commit/d97250fac563c4a41dc0c4dddc84502c0af16ff6>`__
 
@@ -334,41 +334,41 @@ Alexander Bokovoy (12)
 
 -  freeipa.spec.in: -server subpackage should require samba-client-libs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c850cd52dcee8d2e5107af5ddf33e79b4e33527f>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: validate domain SID in incoming PAC for trusted domains for
    S4U
    `commit <https://codeberg.org/freeipa/freeipa/commit/5213c1e42cdedf4a862bf7173d7c632d0c1460b5>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: honor SID from the host or service entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/a95ccd908f9e04375380f5dba1110f6c55a93638>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  SMB: switch IPA domain controller role
    `commit <https://codeberg.org/freeipa/freeipa/commit/693c165ce83df9e21a4928cde64bdea9f997d1a6>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: Use proper account flags for Kerberos principal in PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/adf5ab7344b810106cb4b493c798af597d14a080>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: add PAC_ATTRIBUTES_INFO PAC buffer support
    `commit <https://codeberg.org/freeipa/freeipa/commit/b71467e2fe5942688d2d988999340ef398b97a29>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: add support for PAC_REQUESTER_SID buffer
    `commit <https://codeberg.org/freeipa/freeipa/commit/879ef1b1a69ed187fcfa8fff007ab95ec72a1a65>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: add support for PAC_UPN_DNS_INFO_EX
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cafdac1dfbd95087c3d0510cbf2638fc31c4d94>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: S4U2Proxy target should use a service name without realm
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b5e496101963c7059fac2a4a5c8b5e15ad9f726>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: use entry DN to compare aliased entries in S4U operations
    `commit <https://codeberg.org/freeipa/freeipa/commit/eb5a93ddbe0ab17c36d5c78e5c0fcf020745484a>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: enforce SID checks when generating PAC
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ecbdd8e5968b1b4033bedb90fccdd0f05720b40>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: store SID in the principal entry
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ded98b66ed62a2edc7b27c02e0b94a6e6fa8ae9>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 
 
 
@@ -391,7 +391,7 @@ Christian Heimes (1)
 
 -  Add URI system records for KDC
    `commit <https://codeberg.org/freeipa/freeipa/commit/2cf0ad5cfd2d558c844bc9640c121fa35ebb1c30>`__
-   `#8968 <https://pagure.io/freeipa/issue/8968>`__
+   `#8968 <https://codeberg.org/freeipa/freeipa/issues/8968>`__
 
 
 
@@ -400,7 +400,7 @@ Chris Kelley (1)
 
 -  Make Dogtag return XML for ipa cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbda3590bb20a2915261f2fd9b8a8e0b169f93f4>`__
-   `#8980 <https://pagure.io/freeipa/issue/8980>`__
+   `#8980 <https://codeberg.org/freeipa/freeipa/issues/8980>`__
 
 
 
@@ -409,7 +409,7 @@ Endi Sukma Dewata (1)
 
 -  Specify PKI installation log paths
    `commit <https://codeberg.org/freeipa/freeipa/commit/5abf1bc79f8b32c6638ff98fbe2e4a8dec9a5010>`__
-   `#8966 <https://pagure.io/freeipa/issue/8966>`__
+   `#8966 <https://codeberg.org/freeipa/freeipa/issues/8966>`__
 
 
 
@@ -418,15 +418,15 @@ François Cami (6)
 
 -  freeipa.spec: depend on bind-dnssec-utils
    `commit <https://codeberg.org/freeipa/freeipa/commit/f89d59b6e18b54967682f6a37ce92ae67ab3fcda>`__
-   `#9026 <https://pagure.io/freeipa/issue/9026>`__
+   `#9026 <https://codeberg.org/freeipa/freeipa/issues/9026>`__
 -  pwpolicy: change lifetime error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/76afa643f4afd0167fd670142aa70369d91d7af2>`__
-   `#9038 <https://pagure.io/freeipa/issue/9038>`__
+   `#9038 <https://codeberg.org/freeipa/freeipa/issues/9038>`__
 -  subid: subid-match: display the owner's ID not DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/4785a90946ec694ccc082f062b2181b23c7099e3>`__
 -  ipatests: refactor test_ipa_cert_fix with tasks
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a3a15f45aad016730252c09e3e173a18184603e>`__
-   `#8932 <https://pagure.io/freeipa/issue/8932>`__
+   `#8932 <https://codeberg.org/freeipa/freeipa/issues/8932>`__
 -  freeipa.spec.in: update 389-DS version
    `commit <https://codeberg.org/freeipa/freeipa/commit/210c53dd41a85b7619eb7a2ad427055c994ee1e5>`__
 -  Back to git snapshots
@@ -439,85 +439,85 @@ Florence Blanc-Renaud (27)
 
 -  ipatests: remove xfail on f35+ for test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9c080734cb533d7a494b7259ac8d1ef89394d2c>`__
-   `#8700 <https://pagure.io/freeipa/issue/8700>`__
+   `#8700 <https://codeberg.org/freeipa/freeipa/issues/8700>`__
 -  ipatests: mark test_installation_TestInstallWithCA_DNS3 as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/8ca5b094f829f47b0629301c23818096a5834609>`__
-   `#8700 <https://pagure.io/freeipa/issue/8700>`__
+   `#8700 <https://codeberg.org/freeipa/freeipa/issues/8700>`__
 -  ipatests: fix get_user_result method
    `commit <https://codeberg.org/freeipa/freeipa/commit/421e12468d3ebaf8e259789bdba173a785c9e5d4>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipatests: update the expected output of user-add cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/009a8cdfcba78ab6153e132ef653792018e1662b>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  User plugin: do not return the SID on user creation
    `commit <https://codeberg.org/freeipa/freeipa/commit/61f42aefe35d60432d5542ed5fa3f546e6d71f0b>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  Webui tests: new idrange now requires base RID
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c7e8c669740528812a06f9af73fe927313270c9>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipatests: backup-reinstall-restore needs to clear sssd cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6fd0d00bacf56f1c3bffb2674042058a4608f10>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  User lifecycle: ignore SID when moving from preserved to staged
    `commit <https://codeberg.org/freeipa/freeipa/commit/86d1683e0966a5d33e570b9cc2bb032e9af98bf0>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipatests: adapt expected output with SID
    `commit <https://codeberg.org/freeipa/freeipa/commit/efc9df086725a151e15fc93b7550bc01df8d1151>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipatests: interactive install prompts for netbios name
    `commit <https://codeberg.org/freeipa/freeipa/commit/31d095eac1aa7158761de29aa4f3c42604e83f17>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipatests: add test ensuring SIDs are generated for new installs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5bb56f910c39b3db762b6802a6dfaa25a0e77c76>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipa config: add --enable-sid option
    `commit <https://codeberg.org/freeipa/freeipa/commit/b98ecabba196107c692825e081fd1c7a6123c2aa>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  adtrust install: define constants for rid bases
    `commit <https://codeberg.org/freeipa/freeipa/commit/a91e6712e80a19070cb9f201b2d2f15ac8b28ff4>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  Installers: configure sid generation in server/replica installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/e527857d000e558b3288a7a210400abaf2171237>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  SID generation: define SIDInstallInterface
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd07db29eec92b421569a194a1d2294852cd6a5c>`__
-   `#8995 <https://pagure.io/freeipa/issue/8995>`__
+   `#8995 <https://codeberg.org/freeipa/freeipa/issues/8995>`__
 -  ipa-server-install uninstall: remove tdb files
    `commit <https://codeberg.org/freeipa/freeipa/commit/6302769b83af75f267c76fe6f854d5b42b6b80f5>`__
-   `#8687 <https://pagure.io/freeipa/issue/8687>`__
+   `#8687 <https://codeberg.org/freeipa/freeipa/issues/8687>`__
 -  ipa-client-samba uninstall: remove tdb files
    `commit <https://codeberg.org/freeipa/freeipa/commit/82eaa2eac454aed75a498d2c6ccd9e921f9c8a89>`__
-   `#8687 <https://pagure.io/freeipa/issue/8687>`__
+   `#8687 <https://codeberg.org/freeipa/freeipa/issues/8687>`__
 -  ipatests: Update the subca used in TestIPACommand::test_cacert_manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/34d6f51fb8ddc97d21470db9a638386127c4c581>`__
-   `#9006 <https://pagure.io/freeipa/issue/9006>`__
+   `#9006 <https://codeberg.org/freeipa/freeipa/issues/9006>`__
 -  webui test: close notification after selinux user map update
    `commit <https://codeberg.org/freeipa/freeipa/commit/b706483c827a971aeae855199b9d4ce6005e53b1>`__
-   `#8846 <https://pagure.io/freeipa/issue/8846>`__
+   `#8846 <https://codeberg.org/freeipa/freeipa/issues/8846>`__
 -  ipatests: increase sosreport verbosity
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc384b0773c92e1743152b6c04af12b0f17e842b>`__
-   `#9000 <https://pagure.io/freeipa/issue/9000>`__
+   `#9000 <https://codeberg.org/freeipa/freeipa/issues/9000>`__
 -  ipatests: update expected error message for openssl verify
    `commit <https://codeberg.org/freeipa/freeipa/commit/01dfce68d97f373c92dd82e355392e5123df8f07>`__
-   `#8999 <https://pagure.io/freeipa/issue/8999>`__
+   `#8999 <https://codeberg.org/freeipa/freeipa/issues/8999>`__
 -  ipatests: fix expected msg in tasks.run_ssh_cmd
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef58efe7e4c3f8ed3e31623035eba2a3bdba6e46>`__
-   `#8989 <https://pagure.io/freeipa/issue/8989>`__
+   `#8989 <https://codeberg.org/freeipa/freeipa/issues/8989>`__
 -  ipatests: fix logic waiting for repl in TestIPACommand
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f569c68cde408865389c61f9befb2ea23bd6d30>`__
-   `#8975 <https://pagure.io/freeipa/issue/8975>`__
+   `#8975 <https://codeberg.org/freeipa/freeipa/issues/8975>`__
 -  migrate-ds: workaround to detect compat tree
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c4f9e7347965ff9a887147df34e720224ffa7cc>`__
-   `#8984 <https://pagure.io/freeipa/issue/8984>`__
+   `#8984 <https://codeberg.org/freeipa/freeipa/issues/8984>`__
 -  ipatests: rpcclient now uses --use-kerberos=desired
    `commit <https://codeberg.org/freeipa/freeipa/commit/395b0d26d0b042d5384bc8e7272f0121db0989ed>`__
-   `#8979 <https://pagure.io/freeipa/issue/8979>`__
+   `#8979 <https://codeberg.org/freeipa/freeipa/issues/8979>`__
 -  selinux policy: allow custodia to access /proc/cpuinfo
    `commit <https://codeberg.org/freeipa/freeipa/commit/07e2bf732f54f936cccc4e0c7b468d77f97e911a>`__
-   `#8972 <https://pagure.io/freeipa/issue/8972>`__
+   `#8972 <https://codeberg.org/freeipa/freeipa/issues/8972>`__
 -  ipatests: use whole date for journalctl --since
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5036b5ce9ae4fab011e57fe2b37a35fdd098a70>`__
-   `#8953 <https://pagure.io/freeipa/issue/8953>`__
+   `#8953 <https://codeberg.org/freeipa/freeipa/issues/8953>`__
 
 
 
@@ -526,7 +526,7 @@ Jochen Kellner (1)
 
 -  Remove duplicate \_() in the error path
    `commit <https://codeberg.org/freeipa/freeipa/commit/1660cfa3d2ec4a27c0456b3545a40eadbae45cfb>`__
-   `#9046 <https://pagure.io/freeipa/issue/9046>`__
+   `#9046 <https://codeberg.org/freeipa/freeipa/issues/9046>`__
 
 
 
@@ -535,7 +535,7 @@ Michal Polovka (1)
 
 -  ipatests: webui: Specify configuration loader
    `commit <https://codeberg.org/freeipa/freeipa/commit/17ba2732f90a69b860f70662133e6904d7373b04>`__
-   `#9009 <https://pagure.io/freeipa/issue/9009>`__
+   `#9009 <https://codeberg.org/freeipa/freeipa/issues/9009>`__
 
 
 
@@ -548,10 +548,10 @@ Mohammad Rizwan (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b38afc0487efde57f04cf4a8c15f03be46971f3>`__
 -  ipatests: wait while http/ldap/pkinit cert get renew on replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/a620e5e9e152defe144705913521c3cf556faa0e>`__
-   `#8815 <https://pagure.io/freeipa/issue/8815>`__
+   `#8815 <https://codeberg.org/freeipa/freeipa/issues/8815>`__
 -  ipatests: test to renew certs on replica using ipa-cert-fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0aef5296b66c0b460f7e10993610fe68b312241>`__
-   `#7885 <https://pagure.io/freeipa/issue/7885>`__
+   `#7885 <https://codeberg.org/freeipa/freeipa/issues/7885>`__
 
 
 
@@ -568,10 +568,10 @@ Petr Voborník (2)
 
 -  webui tests: remove unnecessary code in add_record
    `commit <https://codeberg.org/freeipa/freeipa/commit/a286cd31ec031e07b4d196715ae501f873a4bde2>`__
-   `#9036 <https://pagure.io/freeipa/issue/9036>`__
+   `#9036 <https://codeberg.org/freeipa/freeipa/issues/9036>`__
 -  fix(webui): create correct PTR record when navigated from host page
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f5ed837b43d378ed9e003c279e311656b1773ab>`__
-   `#9036 <https://pagure.io/freeipa/issue/9036>`__
+   `#9036 <https://codeberg.org/freeipa/freeipa/issues/9036>`__
 
 
 
@@ -580,25 +580,25 @@ Rob Crittenden (7)
 
 -  Don't limit role-find by hostname when searching for last KRA
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c66226e83bb8797122d3925b555516201edb8bd>`__
-   `#8397 <https://pagure.io/freeipa/issue/8397>`__
+   `#8397 <https://codeberg.org/freeipa/freeipa/issues/8397>`__
 -  Make the schema cache TTL user-configurable
    `commit <https://codeberg.org/freeipa/freeipa/commit/331cadd8f25ab627fc419c48f2db6cc9cafafe40>`__
-   `#8492 <https://pagure.io/freeipa/issue/8492>`__
+   `#8492 <https://codeberg.org/freeipa/freeipa/issues/8492>`__
 -  On redhat-based platforms rely on authselect to enable sudo
    `commit <https://codeberg.org/freeipa/freeipa/commit/c1baae842529d89b7fda78ace5ffcff165a995ce>`__
-   `#8755 <https://pagure.io/freeipa/issue/8755>`__
+   `#8755 <https://codeberg.org/freeipa/freeipa/issues/8755>`__
 -  ipatests: Test that a user can be issued multiple certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/86588640137562b2016fdb0f91142d00bc38e54a>`__
-   `#8986 <https://pagure.io/freeipa/issue/8986>`__
+   `#8986 <https://codeberg.org/freeipa/freeipa/issues/8986>`__
 -  Don't store entries with a usercertificate in the LDAP cache
    `commit <https://codeberg.org/freeipa/freeipa/commit/be1e3bbfc13aff9a583108376f245b81cc3666fb>`__
-   `#8986 <https://pagure.io/freeipa/issue/8986>`__
+   `#8986 <https://codeberg.org/freeipa/freeipa/issues/8986>`__
 -  Increase default limit on LDAP searches to 100k
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fb0f5333613beabeead3feb73dc0fea9694bcdc>`__
-   `#8962 <https://pagure.io/freeipa/issue/8962>`__
+   `#8962 <https://codeberg.org/freeipa/freeipa/issues/8962>`__
 -  Catch and log errors when adding CA profiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6e708ab4006d6623c37de1692de5362fcdb5dd6>`__
-   `#8974 <https://pagure.io/freeipa/issue/8974>`__
+   `#8974 <https://codeberg.org/freeipa/freeipa/issues/8974>`__
 
 
 
@@ -607,7 +607,7 @@ Sumit Bose (1)
 
 -  extdom: return LDAP_NO_SUCH_OBJECT if domains differ
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fca95751ca32a1ed16a6d8a4e557c5799ec5c78>`__
-   `#8965 <https://pagure.io/freeipa/issue/8965>`__
+   `#8965 <https://codeberg.org/freeipa/freeipa/issues/8965>`__
 
 
 
@@ -616,50 +616,50 @@ Stanislav Levin (15)
 
 -  ipatests: TestMultipleExternalCA: Create tempfiles on remote host
    `commit <https://codeberg.org/freeipa/freeipa/commit/7480844765e029ccb5e7149059efd4c56e400982>`__
-   `#9013 <https://pagure.io/freeipa/issue/9013>`__
+   `#9013 <https://codeberg.org/freeipa/freeipa/issues/9013>`__
 -  azure: Don't customize pip's builddir
    `commit <https://codeberg.org/freeipa/freeipa/commit/8dd788daf9fbf694754771082db9ee1d7f64fef0>`__
-   `#9011 <https://pagure.io/freeipa/issue/9011>`__
+   `#9011 <https://codeberg.org/freeipa/freeipa/issues/9011>`__
 -  seccomp profile: Default to ENOSYS instead of EPERM
    `commit <https://codeberg.org/freeipa/freeipa/commit/488fb1049397c3adc10a2b80737374cff5a87af4>`__
-   `#9008 <https://pagure.io/freeipa/issue/9008>`__
+   `#9008 <https://codeberg.org/freeipa/freeipa/issues/9008>`__
 -  test_schema_plugin: Add missing tests for command, class and topic
    commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/973334c9fc247ce6334bcd67f5cd9c3c6b35c660>`__
-   `#8954 <https://pagure.io/freeipa/issue/8954>`__
+   `#8954 <https://codeberg.org/freeipa/freeipa/issues/8954>`__
 -  test_schema_plugin: Drop dependency on Tracker
    `commit <https://codeberg.org/freeipa/freeipa/commit/83405a75c2496c8728f9560823738f8ad51cdc33>`__
-   `#8954 <https://pagure.io/freeipa/issue/8954>`__
+   `#8954 <https://codeberg.org/freeipa/freeipa/issues/8954>`__
 -  command_defaults: Don't crash on nonexistent command
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4839b048040877cc7d780d2d98b25233db62537>`__
-   `#8954 <https://pagure.io/freeipa/issue/8954>`__
+   `#8954 <https://codeberg.org/freeipa/freeipa/issues/8954>`__
 -  schema plugin: Fix commands without metaobject arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f7300732f1be90bfb736a8ec3e5fb58c8ce288>`__
-   `#8954 <https://pagure.io/freeipa/issue/8954>`__
+   `#8954 <https://codeberg.org/freeipa/freeipa/issues/8954>`__
 -  ipatests: Log debug messages for locator plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/12ebc658a8bcde3cf5a9665e10981f822fa00dad>`__
-   `#8353 <https://pagure.io/freeipa/issue/8353>`__
+   `#8353 <https://codeberg.org/freeipa/freeipa/issues/8353>`__
 -  krb5: Pin kpasswd server to a primary one
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fcc0f077bc24e0c7d0c7434fbd4e91372021217>`__
-   `#8353 <https://pagure.io/freeipa/issue/8353>`__
+   `#8353 <https://codeberg.org/freeipa/freeipa/issues/8353>`__
 -  azure: Ignore tar errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfe94640ed8befbf29e3c35f0cb57e702211ef44>`__
-   `#8983 <https://pagure.io/freeipa/issue/8983>`__
+   `#8983 <https://codeberg.org/freeipa/freeipa/issues/8983>`__
 -  docs: Make use of \`text\` highlighting
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1343e8f539679227c8dbfb58ba634810d3857da>`__
-   `#8985 <https://pagure.io/freeipa/issue/8985>`__
+   `#8985 <https://codeberg.org/freeipa/freeipa/issues/8985>`__
 -  ipatests: Add tests for \`schema\` Command
    `commit <https://codeberg.org/freeipa/freeipa/commit/14ad52238543ab845a8d6dadd65ff2fb6e67d8df>`__
-   `#8955 <https://pagure.io/freeipa/issue/8955>`__
+   `#8955 <https://codeberg.org/freeipa/freeipa/issues/8955>`__
 -  schema plugin: Generate stable fingerprint
    `commit <https://codeberg.org/freeipa/freeipa/commit/939d0f5df67aa39cd31f68a6da4153460066ca66>`__
-   `#8955 <https://pagure.io/freeipa/issue/8955>`__
+   `#8955 <https://codeberg.org/freeipa/freeipa/issues/8955>`__
 -  pycodestyle: Check \*.in Python files
    `commit <https://codeberg.org/freeipa/freeipa/commit/31afc004bc034f3170247d4c7ccd3a7cc0d32551>`__
-   `#8961 <https://pagure.io/freeipa/issue/8961>`__
+   `#8961 <https://codeberg.org/freeipa/freeipa/issues/8961>`__
 -  Azure: Run pycodestyle check in Lint job
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b359fbdef8174b9f53d4af0770a6a2e72198e3b>`__
-   `#8961 <https://pagure.io/freeipa/issue/8961>`__
+   `#8961 <https://codeberg.org/freeipa/freeipa/issues/8961>`__
 
 
 
@@ -671,7 +671,7 @@ Sergey Orlov (2)
 -  ipatests: check for message in sssd log only during actual test
    action
    `commit <https://codeberg.org/freeipa/freeipa/commit/e60076690cc02105d4a6abd9afb6aba5dd70b6bd>`__
-   `#8987 <https://pagure.io/freeipa/issue/8987>`__
+   `#8987 <https://codeberg.org/freeipa/freeipa/issues/8987>`__
 
 
 

--- a/src/page/Releases/4.9.9.rst
+++ b/src/page/Releases/4.9.9.rst
@@ -76,144 +76,144 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#6524 <https://pagure.io/freeipa/issue/6524>`__ Vault key archival
+-  `#6524 <https://codeberg.org/freeipa/freeipa/issues/6524>`__ Vault key archival
    using AES
--  `#7671 <https://pagure.io/freeipa/issue/7671>`__ Remove --no-sssd and
+-  `#7671 <https://codeberg.org/freeipa/freeipa/issues/7671>`__ Remove --no-sssd and
    --noac options
--  `#8001 <https://pagure.io/freeipa/issue/8001>`__ Need default
+-  `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__ Need default
    authentication indicators for SPAKE, PKINIT and encrypted challenge
    preauth
--  `#8361 <https://pagure.io/freeipa/issue/8361>`__ Add support for
+-  `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__ Add support for
    managing subuids and subgids in FreeIPA
--  `#8506 <https://pagure.io/freeipa/issue/8506>`__
+-  `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
    (`rhbz#1930038 <https://bugzilla.redhat.com/show_bug.cgi?id=1930038>`__)
    Nightly failure in ipa-server-install --uninstall:
    org.freedesktop.DBus.Error.NoReply
--  `#8582 <https://pagure.io/freeipa/issue/8582>`__ Nightly test failure
+-  `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__ Nightly test failure
    in
    test_replica_promotion.py::TestHiddenReplicaPromotion::test_ipahealthcheck_hidden_replica
    - ClonesConnectivyAndDataCheck
--  `#8605 <https://pagure.io/freeipa/issue/8605>`__
+-  `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
    (`rhbz#1903250 <https://bugzilla.redhat.com/show_bug.cgi?id=1903250>`__)
    backtrace using ipa-replica-manage
--  `#8807 <https://pagure.io/freeipa/issue/8807>`__
+-  `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
    (`rhbz#1688267 <https://bugzilla.redhat.com/show_bug.cgi?id=1688267>`__)
    [RFE] IPA to allow setting a new range type.
--  `#8865 <https://pagure.io/freeipa/issue/8865>`__ [Tracker]
+-  `#8865 <https://codeberg.org/freeipa/freeipa/issues/8865>`__ [Tracker]
    ipa-replica-install fails on 2nd run (f35+)
--  `#8899 <https://pagure.io/freeipa/issue/8899>`__
+-  `#8899 <https://codeberg.org/freeipa/freeipa/issues/8899>`__
    (`rhbz#2061957 <https://bugzilla.redhat.com/show_bug.cgi?id=2061957>`__)
    healthcheck 0.9 warns about permissions of /var/log/ipaupgrade.log
--  `#8906 <https://pagure.io/freeipa/issue/8906>`__
+-  `#8906 <https://codeberg.org/freeipa/freeipa/issues/8906>`__
    (`rhbz#1731484 <https://bugzilla.redhat.com/show_bug.cgi?id=1731484>`__)
    support for SHA384withRSA signing algo missing
--  `#8962 <https://pagure.io/freeipa/issue/8962>`__
+-  `#8962 <https://codeberg.org/freeipa/freeipa/issues/8962>`__
    (`rhbz#1966289 <https://bugzilla.redhat.com/show_bug.cgi?id=1966289>`__)
    Info about searchrecordslimit set search limit to 10,000 after
    upgrade
--  `#9004 <https://pagure.io/freeipa/issue/9004>`__ Can't use --delattr
+-  `#9004 <https://codeberg.org/freeipa/freeipa/issues/9004>`__ Can't use --delattr
    with a date value
--  `#9009 <https://pagure.io/freeipa/issue/9009>`__ Nightly failure
+-  `#9009 <https://codeberg.org/freeipa/freeipa/issues/9009>`__ Nightly failure
    (rawhide) in webui_tests: yaml.load() now requires Loader
--  `#9014 <https://pagure.io/freeipa/issue/9014>`__
+-  `#9014 <https://codeberg.org/freeipa/freeipa/issues/9014>`__
    'init/tmpfilesd/ipa.conf.in' hardcodes apache group
--  `#9024 <https://pagure.io/freeipa/issue/9024>`__ Nightly failure
+-  `#9024 <https://codeberg.org/freeipa/freeipa/issues/9024>`__ Nightly failure
    (updates-testing) in test_fips.py::TestInstallFIPS
--  `#9031 <https://pagure.io/freeipa/issue/9031>`__ Harden FreeIPA KDC
+-  `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__ Harden FreeIPA KDC
    processing of PAC buffers
--  `#9038 <https://pagure.io/freeipa/issue/9038>`__
+-  `#9038 <https://codeberg.org/freeipa/freeipa/issues/9038>`__
    (`rhbz#1825010 <https://bugzilla.redhat.com/show_bug.cgi?id=1825010>`__)
    Concerns regarding 'ipa pwpolicy-mod --minlife 24 --maxlife 1'
--  `#9044 <https://pagure.io/freeipa/issue/9044>`__ Random nightly
+-  `#9044 <https://codeberg.org/freeipa/freeipa/issues/9044>`__ Random nightly
    failure in
    test_otp.py::TestOTPToken::test_check_otpd_after_idle_timeout
--  `#9047 <https://pagure.io/freeipa/issue/9047>`__ Add automation for
+-  `#9047 <https://codeberg.org/freeipa/freeipa/issues/9047>`__ Add automation for
    ipa-replica-conncheck in upstream tests
--  `#9051 <https://pagure.io/freeipa/issue/9051>`__ Nightly test failure
+-  `#9051 <https://codeberg.org/freeipa/freeipa/issues/9051>`__ Nightly test failure
    (selinux/updates-testing) in ipa-restore
--  `#9052 <https://pagure.io/freeipa/issue/9052>`__ Nightly test failure
+-  `#9052 <https://codeberg.org/freeipa/freeipa/issues/9052>`__ Nightly test failure
    (updates-testing) in test_ipa_cert_fix.py::TestCertFixReplica
    teardown
--  `#9054 <https://pagure.io/freeipa/issue/9054>`__ [ipatests]
+-  `#9054 <https://codeberg.org/freeipa/freeipa/issues/9054>`__ [ipatests]
    ipa-healthcheck and URI RRs
--  `#9063 <https://pagure.io/freeipa/issue/9063>`__
+-  `#9063 <https://codeberg.org/freeipa/freeipa/issues/9063>`__
    (`rhbz#2031825 <https://bugzilla.redhat.com/show_bug.cgi?id=2031825>`__)
    Changing default pac type to 'nfs:NONE and MS-PAC' doesnot display
    error 'ipa: ERROR: no modifications to be performed'
--  `#9065 <https://pagure.io/freeipa/issue/9065>`__
+-  `#9065 <https://codeberg.org/freeipa/freeipa/issues/9065>`__
    (`rhbz#2033342 <https://bugzilla.redhat.com/show_bug.cgi?id=2033342>`__)
    Can't log in after ipa user-mod USER --user-auth-type=hardened
--  `#9067 <https://pagure.io/freeipa/issue/9067>`__ Nightly test failure
+-  `#9067 <https://codeberg.org/freeipa/freeipa/issues/9067>`__ Nightly test failure
    (rawhide) in
    test_nfs.py::TestIpaClientAutomountFileRestore::test_nsswitch_backup_restore_sssd
--  `#9068 <https://pagure.io/freeipa/issue/9068>`__ --desc in
+-  `#9068 <https://codeberg.org/freeipa/freeipa/issues/9068>`__ --desc in
    automember-default-group-set and automember-default-group-remove
--  `#9069 <https://pagure.io/freeipa/issue/9069>`__ Nightly test failure
+-  `#9069 <https://codeberg.org/freeipa/freeipa/issues/9069>`__ Nightly test failure
    (updates-testing) in test_winsyncmigrate.py::TestWinsyncMigrate
--  `#9080 <https://pagure.io/freeipa/issue/9080>`__
+-  `#9080 <https://codeberg.org/freeipa/freeipa/issues/9080>`__
    (`rhbz#2032701 <https://bugzilla.redhat.com/show_bug.cgi?id=2032701>`__)
    Build against OpenLDAP 2.6
--  `#9083 <https://pagure.io/freeipa/issue/9083>`__ Support MIT Kerberos
+-  `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__ Support MIT Kerberos
    KDB version 9
--  `#9084 <https://pagure.io/freeipa/issue/9084>`__ ipa-client-automount
+-  `#9084 <https://codeberg.org/freeipa/freeipa/issues/9084>`__ ipa-client-automount
    --no-sssd broken with authselect 1.3.0
--  `#9085 <https://pagure.io/freeipa/issue/9085>`__ ipa-client-install
+-  `#9085 <https://codeberg.org/freeipa/freeipa/issues/9085>`__ ipa-client-install
    fails if pre-existing NIS domain contains a "%"
--  `#9087 <https://pagure.io/freeipa/issue/9087>`__ cifs mounts fails
+-  `#9087 <https://codeberg.org/freeipa/freeipa/issues/9087>`__ cifs mounts fails
    with error: cifs filesystem not supported by the system
--  `#9095 <https://pagure.io/freeipa/issue/9095>`__ After ipa-restore, a
+-  `#9095 <https://codeberg.org/freeipa/freeipa/issues/9095>`__ After ipa-restore, a
    hidden server is not made visible
--  `#9096 <https://pagure.io/freeipa/issue/9096>`__ Nightly test failure
+-  `#9096 <https://codeberg.org/freeipa/freeipa/issues/9096>`__ Nightly test failure
    in testing_master_pki: certificate not retrieved on replica
--  `#9099 <https://pagure.io/freeipa/issue/9099>`__
+-  `#9099 <https://codeberg.org/freeipa/freeipa/issues/9099>`__
    (`rhbz#2049167 <https://bugzilla.redhat.com/show_bug.cgi?id=2049167>`__)
    KRA GetStatus service blocked by IPA proxy
--  `#9100 <https://pagure.io/freeipa/issue/9100>`__
+-  `#9100 <https://codeberg.org/freeipa/freeipa/issues/9100>`__
    (`rhbz#2022483 <https://bugzilla.redhat.com/show_bug.cgi?id=2022483>`__)
    Unable to join RHEL 8.5 Replica to RHEL 7.9 Master for migration
    purposes
--  `#9101 <https://pagure.io/freeipa/issue/9101>`__
+-  `#9101 <https://codeberg.org/freeipa/freeipa/issues/9101>`__
    (`rhbz#2032806 <https://bugzilla.redhat.com/show_bug.cgi?id=2032806>`__)
    Error replacing a replica with CentOS Stream 9
--  `#9103 <https://pagure.io/freeipa/issue/9103>`__
+-  `#9103 <https://codeberg.org/freeipa/freeipa/issues/9103>`__
    (`rhbz#2048558 <https://bugzilla.redhat.com/show_bug.cgi?id=2048558>`__)
    ipa-join tests are failing due to changes in expected output
--  `#9106 <https://pagure.io/freeipa/issue/9106>`__
+-  `#9106 <https://codeberg.org/freeipa/freeipa/issues/9106>`__
    (`rhbz#2050921 <https://bugzilla.redhat.com/show_bug.cgi?id=2050921>`__)
    Nightly failure (rawhide) when calling kinit admin
--  `#9107 <https://pagure.io/freeipa/issue/9107>`__
+-  `#9107 <https://codeberg.org/freeipa/freeipa/issues/9107>`__
    (`rhbz#2051575 <https://bugzilla.redhat.com/show_bug.cgi?id=2051575>`__)
    Enable ipa-ccache-sweep.timer during server installation
--  `#9108 <https://pagure.io/freeipa/issue/9108>`__ ipatests: remove
+-  `#9108 <https://codeberg.org/freeipa/freeipa/issues/9108>`__ ipatests: remove
    additional check for failed units.
--  `#9110 <https://pagure.io/freeipa/issue/9110>`__
+-  `#9110 <https://codeberg.org/freeipa/freeipa/issues/9110>`__
    (`rhbz#2032738 <https://bugzilla.redhat.com/show_bug.cgi?id=2032738>`__)
    IPA LDAP plugin ipa-cldap memory leak
--  `#9111 <https://pagure.io/freeipa/issue/9111>`__ Server host name not
+-  `#9111 <https://codeberg.org/freeipa/freeipa/issues/9111>`__ Server host name not
    saved by the script ?
--  `#9117 <https://pagure.io/freeipa/issue/9117>`__ Pylint 2.12 issues
--  `#9119 <https://pagure.io/freeipa/issue/9119>`__
+-  `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__ Pylint 2.12 issues
+-  `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
    (`rhbz#2057471 <https://bugzilla.redhat.com/show_bug.cgi?id=2057471>`__)
    KRB instance: make provision to work with crypto policy without SHA-1
    HMAC types
--  `#9123 <https://pagure.io/freeipa/issue/9123>`__ Random nightly test
+-  `#9123 <https://codeberg.org/freeipa/freeipa/issues/9123>`__ Random nightly test
    failure in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipa_healthcheck_expiring
--  `#9126 <https://pagure.io/freeipa/issue/9126>`__ allow overriding
+-  `#9126 <https://codeberg.org/freeipa/freeipa/issues/9126>`__ allow overriding
    systemd-tmpfiles program
--  `#9127 <https://pagure.io/freeipa/issue/9127>`__
+-  `#9127 <https://codeberg.org/freeipa/freeipa/issues/9127>`__
    (`rhbz#2062379 <https://bugzilla.redhat.com/show_bug.cgi?id=2062379>`__)
    Use new getorigby{user|group}name() calls in extdom plugin
--  `#9129 <https://pagure.io/freeipa/issue/9129>`__ Remove Python
+-  `#9129 <https://codeberg.org/freeipa/freeipa/issues/9129>`__ Remove Python
    warning about PROTOCOL_SSLv23
--  `#9133 <https://pagure.io/freeipa/issue/9133>`__ Nightly test failure
+-  `#9133 <https://codeberg.org/freeipa/freeipa/issues/9133>`__ Nightly test failure
    in test_fips.py::TestInstallFIPS::test_basic
--  `#9134 <https://pagure.io/freeipa/issue/9134>`__ Nightly test failure
+-  `#9134 <https://codeberg.org/freeipa/freeipa/issues/9134>`__ Nightly test failure
    (rawhide) while establishing two-way trust
--  `#9137 <https://pagure.io/freeipa/issue/9137>`__
+-  `#9137 <https://codeberg.org/freeipa/freeipa/issues/9137>`__
    test_replica_install_after_restore is performing reinit in the wrong
    direction
--  `#9141 <https://pagure.io/freeipa/issue/9141>`__ ipatests: fix xfail
+-  `#9141 <https://codeberg.org/freeipa/freeipa/issues/9141>`__ ipatests: fix xfail
    assertion in auto private group tests
 
 
@@ -231,64 +231,64 @@ Alexander Bokovoy (20)
 -  ipa-sam: retrieve trusted domain account credential from the TDO
    itself
    `commit <https://codeberg.org/freeipa/freeipa/commit/91d083c36e1daf88686bf8096691b3913d2ad23c>`__
-   `#9134 <https://pagure.io/freeipa/issue/9134>`__
+   `#9134 <https://codeberg.org/freeipa/freeipa/issues/9134>`__
 -  ipa-pwd-extop: allow ipasam to request RC4-HMAC in Kerberos keys for
    trusted domain objects
    `commit <https://codeberg.org/freeipa/freeipa/commit/710314a794eb3446f0467d33133d70d2425fbf65>`__
-   `#9134 <https://pagure.io/freeipa/issue/9134>`__
+   `#9134 <https://codeberg.org/freeipa/freeipa/issues/9134>`__
 -  ipatests: fix check for AD topology being present
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6b5f6073bf4e12b8357a6ec9f5a4f6bb683437f>`__
-   `#9133 <https://pagure.io/freeipa/issue/9133>`__
+   `#9133 <https://codeberg.org/freeipa/freeipa/issues/9133>`__
 -  tests: ensure AD-SUPPORT subpolicy is active in more cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/09481117b58f1a237bb1048d3fe8d44caf9e167f>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  ipalib/util.py: switch to ssl.PROTOCOL_TLS_CLIENT by default
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e8a355dd49a6c080103a030ced03597ee4baece>`__
-   `#9129 <https://pagure.io/freeipa/issue/9129>`__
+   `#9129 <https://codeberg.org/freeipa/freeipa/issues/9129>`__
 -  test_krbtpolicy: skip SPAKE-related tests in FIPS mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/2e70535f74e7d9dd76e728eca1119ce522fd138a>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  test_otp: do not use paramiko unless it is really needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/3baae8d1bd0a0c4c707314524289e86e6ecbc0df>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  Kerberos instance: default to AES256-SHA2 for master key encryption
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e54c4362490b4da1b6cb3e141bb6e08fecc58c0>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  freeipa.spec: bump crypto-policies dependency for CentOS 9 Stream
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee39de46a1c1ea96bbe524f159ae435319b2d072>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  ipatests: extend AES keyset to SHA2-based ones
    `commit <https://codeberg.org/freeipa/freeipa/commit/49d9147e38c5b50c52a1ebc7283753c779c2f81f>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  tests: ensure AD-SUPPORT subpolicy is active
    `commit <https://codeberg.org/freeipa/freeipa/commit/b016683552a58f9cc2a05cf628cc467234eaf599>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  KRB instance: make provision to work with crypto policy without SHA-1
    HMAC types
    `commit <https://codeberg.org/freeipa/freeipa/commit/a51900819bd5332bc05ec9d513f062844b3a7763>`__
-   `#9119 <https://pagure.io/freeipa/issue/9119>`__
+   `#9119 <https://codeberg.org/freeipa/freeipa/issues/9119>`__
 -  translations: regenerate translations after changes in help message
    in sudorule
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d034d7fd409a8dbbc48a7307ad6d042a4098a74>`__
-   `#9106 <https://pagure.io/freeipa/issue/9106>`__
+   `#9106 <https://codeberg.org/freeipa/freeipa/issues/9106>`__
 -  pylint: workaround incorrect pylint detection of a local function
    `commit <https://codeberg.org/freeipa/freeipa/commit/10d32d43e4640f61aa3d021b3e8136ca6132e493>`__
 -  OpenLDAP 2.6+: use only -H option to specify LDAP url
    `commit <https://codeberg.org/freeipa/freeipa/commit/85ce7acb733e09ea7916a8a26d42fb3d4b5fe3bd>`__
-   `#9106 <https://pagure.io/freeipa/issue/9106>`__
+   `#9106 <https://codeberg.org/freeipa/freeipa/issues/9106>`__
 -  ipa-kdb: refactor KDB driver to prepare for KDB version 9
    `commit <https://codeberg.org/freeipa/freeipa/commit/ace0bbfdc8eb02a4ba47f8293809ff4734856ab8>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  Support building against OpenLDAP 2.6+
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce112e68bd711199baee1f7103d31a4bb0c5ad97>`__
-   `#9080 <https://pagure.io/freeipa/issue/9080>`__
+   `#9080 <https://codeberg.org/freeipa/freeipa/issues/9080>`__
 -  ipa-kdb: fix requester SID check according to MS-KILE and MS-SFU
    updates
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d93bda31ce0b4e0e22c6e464c9138800dcf8b1c>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 -  ipa-kdb: issue PAC_REQUESTER_SID only for TGTs
    `commit <https://codeberg.org/freeipa/freeipa/commit/669f3d71161741c676ddd6a08bd08d4a4ccd495b>`__
-   `#9031 <https://pagure.io/freeipa/issue/9031>`__
+   `#9031 <https://codeberg.org/freeipa/freeipa/issues/9031>`__
 
 
 
@@ -302,16 +302,16 @@ Anuja More (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/84381001d2e114b1f29fe89e16155c040b56b80f>`__
 -  ipatests: Tests for Autoprivate group.
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b70e3c49acc55b5553101cf850fc40978861979>`__
-   `#8807 <https://pagure.io/freeipa/issue/8807>`__
+   `#8807 <https://codeberg.org/freeipa/freeipa/issues/8807>`__
 -  ipatests: remove additional check for failed units.
    `commit <https://codeberg.org/freeipa/freeipa/commit/b36bcf4ea5ed93baa4dc63f8e2be542d678211fb>`__
-   `#9108 <https://pagure.io/freeipa/issue/9108>`__
+   `#9108 <https://codeberg.org/freeipa/freeipa/issues/9108>`__
 -  ipatests: webui: Tests for subordinate ids.
    `commit <https://codeberg.org/freeipa/freeipa/commit/edbd8f692a28fc999b92e9032614d366511db323>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__
 -  ipatests: Test default value of nsslapd-sizelimit.
    `commit <https://codeberg.org/freeipa/freeipa/commit/465f1669a6c5abc72da1ecaf9aefa8488f80806c>`__
-   `#8962 <https://pagure.io/freeipa/issue/8962>`__
+   `#8962 <https://codeberg.org/freeipa/freeipa/issues/8962>`__
 
 
 
@@ -328,7 +328,7 @@ Brian Turek (1)
 
 -  ipalib: Handle percent signs in saved values
    `commit <https://codeberg.org/freeipa/freeipa/commit/837702199c0bc8df1b2a29defaebed083c51d7b2>`__
-   `#9085 <https://pagure.io/freeipa/issue/9085>`__
+   `#9085 <https://codeberg.org/freeipa/freeipa/issues/9085>`__
 
 
 
@@ -337,7 +337,7 @@ Christian Heimes (1)
 
 -  Support AES for KRA archival wrapping
    `commit <https://codeberg.org/freeipa/freeipa/commit/895e99b6843c2fa2274acab824607c33c1a560a4>`__
-   `#6524 <https://pagure.io/freeipa/issue/6524>`__
+   `#6524 <https://codeberg.org/freeipa/freeipa/issues/6524>`__
 
 
 
@@ -346,47 +346,47 @@ Florence Blanc-Renaud (14)
 
 -  ipatests: fix wrong condition in xfail_context for auto private grp
    `commit <https://codeberg.org/freeipa/freeipa/commit/5ba5143f9ed55e94668501123969e64a9ec180d2>`__
-   `#9141 <https://pagure.io/freeipa/issue/9141>`__
+   `#9141 <https://codeberg.org/freeipa/freeipa/issues/9141>`__
 -  ipatests: Fix a call to run_command with wildcard
    `commit <https://codeberg.org/freeipa/freeipa/commit/85b2c8191b8622a5cfe3c8c6e3811ef5e1eee0eb>`__
-   `#8506 <https://pagure.io/freeipa/issue/8506>`__
+   `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
 -  ipatests: remove certmonger tracking before uninstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/12785a3657996def6c7c142898c6a61b2edc16fe>`__
-   `#9123 <https://pagure.io/freeipa/issue/9123>`__
+   `#9123 <https://codeberg.org/freeipa/freeipa/issues/9123>`__
 -  ipatests: add missing test in the nightly defs
    `commit <https://codeberg.org/freeipa/freeipa/commit/42f41ff637452e5025b205396638b26dfaae77e1>`__
 -  Commit template: use either Fixes or Related
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2731107db5703efbba12cd608b738347a987649>`__
 -  ipatests: update images for f34 and f35
    `commit <https://codeberg.org/freeipa/freeipa/commit/896d0f351646e6a7c96037cb13957b7be0408776>`__
-   `#9051 <https://pagure.io/freeipa/issue/9051>`__,
-   `#9069 <https://pagure.io/freeipa/issue/9069>`__
+   `#9051 <https://codeberg.org/freeipa/freeipa/issues/9051>`__,
+   `#9069 <https://codeberg.org/freeipa/freeipa/issues/9069>`__
 -  ipa-pki-proxy.conf: provide access to /kra/admin/kra/getStatus
    `commit <https://codeberg.org/freeipa/freeipa/commit/9bae5492270d8b695999cd82831cbee62b04626b>`__
-   `#8582 <https://pagure.io/freeipa/issue/8582>`__,
-   `#9099 <https://pagure.io/freeipa/issue/9099>`__
+   `#8582 <https://codeberg.org/freeipa/freeipa/issues/8582>`__,
+   `#9099 <https://codeberg.org/freeipa/freeipa/issues/9099>`__
 -  ipatests: fix expected automount config in nsswitch.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd8e9ce173303e192e848e4973aaf2c7bd31ee0a>`__
-   `#9067 <https://pagure.io/freeipa/issue/9067>`__
+   `#9067 <https://codeberg.org/freeipa/freeipa/issues/9067>`__
 -  ipatests: update images for f34 and f35
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8a7f15e32e9fb62125aa910e18c32117285d672>`__
-   `#9087 <https://pagure.io/freeipa/issue/9087>`__
+   `#9087 <https://codeberg.org/freeipa/freeipa/issues/9087>`__
 -  config plugin: add a test ensuring EmptyModlist is returned
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd735099e86304294217147ed578ac902fcf3dd3>`__
-   `#9063 <https://pagure.io/freeipa/issue/9063>`__
+   `#9063 <https://codeberg.org/freeipa/freeipa/issues/9063>`__
 -  Config plugin: return EmptyModlist when no change is applied
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9c42fed9b6f60801f908c368d0d97a2a69f7bb2>`__
-   `#9063 <https://pagure.io/freeipa/issue/9063>`__
+   `#9063 <https://codeberg.org/freeipa/freeipa/issues/9063>`__
 -  automember default group: remove --desc parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ff7491172961fe210a6ec51b556231af9e123ba>`__
-   `#9068 <https://pagure.io/freeipa/issue/9068>`__
+   `#9068 <https://codeberg.org/freeipa/freeipa/issues/9068>`__
 -  ipatests: update images for f34 and f35
    `commit <https://codeberg.org/freeipa/freeipa/commit/1efdda078e502e1d67a047ccd06e8b7f555f8802>`__
-   `#8865 <https://pagure.io/freeipa/issue/8865>`__,
-   `#9024 <https://pagure.io/freeipa/issue/9024>`__
+   `#8865 <https://codeberg.org/freeipa/freeipa/issues/8865>`__,
+   `#9024 <https://codeberg.org/freeipa/freeipa/issues/9024>`__
 -  ipatests: fix TestOTPToken::test_check_otpd_after_idle_timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/4c54e9d6ddb72eab6f654bf3dc2d29f27498ac96>`__
-   `#9044 <https://pagure.io/freeipa/issue/9044>`__
+   `#9044 <https://codeberg.org/freeipa/freeipa/issues/9044>`__
 
 
 
@@ -395,13 +395,13 @@ Francisco Trivino (3)
 
 -  Set AES as default for KRA archival wrapping
    `commit <https://codeberg.org/freeipa/freeipa/commit/984190eea01ac42cd1f97567a67dd9446e5b0bf9>`__
-   `#6524 <https://pagure.io/freeipa/issue/6524>`__
+   `#6524 <https://codeberg.org/freeipa/freeipa/issues/6524>`__
 -  ipa_cldap: fix memory leak
    `commit <https://codeberg.org/freeipa/freeipa/commit/186ebe311bc9545d7a9860cd5e8c748131bbe41e>`__
-   `#9110 <https://pagure.io/freeipa/issue/9110>`__
+   `#9110 <https://codeberg.org/freeipa/freeipa/issues/9110>`__
 -  Custodia: use a stronger encryption algo when exporting keys
    `commit <https://codeberg.org/freeipa/freeipa/commit/653a7fe02880c168755984133ee143567cc7bb4e>`__
-   `#9101 <https://pagure.io/freeipa/issue/9101>`__
+   `#9101 <https://codeberg.org/freeipa/freeipa/issues/9101>`__
 
 
 
@@ -410,7 +410,7 @@ Fraser Tweedale (1)
 
 -  allow overriding systemd-tmpfiles program
    `commit <https://codeberg.org/freeipa/freeipa/commit/b413a327f33c5d97a1f830fe7a9a8aef39c847c1>`__
-   `#9126 <https://pagure.io/freeipa/issue/9126>`__
+   `#9126 <https://codeberg.org/freeipa/freeipa/issues/9126>`__
 
 
 
@@ -429,8 +429,8 @@ Julien Rische (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/294ae35a61e6ca8816b261c57508e4be21221864>`__
 -  ipa-kdb: do not remove keys for hardened auth-enabled users
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d70421f57d0eca066a922e09416ef7195ee96d4>`__
-   `#8001 <https://pagure.io/freeipa/issue/8001>`__,
-   `#9065 <https://pagure.io/freeipa/issue/9065>`__
+   `#8001 <https://codeberg.org/freeipa/freeipa/issues/8001>`__,
+   `#9065 <https://codeberg.org/freeipa/freeipa/issues/9065>`__
 
 
 
@@ -439,10 +439,10 @@ Michal Polovka (2)
 
 -  ipatests: webui: Use safe-loader for loading YAML configuration file
    `commit <https://codeberg.org/freeipa/freeipa/commit/419d7fd6e5a9ed2d356ad05eef1043309f5646ef>`__
-   `#9009 <https://pagure.io/freeipa/issue/9009>`__
+   `#9009 <https://codeberg.org/freeipa/freeipa/issues/9009>`__
 -  pr-ci definitions: add web-ui subid-related jobs
    `commit <https://codeberg.org/freeipa/freeipa/commit/878859f4a27aa03c905b82f68327815825ceb1fa>`__
-   `#8361 <https://pagure.io/freeipa/issue/8361>`__
+   `#8361 <https://codeberg.org/freeipa/freeipa/issues/8361>`__
 
 
 
@@ -453,25 +453,25 @@ Mohammad Rizwan (8)
    `commit <https://codeberg.org/freeipa/freeipa/commit/de1f4467fb1bd9be857b8c95b2b7398962656342>`__
 -  ipatests: fix the topologysegment-reinitialize command
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3bd6908fa29b479fbd5e8e785c7237c477e29a2>`__
-   `#9137 <https://pagure.io/freeipa/issue/9137>`__
+   `#9137 <https://codeberg.org/freeipa/freeipa/issues/9137>`__
 -  ipatests: Check maxlife error message where minlife > maxlife
    specified
    `commit <https://codeberg.org/freeipa/freeipa/commit/83551693b36c852ba455185469e4e459de435f0e>`__
-   `#9038 <https://pagure.io/freeipa/issue/9038>`__
+   `#9038 <https://codeberg.org/freeipa/freeipa/issues/9038>`__
 -  Test ipa-ccache-sweep.timer enabled by default during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d9eb3d515385412abefe9c33e0099ea14f33cbc>`__
-   `#9107 <https://pagure.io/freeipa/issue/9107>`__
+   `#9107 <https://codeberg.org/freeipa/freeipa/issues/9107>`__
 -  PEP8 Fixes
    `commit <https://codeberg.org/freeipa/freeipa/commit/5444da016edc416c0c9481c660c013053dbb93b5>`__
 -  Test cases for ipa-replica-conncheck command
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d19b860d4cd3bd65a4b143b588425d9a64237fd>`__
-   `#9047 <https://pagure.io/freeipa/issue/9047>`__
+   `#9047 <https://codeberg.org/freeipa/freeipa/issues/9047>`__
 -  ipatests: Test empty cert request doesn't force certmonger to
    segfault
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbd9ac6ab07dfb60f67da762fdd70856ad35c230>`__
 -  ipatests: Fix test_ipa_cert_fix.py::TestCertFixReplica teardown
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba7ec71ba96280da3841ebe47df2a6dc1cd6341e>`__
-   `#9052 <https://pagure.io/freeipa/issue/9052>`__
+   `#9052 <https://codeberg.org/freeipa/freeipa/issues/9052>`__
 
 
 
@@ -480,38 +480,38 @@ Rob Crittenden (11)
 
 -  Remove the --no-sssd option from ipa-client-automount
    `commit <https://codeberg.org/freeipa/freeipa/commit/c46ea21ed33f606a6ca5c3c6aad9f8cd1ae1f796>`__
-   `#7671 <https://pagure.io/freeipa/issue/7671>`__,
-   `#9084 <https://pagure.io/freeipa/issue/9084>`__
+   `#7671 <https://codeberg.org/freeipa/freeipa/issues/7671>`__,
+   `#9084 <https://codeberg.org/freeipa/freeipa/issues/9084>`__
 -  Convert values using \_SYNTAX_MAPPING with --delattr
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd8748f6b7bf5edc3f5a2023393e503ee4399f8c>`__
-   `#9004 <https://pagure.io/freeipa/issue/9004>`__
+   `#9004 <https://codeberg.org/freeipa/freeipa/issues/9004>`__
 -  ipatests: Give the subCA more time to be loaded by the CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a4238ba96e7f4ad5790d65ec4123983062b28a1>`__
-   `#9096 <https://pagure.io/freeipa/issue/9096>`__
+   `#9096 <https://codeberg.org/freeipa/freeipa/issues/9096>`__
 -  Strip off trailing period of a user-provided FQDN in installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/57de18e914e5b448402c18ffe938538cbac5e0a3>`__
-   `#9111 <https://pagure.io/freeipa/issue/9111>`__
+   `#9111 <https://codeberg.org/freeipa/freeipa/issues/9111>`__
 -  Verify the user-provided hostname in the server installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ac8e9696ea1eae9f20640102c0d83fee89db9fa>`__
-   `#9111 <https://pagure.io/freeipa/issue/9111>`__
+   `#9111 <https://codeberg.org/freeipa/freeipa/issues/9111>`__
 -  ipa-restore: Mark a restored server as enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab9e7dac4138ba222c86d0594937ff4d663ba060>`__
-   `#9095 <https://pagure.io/freeipa/issue/9095>`__
+   `#9095 <https://codeberg.org/freeipa/freeipa/issues/9095>`__
 -  Set the mode on ipaupgrade.log during RPM %post snipppet
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8174b0ca60ef123f268f34f47b8be123b8d1c89>`__
-   `#8899 <https://pagure.io/freeipa/issue/8899>`__
+   `#8899 <https://codeberg.org/freeipa/freeipa/issues/8899>`__
 -  ipatests: Remove certmonger tracking before uninstall in cert tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc2348aedbee3e59b31df75a23aa14d1c6bbe10c>`__
-   `#8506 <https://pagure.io/freeipa/issue/8506>`__
+   `#8506 <https://codeberg.org/freeipa/freeipa/issues/8506>`__
 -  Enable the ccache sweep timer during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b6d0bb1245c4891ccc270f360d0f72a4b1444c1>`__
-   `#9107 <https://pagure.io/freeipa/issue/9107>`__
+   `#9107 <https://codeberg.org/freeipa/freeipa/issues/9107>`__
 -  Remove ipa-join errors from behind the debug option
    `commit <https://codeberg.org/freeipa/freeipa/commit/7c5540bb47799b4db95673d22f61995ad5c56440>`__
-   `#9103 <https://pagure.io/freeipa/issue/9103>`__
+   `#9103 <https://codeberg.org/freeipa/freeipa/issues/9103>`__
 -  Don't always override the port in import_included_profiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/edb216849e4f47d6cae95981edf0c3fe2653fd7a>`__
-   `#9100 <https://pagure.io/freeipa/issue/9100>`__
+   `#9100 <https://codeberg.org/freeipa/freeipa/issues/9100>`__
 
 
 
@@ -520,10 +520,10 @@ Sumit Bose (2)
 
 -  ipa-kdb: fix make check
    `commit <https://codeberg.org/freeipa/freeipa/commit/9cd48d1854b19a40a2026891f9e28c1b79af2637>`__
-   `#9083 <https://pagure.io/freeipa/issue/9083>`__
+   `#9083 <https://codeberg.org/freeipa/freeipa/issues/9083>`__
 -  extdom: user getorigby{user|group}name if available
    `commit <https://codeberg.org/freeipa/freeipa/commit/cedca75f4fbae3293b2f2443fa6ee479d59a8ef1>`__
-   `#9127 <https://pagure.io/freeipa/issue/9127>`__
+   `#9127 <https://codeberg.org/freeipa/freeipa/issues/9127>`__
 
 
 
@@ -532,107 +532,107 @@ Stanislav Levin (34)
 
 -  azure: Bump supported Pylint
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e2cf55150e9e4a44c29193e764a709cfec0fa08>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip false-positive invalid-sequence-index
    `commit <https://codeberg.org/freeipa/freeipa/commit/b58ec49da983bcd25473ef6ae246eaadf32cd174>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix useless-suppression
    `commit <https://codeberg.org/freeipa/freeipa/commit/6202a7d85bea2b8717e19fc2f09cca66276dcd9d>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix format-string-without-interpolation
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5b4657869738d6173eaff310bc243df0fff289e>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip unsupported-assignment-operation
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfb233185a7bb863dd94a65674489890c79f6f2f>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix deprecated-method for threading
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd99e4d47a4bb1518686b55e4cf04636d76128ca>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip deprecated-method for match_hostname
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f17ade67f21bfde9eda4d810394577f5a28906d>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix consider-using-in
    `commit <https://codeberg.org/freeipa/freeipa/commit/3ea0e1bd8d25c2f553852c1a0882618d2da86dd3>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix arguments-renamed
    `commit <https://codeberg.org/freeipa/freeipa/commit/a960adc6c26fb4fc9d8f5f4f10029419d8fc3b69>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip use-implicit-booleaness-not-comparison
    `commit <https://codeberg.org/freeipa/freeipa/commit/03cd914381de3fbcd9dbfe228a569fab6a6d62a9>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Enable useless-suppression
    `commit <https://codeberg.org/freeipa/freeipa/commit/2db2c6cb323014580baa5cb2aa4fdbe179327bc8>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip raising-bad-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb515f41b384b3947451bef454acd7c355d67084>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix consider-using-dict-items
    `commit <https://codeberg.org/freeipa/freeipa/commit/322d08921a126183358b8d68d350c33e37453871>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip not-callable
    `commit <https://codeberg.org/freeipa/freeipa/commit/13e5720d184b1f6e31e65be5435cdcca8229b319>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix unused-variable
    `commit <https://codeberg.org/freeipa/freeipa/commit/76c2c08fdb47b5692d3023ebf0a1b9b35a528518>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix no-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/08f2db78555ff1da56122c58275680fd98916c4d>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip isinstance-second-argument-not-valid-type
    `commit <https://codeberg.org/freeipa/freeipa/commit/afba414770ad01a6fe4aec6015e2722860764c2f>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix deprecated-decorator
    `commit <https://codeberg.org/freeipa/freeipa/commit/054376c1a0aa0f600458ad6415e72f2198c7339e>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix unnecessary-dict-index-lookup
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3b384b5ca18a555b54ce4385bcca603ad7251b9>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix deprecated-class
    `commit <https://codeberg.org/freeipa/freeipa/commit/ccf9334da9c51aa9a379141fd2fead0a5b5bf55d>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Remove unused \__convert_iter
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ebf09e061b79e12f3b80fbc224e3aac49608c21>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Drop no longer used \__home
    `commit <https://codeberg.org/freeipa/freeipa/commit/91ff7b87d9b3231ec1145ffec0f8bb072130b701>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix unused-private-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/4da897c3dc71f99911878e0f05ed8ed386867dec>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip unused-private-member for unsupported cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/bffde84c813ddd45ec7971c96c74c2e5b54e3d72>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip unused-private-member for property case
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ca818b1797e03dd41f05eb14d9181546995c246>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Drop no longer used \__finalized
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfa1ceac6f70e32184d2ef19706cd2c582df1cc7>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Drop never used
    \__remove_lightweight_ca_key_retrieval_custodia
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c77949ab458d6e5f8250fe7c2a8757091f8da76>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Clean up \__convert_to_gssapi_replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/04c4032370dddafe5c8c5bd6e26882a24c597628>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Fix use-maxsplit-arg
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fd75de5a72e5f5889c33cdcc802d93dc6f067f3>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip unspecified-encoding
    `commit <https://codeberg.org/freeipa/freeipa/commit/106d011e5f39eea73b4d5db62c82398144a61ec8>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip use-dict-literal/use-list-literal
    `commit <https://codeberg.org/freeipa/freeipa/commit/40ee6a47ac62419caf302882914f2df885abd589>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip consider-using-f-string
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5fc2eeff9779cb868ff56edefd7e3355fcd5bca>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  pylint: Skip redundant-u-string-prefix
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f8b4f036859db570b2874b6c87ba3ba4de70eb1>`__
-   `#9117 <https://pagure.io/freeipa/issue/9117>`__
+   `#9117 <https://codeberg.org/freeipa/freeipa/issues/9117>`__
 -  ipatests: healthcheck: Sync the expected system RRs
    `commit <https://codeberg.org/freeipa/freeipa/commit/86b98b86f62fae195c0f84fa9a5891166f69c786>`__
-   `#9054 <https://pagure.io/freeipa/issue/9054>`__
+   `#9054 <https://codeberg.org/freeipa/freeipa/issues/9054>`__
 
 
 
@@ -643,11 +643,11 @@ Sumedh Sidhaye (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef43ea03ef90cd34f2ce55a946df9a1d8e17badf>`__
 -  Added test automation for SHA384withRSA CSR support
    `commit <https://codeberg.org/freeipa/freeipa/commit/0edf915efbb39fac45c784171dd715ec6b28861a>`__
-   `#8906 <https://pagure.io/freeipa/issue/8906>`__
+   `#8906 <https://codeberg.org/freeipa/freeipa/issues/8906>`__
 -  Extend test to see if replica is not shown when running
    \`ipa-replica-manage list -v \`
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b22ee018c3bb7f58a1b6694a7fd611688f8e74f>`__
-   `#8605 <https://pagure.io/freeipa/issue/8605>`__
+   `#8605 <https://codeberg.org/freeipa/freeipa/issues/8605>`__
 
 
 
@@ -665,7 +665,7 @@ Timo Aaltonen (7)
 
 -  configure: Use HTTPD_GROUP in init/tmpfiles/ipa.conf.in
    `commit <https://codeberg.org/freeipa/freeipa/commit/69f5f319d1b8bf1b18a8798149d2fcffa43642ec>`__
-   `#9014 <https://pagure.io/freeipa/issue/9014>`__
+   `#9014 <https://codeberg.org/freeipa/freeipa/issues/9014>`__
 -  ipaplatform: Modify paths to fips-mode-setup and systemd-tmpfiles
    `commit <https://codeberg.org/freeipa/freeipa/commit/739d3566951e50b6467c80835945b2697fab8576>`__
 -  ipatests/test_ipaplatform: Skip test_ipa_version on Debian

--- a/src/page/V4/ACME.rst
+++ b/src/page/V4/ACME.rst
@@ -546,7 +546,7 @@ To implement this change we need to:
    request for the HTTP service certificate to include the alias, then
    renew the cert.
 
-This change was implemented in https://pagure.io/freeipa/issue/8186.
+This change was implemented in https://codeberg.org/freeipa/freeipa/issues/8186.
 
 Scalability
 -----------

--- a/src/page/V4/Certificate_revocation_behaviour_standardisation.rst
+++ b/src/page/V4/Certificate_revocation_behaviour_standardisation.rst
@@ -17,7 +17,7 @@ always known which certificate should be revoked. Revocation list growth
 was also a concern.
 
 This change in behaviour continues to confuse users and developers. For
-example, https://pagure.io/freeipa/issue/7482 was filed, suggesting the
+example, https://codeberg.org/freeipa/freeipa/issues/7482 was filed, suggesting the
 lack of revocation of the old certificate upon renewal was a regression.
 A patch and `pull
 request <https://github.com/freeipa/freeipa/pull/1915#issuecomment-388295460>`__

--- a/src/page/V4/Healthcheck.rst
+++ b/src/page/V4/Healthcheck.rst
@@ -101,7 +101,7 @@ Related Tickets
 ----------------------------------------------------------------------------------------------
 
 -  `#1749 Need way to remove dangling managed
-   groups <https://pagure.io/freeipa/issue/1749>`__
+   groups <https://codeberg.org/freeipa/freeipa/issues/1749>`__
 
 Important note: v1 healthcheck will only identify issues, not provide a
 mechanism to remediate them.

--- a/src/page/V4/Promotion_to_CRL_generation_master.rst
+++ b/src/page/V4/Promotion_to_CRL_generation_master.rst
@@ -17,7 +17,7 @@ generation on the new CRL generation master). This manual procedure is
 error-prone and can leave the topology in a bad state.
 
 This feature proposes to provide a tool in order to automate these
-manual steps. See issue `5803 <https://pagure.io/freeipa/issue/5803>`__.
+manual steps. See issue `5803 <https://codeberg.org/freeipa/freeipa/issues/5803>`__.
 
 Design
 ======

--- a/src/page/V4/Replica_Promotion.rst
+++ b/src/page/V4/Replica_Promotion.rst
@@ -553,7 +553,7 @@ Handlers (reading and writing keys)
 
 In the original implementation the ``ipa-custodia`` server and Custodia
 client code ran as root and was not properly confined by SELinux (see
-`Ticket 6888 <https://pagure.io/freeipa/issue/6888>`__). As of FreeIPA
+`Ticket 6888 <https://codeberg.org/freeipa/freeipa/issues/6888>`__). As of FreeIPA
 4.8.0, server and client key database handlers are run as separate
 processes, as a non-root user where possible, and the ``DAC_OVERRIDE``
 capability is no longer required for either the main process or the
@@ -584,7 +584,7 @@ handler processes.
 The optional **{alg-oid}** parameter for Lightweight CA signing keys
 requests the specified encryption algorithm be used. This was
 implemented as part of `Ticket 8020 - Support AES in Lightweight CA key
-replication <https://pagure.io/freeipa/issue/8020>`__. This "parameters
+replication <https://codeberg.org/freeipa/freeipa/issues/8020>`__. This "parameters
 as additional path components" facility is available to all handlers,
 but only ``ca_wrapped`` uses it (as of September 2019).
 

--- a/src/release-notes/4-10-2.rst
+++ b/src/release-notes/4-10-2.rst
@@ -118,178 +118,178 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#5130 <https://pagure.io/freeipa/issue/5130>`__
+-  `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
    (`rhbz#1243261 <https://bugzilla.redhat.com/show_bug.cgi?id=1243261>`__)
    non-admin users cannot search hbac rules
--  `#5444 <https://pagure.io/freeipa/issue/5444>`__ [RFE] Support
+-  `#5444 <https://codeberg.org/freeipa/freeipa/issues/5444>`__ [RFE] Support
    Resource based kerberos constrained delegation
--  `#6044 <https://pagure.io/freeipa/issue/6044>`__
+-  `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
    (`rhbz#1353899 <https://bugzilla.redhat.com/show_bug.cgi?id=1353899>`__)
    ipa-advise: object of type 'type' has no len()
--  `#8941 <https://pagure.io/freeipa/issue/8941>`__ Usage of
+-  `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__ Usage of
    \`/usr/bin/env\` in Python scripts
--  `#8990 <https://pagure.io/freeipa/issue/8990>`__ ipa group-mod should
+-  `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__ ipa group-mod should
    fail properly with --posix and --external options
--  `#9086 <https://pagure.io/freeipa/issue/9086>`__ Have
+-  `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__ Have
    ipa-client-install additionally disable the unscd service if using
    SSSD
--  `#9124 <https://pagure.io/freeipa/issue/9124>`__ Nightly test failure
+-  `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#9164 <https://pagure.io/freeipa/issue/9164>`__ Cross realm
+-  `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__ Cross realm
    s4u2self/s4u2proxy fails
--  `#9195 <https://pagure.io/freeipa/issue/9195>`__
+-  `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
    (`rhbz#2158775 <https://bugzilla.redhat.com/show_bug.cgi?id=2158775>`__)
    Hiding a server does not completely clean up DNS records
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9232 <https://pagure.io/freeipa/issue/9232>`__ ipaserver circular
+-  `#9232 <https://codeberg.org/freeipa/freeipa/issues/9232>`__ ipaserver circular
    import
--  `#9249 <https://pagure.io/freeipa/issue/9249>`__
+-  `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
    (`rhbz#2108630 <https://bugzilla.redhat.com/show_bug.cgi?id=2108630>`__)
    Deprecated feature idnssoaserial in IdM appears when creating reverse
    dns zones
--  `#9259 <https://pagure.io/freeipa/issue/9259>`__
+-  `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
    (`rhbz#2144737 <https://bugzilla.redhat.com/show_bug.cgi?id=2144737>`__)
    vault interoperability with older RHEL systems is broken
--  `#9264 <https://pagure.io/freeipa/issue/9264>`__ Nightly failure in
+-  `#9264 <https://codeberg.org/freeipa/freeipa/issues/9264>`__ Nightly failure in
    test_integration/test_sso.py::TestSsoBridge::test_ipa_login_with_sso_user
--  `#9267 <https://pagure.io/freeipa/issue/9267>`__
+-  `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
    (`rhbz#2188567 <https://bugzilla.redhat.com/show_bug.cgi?id=2188567>`__)
    Unconditionally adding 'includedir
    /var/lib/sss/pubconf/krb5.include.d' to /etc/krb5.conf break Java's
    ability to parse krb5.conf
--  `#9278 <https://pagure.io/freeipa/issue/9278>`__ Pylint 2.15 issues
--  `#9279 <https://pagure.io/freeipa/issue/9279>`__ ipa-otpd@.service:
+-  `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__ Pylint 2.15 issues
+-  `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__ ipa-otpd@.service:
    deprecated syslog setting
--  `#9282 <https://pagure.io/freeipa/issue/9282>`__ Nightly test failure
+-  `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__ Nightly test failure
    in
    test_webui/test_subid.py/test_subid/test_subid_range_deletion_not_allowed
--  `#9285 <https://pagure.io/freeipa/issue/9285>`__ ipa-certupdate
+-  `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__ ipa-certupdate
    restarts HTTPd too early
--  `#9286 <https://pagure.io/freeipa/issue/9286>`__
+-  `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
    (`rhbz#2056009 <https://bugzilla.redhat.com/show_bug.cgi?id=2056009>`__)
    memberManager ACIs aren't allowing group-based manager access due to
    missing upgrade code
--  `#9287 <https://pagure.io/freeipa/issue/9287>`__ [RFE] makeapi should
+-  `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__ [RFE] makeapi should
    validate the generated API doc vs stored doc
--  `#9290 <https://pagure.io/freeipa/issue/9290>`__
+-  `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
    (`rhbz#2149889 <https://bugzilla.redhat.com/show_bug.cgi?id=2149889>`__)
    idm:client is missing dependency on krb5-pkinit.
--  `#9291 <https://pagure.io/freeipa/issue/9291>`__ Nightly test failure
+-  `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__ Nightly test failure
    (rawhide) in test_ipa_dns_systemrecords_check
--  `#9294 <https://pagure.io/freeipa/issue/9294>`__
+-  `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
    (`rhbz#2162677 <https://bugzilla.redhat.com/show_bug.cgi?id=2162677>`__)
    Enable the certificate pruning job in PKI
--  `#9295 <https://pagure.io/freeipa/issue/9295>`__ Nightly test failure
+-  `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__ Nightly test failure
    (sssd) in test_trust.py::TestNonPosixAutoPrivateGroup and
    test_trust.py::TestPosixAutoPrivateGroup
--  `#9298 <https://pagure.io/freeipa/issue/9298>`__ [Tracker] Nightly
+-  `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__ [Tracker] Nightly
    test failure (updates-testing) in
    test_acme.py::TestACME::test_certbot_certonly_standalone
--  `#9299 <https://pagure.io/freeipa/issue/9299>`__ NixOS support for
+-  `#9299 <https://codeberg.org/freeipa/freeipa/issues/9299>`__ NixOS support for
    freeipa in ipaplatform
--  `#9306 <https://pagure.io/freeipa/issue/9306>`__
+-  `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
    (`rhbz#2160389 <https://bugzilla.redhat.com/show_bug.cgi?id=2160389>`__)
    'ERROR Could not remove /tmp/tmpbkw6hawo.ipabkp' can be seen prior to
    'ipa-client-install' command was successful.
--  `#9309 <https://pagure.io/freeipa/issue/9309>`__
+-  `#9309 <https://codeberg.org/freeipa/freeipa/issues/9309>`__
    (`rhbz#2160399 <https://bugzilla.redhat.com/show_bug.cgi?id=2160399>`__)
    get_ranges - [file ipa_sidgen_common.c, line 276]: Failed to convert
    LDAP entry to range struct
--  `#9310 <https://pagure.io/freeipa/issue/9310>`__
+-  `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
    (`rhbz#2162335 <https://bugzilla.redhat.com/show_bug.cgi?id=2162335>`__)
    ipa-trust-add with --range-type=ipa-ad-trust-posix fails while
    creating an ID range
--  `#9313 <https://pagure.io/freeipa/issue/9313>`__ Nightly test failure
+-  `#9313 <https://codeberg.org/freeipa/freeipa/issues/9313>`__ Nightly test failure
    (rawhide): automember-rebuild test
--  `#9314 <https://pagure.io/freeipa/issue/9314>`__ Redundant build
+-  `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__ Redundant build
    dependency on python3-paste (if with lint)
--  `#9315 <https://pagure.io/freeipa/issue/9315>`__ [tests]
+-  `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__ [tests]
    test_ipa_healthcheck_fips_enabled fails on system without
    fips-mode-setup
--  `#9316 <https://pagure.io/freeipa/issue/9316>`__
+-  `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
    (`rhbz#2166324 <https://bugzilla.redhat.com/show_bug.cgi?id=2166324>`__)
    Passwordless (GSSAPI) SSH login with AD user
--  `#9318 <https://pagure.io/freeipa/issue/9318>`__ Incomplete fast
+-  `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__ Incomplete fast
    lint/codestyle check if both Python template files and Python modules
    were changed
--  `#9319 <https://pagure.io/freeipa/issue/9319>`__ [tests]
+-  `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__ [tests]
    TestDNSResolver failures on systems without or empty /etc/resolv.conf
--  `#9320 <https://pagure.io/freeipa/issue/9320>`__
+-  `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
    (`rhbz#2018198 <https://bugzilla.redhat.com/show_bug.cgi?id=2018198>`__)
    RFE - Add a warning note about possible performance impact of the
    Auto Member rebuild task.
--  `#9322 <https://pagure.io/freeipa/issue/9322>`__
+-  `#9322 <https://codeberg.org/freeipa/freeipa/issues/9322>`__
    (`rhbz#2162677 <https://bugzilla.redhat.com/show_bug.cgi?id=2162677>`__)
    Nightly test failure in test_integration/test_acme.py::TestACME
--  `#9323 <https://pagure.io/freeipa/issue/9323>`__ Update the design
+-  `#9323 <https://codeberg.org/freeipa/freeipa/issues/9323>`__ Update the design
    doc for certificate pruning
--  `#9324 <https://pagure.io/freeipa/issue/9324>`__ ipatests: Frequent
+-  `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__ ipatests: Frequent
    timeout of test_acme
--  `#9325 <https://pagure.io/freeipa/issue/9325>`__
+-  `#9325 <https://codeberg.org/freeipa/freeipa/issues/9325>`__
    (`rhbz#2168244 <https://bugzilla.redhat.com/show_bug.cgi?id=2168244>`__)
    requestsearchtimelimit=0 doesn't seems to be work with
    ipa-acme-manage pruning command
--  `#9326 <https://pagure.io/freeipa/issue/9326>`__ ipatests: timeout of
+-  `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__ ipatests: timeout of
    test_trust
--  `#9329 <https://pagure.io/freeipa/issue/9329>`__ Azure test:
+-  `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__ Azure test:
    WebUI_Unit_Tests are failing
--  `#9331 <https://pagure.io/freeipa/issue/9331>`__
+-  `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
    (`rhbz#2164349 <https://bugzilla.redhat.com/show_bug.cgi?id=2164349>`__)
    Better handling of the command line and web UI cert search and/or
    list features
--  `#9332 <https://pagure.io/freeipa/issue/9332>`__ Extend negative test
+-  `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__ Extend negative test
    coverage for automember
--  `#9333 <https://pagure.io/freeipa/issue/9333>`__ ipa-client-install
+-  `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__ ipa-client-install
    --pkinit-identity can block in unattended mode
--  `#9338 <https://pagure.io/freeipa/issue/9338>`__ Update 'Auth
+-  `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__ Update 'Auth
    indicators' doc string to show 'ipd' usage
--  `#9339 <https://pagure.io/freeipa/issue/9339>`__ Broken support for
+-  `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__ Broken support for
    dnspython < 2
--  `#9342 <https://pagure.io/freeipa/issue/9342>`__ Fedora trasiition
+-  `#9342 <https://codeberg.org/freeipa/freeipa/issues/9342>`__ Fedora trasiition
    license from short names to SPDX license expression
--  `#9344 <https://pagure.io/freeipa/issue/9344>`__ ipa-server-install
+-  `#9344 <https://codeberg.org/freeipa/freeipa/issues/9344>`__ ipa-server-install
    fails when the named keytab location is overridden in
    ipaplatform/paths.py
--  `#9347 <https://pagure.io/freeipa/issue/9347>`__ Azure Ci does not
+-  `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__ Azure Ci does not
    work with Fedora Rawhide
--  `#9349 <https://pagure.io/freeipa/issue/9349>`__
+-  `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
    (`rhbz#2180914 <https://bugzilla.redhat.com/show_bug.cgi?id=2180914>`__)
    Sequence processing failures for group_add using server context
--  `#9354 <https://pagure.io/freeipa/issue/9354>`__ Implement
+-  `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__ Implement
    resource-based constrained delegation
--  `#9355 <https://pagure.io/freeipa/issue/9355>`__ support python
+-  `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__ support python
    cryptography 40.0
--  `#9358 <https://pagure.io/freeipa/issue/9358>`__
+-  `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
    update_dna_shared_config sometimes blocks installation for 2 minutes
--  `#9361 <https://pagure.io/freeipa/issue/9361>`__ [ipasphinx]
+-  `#9361 <https://codeberg.org/freeipa/freeipa/issues/9361>`__ [ipasphinx]
    deprecated sphinx.util.progress_message
--  `#9362 <https://pagure.io/freeipa/issue/9362>`__ ipatests: Frequent
+-  `#9362 <https://codeberg.org/freeipa/freeipa/issues/9362>`__ ipatests: Frequent
    timeout of test_ipahealthcheck
--  `#9368 <https://pagure.io/freeipa/issue/9368>`__ Test wrong variable
+-  `#9368 <https://codeberg.org/freeipa/freeipa/issues/9368>`__ Test wrong variable
    in ipadb_get_pac()
--  `#9369 <https://pagure.io/freeipa/issue/9369>`__
+-  `#9369 <https://codeberg.org/freeipa/freeipa/issues/9369>`__
    (`rhbz#2164348 <https://bugzilla.redhat.com/show_bug.cgi?id=2164348>`__)
    Better catch of the IPA web UI event "IPA Error
    4301:CertificateOperationError", and IPA httpd error
    CertificateOperationError
--  `#9371 <https://pagure.io/freeipa/issue/9371>`__
+-  `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
    (`rhbz#2182683 <https://bugzilla.redhat.com/show_bug.cgi?id=2182683>`__)
    Tolerate absence of PAC ticket signature depending of domain and
    servers capabilities
--  `#9372 <https://pagure.io/freeipa/issue/9372>`__
+-  `#9372 <https://codeberg.org/freeipa/freeipa/issues/9372>`__
    (`rhbz#2172107 <https://bugzilla.redhat.com/show_bug.cgi?id=2172107>`__)
    'ipa idview-show idviewname' & IPA WebUI takes longer time to return
    the results in RHEL 8.5
--  `#9373 <https://pagure.io/freeipa/issue/9373>`__
+-  `#9373 <https://codeberg.org/freeipa/freeipa/issues/9373>`__
    (`rhbz#2176406 <https://bugzilla.redhat.com/show_bug.cgi?id=2176406>`__)
    Make sign_authdata() generate extended KDC signature
--  `#9374 <https://pagure.io/freeipa/issue/9374>`__ freeipa fails to
+-  `#9374 <https://codeberg.org/freeipa/freeipa/issues/9374>`__ freeipa fails to
    build with updates-testing repo on f37 and f38
--  `#9377 <https://pagure.io/freeipa/issue/9377>`__ test_commands:
+-  `#9377 <https://codeberg.org/freeipa/freeipa/issues/9377>`__ test_commands:
    pseudo-random failure in test_ssh_key_connection
--  `#9383 <https://pagure.io/freeipa/issue/9383>`__ Random nightly test
+-  `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__ Random nightly test
    failure in test_acme.py::TestACMEPrune::test_prune_cert_manual
 
 .. _detailed_changelog_since_4.10.1:
@@ -305,73 +305,73 @@ Alexander Bokovoy (23)
 -  ipa-kdb: be compatible with krb5 1.19 when checking for server
    referral
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b821abca72e0d444c96598799c4947e2173d3f>`__
-   `#9164 <https://pagure.io/freeipa/issue/9164>`__
+   `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
    `commit <https://codeberg.org/freeipa/freeipa/commit/11ce2b2133364916de06f4c42d8a19ce438bd41c>`__
 -  ipa-kdb: skip verification of PAC full checksum
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b55e9b1cb4f192635878b0b7242104d58a37d2b>`__
-   `#9371 <https://pagure.io/freeipa/issue/9371>`__
+   `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
 -  ipa-kdb: process out of realm server lookup during S4U
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd8fcd6f5bc62a4bfc544b69c0d960291be05d37>`__
-   `#9164 <https://pagure.io/freeipa/issue/9164>`__
+   `#9164 <https://codeberg.org/freeipa/freeipa/issues/9164>`__
 -  ipa-kdb: postpone ticket checksum configuration
    `commit <https://codeberg.org/freeipa/freeipa/commit/fefa0248296413b6ee5ad2543d8feb1b31840aee>`__
 -  ipa-kdb: protect against context corruption
    `commit <https://codeberg.org/freeipa/freeipa/commit/803a44777f901217d634f8fd7feed8b66ece352a>`__
 -  ipa-kdb: hint KDC to use aes256-sha1 for forest trust TGT
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d0decd9efc4883328e95f9ff89002aec32462ec>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  Change doc theme to 'book'
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c43d914d9a365097a80c5c2278017b91c619266>`__
 -  doc/designs/rbcd.md: document use of S-1-18-\* SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb18ca31697320a58ae23a67afbfe7a0ff9a55a5>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  doc/designs/rbcd.md: add usage examples
    `commit <https://codeberg.org/freeipa/freeipa/commit/b63e6a257006e846ef5d0a008d9c3c0f935c09bb>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  RBCD: add basic test for RBCD handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d68f4f08361760adab90ad4b44c6da2c4ea664d>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  kdb: implement RBCD handling in KDB driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ac6adfaac30473b14b589a71fac42fe147bc0d9>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  IPA API changes to support RBCD
    `commit <https://codeberg.org/freeipa/freeipa/commit/5b6ad0e65600a96bb4d6f3b1acf4e16773a03493>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  doc: add design document for Kerberos constrained delegation
    `commit <https://codeberg.org/freeipa/freeipa/commit/18cd909b4ad854147008a1010c97c75640a54177>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  ipa-kdb: search S4U2Proxy ACLs in cn=s4u2proxy,cn=etc,$BASEDN subtree
    only
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a7ba45c10a6da4f9e110f6cc57cfc47e0a16a16>`__
-   `#5444 <https://pagure.io/freeipa/issue/5444>`__
+   `#5444 <https://codeberg.org/freeipa/freeipa/issues/5444>`__
 -  test_xmlrpc: adopt to automember plugin message changes in 389-ds
    `commit <https://codeberg.org/freeipa/freeipa/commit/52e6da9056697e2210736d5528826ae424fec9b1>`__
 -  Ignore empty modification error in case cifs/.. principal already
    added
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7506403a988b98cc3381d2d986b53aee48448cb>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
    `commit <https://codeberg.org/freeipa/freeipa/commit/e07ead943abf070107a9669fc4564c9dc7518832>`__
-   `#9355 <https://pagure.io/freeipa/issue/9355>`__
+   `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__
 -  Fix tox in Azure CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/aacaafce9d074342e383ad7007dee1b0e09d9b12>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Use system-wide chromium for webui tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/84f5f87b1f77267aa4c6c13fbc2496793d06a3c7>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Don't fail if optional RPM macros file is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/b93f6b52a29659663fae65be51dafe350606eb6d>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
    `commit <https://codeberg.org/freeipa/freeipa/commit/0206369eec8530e96c66986c4ca501d8962193ce>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
    `commit <https://codeberg.org/freeipa/freeipa/commit/42be04fe4ff317efe599dcbc2637f94ecc6fa220>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -380,16 +380,16 @@ Anuja More (4)
 
 -  ipatests: Test that non admin user can search hbac rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/051bbe36dce57837bd1769aa4a88569e39565774>`__
-   `#5130 <https://pagure.io/freeipa/issue/5130>`__
+   `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
    `commit <https://codeberg.org/freeipa/freeipa/commit/983a6516f147ae95a512435cd05d237233d0b5fc>`__
-   `#6044 <https://pagure.io/freeipa/issue/6044>`__
+   `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a2132ccfd3cfb26f5da550a829b267ca0a4f6ae>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  Add test for SSH with GSSAPI auth.
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6cb905de74da38d62f9c3bd7957018924282521>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 
 
 
@@ -406,14 +406,14 @@ Antonio Torres (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/3eed25e92f951689658f6bbd178a5baca37442c6>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
    `commit <https://codeberg.org/freeipa/freeipa/commit/b1b7cbc08d96e125ce21113ba1793a592d0ba35a>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/649c35aa3b46e6d2f034d9afdc4c7ae1542630da>`__
 -  API doc: add note about ipa show-mappings to usage guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a20acb6f833a22baad214a466848cb5833954532>`__
 -  API doc: validate generated reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/364116c25f68b6b21c0a64466bda09c70cf146ec>`__
-   `#9287 <https://pagure.io/freeipa/issue/9287>`__
+   `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__
 -  API doc: add basic user management guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a10627bdb90bb6eeaf6a156476253edc503c72df>`__
 -  Back to git snapshots
@@ -426,7 +426,7 @@ Carla Martinez (1)
 
 -  Update 'Auth indicators' doc string
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a4d34fba90ede0a9d600daa24a8d95190a42495>`__
-   `#9338 <https://pagure.io/freeipa/issue/9338>`__
+   `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__
 
 
 
@@ -435,13 +435,13 @@ Christian Heimes (3)
 
 -  Speed up installer by restarting DS after DNA plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/d63756eb08759740fe8b03f48d0a240f9935e6aa>`__
-   `#9358 <https://pagure.io/freeipa/issue/9358>`__
+   `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
 -  Don't block when kinit_pkinit() fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/8803938570dfb70586fa89d2d2d7aad4b0965305>`__
-   `#9333 <https://pagure.io/freeipa/issue/9333>`__
+   `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/8e7d1ac4e4779cc15b39a9901bb26c5f5997eb5b>`__
-   `#9285 <https://pagure.io/freeipa/issue/9285>`__
+   `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__
 
 
 
@@ -469,7 +469,7 @@ Erik Belko (1)
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1f4f655a65777f5096e65b8e5c3e079f77f6ecc>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -487,10 +487,10 @@ Florence Blanc-Renaud (55)
 
 -  ipatest: remove xfail from test_smb
    `commit <https://codeberg.org/freeipa/freeipa/commit/283f5463f091ac9fcc733092fc6becff586ae97f>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6f485fcade619980f6538edadf115dca69e1314>`__
-   `#9383 <https://pagure.io/freeipa/issue/9383>`__
+   `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__
 -  user or group name: explain the supported format
    `commit <https://codeberg.org/freeipa/freeipa/commit/7830ab96cc295e4151ad3d86cbbaf400a7ab2016>`__
 -  azure tests: move to fedora 38
@@ -499,121 +499,121 @@ Florence Blanc-Renaud (55)
    `commit <https://codeberg.org/freeipa/freeipa/commit/12d1aafe60de457815adb822bbef466926626d6f>`__
 -  idview: improve performance of idview-show
    `commit <https://codeberg.org/freeipa/freeipa/commit/3a9a5bdae7cb3dee65ba74b00169badb72fe6dda>`__
-   `#9372 <https://pagure.io/freeipa/issue/9372>`__
+   `#9372 <https://codeberg.org/freeipa/freeipa/issues/9372>`__
 -  spec file: force nodejs < 20 on fedora < 39
    `commit <https://codeberg.org/freeipa/freeipa/commit/d95c4cf137574ffa79a191cbe5f6d0687b53cdc1>`__
-   `#9374 <https://pagure.io/freeipa/issue/9374>`__
+   `#9374 <https://codeberg.org/freeipa/freeipa/issues/9374>`__
 -  Nightly test: add +15min for test_ipahealthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/717228c908816c72b98cee86abfe7c22cb07c44e>`__
-   `#9362 <https://pagure.io/freeipa/issue/9362>`__
+   `#9362 <https://codeberg.org/freeipa/freeipa/issues/9362>`__
 -  cert_find: fix call with --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/918b6e011795ba4854d178d18c86ad54f3cf75ab>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  ipatests: mark known failures for autoprivategroup
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2b08433cf7cf74dea81b88953a4b8daa4c38614>`__
-   `#9295 <https://pagure.io/freeipa/issue/9295>`__
+   `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__
 -  ipatests: fix test definition for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/def07260da883b1d27330b308bd0337205bf53a8>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: increase timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae014c6a3e17da7b0775be79a425d769a2717243>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: adapt for new automembership fixup behavior
    `commit <https://codeberg.org/freeipa/freeipa/commit/34d048ede0c439b3a53e02f8ace96ff91aa1609d>`__
-   `#9313 <https://pagure.io/freeipa/issue/9313>`__
+   `#9313 <https://codeberg.org/freeipa/freeipa/issues/9313>`__
 -  ipatests: increase timeout for test_acme
    `commit <https://codeberg.org/freeipa/freeipa/commit/0a8a3922487b8029c509635c85b533474008bb9d>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/2857bc69957bde7e59fff1c66c5a83c7f560616b>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
    `commit <https://codeberg.org/freeipa/freeipa/commit/97fc368df2db3b559a9def236d3c3e0a12bcdd0a>`__
-   `#9310 <https://pagure.io/freeipa/issue/9310>`__
+   `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
 -  Spec file: use %autosetup instead of %setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a69d056176edd4ef0b1f4e59eb0548a483bc6e5>`__
 -  Spec file: unify with RHEL9 spec
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e06786a44f8d12b08961fe0720a1b712e82c5cf>`__
 -  Installer: create RID base before domain object
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d1a35852fa53bcf3b88a8a80a2e86ef88a75795>`__
-   `#9309 <https://pagure.io/freeipa/issue/9309>`__
+   `#9309 <https://codeberg.org/freeipa/freeipa/issues/9309>`__
 -  Tests: force key type in ACME tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/0fa95852c935c7b079f8ed966d4f194099217038>`__
-   `#9298 <https://pagure.io/freeipa/issue/9298>`__
+   `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__
 -  server install: remove error log about missing bkup file
    `commit <https://codeberg.org/freeipa/freeipa/commit/894dca12c120f0bfa705307a0609da47326b8fb2>`__
-   `#9306 <https://pagure.io/freeipa/issue/9306>`__
+   `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
 -  ipatests: mark test_smb as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5f2b0b1b213149b5bfe2653c9e40de98249dc73>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  pylint: disable deprecated-module message
    `commit <https://codeberg.org/freeipa/freeipa/commit/85037db2e1927c76fba963c6fde4ce17d2b95929>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix comparison-of-constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/62e2d111fc3113aa5c9f22ae75068094403d1d39>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable comparison-of-constants
    `commit <https://codeberg.org/freeipa/freeipa/commit/015e25a581353aaf628f9e2ea8306fda89842cd5>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix consider-iterating-dictionary
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d211b4f9f6950a2810496f30e57a421eeb31e85>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: globally disable useless-object-inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e998848f08b52760225c5bcb1afa9a6b2f6361b>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable unhashable-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/07111438389fde4a74845f9f797656712335795f>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable invalid-sequence-index
    `commit <https://codeberg.org/freeipa/freeipa/commit/a95e11dbbff58804c5b85acaa4d70b72ce750ae0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix deprecated-class SafeConfigParser
    `commit <https://codeberg.org/freeipa/freeipa/commit/433599fdef1bf0608991d25ddbe6c891ae382ae0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix duplicate-value
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9ea3fcbdb9ab07153873aeea7d3e1bd69e0d065>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: fix implicit-str-concat
    `commit <https://codeberg.org/freeipa/freeipa/commit/71496be75f6523b51f9316d3dcf7e0662d2cb606>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable missing-timeout message
    `commit <https://codeberg.org/freeipa/freeipa/commit/84c4792bdbf82108771d796ae317e2cb1f1d2100>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: globally disable unnecessary-lambda-assignment message
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b97c8caad267f97780d7ee8d940577c17ef1499>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable unnecessary-dunder-call message
    `commit <https://codeberg.org/freeipa/freeipa/commit/3336236ff1133ae86a5c9e2caeb90db7169fa454>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable using-constant-test
    `commit <https://codeberg.org/freeipa/freeipa/commit/5434c12b6012f035528f0b137c1af5c1be113542>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove arguments-renamed warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/22f182ee9203be5e014d438f2a27b8721dd0c3ae>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable modified-iterating-list
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac69ad4ba5ec644fbb1b2768237fd2412d7e3101>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: replace deprecated distutils module
    `commit <https://codeberg.org/freeipa/freeipa/commit/328fb642f6aba1a15040b7374a59cb6f7679f8f5>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable used-before-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/081dd26376b8ff704a83e1c783d97c40951c43b3>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: disable redefined-slots-in-subclass
    `commit <https://codeberg.org/freeipa/freeipa/commit/240b46db1451b8fed5f04244e9927b8fc03f10c0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove useless suppression
    `commit <https://codeberg.org/freeipa/freeipa/commit/51e0f751e9c3b5cade75360d24ba64c75ec926ba>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: remove unneeded disable=unused-private-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd21204559bd8fcac6a1b321adda163cd88aa149>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  azure tests: move to fedora 37
    `commit <https://codeberg.org/freeipa/freeipa/commit/782873a2277ca7defa5554d2b7859f1c14767d68>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/304978924a09677805fd3b73614aad6a2de232a2>`__
-   `#9135 <https://pagure.io/freeipa/issue/9135>`__
+   `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/2904b15a94eebbb37ca6a289eccd6b95f063d7ca>`__
 -  FIPS setup: fix typo filtering camellia encryption
@@ -622,24 +622,24 @@ Florence Blanc-Renaud (55)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c853cfde56fb56798424bd402012d78ed47647c0>`__
 -  ipatests: update the fake fips mode expected message
    `commit <https://codeberg.org/freeipa/freeipa/commit/68f6574cb2bcf0b04840b4f62a8ac70b4d45cb1a>`__
-   `#9002 <https://pagure.io/freeipa/issue/9002>`__
+   `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__
 -  ipatests: xfail on all fedora for test_ipa_login_with_sso_user
    `commit <https://codeberg.org/freeipa/freeipa/commit/9599e975bcdc0a58a32ccee6ad531c7298661a1d>`__
-   `#9264 <https://pagure.io/freeipa/issue/9264>`__
+   `#9264 <https://codeberg.org/freeipa/freeipa/issues/9264>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a0cc40fb8674f30ba62980b1953cef840009e>`__
-   `#9290 <https://pagure.io/freeipa/issue/9290>`__
+   `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
 -  webui tests: fix assertion in test_subid.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/c411c2e7b2e400829ffac250db81609ef3c56faa>`__
-   `#9282 <https://pagure.io/freeipa/issue/9282>`__
+   `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__
 -  PRCI: update memory reqs for each topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/aeb9cc9b622d3d4a40a7eb3fe5800649c68c3b96>`__
 -  API reference: update dnszone_add generated doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/660da9ab1d93fd8e561643728ae3821193953433>`__
-   `#9249 <https://pagure.io/freeipa/issue/9249>`__
+   `#9249 <https://codeberg.org/freeipa/freeipa/issues/9249>`__
 -  API reference: update vault doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/42957f9e7819ad76394b20337e65c7bee828dd8f>`__
-   `#9259 <https://pagure.io/freeipa/issue/9259>`__
+   `#9259 <https://codeberg.org/freeipa/freeipa/issues/9259>`__
 
 
 
@@ -648,7 +648,7 @@ s1341 (1)
 
 -  ipaplatform: add initial nixos support
    `commit <https://codeberg.org/freeipa/freeipa/commit/16a81062ba1c92773eb6206d68af6a2b3ba1d54d>`__
-   `#9299 <https://pagure.io/freeipa/issue/9299>`__
+   `#9299 <https://codeberg.org/freeipa/freeipa/issues/9299>`__
 
 
 
@@ -657,7 +657,7 @@ Jarl Gullberg (2)
 
 -  install: Fix missing dyndb keytab directive
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b38ab1771944b51ddaeea972ea92a8e8ee5b92b>`__
-   `#9344 <https://pagure.io/freeipa/issue/9344>`__
+   `#9344 <https://codeberg.org/freeipa/freeipa/issues/9344>`__
 -  ipaplatform/debian: fix path to ldap.so
    `commit <https://codeberg.org/freeipa/freeipa/commit/03180bedcf99075d98f206d271a31ae7ceddc50d>`__
 
@@ -671,10 +671,10 @@ Julien Rische (3)
 -  Tolerate absence of PAC ticket signature depending of server
    capabilities
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbe545ff9feb972e549c743025e4a26b14ef8f89>`__
-   `#9371 <https://pagure.io/freeipa/issue/9371>`__
+   `#9371 <https://codeberg.org/freeipa/freeipa/issues/9371>`__
 -  kdb: Use krb5_pac_full_sign_compat() when available
    `commit <https://codeberg.org/freeipa/freeipa/commit/630cda5c06428825dd5604493621b9cbdab70073>`__
-   `#9373 <https://pagure.io/freeipa/issue/9373>`__
+   `#9373 <https://codeberg.org/freeipa/freeipa/issues/9373>`__
 
 
 
@@ -691,19 +691,19 @@ mbhalodi (5)
 
 -  ipatests: add remove automember condition tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/846c267f58ecfa4fc1a1a3be91c404e58074b1b3>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: Test for sequence processing failures with server context
    `commit <https://codeberg.org/freeipa/freeipa/commit/304fd550613e83d120c72f0dad89f6a89d31231c>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  ipatests: add missing automember-cli tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/6db9bbd85a837950d9244502507535c1f79ab64a>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd07413cba37150b12d6b279510941aad49b5afb>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/88b9be29036a3580a8bccd31986fc30faa9852df>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 
 
 
@@ -712,10 +712,10 @@ Michal Polovka (2)
 
 -  ipatests: commands: Wait for the SSSD to become available
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc39443211e998d7088571f0ef70233b6e456e1d>`__
-   `#9377 <https://pagure.io/freeipa/issue/9377>`__
+   `#9377 <https://codeberg.org/freeipa/freeipa/issues/9377>`__
 -  ipatest: loginscreen: do not use hardcoded password
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f10aebcc5b3568a9992111e377c5caecc1e035f>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 
 
 
@@ -726,10 +726,10 @@ Mohammad Rizwan (3)
    `commit <https://codeberg.org/freeipa/freeipa/commit/edcdcf83452dce837c1522c353c4a80c967ea57b>`__
 -  ipatests: fix tests in TestACMEPrune
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7c642bafcead5ce344f3b129d916045b00d0c1e>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  ipatests: tests for certificate pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f77b359e241fc4055fb8d785e18f96338451ebf>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 
 
 
@@ -738,49 +738,49 @@ Rob Crittenden (15)
 
 -  Don't allow a group to be converted to POSIX and external
    `commit <https://codeberg.org/freeipa/freeipa/commit/58017abeb88b2f2c8ee2e4f5a6ed808d28c672a4>`__
-   `#8990 <https://pagure.io/freeipa/issue/8990>`__
+   `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
    `commit <https://codeberg.org/freeipa/freeipa/commit/325a13196b32c627854c8d7594e23b58167499f0>`__
-   `#8941 <https://pagure.io/freeipa/issue/8941>`__
+   `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/abe71fe145a3d16257043ccfbb43002607458cee>`__
-   `#9086 <https://pagure.io/freeipa/issue/9086>`__
+   `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__
 -  Return the value cert-find failures from the CA
    `commit <https://codeberg.org/freeipa/freeipa/commit/81a6b9ad2d42fecdd94e17fa7c888bbdea2daf3c>`__
-   `#9369 <https://pagure.io/freeipa/issue/9369>`__
+   `#9369 <https://codeberg.org/freeipa/freeipa/issues/9369>`__
 -  Use the OpenSSL certificate parser in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/50dd79d1a35549034bc281fbdffea4399baed3c7>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Enforce sizelimit in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/e2576670e692117c11987118abd5e9381bb90b1f>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  doc: Update pruning design with implement enable/disable options
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe13baa0acdb885dd981cbd8fdf6cee5e5ef22e3>`__
-   `#9323 <https://pagure.io/freeipa/issue/9323>`__
+   `#9323 <https://codeberg.org/freeipa/freeipa/issues/9323>`__
 -  Wipe the ipa-ca DNS record when updating system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e0ad96fbd9f438c884eeeaa60c2fb0c910a2b61>`__
-   `#9195 <https://pagure.io/freeipa/issue/9195>`__
+   `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
 -  Fix setting values of 0 in ACME pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/20ff7c16022793c707f6c2b8fb38a801870bc0e2>`__
-   `#9325 <https://pagure.io/freeipa/issue/9325>`__
+   `#9325 <https://codeberg.org/freeipa/freeipa/issues/9325>`__
 -  tests: add wrapper around ACME RSNv3 test
    `commit <https://codeberg.org/freeipa/freeipa/commit/d24b69981d94fce7b1e1aa4a5c1ab88a123f96b5>`__
-   `#9322 <https://pagure.io/freeipa/issue/9322>`__
+   `#9322 <https://codeberg.org/freeipa/freeipa/issues/9322>`__
 -  doc: add the --run command for manual job execution
    `commit <https://codeberg.org/freeipa/freeipa/commit/f10d1a0f84ed0f16ab4a1469f16ffadb3e79e59e>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  ipa-acme-manage: add certificate/request pruning management
    `commit <https://codeberg.org/freeipa/freeipa/commit/9246a8a003b2b0062e07c289cd7cde8fe902b16f>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ca119686aadfa72c0474f72758b63cd671952d4>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff31b0c40cc5e046f839b98b80bd16bb649205ac>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  doc: Design for certificate pruning
    `commit <https://codeberg.org/freeipa/freeipa/commit/51b1c22d025bf40e9ef488bb0faf0c8dff303ccd>`__
-   `#9294 <https://pagure.io/freeipa/issue/9294>`__
+   `#9294 <https://codeberg.org/freeipa/freeipa/issues/9294>`__
 
 
 
@@ -789,10 +789,10 @@ Rafael Guterres Jeffman (2)
 
 -  Fix "no entry" condition when searching PAC info
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a7c068300a80f14b4b2fa4d63b0512768d326ad>`__
-   `#9368 <https://pagure.io/freeipa/issue/9368>`__
+   `#9368 <https://codeberg.org/freeipa/freeipa/issues/9368>`__
 -  Migrated to SPDX license.
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3507563877f1d64567f24b7f2e33ade8c310f86>`__
-   `#9342 <https://pagure.io/freeipa/issue/9342>`__
+   `#9342 <https://codeberg.org/freeipa/freeipa/issues/9342>`__
 
 
 
@@ -801,68 +801,68 @@ Stanislav Levin (21)
 
 -  ipasphinx: Correct import of progress_message for Sphinx 6.1.0+
    `commit <https://codeberg.org/freeipa/freeipa/commit/3d787c2107ca10de15602afc757fc9b24fdd89bf>`__
-   `#9361 <https://pagure.io/freeipa/issue/9361>`__
+   `#9361 <https://codeberg.org/freeipa/freeipa/issues/9361>`__
 -  fastlint: Correct concatenation of file lists
    `commit <https://codeberg.org/freeipa/freeipa/commit/540262700d73b701b0fd5dd3b79e5b20f0fc84c3>`__
-   `#9318 <https://pagure.io/freeipa/issue/9318>`__
+   `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__
 -  dns: Fix support for dnspython 1.1x
    `commit <https://codeberg.org/freeipa/freeipa/commit/b152e8c3aea9f2c3ade319934fd7c81cb5432407>`__
-   `#9339 <https://pagure.io/freeipa/issue/9339>`__
+   `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__
 -  tests: webui: Update vendored qunit
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b8e8edc22ade3027a5c3da487783f598e0732fd>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  AP: webui: List installed nodejs packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fe8b262232ce65dddea8c92838200a1c5121f13>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Load qunit only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/425cad6f114c981bfe41a30c7ad626164ac29be4>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Allow file access from files in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/450e78f5f3be3064d7ee1c6be5103dfae2ebaf87>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
    `commit <https://codeberg.org/freeipa/freeipa/commit/d662b125985369181a3ebcbad82a4a43215282f6>`__
-   `#9319 <https://pagure.io/freeipa/issue/9319>`__
+   `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__
 -  spec: Drop no longer used build dependency on paste
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb22c8e5bf9432b4a7c2866d5d210c353985ea50>`__
-   `#9314 <https://pagure.io/freeipa/issue/9314>`__
+   `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/1be3188e3168e7a097e44a97f86e29b7e42fcae6>`__
-   `#9315 <https://pagure.io/freeipa/issue/9315>`__
+   `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__
 -  pylint: Replace deprecated cgi module
    `commit <https://codeberg.org/freeipa/freeipa/commit/2009889d763ccc26479c966931ca1b60378496fd>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix useless-object-inheritance
    `commit <https://codeberg.org/freeipa/freeipa/commit/bccd3c942084c753543d63b4d409ac46f819d314>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix unhashable-member
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd7b5bf71c443daa3ac12ff194748845a84b08f0>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix unnecessary-lambda-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc8c8a7824565178333ef7ae8ac7934467424691>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix modified-iterating-list
    `commit <https://codeberg.org/freeipa/freeipa/commit/acc2daf25f5c12ef1d9a823de15df080ba42d059>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix used-before-assignment
    `commit <https://codeberg.org/freeipa/freeipa/commit/b12376560da944b0845b9ac0d424adaf5435670f>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Replace deprecated pipes
    `commit <https://codeberg.org/freeipa/freeipa/commit/1261bbf0016d4824f908a589d4943513e98f8b01>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Fix cyclic-import
    `commit <https://codeberg.org/freeipa/freeipa/commit/c48c76e9d34bae09dc4eac1f3b33f7cb72355c25>`__
-   `#9232 <https://pagure.io/freeipa/issue/9232>`__,
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9232 <https://codeberg.org/freeipa/freeipa/issues/9232>`__,
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Replace deprecated extension-pkg-whitelist
    `commit <https://codeberg.org/freeipa/freeipa/commit/68ab438f5c2250d96733a0c1b47cbb3a1c518bed>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: More allowed C extensions
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9822697659f134146e1dcfce0c48e2279a8becb>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 -  pylint: Lint in single process mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/d673fdab6097ae783bd0075c0e990e42bc24f833>`__
-   `#9278 <https://pagure.io/freeipa/issue/9278>`__
+   `#9278 <https://codeberg.org/freeipa/freeipa/issues/9278>`__
 
 
 
@@ -873,7 +873,7 @@ Sudhir Menon (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/76c788274a2ee3993ee36d12d91e22200817dfc9>`__
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/65a14a36936b8ebfdb17560d5976447c6f4cdf7e>`__
-   `#9279 <https://pagure.io/freeipa/issue/9279>`__
+   `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__
 
 
 
@@ -882,7 +882,7 @@ Timo Aaltonen (1)
 
 -  Drop duplicate includedir from krb5.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdb77a3d810837e3e349ce6b5625662be281f2cd>`__
-   `#9267 <https://pagure.io/freeipa/issue/9267>`__
+   `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
 
 
 

--- a/src/release-notes/4-11-0-beta.rst
+++ b/src/release-notes/4-11-0-beta.rst
@@ -117,83 +117,83 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#9003 <https://pagure.io/freeipa/issue/9003>`__ ipa-server-install
+-  `#9003 <https://codeberg.org/freeipa/freeipa/issues/9003>`__ ipa-server-install
    not validating hostname != domain
--  `#9261 <https://pagure.io/freeipa/issue/9261>`__ Add CLI and WebUI to
+-  `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__ Add CLI and WebUI to
    register a passkey for a user
--  `#9262 <https://pagure.io/freeipa/issue/9262>`__ Add "passkey"
+-  `#9262 <https://codeberg.org/freeipa/freeipa/issues/9262>`__ Add "passkey"
    authentication type
--  `#9263 <https://pagure.io/freeipa/issue/9263>`__ Add support for
+-  `#9263 <https://codeberg.org/freeipa/freeipa/issues/9263>`__ Add support for
    passkey authentication type in kdb driver
--  `#9317 <https://pagure.io/freeipa/issue/9317>`__ Distinguish between
+-  `#9317 <https://codeberg.org/freeipa/freeipa/issues/9317>`__ Distinguish between
    different location meaning
--  `#9330 <https://pagure.io/freeipa/issue/9330>`__
+-  `#9330 <https://codeberg.org/freeipa/freeipa/issues/9330>`__
    (`rhbz#2214933 <https://bugzilla.redhat.com/show_bug.cgi?id=2214933>`__)
    Nightly test failure (testing_master_pki):
    TestBackupReinstallRestoreWithKRA::test_full_backup_reinstall_restore_with_vault
--  `#9331 <https://pagure.io/freeipa/issue/9331>`__
+-  `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
    (`rhbz#2164349 <https://bugzilla.redhat.com/show_bug.cgi?id=2164349>`__)
    Better handling of the command line and web UI cert search and/or
    list features
--  `#9336 <https://pagure.io/freeipa/issue/9336>`__ Allow custom real
+-  `#9336 <https://codeberg.org/freeipa/freeipa/issues/9336>`__ Allow custom real
    name in IPA-EPN
--  `#9378 <https://pagure.io/freeipa/issue/9378>`__
+-  `#9378 <https://codeberg.org/freeipa/freeipa/issues/9378>`__
    (`rhbz#2150217 <https://bugzilla.redhat.com/show_bug.cgi?id=2150217>`__)
    [RFE] Descriptive error message in ipa user-add
--  `#9381 <https://pagure.io/freeipa/issue/9381>`__
+-  `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
    (`rhbz#2215336 <https://bugzilla.redhat.com/show_bug.cgi?id=2215336>`__)
    Race condition in ipa-server-upgrade where pki-tomcat needs dirsrv
    while it's stopped
--  `#9385 <https://pagure.io/freeipa/issue/9385>`__
+-  `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
    (`rhbz#2216549 <https://bugzilla.redhat.com/show_bug.cgi?id=2216549>`__)
    Upgrade to 4.9.10-6.0.1 fails: attributes are managed by topology
    plugin
--  `#9386 <https://pagure.io/freeipa/issue/9386>`__ Update SELinux
+-  `#9386 <https://codeberg.org/freeipa/freeipa/issues/9386>`__ Update SELinux
    policy
--  `#9389 <https://pagure.io/freeipa/issue/9389>`__ Nightly test failure
+-  `#9389 <https://codeberg.org/freeipa/freeipa/issues/9389>`__ Nightly test failure
    in test_webui_service
--  `#9396 <https://pagure.io/freeipa/issue/9396>`__ Renaming user or
+-  `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__ Renaming user or
    group with --setattr does not check supported formats
--  `#9399 <https://pagure.io/freeipa/issue/9399>`__ Nightly
+-  `#9399 <https://codeberg.org/freeipa/freeipa/issues/9399>`__ Nightly
    tests(rawhide): test_epn not compatible with dnf5
--  `#9402 <https://pagure.io/freeipa/issue/9402>`__
+-  `#9402 <https://codeberg.org/freeipa/freeipa/issues/9402>`__
    (`rhbz#2216872 <https://bugzilla.redhat.com/show_bug.cgi?id=2216872>`__)
    OTP authentication failure on s390x
--  `#9404 <https://pagure.io/freeipa/issue/9404>`__ Nightly test failure
+-  `#9404 <https://codeberg.org/freeipa/freeipa/issues/9404>`__ Nightly test failure
    in
    test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica::test_full_backup_and_restore_with_replica
--  `#9409 <https://pagure.io/freeipa/issue/9409>`__ freeipa uses
+-  `#9409 <https://codeberg.org/freeipa/freeipa/issues/9409>`__ freeipa uses
    ssl.match_hostname() which was removed from Python 3.12
--  `#9416 <https://pagure.io/freeipa/issue/9416>`__
+-  `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
    (`rhbz#2224570 <https://bugzilla.redhat.com/show_bug.cgi?id=2224570>`__)
    Better error description when managing a user with '--idp'
--  `#9419 <https://pagure.io/freeipa/issue/9419>`__  Nightly test failure in test_epn.py::TestEPN::test_EPN_config_file
--  `#9403 <https://pagure.io/freeipa/issue/9403>`__
+-  `#9419 <https://codeberg.org/freeipa/freeipa/issues/9419>`__  Nightly test failure in test_epn.py::TestEPN::test_EPN_config_file
+-  `#9403 <https://codeberg.org/freeipa/freeipa/issues/9403>`__
    (`rhbz#2209636 <https://bugzilla.redhat.com/show_bug.cgi?id=2209636>`__)
    libipa_otp_lasttoken plugin memory leak
--  `#9421 <https://pagure.io/freeipa/issue/9421>`__ ipa idp-add
+-  `#9421 <https://codeberg.org/freeipa/freeipa/issues/9421>`__ ipa idp-add
    --provider silently ignores options like --scope
--  `#9422 <https://pagure.io/freeipa/issue/9422>`__
+-  `#9422 <https://codeberg.org/freeipa/freeipa/issues/9422>`__
    (`rhbz#2214638 <https://bugzilla.redhat.com/show_bug.cgi?id=2214638>`__,
    `rhbz#2227831 <https://bugzilla.redhat.com/show_bug.cgi?id=2227831>`__,
    `rhbz#2227832 <https://bugzilla.redhat.com/show_bug.cgi?id=2227832>`__)
    Interrupt request processing in ipadb_fill_info3() if connection to
    389ds is lost
--  `#8878 <https://pagure.io/freeipa/issue/8878>`__
+-  `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
    (`rhbz#1821181 <https://bugzilla.redhat.com/show_bug.cgi?id=1821181>`__,
    `rhbz#2229712 <https://bugzilla.redhat.com/show_bug.cgi?id=2229712>`__)
    Prevent deletion of 'admin' account with web UI
--  `#9348 <https://pagure.io/freeipa/issue/9348>`__ Nightly test failure
+-  `#9348 <https://codeberg.org/freeipa/freeipa/issues/9348>`__ Nightly test failure
    (testing_master_pki):
    test_integration/test_acme.py::TestACMEPrune::test_prune_cert_manual
--  `#9425 <https://pagure.io/freeipa/issue/9425>`__ Python 3.12 issues:
+-  `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__ Python 3.12 issues:
    datetime.utcnow is deprecated
--  `#9427 <https://pagure.io/freeipa/issue/9427>`__
+-  `#9427 <https://codeberg.org/freeipa/freeipa/issues/9427>`__
    (`rhbz#2216532 <https://bugzilla.redhat.com/show_bug.cgi?id=2216532>`__)
    RHEL 8.8 & 9.2 fails to create AD trust with STIG applied
--  `#9418 <https://pagure.io/freeipa/issue/9418>`__ Typo in "Subordinate
+-  `#9418 <https://codeberg.org/freeipa/freeipa/issues/9418>`__ Typo in "Subordinate
    ID Selfservice User" role
--  `#9395 <https://pagure.io/freeipa/issue/9395>`__ Search for user by
+-  `#9395 <https://codeberg.org/freeipa/freeipa/issues/9395>`__ Search for user by
    krbPrincipalExpiration not returning results
 
 .. _detailed_changelog_since_4.10.2:
@@ -224,21 +224,21 @@ Alexander Bokovoy (10)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5c292cdada69a93a03de0fa6e48aa713b432ba1>`__
 -  ipa-kdb: initial support for passkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/56e179748ba4844ce0c5e505803170b901e2a3c4>`__
-   `#9263 <https://pagure.io/freeipa/issue/9263>`__
+   `#9263 <https://codeberg.org/freeipa/freeipa/issues/9263>`__
 -  Change doc theme to 'book'
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0c4f83abdbbaaa77707e5d15f91ce2bb0bf9329>`__
 -  idp: when adding an IdP allow to override IdP options
    `commit <https://codeberg.org/freeipa/freeipa/commit/69e4397421d16fad7d16b2f5d53d2bd9316407a1>`__
-   `#9421 <https://pagure.io/freeipa/issue/9421>`__
+   `#9421 <https://codeberg.org/freeipa/freeipa/issues/9421>`__
 -  ipa-epn: don't use too general exception
    `commit <https://codeberg.org/freeipa/freeipa/commit/8173e5df2d0e8dac48f26882ff16979d0da325b5>`__
-   `#9425 <https://pagure.io/freeipa/issue/9425>`__
+   `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__
 -  python 3.12: utcnow function is deprecated
    `commit <https://codeberg.org/freeipa/freeipa/commit/09497d2df0fbd4bb5ad798e5c0798a0faa632f11>`__
-   `#9425 <https://pagure.io/freeipa/issue/9425>`__
+   `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__
 -  support more DateTime attributes in LDAP searches in IPA API
    `commit <https://codeberg.org/freeipa/freeipa/commit/ef955c90150d7d1df145b16b1f17940769d42f56>`__
-   `#9395 <https://pagure.io/freeipa/issue/9395>`__
+   `#9395 <https://codeberg.org/freeipa/freeipa/issues/9395>`__
 
 
 .. _andika_triwidada_1:
@@ -335,7 +335,7 @@ Erik Belko (1)
 
 -  test: add tests for descriptive error message in ipa user-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a3e3efb84cee9e3784246f3bc47f1f56b266bc0>`__
-   `#9378 <https://pagure.io/freeipa/issue/9378>`__
+   `#9378 <https://codeberg.org/freeipa/freeipa/issues/9378>`__
 
 .. _endi_sukma_dewata_2:
 
@@ -371,46 +371,46 @@ Florence Blanc-Renaud (56)
 
 -  xmlrpc tests: add a test for user plugin with non-existing idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/7517e2ce217c20651b720b8a5e5a4a134e7cdfbf>`__
-   `#9416 <https://pagure.io/freeipa/issue/9416>`__
+   `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
 -  User plugin: improve error related to non existing idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/f57a7dbf508b9214dc8222ea0ba0acf162025d2e>`__
-   `#9416 <https://pagure.io/freeipa/issue/9416>`__
+   `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
 -  OTP: fix data type to avoid endianness issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/7060e3a031fb4e4cdf85f616f1e1a3435d61e696>`__
-   `#9402 <https://pagure.io/freeipa/issue/9402>`__
+   `#9402 <https://codeberg.org/freeipa/freeipa/issues/9402>`__
 -  ipatests: use dnf download to download pkgs
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce9346e74e98a73c927bda5d294e9bab2785c713>`__
-   `#9399 <https://pagure.io/freeipa/issue/9399>`__
+   `#9399 <https://codeberg.org/freeipa/freeipa/issues/9399>`__
 -  tests: fix backup-restore scenario with replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/8de6405b1130a9b21bae87689a18439059515399>`__
-   `#9404 <https://pagure.io/freeipa/issue/9404>`__
+   `#9404 <https://codeberg.org/freeipa/freeipa/issues/9404>`__
 -  Detection of PKI subsystem
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c84ae5c3035ecd917404cc41c32a4b25c607b46>`__
-   `#9330 <https://pagure.io/freeipa/issue/9330>`__
+   `#9330 <https://codeberg.org/freeipa/freeipa/issues/9330>`__
 -  Uninstaller: uninstall PKI before shutting down services
    `commit <https://codeberg.org/freeipa/freeipa/commit/67a33e5a305c7510fb182f84e46f304043f6ab37>`__
-   `#9330 <https://pagure.io/freeipa/issue/9330>`__
+   `#9330 <https://codeberg.org/freeipa/freeipa/issues/9330>`__
 -  Integration tests: add a test to ipa-server-upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac78a84fbe90f361a4a58fb2748d539647ffea52>`__
-   `#9385 <https://pagure.io/freeipa/issue/9385>`__
+   `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
 -  Upgrade: fix replica agreement
    `commit <https://codeberg.org/freeipa/freeipa/commit/143c3eb1612f9bb7f015dcf2dcb496e8ef324a38>`__
-   `#9385 <https://pagure.io/freeipa/issue/9385>`__
+   `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
 -  Integration test: add a test for upgrade and PKI drop-in file
    `commit <https://codeberg.org/freeipa/freeipa/commit/d76f8fcedab7cb6e1089eb32bbc7f7856a4e4b0d>`__
-   `#9381 <https://pagure.io/freeipa/issue/9381>`__
+   `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
 -  Upgrade: add PKI drop-in file if missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/0472067ca63e4c4a9a3f060de7802b39af6d671d>`__
-   `#9381 <https://pagure.io/freeipa/issue/9381>`__
+   `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
 -  xmlrpc tests: add test renaming user or group with setattr
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae6549ffae1ffe2bb6a1ba7dce0620ec0c20cabf>`__
-   `#9396 <https://pagure.io/freeipa/issue/9396>`__
+   `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__
 -  User and groups: rename with --setattr must check format
    `commit <https://codeberg.org/freeipa/freeipa/commit/794b2c32f67aa8e69616171f3e8de99654698b7e>`__
-   `#9396 <https://pagure.io/freeipa/issue/9396>`__
+   `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__
 -  webuitests: close notification which hides Add button
    `commit <https://codeberg.org/freeipa/freeipa/commit/1aea1cc29e3235313a97dfbd979437a396411a7c>`__
-   `#9389 <https://pagure.io/freeipa/issue/9389>`__
+   `#9389 <https://codeberg.org/freeipa/freeipa/issues/9389>`__
 -  Spec file: bump SSSD version for passkey support
    `commit <https://codeberg.org/freeipa/freeipa/commit/665227e43755c0869f25e986265c0533af1cc7f7>`__
 -  Passkey: add a weak dependency on sssd-passkey
@@ -427,41 +427,41 @@ Florence Blanc-Renaud (56)
    `commit <https://codeberg.org/freeipa/freeipa/commit/b650783a180e6c81a6ccec3fd18ee9ed13edaf12>`__
 -  Passkey: add "passkey configuration" to webui
    `commit <https://codeberg.org/freeipa/freeipa/commit/c016e271b2bddde5c26822fee78e7f07b95dddc3>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  WebUI: improve passkey display
    `commit <https://codeberg.org/freeipa/freeipa/commit/510f806a9f4f82d39772f22e3262ca6c17c918be>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  Passkey support: show the passkey in webui
    `commit <https://codeberg.org/freeipa/freeipa/commit/c58e483095d21aaa98f546425a99dc22d31dfb4a>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  Passkey: add support for discoverable credentials
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f0da62f5afa65941c280e16bd12215a57e4d6b0>`__
 -  WebUI tests: add test for krbtpolicy passkey maxlife/maxrenew
    `commit <https://codeberg.org/freeipa/freeipa/commit/d207f6bf328a9f2a3e07094aeab111aebca932de>`__
-   `#9262 <https://pagure.io/freeipa/issue/9262>`__
+   `#9262 <https://codeberg.org/freeipa/freeipa/issues/9262>`__
 -  WebUI: add support for passkey auth type and auth indicator
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8580cae4b01568a6ab98b405435e83231994896>`__
-   `#9262 <https://pagure.io/freeipa/issue/9262>`__
+   `#9262 <https://codeberg.org/freeipa/freeipa/issues/9262>`__
 -  XMLRPC tests: add new tests for passkey auth type
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7d90c1ef5e70a532f4515c18bf3e073c11ab87c>`__
 -  CLI: add support for passkey authentication type
    `commit <https://codeberg.org/freeipa/freeipa/commit/7911b2466d892386721952991d5150412530fb6e>`__
-   `#9262 <https://pagure.io/freeipa/issue/9262>`__
+   `#9262 <https://codeberg.org/freeipa/freeipa/issues/9262>`__
 -  XMLRPC tests: test new passkey commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae3c281a64c994cae10709a2e284f3830de64781>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  API: add new commands for passkey mappings
    `commit <https://codeberg.org/freeipa/freeipa/commit/a21214cb9e96ff7fdb4f55b5a4817b1ce60632c0>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  API: add new commands for ipa passkeyconfig-show \| mod
    `commit <https://codeberg.org/freeipa/freeipa/commit/4bd1be9e90ea7369edb4ae15ff8c51232d5ab850>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  New schema for Passkey mappings
    `commit <https://codeberg.org/freeipa/freeipa/commit/af569508c1cefbbbfde2fe52b02fe4545818b04a>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  Design for passkey support
    `commit <https://codeberg.org/freeipa/freeipa/commit/574517cb165eb3d89dc3492895cf830a9bde67b2>`__
-   `#9261 <https://pagure.io/freeipa/issue/9261>`__
+   `#9261 <https://codeberg.org/freeipa/freeipa/issues/9261>`__
 -  PRCI: update rawhide box
    `commit <https://codeberg.org/freeipa/freeipa/commit/2be07242b70b5c80ecf606d76378f0c299fdb829>`__
 -  user or group name: explain the supported format
@@ -472,7 +472,7 @@ Florence Blanc-Renaud (56)
    `commit <https://codeberg.org/freeipa/freeipa/commit/72cc53a22e585b68bf3a111b17aceae1a1e93919>`__
 -  cert_find: fix call with --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f30cc65276a532e7288217f216b72a2b0628c8f>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Spec file: use %autosetup instead of %setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/295b4e23b44c74817fd83428f9ffe4cdb1e7bb8a>`__
 -  Spec file: unify with RHEL9 spec
@@ -495,27 +495,27 @@ Florence Blanc-Renaud (56)
    `commit <https://codeberg.org/freeipa/freeipa/commit/21091c2bc779d65d9049e01cd6ac6a7f2d2ef60d>`__
 -  ipatests: update expected cksum for epn.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb9b44f5700564e936a928b4063d241b8996e172>`__
-   `#9419 <https://pagure.io/freeipa/issue/9419>`__
+   `#9419 <https://codeberg.org/freeipa/freeipa/issues/9419>`__
 -  ipatests: update expected webui msg for admin deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/e49ec1048db85f514e2db5960f773e5d56fa0cec>`__
-   `#8878 <https://pagure.io/freeipa/issue/8878>`__
+   `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
 -  ipatests: fixture can produce IndexError
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6f01115cf2abbf6be5570d96fa607e716ba7ba9>`__
-   `#9348 <https://pagure.io/freeipa/issue/9348>`__
+   `#9348 <https://codeberg.org/freeipa/freeipa/issues/9348>`__
 -  ipatests: fix test_topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f5fe80de0ee9a5474fdfa5ae7880910b7384a62>`__
 -  Installer: activate nss and pam services in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/7796b7b9585e9459bb44b8ea92c50eb2592319cf>`__
-   `#9427 <https://pagure.io/freeipa/issue/9427>`__
+   `#9427 <https://codeberg.org/freeipa/freeipa/issues/9427>`__
 -  ipa-server-guard: make the lock timezone aware
    `commit <https://codeberg.org/freeipa/freeipa/commit/33549183effa3a880f2d79955939b25142e72ff9>`__
-   `#9425 <https://pagure.io/freeipa/issue/9425>`__
+   `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__
 -  ipa-cert-fix: use timezone-aware datetime
    `commit <https://codeberg.org/freeipa/freeipa/commit/0f16b72bcb86764aaffa69a9ccad4011e811f856>`__
-   `#9425 <https://pagure.io/freeipa/issue/9425>`__
+   `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__
 -  ipa-epn: include timezone info
    `commit <https://codeberg.org/freeipa/freeipa/commit/59e68f79e48e5eaa18c60f3dc418d0bf516684ab>`__
-   `#9425 <https://pagure.io/freeipa/issue/9425>`__
+   `#9425 <https://codeberg.org/freeipa/freeipa/issues/9425>`__
 
 .. _fraser_tweedale_3:
 
@@ -556,7 +556,7 @@ Julien Rische (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/545a363dd2f7f551fa3ec3fed66c80b30ae3c1e1>`__
 -  ipa-kdb: fix error handling of is_master_host()
    `commit <https://codeberg.org/freeipa/freeipa/commit/c84c59c66f1b22ebc671960cae90088a024d2d62>`__
-   `#9422 <https://pagure.io/freeipa/issue/9422>`__
+   `#9422 <https://codeberg.org/freeipa/freeipa/issues/9422>`__
 
 .. _lenz_grimmer_1:
 
@@ -583,7 +583,7 @@ Miro Hrončok (1)
 -  Use ssl.match_hostname from urllib3 as it was removed from Python
    3.12
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2ed490ff446d96520b89ea47387ce8ee33c1c7d>`__
-   `#9409 <https://pagure.io/freeipa/issue/9409>`__
+   `#9409 <https://codeberg.org/freeipa/freeipa/issues/9409>`__
 
 .. _mohammad_rizwan_5:
 
@@ -598,7 +598,7 @@ Mohammad Rizwan (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/746a036c7eab177fd87a37f0515a46419f22c12b>`__
 -  ipatests: remove fixture call and wait to get things settle
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbb53a12711f864601a9d7c024145603c9c596a1>`__
-   `#9348 <https://pagure.io/freeipa/issue/9348>`__
+   `#9348 <https://codeberg.org/freeipa/freeipa/issues/9348>`__
 
 .. _weblate_5:
 
@@ -633,34 +633,34 @@ Rob Crittenden (10)
 
 -  Differentiate location meaning between host and server
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1ed46eb93bcb5bc87783dc3daad72faffc7c6af>`__
-   `#9317 <https://pagure.io/freeipa/issue/9317>`__
+   `#9317 <https://codeberg.org/freeipa/freeipa/issues/9317>`__
 -  Use the python-cryptography parser directly in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa3a69f91fcb4e15714f78a6eee4944bb8ca5e1b>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Revert "cert_find: fix call with --all"
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a250201494fa0864c81ba0bb2d16a485cdd2533>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Revert "Use the OpenSSL certificate parser in cert-find"
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a605c5d07906e157e79458724be098aab28cc7c>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Don't allow the FQDN to match the domain on server installs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2bce952d8f4358a028eb067154011cc1f6d8a44>`__
-   `#9003 <https://pagure.io/freeipa/issue/9003>`__
+   `#9003 <https://codeberg.org/freeipa/freeipa/issues/9003>`__
 -  Use the OpenSSL certificate parser in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/191880bc9f77c3e8a3cecc82e6eea33ab5ad03e4>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Enforce sizelimit in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b2f10c2eb7f3b796c68771bc8cbf5dbaa646481>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Fix memory leak in the OTP last token plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/089907b4853207ea70c7ca02896b84718251cf6f>`__
-   `#9403 <https://pagure.io/freeipa/issue/9403>`__
+   `#9403 <https://codeberg.org/freeipa/freeipa/issues/9403>`__
 -  Prevent the admin user from being deleted
    `commit <https://codeberg.org/freeipa/freeipa/commit/dea35922cd086883c0699646ec39fdef8f0ba579>`__
-   `#8878 <https://pagure.io/freeipa/issue/8878>`__
+   `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
 -  Remove all references to deleted indirect map from parent map
    `commit <https://codeberg.org/freeipa/freeipa/commit/d98d5e475133ad5fae0af3d08beca8b01950427f>`__
-   `#9397 <https://pagure.io/freeipa/issue/9397>`__
+   `#9397 <https://codeberg.org/freeipa/freeipa/issues/9397>`__
 
 .. _ricky_tigg_3:
 
@@ -681,10 +681,10 @@ Rafael Guterres Jeffman (2)
 
 -  selinux: Update SELinux policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/a78c47b2d331d22c0a21d449a4f13370913f58ed>`__
-   `#9386 <https://pagure.io/freeipa/issue/9386>`__
+   `#9386 <https://codeberg.org/freeipa/freeipa/issues/9386>`__
 -  Fix typo in "Subordinate ID Selfservice User" role
    `commit <https://codeberg.org/freeipa/freeipa/commit/82b129fe765ad32328df540be2ec4d27fc33df0a>`__
-   `#9418 <https://pagure.io/freeipa/issue/9418>`__
+   `#9418 <https://codeberg.org/freeipa/freeipa/issues/9418>`__
 
 .. _sumit_bose_7:
 
@@ -728,7 +728,7 @@ Simon Nussbaum (1)
 
 -  component: mail_from_realname config setting added to IPA-EPN
    `commit <https://codeberg.org/freeipa/freeipa/commit/fcad9c9aa76b5e027ca247941620c4e6a4be991e>`__
-   `#9336 <https://pagure.io/freeipa/issue/9336>`__
+   `#9336 <https://codeberg.org/freeipa/freeipa/issues/9336>`__
 
 
 .. _scott_poore_5:

--- a/src/release-notes/4-11-0.rst
+++ b/src/release-notes/4-11-0.rst
@@ -147,35 +147,35 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#9289 <https://pagure.io/freeipa/issue/9289>`__
+-  `#9289 <https://codeberg.org/freeipa/freeipa/issues/9289>`__
    (`rhbz#2149344 <https://bugzilla.redhat.com/show_bug.cgi?id=2149344>`__)
    Configure server affinity during replica installation
--  `#9345 <https://pagure.io/freeipa/issue/9345>`__ Convert PKI API to
+-  `#9345 <https://codeberg.org/freeipa/freeipa/issues/9345>`__ Convert PKI API to
    use JSON instead of XML
--  `#9354 <https://pagure.io/freeipa/issue/9354>`__ Implement
+-  `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__ Implement
    resource-based constrained delegation
--  `#9379 <https://pagure.io/freeipa/issue/9379>`__ Test failure in
+-  `#9379 <https://codeberg.org/freeipa/freeipa/issues/9379>`__ Test failure in
    test_ipa_cert_fix.py::TestCertFixReplica::test_renew_expired_cert_replica
--  `#9428 <https://pagure.io/freeipa/issue/9428>`__ Failure in
+-  `#9428 <https://codeberg.org/freeipa/freeipa/issues/9428>`__ Failure in
    test_integration/test_acme.py::TestACMEPrune::test_prune_cert_manual
--  `#9433 <https://pagure.io/freeipa/issue/9433>`__
+-  `#9433 <https://codeberg.org/freeipa/freeipa/issues/9433>`__
    (`rhbz#2234480 <https://bugzilla.redhat.com/show_bug.cgi?id=2234480>`__)
    ipa user-mod --idp-user-id fails with: attribute "ipaIdpSub" not
    allowed
--  `#9434 <https://pagure.io/freeipa/issue/9434>`__ Support SELinux
+-  `#9434 <https://codeberg.org/freeipa/freeipa/issues/9434>`__ Support SELinux
    booleans in the client installer
--  `#9435 <https://pagure.io/freeipa/issue/9435>`__ BDB tuning should be
+-  `#9435 <https://codeberg.org/freeipa/freeipa/issues/9435>`__ BDB tuning should be
    applied only when BDB backend is used
--  `#9437 <https://pagure.io/freeipa/issue/9437>`__ ImportWarning:
+-  `#9437 <https://codeberg.org/freeipa/freeipa/issues/9437>`__ ImportWarning:
    IpaMetaImporter.find_spec() not found; falling back to find_module()
--  `#9446 <https://pagure.io/freeipa/issue/9446>`__
+-  `#9446 <https://codeberg.org/freeipa/freeipa/issues/9446>`__
    (`rhbz#2149344 <https://bugzilla.redhat.com/show_bug.cgi?id=2149344>`__)
    Nightly test failure for replica installation with --setup-ca
--  `#9447 <https://pagure.io/freeipa/issue/9447>`__ Nightly test failure
+-  `#9447 <https://codeberg.org/freeipa/freeipa/issues/9447>`__ Nightly test failure
    in test_sso.py
--  `#9431 <https://pagure.io/freeipa/issue/9431>`__  Covscan issues: 
+-  `#9431 <https://codeberg.org/freeipa/freeipa/issues/9431>`__  Covscan issues: 
    deadcode and Use after free
--  `#9443 <https://pagure.io/freeipa/issue/9443>`__   Context manager 
+-  `#9443 <https://codeberg.org/freeipa/freeipa/issues/9443>`__   Context manager 
    for ipalib.api to automatically configure, connect, and disconnect
 
 .. _detailed_changelog_since_4.11.0_beta:
@@ -190,16 +190,16 @@ Alexander Bokovoy (4)
 
 -  Allow ipa-otpd to access USB devices for passkeys
    `commit <https://codeberg.org/freeipa/freeipa/commit/637ccae0b4b0ecd36756b4540c666724a73f4633>`__
-   `#9434 <https://pagure.io/freeipa/issue/9434>`__
+   `#9434 <https://codeberg.org/freeipa/freeipa/issues/9434>`__
 -  Restore selinux states if they exist at uninstall time
    `commit <https://codeberg.org/freeipa/freeipa/commit/2220f72321dc6af8a7a94e1fad1c6980ee4cf522>`__
-   `#9434 <https://pagure.io/freeipa/issue/9434>`__
+   `#9434 <https://codeberg.org/freeipa/freeipa/issues/9434>`__
 -  ipa-client-install: enable SELinux for SSSD
    `commit <https://codeberg.org/freeipa/freeipa/commit/d62be1da4542e91521b44595f2d41b557ba7a49e>`__
-   `#9434 <https://pagure.io/freeipa/issue/9434>`__
+   `#9434 <https://codeberg.org/freeipa/freeipa/issues/9434>`__
 -  updates: add ACIs for RBCD self-management
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc9b527dee2652c8056eb99080d9a050a7e648ff>`__
-   `#9354 <https://pagure.io/freeipa/issue/9354>`__
+   `#9354 <https://codeberg.org/freeipa/freeipa/issues/9354>`__
 
 .. _alexandra_nikandrova_1:
 
@@ -216,7 +216,7 @@ Antonio Torres (2)
 
 -  ipatests: rename 'ipatuura' directory to 'scim' in bridge tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/47463294097e01e08b0df3a51f3e2ccc9df9e309>`__
-   `#9447 <https://pagure.io/freeipa/issue/9447>`__
+   `#9447 <https://codeberg.org/freeipa/freeipa/issues/9447>`__
 -  Back to git snapshots
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b1c5a5a83e4e5d667218e1b1b32322e7a0e29de>`__
 
@@ -227,10 +227,10 @@ Christian Heimes (2)
 
 -  Use find_spec() in meta importer
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc9385d15cf7a975063754572eb65556a1df9c8a>`__
-   `#9437 <https://pagure.io/freeipa/issue/9437>`__
+   `#9437 <https://codeberg.org/freeipa/freeipa/issues/9437>`__
 -  Add context manager to ipalib.API
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed094e11ec59409c6cb361fa871e9b5e3da02172>`__
-   `#9443 <https://pagure.io/freeipa/issue/9443>`__
+   `#9443 <https://codeberg.org/freeipa/freeipa/issues/9443>`__
 
 .. _florence_blanc_renaud_1:
 
@@ -239,7 +239,7 @@ Florence Blanc-Renaud (1)
 
 -  idp: add the ipaidpuser objectclass when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/f16b6e3e0a1f3dc507c3150c347276255f3b3e72>`__
-   `#9433 <https://pagure.io/freeipa/issue/9433>`__
+   `#9433 <https://codeberg.org/freeipa/freeipa/issues/9433>`__
 
 .. _francisco_trivino_1:
 
@@ -256,10 +256,10 @@ Mohammad Rizwan (2)
 
 -  ipatests: restart ipa services after moving date
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c10d7ee2c7a7f1f2c2643e19e3a3b8cf8a211be>`__
-   `#9379 <https://pagure.io/freeipa/issue/9379>`__
+   `#9379 <https://codeberg.org/freeipa/freeipa/issues/9379>`__
 -  ipatests: accommodate DST in ACME cert expiry
    `commit <https://codeberg.org/freeipa/freeipa/commit/b13b8fbb472ec24dfe35a690147e43aea363f3e4>`__
-   `#9428 <https://pagure.io/freeipa/issue/9428>`__
+   `#9428 <https://codeberg.org/freeipa/freeipa/issues/9428>`__
 
 .. _rob_crittenden_4:
 
@@ -268,19 +268,19 @@ Rob Crittenden (5)
 
 -  Don't assume KRB5CCNAME is in the environment in replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/169f9abb6b9fdc11dc5d3e4ec8e6e9c3ef4dfd4f>`__
-   `#9446 <https://pagure.io/freeipa/issue/9446>`__
+   `#9446 <https://codeberg.org/freeipa/freeipa/issues/9446>`__
 -  Configure affinity during server installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/54a251bceaabfaf82d0a18b2614c261e2bded0c0>`__
-   `#9289 <https://pagure.io/freeipa/issue/9289>`__
+   `#9289 <https://codeberg.org/freeipa/freeipa/issues/9289>`__
 -  Adjust test to handle revocation reason REMOVE_FROM_CRL
    `commit <https://codeberg.org/freeipa/freeipa/commit/37b433d4a79ae3f9160a27b6a03a58f371d2bd34>`__
-   `#9345 <https://pagure.io/freeipa/issue/9345>`__
+   `#9345 <https://codeberg.org/freeipa/freeipa/issues/9345>`__
 -  Use the PKI REST API wherever possible instead of XML
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b870694f62701534a32fdb4cbdd5c06a3ea4559>`__
-   `#9345 <https://pagure.io/freeipa/issue/9345>`__
+   `#9345 <https://codeberg.org/freeipa/freeipa/issues/9345>`__
 -  Covscan issues: deadcode and Use after free
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb14a30a1523305606d3bfbf7211cda1e197c9e9>`__
-   `#9345 <https://pagure.io/freeipa/issue/9431>`__
+   `#9345 <https://codeberg.org/freeipa/freeipa/issues/9431>`__
 
 .. _viktor_ashirov_1:
 
@@ -289,4 +289,4 @@ Viktor Ashirov (1)
 
 -  BDB tuning should be applied only when BDB backend is used
    `commit <https://codeberg.org/freeipa/freeipa/commit/3f874eece90741cd3951578b15fd78fae9d50750>`__
-   `#9435 <https://pagure.io/freeipa/issue/9435>`__
+   `#9435 <https://codeberg.org/freeipa/freeipa/issues/9435>`__

--- a/src/release-notes/4-12-0.rst
+++ b/src/release-notes/4-12-0.rst
@@ -162,202 +162,202 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#3656 <https://pagure.io/freeipa/issue/3656>`__
+-  `#3656 <https://codeberg.org/freeipa/freeipa/issues/3656>`__
    (`rhbz#1465917 <https://bugzilla.redhat.com/show_bug.cgi?id=1465917>`__)
    [RFE] FreeIPA-to-FreeIPA migration
--  `#5169 <https://pagure.io/freeipa/issue/5169>`__ [RFE] Enforce OTP
+-  `#5169 <https://codeberg.org/freeipa/freeipa/issues/5169>`__ [RFE] Enforce OTP
    for a subset of scenarios
--  `#7677 <https://pagure.io/freeipa/issue/7677>`__ HSM: ipa ca-add
+-  `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__ HSM: ipa ca-add
    fails with error in ipa-pki-retrieve-key
--  `#9191 <https://pagure.io/freeipa/issue/9191>`__ ipa vault-add is
+-  `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__ ipa vault-add is
    failing with ipa in RHEL9: ERROR: an internal error has occurred in
    FIPS mode
--  `#9272 <https://pagure.io/freeipa/issue/9272>`__ Install CA
+-  `#9272 <https://codeberg.org/freeipa/freeipa/issues/9272>`__ Install CA
    certificates only for PKINIT or TLS client auth
--  `#9273 <https://pagure.io/freeipa/issue/9273>`__
+-  `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
    (`rhbz#1405935 <https://bugzilla.redhat.com/show_bug.cgi?id=1405935>`__)
    [RFE] Support IPA CA installation on an HSM
--  `#9295 <https://pagure.io/freeipa/issue/9295>`__ Nightly test failure
+-  `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__ Nightly test failure
    (sssd) in test_trust.py::TestNonPosixAutoPrivateGroup and
    test_trust.py::TestPosixAutoPrivateGroup
--  `#9297 <https://pagure.io/freeipa/issue/9297>`__ Minimum length
+-  `#9297 <https://codeberg.org/freeipa/freeipa/issues/9297>`__ Minimum length
    parameter in pwpolicy cannot be removed with empty string.
--  `#9353 <https://pagure.io/freeipa/issue/9353>`__ certmonger helper
+-  `#9353 <https://codeberg.org/freeipa/freeipa/issues/9353>`__ certmonger helper
    renew_ca_cert does not set the P trust flag on the KRA audit
    certificate during renewal
--  `#9390 <https://pagure.io/freeipa/issue/9390>`__ [webui][RFE] Unify
+-  `#9390 <https://codeberg.org/freeipa/freeipa/issues/9390>`__ [webui][RFE] Unify
    user group members columns with users columns
--  `#9400 <https://pagure.io/freeipa/issue/9400>`__ Nightly test
+-  `#9400 <https://codeberg.org/freeipa/freeipa/issues/9400>`__ Nightly test
    failure: healthcheck reports nsslapd-accesslog-logbuffering is set to
    'off'
--  `#9405 <https://pagure.io/freeipa/issue/9405>`__ Nightly test failure
+-  `#9405 <https://codeberg.org/freeipa/freeipa/issues/9405>`__ Nightly test failure
    (rawhide) in test_installation_TestKRAinstallAfterCertRenew
--  `#9415 <https://pagure.io/freeipa/issue/9415>`__ Nightly test failure
+-  `#9415 <https://codeberg.org/freeipa/freeipa/issues/9415>`__ Nightly test failure
    in
    test_integration/test_installation.py::TestInstallMaster::test_ipactl_scenario_check
--  `#9438 <https://pagure.io/freeipa/issue/9438>`__
+-  `#9438 <https://codeberg.org/freeipa/freeipa/issues/9438>`__
    (`rhbz#1513934 <https://bugzilla.redhat.com/show_bug.cgi?id=1513934>`__)
    Allow applications to override cache directory
--  `#9449 <https://pagure.io/freeipa/issue/9449>`__ Squished FreeIPA
+-  `#9449 <https://codeberg.org/freeipa/freeipa/issues/9449>`__ Squished FreeIPA
    favicon
--  `#9454 <https://pagure.io/freeipa/issue/9454>`__ module 'datetime'
+-  `#9454 <https://codeberg.org/freeipa/freeipa/issues/9454>`__ module 'datetime'
    has no attribute 'UTC'
--  `#9459 <https://pagure.io/freeipa/issue/9459>`__ Nightly test failure
+-  `#9459 <https://codeberg.org/freeipa/freeipa/issues/9459>`__ Nightly test failure
    (with healthcheck 0.14) in
    test_ipahealthcheck.py::TestIpaHealthCheckWithoutDNS::test_ipa_dns_systemrecords_check
--  `#9460 <https://pagure.io/freeipa/issue/9460>`__ Nightly test failure
+-  `#9460 <https://codeberg.org/freeipa/freeipa/issues/9460>`__ Nightly test failure
    (with healthcheck 0.14) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_source_ipahealthcheck_meta_services_check
--  `#9462 <https://pagure.io/freeipa/issue/9462>`__ Server install:
+-  `#9462 <https://codeberg.org/freeipa/freeipa/issues/9462>`__ Server install:
    failure to install with externally signed CA because of timezone
    issue
--  `#9465 <https://pagure.io/freeipa/issue/9465>`__ IPA stops working if
+-  `#9465 <https://codeberg.org/freeipa/freeipa/issues/9465>`__ IPA stops working if
    HTTP/... service principal was created before FreeIPA 4.4.0 and never
    modified
--  `#9466 <https://pagure.io/freeipa/issue/9466>`__ Regression:
+-  `#9466 <https://codeberg.org/freeipa/freeipa/issues/9466>`__ Regression:
    group-add-member --external does not work
--  `#9467 <https://pagure.io/freeipa/issue/9467>`__ Mitigate
+-  `#9467 <https://codeberg.org/freeipa/freeipa/issues/9467>`__ Mitigate
    deprecations included in python 3.13+
--  `#9471 <https://pagure.io/freeipa/issue/9471>`__ Pre-authentication
+-  `#9471 <https://codeberg.org/freeipa/freeipa/issues/9471>`__ Pre-authentication
    with trusted domain object over IPA to IPA trust fails due to wrong
    canonical name choice
--  `#9476 <https://pagure.io/freeipa/issue/9476>`__ Nightly test failure
+-  `#9476 <https://codeberg.org/freeipa/freeipa/issues/9476>`__ Nightly test failure
    in test_sso.py::TestSsoBridge::test_sso_login_with_ipa_user
--  `#9477 <https://pagure.io/freeipa/issue/9477>`__ Document ID mapping
+-  `#9477 <https://codeberg.org/freeipa/freeipa/issues/9477>`__ Document ID mapping
    in FreeIPA
--  `#9482 <https://pagure.io/freeipa/issue/9482>`__ Test failure in
+-  `#9482 <https://codeberg.org/freeipa/freeipa/issues/9482>`__ Test failure in
    test_integration.test_ipahealthcheck.py::TestIpaHealthCheck::test_source_ipahealthcheck_ipa_host_check_ipahostkeytab
--  `#9483 <https://pagure.io/freeipa/issue/9483>`__ Fixes: Python
+-  `#9483 <https://codeberg.org/freeipa/freeipa/issues/9483>`__ Fixes: Python
    warnings in ipa-replica-manage
--  `#9484 <https://pagure.io/freeipa/issue/9484>`__ Traceback in
+-  `#9484 <https://codeberg.org/freeipa/freeipa/issues/9484>`__ Traceback in
    ipaserver/dcerpc.py
--  `#9485 <https://pagure.io/freeipa/issue/9485>`__ handle better
+-  `#9485 <https://codeberg.org/freeipa/freeipa/issues/9485>`__ handle better
    default user authentication types for services
--  `#9486 <https://pagure.io/freeipa/issue/9486>`__ hbactest does not
+-  `#9486 <https://codeberg.org/freeipa/freeipa/issues/9486>`__ hbactest does not
    display messages, like search truncated
--  `#9487 <https://pagure.io/freeipa/issue/9487>`__ ipa-client-install
+-  `#9487 <https://codeberg.org/freeipa/freeipa/issues/9487>`__ ipa-client-install
    --automount-location does not work
--  `#9489 <https://pagure.io/freeipa/issue/9489>`__ The change for
+-  `#9489 <https://codeberg.org/freeipa/freeipa/issues/9489>`__ The change for
    preventing deletion of the admin user caused a regression in disable
--  `#9490 <https://pagure.io/freeipa/issue/9490>`__ The test
+-  `#9490 <https://codeberg.org/freeipa/freeipa/issues/9490>`__ The test
    test_external_ca.py fails if running on a test controller with
    python-cryptography 41.0.0
--  `#9491 <https://pagure.io/freeipa/issue/9491>`__ CA less servers are
+-  `#9491 <https://codeberg.org/freeipa/freeipa/issues/9491>`__ CA less servers are
    failing to be added in topology segment for domain suffix
--  `#9492 <https://pagure.io/freeipa/issue/9492>`__ WebUI tests: code
+-  `#9492 <https://codeberg.org/freeipa/freeipa/issues/9492>`__ WebUI tests: code
    not compatible with selenium driver 4.10
--  `#9493 <https://pagure.io/freeipa/issue/9493>`__ test_external_idp
+-  `#9493 <https://codeberg.org/freeipa/freeipa/issues/9493>`__ test_external_idp
    fails in f39+
--  `#9496 <https://pagure.io/freeipa/issue/9496>`__ ipa client 4.10.2 -
+-  `#9496 <https://codeberg.org/freeipa/freeipa/issues/9496>`__ ipa client 4.10.2 -
    Failed to obtain host TGT
--  `#9497 <https://pagure.io/freeipa/issue/9497>`__ Improve debugging
+-  `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__ Improve debugging
    logging in DS plugins
--  `#9498 <https://pagure.io/freeipa/issue/9498>`__ Test failure in
+-  `#9498 <https://codeberg.org/freeipa/freeipa/issues/9498>`__ Test failure in
    tests calling dnf upgrade
--  `#9499 <https://pagure.io/freeipa/issue/9499>`__ ipa-client should
+-  `#9499 <https://codeberg.org/freeipa/freeipa/issues/9499>`__ ipa-client should
    check if IPA_CA_CERT is not empty after it has been downloaded from
    server
--  `#9501 <https://pagure.io/freeipa/issue/9501>`__ Support for
+-  `#9501 <https://codeberg.org/freeipa/freeipa/issues/9501>`__ Support for
    OpenCloudOS/TencentOS ipaplatform
--  `#9503 <https://pagure.io/freeipa/issue/9503>`__ Handle change in
+-  `#9503 <https://codeberg.org/freeipa/freeipa/issues/9503>`__ Handle change in
    behavior of pki-server ca-config-show in pki 11.5.0
--  `#9504 <https://pagure.io/freeipa/issue/9504>`__ Gating-DL1 test
+-  `#9504 <https://codeberg.org/freeipa/freeipa/issues/9504>`__ Gating-DL1 test
    failure in
    test_integration/test_dns_locations.py::TestDNSLocations::()::test_ipa_ca_records
--  `#9506 <https://pagure.io/freeipa/issue/9506>`__
+-  `#9506 <https://codeberg.org/freeipa/freeipa/issues/9506>`__
    'DogtagCertsConfigCheck' fails, displaying the error message
    'Malformed directive: ca.signing.certnickname=caSigningCert
    cert-pki-ca'
--  `#9510 <https://pagure.io/freeipa/issue/9510>`__ Nightly test failure
+-  `#9510 <https://codeberg.org/freeipa/freeipa/issues/9510>`__ Nightly test failure
    in
    test_replication_layouts.py::TestLineTopologyWithoutCA::test_line_topology_without_ca
--  `#9514 <https://pagure.io/freeipa/issue/9514>`__ Make sure a default
+-  `#9514 <https://codeberg.org/freeipa/freeipa/issues/9514>`__ Make sure a default
    NetBIOS name is set if not passed in by ADTrust instance constructor
--  `#9515 <https://pagure.io/freeipa/issue/9515>`__ Improve test
+-  `#9515 <https://codeberg.org/freeipa/freeipa/issues/9515>`__ Improve test
    coverage for ipa user plugin
--  `#9516 <https://pagure.io/freeipa/issue/9516>`__ Nightly test failure
+-  `#9516 <https://codeberg.org/freeipa/freeipa/issues/9516>`__ Nightly test failure
    (389ds) in
    test_backup_and_restore_TestUserRootFilesOwnershipPermission
--  `#9517 <https://pagure.io/freeipa/issue/9517>`__ sidgen plugin does
+-  `#9517 <https://codeberg.org/freeipa/freeipa/issues/9517>`__ sidgen plugin does
    not ignore staged users
--  `#9518 <https://pagure.io/freeipa/issue/9518>`__ tox failure on
+-  `#9518 <https://codeberg.org/freeipa/freeipa/issues/9518>`__ tox failure on
    ipa-4-10 and ipa-4-9 branches
--  `#9519 <https://pagure.io/freeipa/issue/9519>`__ session cookie can't
+-  `#9519 <https://codeberg.org/freeipa/freeipa/issues/9519>`__ session cookie can't
    be read
--  `#9520 <https://pagure.io/freeipa/issue/9520>`__ Memory leak in PAC
+-  `#9520 <https://codeberg.org/freeipa/freeipa/issues/9520>`__ Memory leak in PAC
    verification process
--  `#9522 <https://pagure.io/freeipa/issue/9522>`__ Nightly test failure
+-  `#9522 <https://codeberg.org/freeipa/freeipa/issues/9522>`__ Nightly test failure
    (rawhide) in test_external_idp
--  `#9526 <https://pagure.io/freeipa/issue/9526>`__
+-  `#9526 <https://codeberg.org/freeipa/freeipa/issues/9526>`__
    (`rhbz#2262860 <https://bugzilla.redhat.com/show_bug.cgi?id=2262860>`__)
    ipa-restore fails with 'Cannot restore a data backup into an empty
    system'
--  `#9530 <https://pagure.io/freeipa/issue/9530>`__ ipatests:
+-  `#9530 <https://codeberg.org/freeipa/freeipa/issues/9530>`__ ipatests:
    wait_for_replication method is broken
--  `#9535 <https://pagure.io/freeipa/issue/9535>`__ ipa-kdb: Cannot
+-  `#9535 <https://codeberg.org/freeipa/freeipa/issues/9535>`__ ipa-kdb: Cannot
    determine if PAC generator is available
--  `#9536 <https://pagure.io/freeipa/issue/9536>`__ Client configuration
+-  `#9536 <https://codeberg.org/freeipa/freeipa/issues/9536>`__ Client configuration
    of ssh: Replace sss_ssh_knownhostsproxy with sss_ssh_knownhosts
--  `#9541 <https://pagure.io/freeipa/issue/9541>`__
+-  `#9541 <https://codeberg.org/freeipa/freeipa/issues/9541>`__
    (`rhbz#2265129 <https://bugzilla.redhat.com/show_bug.cgi?id=2265129>`__)
    specially crafted HTTP requests potentially lead to DoS or data
    exposure
--  `#9542 <https://pagure.io/freeipa/issue/9542>`__ Fix replica
+-  `#9542 <https://codeberg.org/freeipa/freeipa/issues/9542>`__ Fix replica
    connection check for use with AD administrator
--  `#9544 <https://pagure.io/freeipa/issue/9544>`__ AD administrator in
+-  `#9544 <https://codeberg.org/freeipa/freeipa/issues/9544>`__ AD administrator in
    the admin group blocks admin group management on replicas without
    adtrust setup
--  `#9547 <https://pagure.io/freeipa/issue/9547>`__ Update ipa to ipa
+-  `#9547 <https://codeberg.org/freeipa/freeipa/issues/9547>`__ Update ipa to ipa
    migration doc
--  `#9548 <https://pagure.io/freeipa/issue/9548>`__ Nightly test failure
+-  `#9548 <https://codeberg.org/freeipa/freeipa/issues/9548>`__ Nightly test failure
    in
    test_integration/test_ipa_cert_fix.py/TestCertFixReplica/test_renew_expired_cert_replica
--  `#9551 <https://pagure.io/freeipa/issue/9551>`__ filter out
+-  `#9551 <https://codeberg.org/freeipa/freeipa/issues/9551>`__ filter out
    subdomains from realmdomains list when submitting to a trusted AD DCs
--  `#9554 <https://pagure.io/freeipa/issue/9554>`__ Nightly tests: fail
+-  `#9554 <https://codeberg.org/freeipa/freeipa/issues/9554>`__ Nightly tests: fail
    to build if @389ds/389-ds-base-nightly copr repo is enabled
--  `#9555 <https://pagure.io/freeipa/issue/9555>`__ Remove dependency on
+-  `#9555 <https://codeberg.org/freeipa/freeipa/issues/9555>`__ Remove dependency on
    python-netifaces.
--  `#9558 <https://pagure.io/freeipa/issue/9558>`__ ipa idrange-add
+-  `#9558 <https://codeberg.org/freeipa/freeipa/issues/9558>`__ ipa idrange-add
    should display a warning that 389ds restart is required
--  `#9562 <https://pagure.io/freeipa/issue/9562>`__ ipa ca-show NAME
+-  `#9562 <https://codeberg.org/freeipa/freeipa/issues/9562>`__ ipa ca-show NAME
    --certificate-out=file creates empty file when NAME does not exist
--  `#9565 <https://pagure.io/freeipa/issue/9565>`__ Python 3.12
+-  `#9565 <https://codeberg.org/freeipa/freeipa/issues/9565>`__ Python 3.12
    SyntaxWarning
--  `#9566 <https://pagure.io/freeipa/issue/9566>`__ [CI] docker-compose
+-  `#9566 <https://codeberg.org/freeipa/freeipa/issues/9566>`__ [CI] docker-compose
    V1 was removed from images
--  `#9567 <https://pagure.io/freeipa/issue/9567>`__ Nightly test failure
+-  `#9567 <https://codeberg.org/freeipa/freeipa/issues/9567>`__ Nightly test failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheckWithExternalCA::test_opensslchainvalidation_ipa_ca_cert
--  `#9568 <https://pagure.io/freeipa/issue/9568>`__ Update IPA to IPA
+-  `#9568 <https://codeberg.org/freeipa/freeipa/issues/9568>`__ Update IPA to IPA
    migration design doc
--  `#9569 <https://pagure.io/freeipa/issue/9569>`__ ipa-crlgen-manage
+-  `#9569 <https://codeberg.org/freeipa/freeipa/issues/9569>`__ ipa-crlgen-manage
    should unset ca.certStatusUpdateInterval on enable
--  `#9570 <https://pagure.io/freeipa/issue/9570>`__ IPA migration tool -
+-  `#9570 <https://codeberg.org/freeipa/freeipa/issues/9570>`__ IPA migration tool -
    migrate nsaccountlock
--  `#9574 <https://pagure.io/freeipa/issue/9574>`__ Nightly failure in
+-  `#9574 <https://codeberg.org/freeipa/freeipa/issues/9574>`__ Nightly failure in
    test_webui/test_user.py::test_user::test_disable_delete_admin
--  `#9575 <https://pagure.io/freeipa/issue/9575>`__ Update of a test
+-  `#9575 <https://codeberg.org/freeipa/freeipa/issues/9575>`__ Update of a test
    test_adtrust_install_with_incorrect_admin_password
--  `#9579 <https://pagure.io/freeipa/issue/9579>`__ Remove
+-  `#9579 <https://codeberg.org/freeipa/freeipa/issues/9579>`__ Remove
    bash_completions_dir for rhel builds
--  `#9583 <https://pagure.io/freeipa/issue/9583>`__ batch is failing on
+-  `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__ batch is failing on
    missing attribute principal in error case using server context
--  `#9586 <https://pagure.io/freeipa/issue/9586>`__ Spec file: depend on
+-  `#9586 <https://codeberg.org/freeipa/freeipa/issues/9586>`__ Spec file: depend on
    nfs-utils or nfsv4-client-utils
--  `#9589 <https://pagure.io/freeipa/issue/9589>`__ add systemd journal
+-  `#9589 <https://codeberg.org/freeipa/freeipa/issues/9589>`__ add systemd journal
    audit of executed API commands
--  `#9590 <https://pagure.io/freeipa/issue/9590>`__ handle IPA public
+-  `#9590 <https://codeberg.org/freeipa/freeipa/issues/9590>`__ handle IPA public
    exceptions in 'ipa console' in a better way
--  `#9591 <https://pagure.io/freeipa/issue/9591>`__ ipa-replica-manage
+-  `#9591 <https://codeberg.org/freeipa/freeipa/issues/9591>`__ ipa-replica-manage
    clean-dangling-ruv is failing to handle invalid RUVs
--  `#9593 <https://pagure.io/freeipa/issue/9593>`__ ipa-kra-install
+-  `#9593 <https://codeberg.org/freeipa/freeipa/issues/9593>`__ ipa-kra-install
    tries to validate the HSM config even when no HSM is set up
--  `#9594 <https://pagure.io/freeipa/issue/9594>`__ topologysegment
+-  `#9594 <https://codeberg.org/freeipa/freeipa/issues/9594>`__ topologysegment
    commands cannot be delegated
--  `#9597 <https://pagure.io/freeipa/issue/9597>`__ Remove use of
+-  `#9597 <https://codeberg.org/freeipa/freeipa/issues/9597>`__ Remove use of
    deprecated functions in custodia
--  `#9598 <https://pagure.io/freeipa/issue/9598>`__ Nightly test failure
+-  `#9598 <https://codeberg.org/freeipa/freeipa/issues/9598>`__ Nightly test failure
    in test_ipahealthcheck
 
 .. _detailed_changelog_since_4.11.1:
@@ -372,7 +372,7 @@ Detailed changelog since 4.11.1
 
 -  webui: Unify user group members columns with users columns
    `commit <https://codeberg.org/freeipa/freeipa/commit/49c090b97655cf1b845a270503bd6cbe75a48278>`__
-   `#9390 <https://pagure.io/freeipa/issue/9390>`__
+   `#9390 <https://codeberg.org/freeipa/freeipa/issues/9390>`__
 
 .. _alexander_bokovoy_31:
 
@@ -381,123 +381,123 @@ Alexander Bokovoy (43)
 
 -  console: for public errors only print a final one
    `commit <https://codeberg.org/freeipa/freeipa/commit/1223016ef29aef4009a0d976af0d0b2bca871013>`__
-   `#9590 <https://pagure.io/freeipa/issue/9590>`__
+   `#9590 <https://codeberg.org/freeipa/freeipa/issues/9590>`__
 -  custodia: do not use deprecated jwcrypto wrappers
    `commit <https://codeberg.org/freeipa/freeipa/commit/536812080502baa51818d9a33ea6533675800b30>`__
-   `#9597 <https://pagure.io/freeipa/issue/9597>`__
+   `#9597 <https://codeberg.org/freeipa/freeipa/issues/9597>`__
 -  frontend: add systemd journal audit of executed API commands
    `commit <https://codeberg.org/freeipa/freeipa/commit/84eed2a67fb515f4d5d0af3479c077bf5b788d56>`__
-   `#9589 <https://pagure.io/freeipa/issue/9589>`__
+   `#9589 <https://codeberg.org/freeipa/freeipa/issues/9589>`__
 -  ipalib/rpc: Reformat after moving json code around
    `commit <https://codeberg.org/freeipa/freeipa/commit/145e33174d99e4826d388b4796ecadb73698cf47>`__
 -  ipalib: move json formatter to a separate file
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd0f432fec692a2db25c270b2e69b3f423ba7f4a>`__
 -  batch: add keeponly option
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e861693fcb79d256af6d0cfe26f27c7f7ff8e13>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  pylint: use yield_from for trivial cases
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cc0a0b9a8439f97cfc688e5610c25b5e494ba0b>`__
 -  user: handle LDAP auto-bind for whoami case
    `commit <https://codeberg.org/freeipa/freeipa/commit/c325f9c045787a4c4e18096e23cb2f84f514b28e>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  passwd: handle LDAP auto-bind use case as well
    `commit <https://codeberg.org/freeipa/freeipa/commit/902c8b0bae90b04d3f1d91f0703c2a0eca4e39f1>`__
 -  cert: use context.principal only when it is defined
    `commit <https://codeberg.org/freeipa/freeipa/commit/e386e22046fec4de062116245a3cd9e79c457499>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  trust: handle stray pylint warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6131b57371f6eade697125a4500c140997478c0>`__
 -  trust: use context.principal only when it is defined
    `commit <https://codeberg.org/freeipa/freeipa/commit/08f1e6f2fdb19db681c0560db53a7a5fa1ce3784>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  server: use context.principal only when it is defined
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab5465639d5c083d6396551f06c450fe4d349d1b>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  config: use context.principal only when it is defined
    `commit <https://codeberg.org/freeipa/freeipa/commit/71d886f0713b2c58d8eb57f2267d59cc0be39345>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  batch: account for auto-binding in server context
    `commit <https://codeberg.org/freeipa/freeipa/commit/3608b2b63de736186176f8da0fad36ce3b0d57a3>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  privilege: use context.principal only when it is defined
    `commit <https://codeberg.org/freeipa/freeipa/commit/295ac6385c33d28502396ffeb9e7a5297b63a005>`__
-   `#9583 <https://pagure.io/freeipa/issue/9583>`__
+   `#9583 <https://codeberg.org/freeipa/freeipa/issues/9583>`__
 -  internal: fix 'tokensfor' typo and regenerate pot file
    `commit <https://codeberg.org/freeipa/freeipa/commit/d16c34997f2223bd3f3d00a734c3372552bd8863>`__
 -  Use raw strings for Python 3 compatibility in old API client code
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca6604b58be0448e45b2a68d03d4f8dacbceab7b>`__
-   `#9565 <https://pagure.io/freeipa/issue/9565>`__
+   `#9565 <https://codeberg.org/freeipa/freeipa/issues/9565>`__
 -  idrange: only issue warning to restart services for a local range
    `commit <https://codeberg.org/freeipa/freeipa/commit/a57b665be027bd67b582cba784aca5f2f8399459>`__
-   `#9558 <https://pagure.io/freeipa/issue/9558>`__
+   `#9558 <https://codeberg.org/freeipa/freeipa/issues/9558>`__
 -  dcerpc: invalidate forest trust info cache when filtering out realm
    domains
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9a1d74f5ea63a63880abf8d4b5568664c372417>`__
-   `#9551 <https://pagure.io/freeipa/issue/9551>`__
+   `#9551 <https://codeberg.org/freeipa/freeipa/issues/9551>`__
 -  ipa-pwd-extop: declare operation notes support from 389-ds locally
    `commit <https://codeberg.org/freeipa/freeipa/commit/e431ce0ce7699a3857ee4ef1e6b4e27d57874370>`__
-   `#9554 <https://pagure.io/freeipa/issue/9554>`__
+   `#9554 <https://codeberg.org/freeipa/freeipa/issues/9554>`__
 -  ipa-pwd-extop: add MFA note in case of a successful LDAP bind with
    OTP
    `commit <https://codeberg.org/freeipa/freeipa/commit/23b224d7ad2e90d03543a0001f9a83731a8a14a5>`__
-   `#5169 <https://pagure.io/freeipa/issue/5169>`__
+   `#5169 <https://codeberg.org/freeipa/freeipa/issues/5169>`__
 -  ipa-pwd-extop: allow enforcing 2FA-only over LDAP bind
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d2897e3d7cc88c2c5698126ecb1e59fff396bbc>`__
-   `#5169 <https://pagure.io/freeipa/issue/5169>`__
+   `#5169 <https://codeberg.org/freeipa/freeipa/issues/5169>`__
 -  rpcserver: validate Kerberos principal name before running kinit
    `commit <https://codeberg.org/freeipa/freeipa/commit/404fe1018e08e546fd14c83741e00b900c1cd208>`__
-   `#9541 <https://pagure.io/freeipa/issue/9541>`__
+   `#9541 <https://codeberg.org/freeipa/freeipa/issues/9541>`__
 -  ipa-kdb: support Samba 4.20 private libraries
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd04dc28c829649e27ee0ceb207f24a56edd35c4>`__
 -  kdb: PAC generator: do not fail if canonical principal is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed977a6e8206366a33fe90ba97844834068f56c8>`__
-   `#9465 <https://pagure.io/freeipa/issue/9465>`__
+   `#9465 <https://codeberg.org/freeipa/freeipa/issues/9465>`__
 -  sidgen: fix missing prototypes
    `commit <https://codeberg.org/freeipa/freeipa/commit/89d945fe6f9265c5667e825554b2663cc63db3e3>`__
 -  sidgen: ignore staged users when generating SIDs
    `commit <https://codeberg.org/freeipa/freeipa/commit/f8dcd78873cc098d5a60e2c56ea4102009631fd6>`__
-   `#9517 <https://pagure.io/freeipa/issue/9517>`__
+   `#9517 <https://codeberg.org/freeipa/freeipa/issues/9517>`__
 -  doc/designs/id-mapping.md: expand on ID range allocation details
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4ffc53b2a3534d4f6c12e150fdfb3cfcb11cbae>`__
-   `#9477 <https://pagure.io/freeipa/issue/9477>`__
+   `#9477 <https://codeberg.org/freeipa/freeipa/issues/9477>`__
 -  doc/Makefile: run sphinx in serial mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/5adc07ae55ff83332f7eeddc4a0eb2a9e4c07c29>`__
 -  ipasam: make krbtgt TDO principal canonical
    `commit <https://codeberg.org/freeipa/freeipa/commit/e399232a78a60cd4ab895c9c2cb363fafbb84198>`__
-   `#9471 <https://pagure.io/freeipa/issue/9471>`__
+   `#9471 <https://codeberg.org/freeipa/freeipa/issues/9471>`__
 -  adtrustinstance: make sure NetBIOS name defaults are set properly
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b456101a3072cdf7f48dfdcfea1002d10d35597>`__
-   `#9514 <https://pagure.io/freeipa/issue/9514>`__
+   `#9514 <https://codeberg.org/freeipa/freeipa/issues/9514>`__
 -  host: update System: Manage Host Keytab permission
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5d38ca17100fc2d0550e8ebda9347acafd1398b>`__
-   `#9496 <https://pagure.io/freeipa/issue/9496>`__
+   `#9496 <https://codeberg.org/freeipa/freeipa/issues/9496>`__
 -  ipatests: make sure PKINIT enrollment works with a strict policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3bc938650b19a51706d8ccd98cdf8deaa26dc28>`__
-   `#9485 <https://pagure.io/freeipa/issue/9485>`__
+   `#9485 <https://codeberg.org/freeipa/freeipa/issues/9485>`__
 -  ipa-kdb: clarify user auth table mapping use of \_AUTH_PASSWORD
    `commit <https://codeberg.org/freeipa/freeipa/commit/62c44c9e69aa2721990ca3628434713e1af6f59b>`__
-   `#9485 <https://pagure.io/freeipa/issue/9485>`__
+   `#9485 <https://codeberg.org/freeipa/freeipa/issues/9485>`__
 -  ipa-kdb: when applying ticket policy, do not deny PKINIT
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ae9febfb4462766b3bfe3e07e76550ece97b42>`__
-   `#9485 <https://pagure.io/freeipa/issue/9485>`__
+   `#9485 <https://codeberg.org/freeipa/freeipa/issues/9485>`__
 -  ipa-kdb: add better detection of allowed user auth type
    `commit <https://codeberg.org/freeipa/freeipa/commit/00f8ddbfd2795228b343e1c39c1944b44d482c18>`__
-   `#9485 <https://pagure.io/freeipa/issue/9485>`__
+   `#9485 <https://codeberg.org/freeipa/freeipa/issues/9485>`__
 -  doc/designs: add description of identity mapping in IPA
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ee2d7d359a80876ae536f3427caaae20d03af17>`__
-   `#9477 <https://pagure.io/freeipa/issue/9477>`__
+   `#9477 <https://codeberg.org/freeipa/freeipa/issues/9477>`__
 -  Remove upgrade test from Azure CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/6bc9e9d06ec33a1fbeb8d06a2ce30d0ca2e555d3>`__
 -  Remove ipaserver.custodia.\__init\_\_.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/5e17c134aa67abbcee788f4ab4ea0b7f694aed5a>`__
-   `#9467 <https://pagure.io/freeipa/issue/9467>`__
+   `#9467 <https://codeberg.org/freeipa/freeipa/issues/9467>`__
 -  Azure CI: increase memory for forced reenrollment test
    `commit <https://codeberg.org/freeipa/freeipa/commit/b22605ee54ec82b9a4b6a435be06fe8b39f2fe23>`__
 -  Increase memory usage for Azure CI upgrade test
    `commit <https://codeberg.org/freeipa/freeipa/commit/48cfe6848ccfd55d945531fbd2b34221e153adee>`__
 -  Use datetime.timezone.utc instead of newer datetime.UTC alias
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a2cd7f408a274759584ddadd358360d39b3c4fa>`__
-   `#9454 <https://pagure.io/freeipa/issue/9454>`__
+   `#9454 <https://codeberg.org/freeipa/freeipa/issues/9454>`__
 
 .. _alexandra_nikandrova_1:
 
@@ -546,18 +546,18 @@ Christian Heimes (6)
    `commit <https://codeberg.org/freeipa/freeipa/commit/38d0e74b6da63deedf3380a04dda2f6fe7c75d82>`__
 -  test_acme: Use ipalib.x509
    `commit <https://codeberg.org/freeipa/freeipa/commit/22875ea2c61039163766332dd9eb4a524d9d3c75>`__
-   `#9518 <https://pagure.io/freeipa/issue/9518>`__
+   `#9518 <https://codeberg.org/freeipa/freeipa/issues/9518>`__
 -  Compatibility fix for PyCA cryptography 42.0.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/a45a7a20d96af51d463a285cb9318582720be708>`__
-   `#9518 <https://pagure.io/freeipa/issue/9518>`__
+   `#9518 <https://codeberg.org/freeipa/freeipa/issues/9518>`__
 -  Add 'cache_dir' option to api.env
    `commit <https://codeberg.org/freeipa/freeipa/commit/5deeee31c0ebbbf15642a928d9c30e42150bbfc2>`__
-   `#9438 <https://pagure.io/freeipa/issue/9438>`__
+   `#9438 <https://codeberg.org/freeipa/freeipa/issues/9438>`__
 -  docs: Mention that Keycloak requires openid scope
    `commit <https://codeberg.org/freeipa/freeipa/commit/d97d62dead0a7b75929dec89ab072b87a0d889dd>`__
 -  Refactor CA file handling in replica installer
    `commit <https://codeberg.org/freeipa/freeipa/commit/8f25b2a74a587548976f3d29f0b69d566d70125d>`__
-   `#9272 <https://pagure.io/freeipa/issue/9272>`__
+   `#9272 <https://codeberg.org/freeipa/freeipa/issues/9272>`__
 
 .. _jan_kuparinen_1:
 
@@ -574,10 +574,10 @@ Erik Belko (2)
 
 -  ipatests: Update ipa-adtrust-install test
    `commit <https://codeberg.org/freeipa/freeipa/commit/47920e78c81380c0a40986e55f05246aac132fbb>`__
-   `#9575 <https://pagure.io/freeipa/issue/9575>`__
+   `#9575 <https://codeberg.org/freeipa/freeipa/issues/9575>`__
 -  xmlrpc tests: Create user with manager option set using user-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc7c2cb6243468d150e6be7c78a0e3f906a7e291>`__
-   `#9515 <https://pagure.io/freeipa/issue/9515>`__
+   `#9515 <https://codeberg.org/freeipa/freeipa/issues/9515>`__
 
 .. _endi_sukma_dewata_4:
 
@@ -608,37 +608,37 @@ Florence Blanc-Renaud (30)
 
 -  ipa-replica-manage list-ruvs: display FQDN in the output
    `commit <https://codeberg.org/freeipa/freeipa/commit/69c6a817ce84a9c2bd111158bec4b10850dba544>`__
-   `#9598 <https://pagure.io/freeipa/issue/9598>`__
+   `#9598 <https://codeberg.org/freeipa/freeipa/issues/9598>`__
 -  Spec file: depend on nfs-utils or nfsv4-client-utils
    `commit <https://codeberg.org/freeipa/freeipa/commit/bb8dd0bfcd42f9221e12f4a675b54432848db441>`__
-   `#9586 <https://pagure.io/freeipa/issue/9586>`__
+   `#9586 <https://codeberg.org/freeipa/freeipa/issues/9586>`__
 -  webui test: Update message for admin disable
    `commit <https://codeberg.org/freeipa/freeipa/commit/dda223668acf76f19efc6b85829139beba424cd6>`__
-   `#9489 <https://pagure.io/freeipa/issue/9489>`__,
-   `#9574 <https://pagure.io/freeipa/issue/9574>`__
+   `#9489 <https://codeberg.org/freeipa/freeipa/issues/9489>`__,
+   `#9574 <https://codeberg.org/freeipa/freeipa/issues/9574>`__
 -  xmlrpc: adapt range plugin test
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cc668ffeb7ddd4ebd75304f14adaa3aaf3b4cb0>`__
-   `#9558 <https://pagure.io/freeipa/issue/9558>`__
+   `#9558 <https://codeberg.org/freeipa/freeipa/issues/9558>`__
 -  idrange-add: add a warning because 389ds restart is required
    `commit <https://codeberg.org/freeipa/freeipa/commit/64861a0cf9a8ac18d83a206c11fd3b42be3c578c>`__
-   `#9558 <https://pagure.io/freeipa/issue/9558>`__
+   `#9558 <https://codeberg.org/freeipa/freeipa/issues/9558>`__
 -  ipatests: some tests are date-sensitive and fail Feb 29
    `commit <https://codeberg.org/freeipa/freeipa/commit/558a7de8b7fa920c2c597e0a10d8480f3e66e1c6>`__
-   `#9548 <https://pagure.io/freeipa/issue/9548>`__
+   `#9548 <https://codeberg.org/freeipa/freeipa/issues/9548>`__
 -  ipatests: fix tasks.wait_for_replication method
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5bb0f392a5f0a6e49c92b2da953b12c5cd66ffc>`__
-   `#9530 <https://pagure.io/freeipa/issue/9530>`__
+   `#9530 <https://codeberg.org/freeipa/freeipa/issues/9530>`__
 -  ipatests: add xfail for autoprivate group test with override
    `commit <https://codeberg.org/freeipa/freeipa/commit/908ef6a17946b75c69bf48486f43fddb9158b993>`__
 -  ipatests: remove xfail thanks to sssd 2.9.4
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfb5099e7f5abfbacf8ac1abc57630da845e433f>`__
-   `#9295 <https://pagure.io/freeipa/issue/9295>`__
+   `#9295 <https://codeberg.org/freeipa/freeipa/issues/9295>`__
 -  ipatests: test_idp fails calling yum list wget
    `commit <https://codeberg.org/freeipa/freeipa/commit/9c470d10a59f18c2861f39c74c3ae928e7909b26>`__
-   `#9522 <https://pagure.io/freeipa/issue/9522>`__
+   `#9522 <https://codeberg.org/freeipa/freeipa/issues/9522>`__
 -  ipa-backup: adapt for 389ds switch to LMDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/677d30806662856595289525ef529a77adbf2272>`__
-   `#9516 <https://pagure.io/freeipa/issue/9516>`__
+   `#9516 <https://codeberg.org/freeipa/freeipa/issues/9516>`__
 -  Nightly tests: test on f38 and f39
    `commit <https://codeberg.org/freeipa/freeipa/commit/717ae87a756f9a4859804bbe09057c90381db668>`__
 -  Tox: use sitepackages
@@ -653,42 +653,42 @@ Florence Blanc-Renaud (30)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8981ede1a2d62e61d24b0c500016212e20c31a13>`__
 -  ipatests: disable dnssec validation in tests using dnf
    `commit <https://codeberg.org/freeipa/freeipa/commit/a177121af66516deed7c6794b92f15a74cc30bd3>`__
-   `#9498 <https://pagure.io/freeipa/issue/9498>`__
+   `#9498 <https://codeberg.org/freeipa/freeipa/issues/9498>`__
 -  Webui: use service options to init Firefox driver
    `commit <https://codeberg.org/freeipa/freeipa/commit/25b58e6dea2b3ff7237eea5600891f8e72054531>`__
-   `#9492 <https://pagure.io/freeipa/issue/9492>`__
+   `#9492 <https://codeberg.org/freeipa/freeipa/issues/9492>`__
 -  test_install: restart services after date change
    `commit <https://codeberg.org/freeipa/freeipa/commit/9abb50eb1e9a186161e1f3a9d2f1d07763f5e279>`__
-   `#9405 <https://pagure.io/freeipa/issue/9405>`__
+   `#9405 <https://codeberg.org/freeipa/freeipa/issues/9405>`__
 -  test_external_idp: update code for selenium 4.10
    `commit <https://codeberg.org/freeipa/freeipa/commit/53951ca860db1564666b2eb6886389ff0f85e46c>`__
-   `#9493 <https://pagure.io/freeipa/issue/9493>`__
+   `#9493 <https://codeberg.org/freeipa/freeipa/issues/9493>`__
 -  Make test_external_ca.py compatible with crypto 41.0.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/d61d1b059c8d760b37c7aae9ea47cb06674c76cd>`__
-   `#9490 <https://pagure.io/freeipa/issue/9490>`__
+   `#9490 <https://codeberg.org/freeipa/freeipa/issues/9490>`__
 -  Integration tests: disable test_sso
    `commit <https://codeberg.org/freeipa/freeipa/commit/5028b391f16a9dcb275037a430a6e3c6f3eed872>`__
-   `#9476 <https://pagure.io/freeipa/issue/9476>`__
+   `#9476 <https://codeberg.org/freeipa/freeipa/issues/9476>`__
 -  ipatests: fix expected output for ipahealthcheck.meta.services
    `commit <https://codeberg.org/freeipa/freeipa/commit/07e5637269e470f5c2fd24ec62949af81c66bee5>`__
-   `#9460 <https://pagure.io/freeipa/issue/9460>`__
+   `#9460 <https://codeberg.org/freeipa/freeipa/issues/9460>`__
 -  Handle samba changes in samba.security.dom_sid()
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed6fa6029d863aed1522b449d3360e6c4028e066>`__
-   `#9466 <https://pagure.io/freeipa/issue/9466>`__
+   `#9466 <https://codeberg.org/freeipa/freeipa/issues/9466>`__
 -  group-add-member fails with an external member
    `commit <https://codeberg.org/freeipa/freeipa/commit/d50624dce932d02ea03a00d3ac2ec1be69e8d3b6>`__
-   `#9466 <https://pagure.io/freeipa/issue/9466>`__
+   `#9466 <https://codeberg.org/freeipa/freeipa/issues/9466>`__
 -  ipalib: fix the IPACertificate validity dates
    `commit <https://codeberg.org/freeipa/freeipa/commit/b6af3a43c7bf7ef632c60cfd633b9cb98b31dcd8>`__
-   `#9462 <https://pagure.io/freeipa/issue/9462>`__
+   `#9462 <https://codeberg.org/freeipa/freeipa/issues/9462>`__
 -  ipatests: fix test_ipactl_scenario_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/430054db4102c6bde873414fc2f25e650baaebb6>`__
-   `#9415 <https://pagure.io/freeipa/issue/9415>`__
+   `#9415 <https://codeberg.org/freeipa/freeipa/issues/9415>`__
 -  ipatests: fix healthcheck test for --indent option
    `commit <https://codeberg.org/freeipa/freeipa/commit/e459e5b8bc81c4bb3b39dc51a50f388a8c8dd34d>`__
 -  ipatests: fix healthcheck test without DNS
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9075f9f77ec2c8b595210a5de478f8650943733>`__
-   `#9459 <https://pagure.io/freeipa/issue/9459>`__
+   `#9459 <https://codeberg.org/freeipa/freeipa/issues/9459>`__
 
 
 .. _francisco_trivino_6:
@@ -698,19 +698,19 @@ Francisco Trivino (6)
 
 -  Spec file: add support for sss_ssh_knownhosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/b34525c76e9f8182950bbbdd6fa3ae62f5301064>`__
-   `#9536 <https://pagure.io/freeipa/issue/9536>`__
+   `#9536 <https://codeberg.org/freeipa/freeipa/issues/9536>`__
 -  ipa-client-install: add support for sss_ssh_knownhosts
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d54a6daaf0ef91d608d67b3c70e2d566868be05>`__
-   `#9536 <https://pagure.io/freeipa/issue/9536>`__
+   `#9536 <https://codeberg.org/freeipa/freeipa/issues/9536>`__
 -  kra: set RSA-OAEP as default wrapping algo when FIPS is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/305fcc25b4dd0aea4f87a0508c5f47c7634cfb82>`__
-   `#9191 <https://pagure.io/freeipa/issue/9191>`__
+   `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__
 -  Vault: improve vault server archival/retrieval calls error handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/4cc6b9cd1791e1a5fdbcd8e28904a5856e1f0b41>`__
-   `#9191 <https://pagure.io/freeipa/issue/9191>`__
+   `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__
 -  Vault: add support for RSA-OAEP wrapping algo
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d0a088f93ec27ddb55c82e43c33bcc425a759ef>`__
-   `#9191 <https://pagure.io/freeipa/issue/9191>`__
+   `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__
 -  Workshop: fix broken Sphinx cross-references.
    `commit <https://codeberg.org/freeipa/freeipa/commit/4af05dde4819c6dd9926baacb4f642e7d1c5bde9>`__
 
@@ -721,7 +721,7 @@ Jeremy Frasier (1)
 
 -  Fixes: Python SyntaxWarnings about invalid escape sequences
    `commit <https://codeberg.org/freeipa/freeipa/commit/c63fe925fb3173f5845664627499f3f0f0cadcec>`__
-   `#9483 <https://pagure.io/freeipa/issue/9483>`__
+   `#9483 <https://codeberg.org/freeipa/freeipa/issues/9483>`__
 
 .. _julien_rische_3:
 
@@ -730,13 +730,13 @@ Julien Rische (3)
 
 -  ipa-kdb: Fix double free in ipadb_reinit_mspac()
    `commit <https://codeberg.org/freeipa/freeipa/commit/dc3e902b0bf9f817f7aafb606f1d5d3287873ab2>`__
-   `#9535 <https://pagure.io/freeipa/issue/9535>`__
+   `#9535 <https://codeberg.org/freeipa/freeipa/issues/9535>`__
 -  ipa-kdb: Rework ipadb_reinit_mspac()
    `commit <https://codeberg.org/freeipa/freeipa/commit/835929353d935613ae3dd6fc6f70b21d3252fbc8>`__
-   `#9535 <https://pagure.io/freeipa/issue/9535>`__
+   `#9535 <https://codeberg.org/freeipa/freeipa/issues/9535>`__
 -  ipa-kdb: Fix memory leak during PAC verification
    `commit <https://codeberg.org/freeipa/freeipa/commit/75afdfea5d0aa7540fa20f6e8ad15625d56513b6>`__
-   `#9520 <https://pagure.io/freeipa/issue/9520>`__
+   `#9520 <https://codeberg.org/freeipa/freeipa/issues/9520>`__
 
 .. _masahiro_matsuya_1:
 
@@ -745,7 +745,7 @@ Masahiro Matsuya (1)
 
 -  ipatests: wait for replica update in test_dns_locations
    `commit <https://codeberg.org/freeipa/freeipa/commit/c740cb84ba1e5cab871ae4f197a04d87f40c5b9e>`__
-   `#9504 <https://pagure.io/freeipa/issue/9504>`__
+   `#9504 <https://codeberg.org/freeipa/freeipa/issues/9504>`__
 
 .. _mark_reynolds_16:
 
@@ -754,52 +754,52 @@ Mark Reynolds (16)
 
 -  Issue 9591 - Allow get_ruv() to handle incomplete RUV elements
    `commit <https://codeberg.org/freeipa/freeipa/commit/544652aae43506ef974fc7331ce8612884a7d01e>`__
-   `#9591 <https://pagure.io/freeipa/issue/9591>`__
+   `#9591 <https://codeberg.org/freeipa/freeipa/issues/9591>`__
 -  Issue 9579 - Remove bash_completions_dir for RHEL
    `commit <https://codeberg.org/freeipa/freeipa/commit/cce8dc4da87a934644712158b97242960a8d138e>`__
-   `#9579 <https://pagure.io/freeipa/issue/9579>`__
+   `#9579 <https://codeberg.org/freeipa/freeipa/issues/9579>`__
 -  Issue 9570 - migrate nsaccountlock
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9f96ac4a802e9b38d156fddbc98592ac0981726>`__
-   `#9570 <https://pagure.io/freeipa/issue/9570>`__
+   `#9570 <https://codeberg.org/freeipa/freeipa/issues/9570>`__
 -  Issue 9568 - Update IPA to IPA migration design doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/8084b94c17d2d2e83288cae5aa9ab96dc7c32ce4>`__
-   `#9568 <https://pagure.io/freeipa/issue/9568>`__
+   `#9568 <https://codeberg.org/freeipa/freeipa/issues/9568>`__
 -  IPA-to-IPA migration tool (beta)
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbe18735913aa1d033937088c1f2628a962a9254>`__
-   `#3656 <https://pagure.io/freeipa/issue/3656>`__
+   `#3656 <https://codeberg.org/freeipa/freeipa/issues/3656>`__
 -  Issue 9547 - Update IPA to IPA migration design doc
    `commit <https://codeberg.org/freeipa/freeipa/commit/557f0a5639e65b952ed0ce82e4ef42683bf75178>`__
-   `#9547 <https://pagure.io/freeipa/issue/9547>`__
+   `#9547 <https://codeberg.org/freeipa/freeipa/issues/9547>`__
 -  Issue 9497 - update debug logging in ipa_uuid
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d3d191825f4da5b2f4e98845b0be9770172f71c>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa-pwd-extop
    `commit <https://codeberg.org/freeipa/freeipa/commit/0007876f4205c289018fd6828f87529890c9ba2f>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa_otp_lasttoken
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cd5a0847a49083da7d76525142880628931078d>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa_otp_counter
    `commit <https://codeberg.org/freeipa/freeipa/commit/2a1d454c748792434d6d27306c1330e6d518a6c3>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa_modrdn
    `commit <https://codeberg.org/freeipa/freeipa/commit/79b08556a4b4a5750bc53eb29be67c7e018213b4>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa_lockout
    `commit <https://codeberg.org/freeipa/freeipa/commit/23ead1dc2388947a254cecf4cf90147a317bcefc>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - update debug logging in ipa_graceperiod
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a6361dc755b97b19380a96050c474e4d7eb4c15>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - Update logging in ipa_enrollment
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a16130a9a98f4d735fc76129f4cb434eafc3e67>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 9497 - Add new password policy logging function
    `commit <https://codeberg.org/freeipa/freeipa/commit/3fd5d57ed670232fc03aef1feed4fe04f3d996d9>`__
-   `#9497 <https://pagure.io/freeipa/issue/9497>`__
+   `#9497 <https://codeberg.org/freeipa/freeipa/issues/9497>`__
 -  Issue 3656 - Extend schema function to return MAY or MUST attrs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5c8614157d5546033528f92700f5abfebd4e5838>`__
-   `#3656 <https://pagure.io/freeipa/issue/3656>`__
+   `#3656 <https://codeberg.org/freeipa/freeipa/issues/3656>`__
 
 .. _mohammad_rizwan_4:
 
@@ -808,10 +808,10 @@ Mohammad Rizwan (2)
 
 -  ipatests: test software HSM installation with server & replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ec875c6fe677357d4dfb50090dc18ae902328a1>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  ipatests: test software HSM installation with server & replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/36dbc6b0258f3e21a3fe6c72cd55bf0c141c0946>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 
 .. _weblate_translation_memory_19:
 
@@ -898,37 +898,37 @@ Rob Crittenden (55)
 
 -  Add permissions for topologysegment
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fc35156d91ce2265f02ed12224bce08c21b99e6>`__
-   `#9594 <https://pagure.io/freeipa/issue/9594>`__
+   `#9594 <https://codeberg.org/freeipa/freeipa/issues/9594>`__
 -  Don't try to validate the HSM arguments on a non-HSM installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/f225b3df17a4c01e62f659fe70fc5427bab1f387>`__
-   `#9593 <https://pagure.io/freeipa/issue/9593>`__
+   `#9593 <https://codeberg.org/freeipa/freeipa/issues/9593>`__
 -  docs: Add a section on SELinux modules to the HSM design
    `commit <https://codeberg.org/freeipa/freeipa/commit/6af8577d58c4b2bed04ec0bd02042ba7122ab518>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add SELinux module checking to hsm_validator
    `commit <https://codeberg.org/freeipa/freeipa/commit/c861ce5a1634b43b04c3d38d49d5b3e4e599b7d7>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Call hsm_validator on KRA installs and validate the HSM password
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b6c1879c5174869128ae28048673995242b18c1>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Include the HSM tests in the nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/879a937dddf17478378d9e855317ee199ac645c9>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Require certmonger 0.79.17+ for required HSM changes
    `commit <https://codeberg.org/freeipa/freeipa/commit/bcd8d2d90a41eb94422ad5fad730bd0570108f91>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  After an HSM replica install ensure all certs are visible
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea0bf4020ce0b1e32572e128e9323c5af60ec93d>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  KRA: force OAEP for some HSM-based installations
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9ec2fb0a91034934b48d419c2d0eaa2c36faef1>`__
-   `#9191 <https://pagure.io/freeipa/issue/9191>`__
+   `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__
 -  Prompt for token password if not provided in replica/ipa-ca-install
    `commit <https://codeberg.org/freeipa/freeipa/commit/31fda79a0e3f34dcf71a9e2687faa958ecb91ab8>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  dogtag-ipa-ca-renew-agent-submit: expect certs to be on HSMs
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6f2d0212bf9aa2ed816779540d69233fe7110a5>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  tests: Fix failing test test_testconfig.py with missing token
    variables
    `commit <https://codeberg.org/freeipa/freeipa/commit/b63103c88a57b1320ce2e38f7483ef37692feebd>`__
@@ -940,120 +940,120 @@ Rob Crittenden (55)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c6dd21f04e9f14b0c1e5c064e87b3266ff02f60f>`__
 -  Validate the HSM token library path and name during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/31d66bac64501efd54afe2041b9d00da66ac0ae3>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  After installing a KRA, copy the updated token to other machines
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b894f28b5ac07fff3863cc4fec6b9a2383b615e>`__
 -  tests: helper to copy files from one host to another
    `commit <https://codeberg.org/freeipa/freeipa/commit/06a8791b9beec5a95a5072e9a02a4379ac46770d>`__
 -  renew_ca_cert: set peer trust on the KRA audit certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/b89aa919778a048fbb54f0a3426423d23f6c38df>`__
-   `#9353 <https://pagure.io/freeipa/issue/9353>`__
+   `#9353 <https://codeberg.org/freeipa/freeipa/issues/9353>`__
 -  renew_ca_cert: skip removing non-CA certs, fix nickname
    `commit <https://codeberg.org/freeipa/freeipa/commit/0708f603e2d632db77a95d135e28242c6d1a7ee7>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  If HSM is configured add the token name to config-show output
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0c489e28228f4ce5f92c2dfc2c7b9e86c7fcb36>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add token support to the renew_ca_cert certmonger helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/93622005ba0f14e68010a84b07cc050cfdc4bedc>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Update SELinux policy to allow certmonger to PKI config files
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ad3b489f6272e5b041d410f8098f454b584209e>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add attribute ipacahsmconfiguration to the "Read CAs" ACI
    `commit <https://codeberg.org/freeipa/freeipa/commit/a99091adc0bf8dd745ef3f5980a5bc66294e8c06>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add HSM configuration options to installer scripts
    `commit <https://codeberg.org/freeipa/freeipa/commit/82c0b19acce147b3f82183b561883c7ca9137403>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add LDAP attribute ipaCaHSMConfiguration to store HSM state
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9efa728c5c93e232eaf03b432b0699804189012>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  doc: Add token-password-file to HSM design, set new OID
    `commit <https://codeberg.org/freeipa/freeipa/commit/f658a264f9cbdb190aa4ff6ab21903da0a7e84c8>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Don't move KRA keys when key backup is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3234708ac356065641ce1ea4d6460c7fd50c815>`__
-   `#7677 <https://pagure.io/freeipa/issue/7677>`__,
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#7677 <https://codeberg.org/freeipa/freeipa/issues/7677>`__,
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Only generate kracert.p12 when not installing with HSM
    `commit <https://codeberg.org/freeipa/freeipa/commit/73d52a613518ca1e2d2303b660f9dc439987f90f>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Add token support to installer certificate handling
    `commit <https://codeberg.org/freeipa/freeipa/commit/34f28f06db291c7408fbeb7276dcdaae5f0ef18a>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Don't generate a cafile on HSM instalations
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6078c639c332e0079fa0cbff3fa54882d79b3bd>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  Support the certmonger nss-user option
    `commit <https://codeberg.org/freeipa/freeipa/commit/cba3094c9af5ceac66dd2c11839acbab80c6e9d3>`__
-   `#9273 <https://pagure.io/freeipa/issue/9273>`__
+   `#9273 <https://codeberg.org/freeipa/freeipa/issues/9273>`__
 -  ipa-crlgen-manage: manage the cert status task execution time
    `commit <https://codeberg.org/freeipa/freeipa/commit/f78d25fc972813f500c4ccfcf0faa2c6aa0d48b2>`__
-   `#9569 <https://pagure.io/freeipa/issue/9569>`__
+   `#9569 <https://codeberg.org/freeipa/freeipa/issues/9569>`__
 -  Allow the admin user to be disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b0f6ff19e4b56b775cca91435be0a612600f837>`__
-   `#9489 <https://pagure.io/freeipa/issue/9489>`__
+   `#9489 <https://codeberg.org/freeipa/freeipa/issues/9489>`__
 -  ipatests: Ignore spacing in OpenSSL validation error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/6294b93e14e3b538061a2892bc48edcb31866928>`__
-   `#9567 <https://pagure.io/freeipa/issue/9567>`__
+   `#9567 <https://codeberg.org/freeipa/freeipa/issues/9567>`__
 -  Return 2 when certificates are not found during requests
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d3c6b761b9d59ce6640d1141848eb66585795f7>`__
-   `#9562 <https://pagure.io/freeipa/issue/9562>`__
+   `#9562 <https://codeberg.org/freeipa/freeipa/issues/9562>`__
 -  Check for file permissions after the ca/cert-show is complete
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9bb811296b99d21a150adf0c7a0282df3337c7c>`__
-   `#9562 <https://pagure.io/freeipa/issue/9562>`__
+   `#9562 <https://codeberg.org/freeipa/freeipa/issues/9562>`__
 -  Vault: add additional fallback to RSA-OAEP wrapping algo
    `commit <https://codeberg.org/freeipa/freeipa/commit/c3d228d4a3c99f8eaf3d9f1d5825fed5cdff5810>`__
-   `#9191 <https://pagure.io/freeipa/issue/9191>`__
+   `#9191 <https://codeberg.org/freeipa/freeipa/issues/9191>`__
 -  ipa-restore: adapt for 389-ds switch to LMDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/3766fb98637254110db04b086299e2eefd59cca6>`__
-   `#9526 <https://pagure.io/freeipa/issue/9526>`__
+   `#9526 <https://codeberg.org/freeipa/freeipa/issues/9526>`__
 -  validate_principal: Don't try to verify that the realm is known
    `commit <https://codeberg.org/freeipa/freeipa/commit/33af154b7f2c92e199d10a36a48310da9b7e77a8>`__
-   `#9541 <https://pagure.io/freeipa/issue/9541>`__
+   `#9541 <https://codeberg.org/freeipa/freeipa/issues/9541>`__
 -  Server affinity: call ca.install() if there is a CA in the topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6014a5c1996528b255480b67fe2937203bff81b>`__
-   `#9510 <https://pagure.io/freeipa/issue/9510>`__
+   `#9510 <https://codeberg.org/freeipa/freeipa/issues/9510>`__
 -  Server affinity: Don't rely just on [ca|kra]_enabled for installs
    `commit <https://codeberg.org/freeipa/freeipa/commit/3645543670562f9c7c0b9ac04721f146844e07de>`__
-   `#9510 <https://pagure.io/freeipa/issue/9510>`__
+   `#9510 <https://codeberg.org/freeipa/freeipa/issues/9510>`__
 -  get_directive: don't error out on substring mismatch
    `commit <https://codeberg.org/freeipa/freeipa/commit/e5a9e46138041876c650bc2c3eab4b5dde28b2ea>`__
-   `#9506 <https://pagure.io/freeipa/issue/9506>`__
+   `#9506 <https://codeberg.org/freeipa/freeipa/issues/9506>`__
 -  ipa-client-automount: Don't use deprecated ipadiscovery.IPADiscovery
    `commit <https://codeberg.org/freeipa/freeipa/commit/54fb1173f9ab1025c12a77b3a5bf205afa8f63e2>`__
-   `#9487 <https://pagure.io/freeipa/issue/9487>`__
+   `#9487 <https://codeberg.org/freeipa/freeipa/issues/9487>`__
 -  ipatests: Test client install/uninstall with automount enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce811db6be532a9f258d7429234028975eb99f50>`__
-   `#9487 <https://pagure.io/freeipa/issue/9487>`__
+   `#9487 <https://codeberg.org/freeipa/freeipa/issues/9487>`__
 -  Fix ipa-client-automount install/uninstall with new install states
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4420624ffed47c42b3bd0dfd580cd98f667e843>`__
-   `#9487 <https://pagure.io/freeipa/issue/9487>`__
+   `#9487 <https://codeberg.org/freeipa/freeipa/issues/9487>`__
 -  ACME: Don't treat pki-server ca-config-show failures as fatal
    `commit <https://codeberg.org/freeipa/freeipa/commit/a44cb097137453aa13bbc1b9e206a7e70628ef88>`__
-   `#9503 <https://pagure.io/freeipa/issue/9503>`__
+   `#9503 <https://codeberg.org/freeipa/freeipa/issues/9503>`__
 -  Include supported migration scenarios in the ipa-to-ipa docs
    `commit <https://codeberg.org/freeipa/freeipa/commit/11877d59030ef3cd158aefb298c3a6a334047412>`__
 -  ipatests: Verify that hbactest will return messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1e09c68af8ac77f656dd639af5d9a7f07c41f9d>`__
-   `#9486 <https://pagure.io/freeipa/issue/9486>`__
+   `#9486 <https://codeberg.org/freeipa/freeipa/issues/9486>`__
 -  hbactest was not collecting or returning messages
    `commit <https://codeberg.org/freeipa/freeipa/commit/48846e98e5e988d600ddf81c937f353fcecdea1a>`__
-   `#9486 <https://pagure.io/freeipa/issue/9486>`__
+   `#9486 <https://codeberg.org/freeipa/freeipa/issues/9486>`__
 -  ipatests: fix expected output for ipahealthcheck.ipa.host
    `commit <https://codeberg.org/freeipa/freeipa/commit/f00b52ce6dbc1a4008974e118f252d90e26301a1>`__
-   `#9482 <https://pagure.io/freeipa/issue/9482>`__
+   `#9482 <https://codeberg.org/freeipa/freeipa/issues/9482>`__
 -  ipatests: ignore nsslapd-accesslog-logbuffering WARN in healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/d659d21b432cde9fb3a6e1fe4ba65014587a127f>`__
-   `#9400 <https://pagure.io/freeipa/issue/9400>`__
+   `#9400 <https://codeberg.org/freeipa/freeipa/issues/9400>`__
 -  WIP: Get the PKI version from the remote to determine the argument
    `commit <https://codeberg.org/freeipa/freeipa/commit/caccd6c693fe86e09a84f7fe7263a08d34a22d7e>`__
 -  ipa-client: correct directory location by using constants instead
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8a923033bf764b744496199d8f86ff7a7fe183e>`__
 -  Allow password policy minlength to be removed like other values
    `commit <https://codeberg.org/freeipa/freeipa/commit/62454574a1504354935e69e3769fb1b2451d72b9>`__
-   `#9297 <https://pagure.io/freeipa/issue/9297>`__
+   `#9297 <https://codeberg.org/freeipa/freeipa/issues/9297>`__
 
 
 .. _rafael_guterres_jeffman_2:
@@ -1063,10 +1063,10 @@ Rafael Guterres Jeffman (2)
 
 -  Replace netifaces with ifaddr
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c6b9354b5f970983655ca5423c726763d9015fa>`__
-   `#9555 <https://pagure.io/freeipa/issue/9555>`__
+   `#9555 <https://codeberg.org/freeipa/freeipa/issues/9555>`__
 -  ipaserver/dcerpc: avoid logging stack trace in retrieve_anonymously
    `commit <https://codeberg.org/freeipa/freeipa/commit/60fe752da468e84a642af51090b27468446606f7>`__
-   `#9484 <https://pagure.io/freeipa/issue/9484>`__
+   `#9484 <https://codeberg.org/freeipa/freeipa/issues/9484>`__
 
 .. _김인수_19:
 
@@ -1119,16 +1119,16 @@ Stanislav Levin (4)
 
 -  ap: Migrate to docker compose V2
    `commit <https://codeberg.org/freeipa/freeipa/commit/1df2abbd5f3d758d494a196567cc2323bf2ab91c>`__
-   `#9566 <https://pagure.io/freeipa/issue/9566>`__
+   `#9566 <https://codeberg.org/freeipa/freeipa/issues/9566>`__
 -  ipapython: Propagate KRB5Error exceptions on iterating ccache
    `commit <https://codeberg.org/freeipa/freeipa/commit/9802e852cb29fdbc43b056816ade27f453001706>`__
-   `#9519 <https://pagure.io/freeipa/issue/9519>`__
+   `#9519 <https://codeberg.org/freeipa/freeipa/issues/9519>`__
 -  ipapython: Correct return type of krb5_free_cred_contents
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cd04875dea09c83e01261a805aa27360768d46f>`__
-   `#9519 <https://pagure.io/freeipa/issue/9519>`__
+   `#9519 <https://codeberg.org/freeipa/freeipa/issues/9519>`__
 -  ipapython: Clean up krb5_error
    `commit <https://codeberg.org/freeipa/freeipa/commit/d002a4d7c991966ccb73e4ab34d0288b90f033ab>`__
-   `#9519 <https://pagure.io/freeipa/issue/9519>`__
+   `#9519 <https://codeberg.org/freeipa/freeipa/issues/9519>`__
 
 .. _sudhir_menon_4:
 
@@ -1172,7 +1172,7 @@ Thorsten Scherf (1)
 
 -  ipa-client: Check if IPA CA cert is empty
    `commit <https://codeberg.org/freeipa/freeipa/commit/821259f069941ec1bf38a417bd029c13932314b1>`__
-   `#9499 <https://pagure.io/freeipa/issue/9499>`__
+   `#9499 <https://codeberg.org/freeipa/freeipa/issues/9499>`__
 
 .. _thomas_woerner_1:
 
@@ -1181,10 +1181,10 @@ Thomas Woerner (2)
 
 -  idviews: Use ipaAnchorUUID without DCERPC bindings for SID anchors
    `commit <https://codeberg.org/freeipa/freeipa/commit/9dc57ef77e276773b91c567f83498a69d382ba13>`__
-   `#9544 <https://pagure.io/freeipa/issue/9544>`__
+   `#9544 <https://codeberg.org/freeipa/freeipa/issues/9544>`__
 -  principal_has_privilege: Check also idoverriseuser (ipaOriginalUid)
    `commit <https://codeberg.org/freeipa/freeipa/commit/182dca38c2bb84acce8ab5dcfab6fb5e4abf31da>`__
-   `#9542 <https://pagure.io/freeipa/issue/9542>`__
+   `#9542 <https://codeberg.org/freeipa/freeipa/issues/9542>`__
 
 .. _viktor_ashirov_2:
 
@@ -1193,7 +1193,7 @@ Viktor Ashirov (1)
 
 -  WebUI: update favicon.ico
    `commit <https://codeberg.org/freeipa/freeipa/commit/fe005dd3880baff72bda2c2857f9445d3b129b87>`__
-   `#9449 <https://pagure.io/freeipa/issue/9449>`__
+   `#9449 <https://codeberg.org/freeipa/freeipa/issues/9449>`__
 
 .. _yuri_chornoivan_1:
 
@@ -1210,4 +1210,4 @@ zoedong (1)
 
 -  ipaplatform: add opencloudos/tencentos support
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c0fe1dd924b428eef1fcc4ebf209a1f0dfe3de1>`__
-   `#9501 <https://pagure.io/freeipa/issue/9501>`__
+   `#9501 <https://codeberg.org/freeipa/freeipa/issues/9501>`__

--- a/src/release-notes/4-12-2.rst
+++ b/src/release-notes/4-12-2.rst
@@ -99,80 +99,80 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#5169 <https://pagure.io/freeipa/issue/5169>`__ [RFE] Enforce OTP
+-  `#5169 <https://codeberg.org/freeipa/freeipa/issues/5169>`__ [RFE] Enforce OTP
    for a subset of scenarios
--  `#8080 <https://pagure.io/freeipa/issue/8080>`__ ipa-server-install
+-  `#8080 <https://codeberg.org/freeipa/freeipa/issues/8080>`__ ipa-server-install
    --uninstall leaves files
--  `#9367 <https://pagure.io/freeipa/issue/9367>`__ Covscan issues:
+-  `#9367 <https://codeberg.org/freeipa/freeipa/issues/9367>`__ Covscan issues:
    Resource Leak
--  `#9488 <https://pagure.io/freeipa/issue/9488>`__ Nightly test failure
+-  `#9488 <https://codeberg.org/freeipa/freeipa/issues/9488>`__ Nightly test failure
    in test_trust.py::TestTrust::test_server_option_with_unreachable_ad
--  `#9542 <https://pagure.io/freeipa/issue/9542>`__ Fix replica
+-  `#9542 <https://codeberg.org/freeipa/freeipa/issues/9542>`__ Fix replica
    connection check for use with AD administrator
--  `#9584 <https://pagure.io/freeipa/issue/9584>`__ Race condition in
+-  `#9584 <https://codeberg.org/freeipa/freeipa/issues/9584>`__ Race condition in
    ipa-backup
--  `#9594 <https://pagure.io/freeipa/issue/9594>`__ topologysegment
+-  `#9594 <https://codeberg.org/freeipa/freeipa/issues/9594>`__ topologysegment
    commands cannot be delegated
--  `#9603 <https://pagure.io/freeipa/issue/9603>`__ ipa-server-install:
+-  `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__ ipa-server-install:
    token_password_file read in kra.install_check after calling
    hsm_validator in ca.install_check
--  `#9606 <https://pagure.io/freeipa/issue/9606>`__ Nightly test failure
+-  `#9606 <https://codeberg.org/freeipa/freeipa/issues/9606>`__ Nightly test failure
    (f40+) in
    test_cert.py::TestCAShowErrorHandling::test_ca_show_error_handling
--  `#9607 <https://pagure.io/freeipa/issue/9607>`__ Nightly test failure
+-  `#9607 <https://codeberg.org/freeipa/freeipa/issues/9607>`__ Nightly test failure
    (f40+) in test_commands.py::TestIPACommand::test_ssh_key_connection
--  `#9609 <https://pagure.io/freeipa/issue/9609>`__ ipa-otptoken-import
+-  `#9609 <https://codeberg.org/freeipa/freeipa/issues/9609>`__ ipa-otptoken-import
    fails to import encrypted file
--  `#9610 <https://pagure.io/freeipa/issue/9610>`__ ipa-client rpm post
+-  `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__ ipa-client rpm post
    script creates always ssh_config.orig even if nothing needs to be
    changed
--  `#9611 <https://pagure.io/freeipa/issue/9611>`__ kdc.crt certificate
+-  `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__ kdc.crt certificate
    not getting automatically renewed by certmonger in IPA Hidden replica
--  `#9613 <https://pagure.io/freeipa/issue/9613>`__ After backup/restore
+-  `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__ After backup/restore
    of dnssec master, zones are not signed
--  `#9615 <https://pagure.io/freeipa/issue/9615>`__ Nightly test failure
+-  `#9615 <https://codeberg.org/freeipa/freeipa/issues/9615>`__ Nightly test failure
    (f40+) in test_sssd.py::TestNestedMembers::test_nested_group_members
--  `#9616 <https://pagure.io/freeipa/issue/9616>`__ Nightly test failure
+-  `#9616 <https://codeberg.org/freeipa/freeipa/issues/9616>`__ Nightly test failure
    in test_backup_and_restore_TestReplicaInstallAfterRestore
--  `#9617 <https://pagure.io/freeipa/issue/9617>`__ The ipa-advise,
+-  `#9617 <https://codeberg.org/freeipa/freeipa/issues/9617>`__ The ipa-advise,
    ipa-backup, and ipa-restore manuals incorrectly show the --v option.
--  `#9618 <https://pagure.io/freeipa/issue/9618>`__ Allow IPA SIDgen
+-  `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__ Allow IPA SIDgen
    task to continue if it finds an entity that SID can't be assigned to
--  `#9619 <https://pagure.io/freeipa/issue/9619>`__ ipa-migrate starttls
+-  `#9619 <https://codeberg.org/freeipa/freeipa/issues/9619>`__ ipa-migrate starttls
    does not work
--  `#9620 <https://pagure.io/freeipa/issue/9620>`__ ipa-migrate remove
+-  `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__ ipa-migrate remove
    -V option
--  `#9621 <https://pagure.io/freeipa/issue/9621>`__ ipa-migrate should
+-  `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__ ipa-migrate should
    not update mapped attributes in managed entries
--  `#9624 <https://pagure.io/freeipa/issue/9624>`__ A missing cccache
+-  `#9624 <https://codeberg.org/freeipa/freeipa/issues/9624>`__ A missing cccache
    prevents Kerberos SSO
--  `#9625 <https://pagure.io/freeipa/issue/9625>`__ Executing the -d
+-  `#9625 <https://codeberg.org/freeipa/freeipa/issues/9625>`__ Executing the -d
    option results in an error.
--  `#9626 <https://pagure.io/freeipa/issue/9626>`__
+-  `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
    ipa-replica/server-install with softhsm needs to check
    permission/ownership of /var/lib/softhsm/tokens to avoid install
    failure.
--  `#9629 <https://pagure.io/freeipa/issue/9629>`__ Syntax error
+-  `#9629 <https://codeberg.org/freeipa/freeipa/issues/9629>`__ Syntax error
    uninstalling the selinux-luna subpackage
--  `#9632 <https://pagure.io/freeipa/issue/9632>`__ Unconditionally add
+-  `#9632 <https://codeberg.org/freeipa/freeipa/issues/9632>`__ Unconditionally add
    MS-PAC to global config
--  `#9633 <https://pagure.io/freeipa/issue/9633>`__ Remove RC4 and 3DES
+-  `#9633 <https://codeberg.org/freeipa/freeipa/issues/9633>`__ Remove RC4 and 3DES
    default encryption types on update
--  `#9635 <https://pagure.io/freeipa/issue/9635>`__ Ignore time skew
+-  `#9635 <https://codeberg.org/freeipa/freeipa/issues/9635>`__ Ignore time skew
    during CA replica installation
--  `#9636 <https://pagure.io/freeipa/issue/9636>`__ misleading warning
+-  `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__ misleading warning
    for missing ipa-selinux-nfast package on luna hsm
--  `#9637 <https://pagure.io/freeipa/issue/9637>`__ adtrustinstance only
+-  `#9637 <https://codeberg.org/freeipa/freeipa/issues/9637>`__ adtrustinstance only
    prints issues in check_inst() and does not log them
--  `#9641 <https://pagure.io/freeipa/issue/9641>`__ support for python
+-  `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__ support for python
    cryptography 43.0.0
--  `#9642 <https://pagure.io/freeipa/issue/9642>`__ ipa-migrate -
+-  `#9642 <https://codeberg.org/freeipa/freeipa/issues/9642>`__ ipa-migrate -
    properly handle invalid certificates
--  `#9643 <https://pagure.io/freeipa/issue/9643>`__ freeipa fails to
+-  `#9643 <https://codeberg.org/freeipa/freeipa/issues/9643>`__ freeipa fails to
    build with nodejs22 on f39 and f40
--  `#9644 <https://pagure.io/freeipa/issue/9644>`__ Fedora 40 pylint
+-  `#9644 <https://codeberg.org/freeipa/freeipa/issues/9644>`__ Fedora 40 pylint
    issues with PY2/PY3 compatibility
--  `#9648 <https://pagure.io/freeipa/issue/9648>`__ Nightly test
+-  `#9648 <https://codeberg.org/freeipa/freeipa/issues/9648>`__ Nightly test
    failures in test_hsm_TestHSMNegative
 
 .. _detailed_changelog_since_4.12.1:
@@ -187,19 +187,19 @@ Alexander Bokovoy (5)
 
 -  Get rid of unicode and long helpers in ipa-otptoken-import
    `commit <https://codeberg.org/freeipa/freeipa/commit/7b5f3d79712a84f88ced6e9055bc96c9980b0b20>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  ipalib/constants.py: factor out TripleDES use
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc029043401bb852d2bfe8e8eccb926f50627b3b>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  ipalib/x509.py: get rid of unicode helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/7f9c890c049f1151d3225e154fcde9bfed8cebb3>`__
-   `#9644 <https://pagure.io/freeipa/issue/9644>`__
+   `#9644 <https://codeberg.org/freeipa/freeipa/issues/9644>`__
 -  ipalib/x509.py: support Cryptography 43
    `commit <https://codeberg.org/freeipa/freeipa/commit/531bd05de9b3764b90804fcdad3b0b49ceb06110>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  ipa-pwd-extop: differentiate OTP requirements in LDAP binds
    `commit <https://codeberg.org/freeipa/freeipa/commit/051d61fdc301f2768ac78c45e93a5f9eeff8aa28>`__
-   `#5169 <https://pagure.io/freeipa/issue/5169>`__
+   `#5169 <https://codeberg.org/freeipa/freeipa/issues/5169>`__
 
 .. _anuja_more_1:
 
@@ -208,7 +208,7 @@ Anuja More (1)
 
 -  ipatests: Test replica installation using AD admin.
    `commit <https://codeberg.org/freeipa/freeipa/commit/8b703150a47bf509f37856bdc27cfa99e85e5e6b>`__
-   `#9542 <https://pagure.io/freeipa/issue/9542>`__
+   `#9542 <https://codeberg.org/freeipa/freeipa/issues/9542>`__
 
 .. _antonio_torres_2:
 
@@ -227,62 +227,62 @@ Florence Blanc-Renaud (20)
 
 -  trust-add: handle unavailable domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/f37c2eb8782ec06e538d8964bf904f1b7e79c15e>`__
-   `#9488 <https://pagure.io/freeipa/issue/9488>`__
+   `#9488 <https://codeberg.org/freeipa/freeipa/issues/9488>`__
 -  HSM: fix the module name
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fc63e2b5150548edb3e910aa270e49c8b35223b>`__
-   `#9636 <https://pagure.io/freeipa/issue/9636>`__
+   `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__
 -  ipatests: skip HSM test if pki < 11.5.9
    `commit <https://codeberg.org/freeipa/freeipa/commit/84751a26a95ee7bda541122c921a9c7fe4eb13d7>`__
-   `#9648 <https://pagure.io/freeipa/issue/9648>`__
+   `#9648 <https://codeberg.org/freeipa/freeipa/issues/9648>`__
 -  ipatests: increase the timeout for test_hsm.py::TestHSMInstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/81401e6c010a05b52bcc10306400dee9075b0e91>`__
 -  Replica CA installation: ignore time skew during initial replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/aadb8051d4a3172aac3790f47ff4d241a245bab4>`__
-   `#9635 <https://pagure.io/freeipa/issue/9635>`__
+   `#9635 <https://codeberg.org/freeipa/freeipa/issues/9635>`__
 -  spec file: do not use nodejs-22 on f39 and f40
    `commit <https://codeberg.org/freeipa/freeipa/commit/2ddca5d5d57a877fbd598d8bdc29d0fe032621e8>`__
-   `#9643 <https://pagure.io/freeipa/issue/9643>`__
+   `#9643 <https://codeberg.org/freeipa/freeipa/issues/9643>`__
 -  ipatests: remove xfail for test_ipa_migrate_stage_mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/6eb6a929308c2916df9aed2da9ee6ef9d98e2438>`__
-   `#9621 <https://pagure.io/freeipa/issue/9621>`__
+   `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__
 -  ipatests: remove xfail for test_ipa_migrate_version_option
    `commit <https://codeberg.org/freeipa/freeipa/commit/de940802bb6631fbbc97afd11869d87cba18f47f>`__
-   `#9620 <https://pagure.io/freeipa/issue/9620>`__
+   `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__
 -  test_replica_install_after_restore: kinit after restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/d635d701100c9d3bdc179bae1f0d715fce30b461>`__
-   `#9613 <https://pagure.io/freeipa/issue/9613>`__
+   `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__
 -  Uninstall: stop sssd-kcm before removing KCM ccaches database
    `commit <https://codeberg.org/freeipa/freeipa/commit/6fe268af5bc6c5296f7a380917e3134f8fa46fda>`__
-   `#9616 <https://pagure.io/freeipa/issue/9616>`__
+   `#9616 <https://codeberg.org/freeipa/freeipa/issues/9616>`__
 -  ipa-ods-enforcer: stop must also stop the socket
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f902efd0e47eb2461429ce658f89d2a11f0891e>`__
-   `#9613 <https://pagure.io/freeipa/issue/9613>`__
+   `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__
 -  ipatests: fix / permissions for test_nested_group_members
    `commit <https://codeberg.org/freeipa/freeipa/commit/48ff7da5cb7ca8c3a5c21ce57f7c51e3e19958c8>`__
-   `#9615 <https://pagure.io/freeipa/issue/9615>`__
+   `#9615 <https://codeberg.org/freeipa/freeipa/issues/9615>`__
 -  ipatests: fix / permissions to allow ssh with private key
    `commit <https://codeberg.org/freeipa/freeipa/commit/60c127d197f79fa4ed612f7173e752d156885415>`__
-   `#9607 <https://pagure.io/freeipa/issue/9607>`__
+   `#9607 <https://codeberg.org/freeipa/freeipa/issues/9607>`__
 -  ipatests: mark test_ca_show_error_handling as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/4521fe5f9125c74b4ad6e4e51f8c66c009079281>`__
-   `#9606 <https://pagure.io/freeipa/issue/9606>`__
+   `#9606 <https://codeberg.org/freeipa/freeipa/issues/9606>`__
 -  ipatests: configure gating and nightly tests on ipa-4-12 branch
    `commit <https://codeberg.org/freeipa/freeipa/commit/58154be74fa950b3356712e60687930abb6480f1>`__
 -  ipatests: add test for PKINIT renewal on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/467ec04f93a29fd31ba037cef348c09547541fe7>`__
-   `#9611 <https://pagure.io/freeipa/issue/9611>`__
+   `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__
 -  PKINIT certificate: fix renewal on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8e3fdeb0015f9c52c64816d6cd39279c5d3ad5a>`__
-   `#9611 <https://pagure.io/freeipa/issue/9611>`__
+   `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__
 -  ipatests: add test for ticket 9610
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d51446bd3cd9ab222f9978f8f5def1f3a37fa0e>`__
-   `#9610 <https://pagure.io/freeipa/issue/9610>`__
+   `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__
 -  spec file: do not create /etc/ssh/ssh_config.orig if unchanged
    `commit <https://codeberg.org/freeipa/freeipa/commit/09e66dc936cf2d99bcc44d60d6851aafa9ede46a>`__
-   `#9610 <https://pagure.io/freeipa/issue/9610>`__
+   `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__
 -  ipa-otptoken-import: open the key file in binary mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/9de053ef02db8cb63e14edc64ac22ec2d3d7bbc9>`__
-   `#9609 <https://pagure.io/freeipa/issue/9609>`__
+   `#9609 <https://codeberg.org/freeipa/freeipa/issues/9609>`__
 
 .. _julien_rische_4:
 
@@ -291,10 +291,10 @@ Julien Rische (4)
 
 -  Remove RC4 and 3DES default encryption types on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f88188204e443dd5d1d22ebe65b947452558f66>`__
-   `#9633 <https://pagure.io/freeipa/issue/9633>`__
+   `#9633 <https://codeberg.org/freeipa/freeipa/issues/9633>`__
 -  Unconditionally add MS-PAC to global config on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1a485a435ea9dba7587d1998451a09d3aa4077b>`__
-   `#9632 <https://pagure.io/freeipa/issue/9632>`__
+   `#9632 <https://codeberg.org/freeipa/freeipa/issues/9632>`__
 -  kdb: apply combinatorial logic for ticket flags
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a61184da640759e9cd8907eaf975a8bfe9a1263>`__
 -  kdb: fix vulnerability in GCD rules handling
@@ -307,7 +307,7 @@ TAKAHASHI Masatsuna (1)
 
 -  ipa-advise ipa-backup ipa-restore: Fix --v option of the manual.
    `commit <https://codeberg.org/freeipa/freeipa/commit/52ea4ad46e5579bd41939680d75bf02c76ab119d>`__
-   `#9617 <https://pagure.io/freeipa/issue/9617>`__
+   `#9617 <https://codeberg.org/freeipa/freeipa/issues/9617>`__
 
 .. _shunsuke_matsumoto_1:
 
@@ -316,7 +316,7 @@ Shunsuke matsumoto (1)
 
 -  The -d option of the ipa-advise command was able to used.
    `commit <https://codeberg.org/freeipa/freeipa/commit/06c02f5f2c524928b23ae3deeb42c6c57d3e47aa>`__
-   `#9625 <https://pagure.io/freeipa/issue/9625>`__
+   `#9625 <https://codeberg.org/freeipa/freeipa/issues/9625>`__
 
 .. _mark_reynolds_4:
 
@@ -325,17 +325,17 @@ Mark Reynolds (4)
 
 -  ipa-migrate - properly handle invalid certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e4fbc3b0d15fd219d831b0b49f5312894448206>`__
-   `#9642 <https://pagure.io/freeipa/issue/9642>`__
+   `#9642 <https://codeberg.org/freeipa/freeipa/issues/9642>`__
 -  Issue 9621 - ipa-migrate - should not update mapped attributes in
    managed entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/85a853ba93c1d23d5bad13a1ae2bee802dc90131>`__
-   `#9621 <https://pagure.io/freeipa/issue/9621>`__
+   `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__
 -  ipa-migrate - starttls does not work
    `commit <https://codeberg.org/freeipa/freeipa/commit/eeade50933cb2251b43ee34c642bcae69a216655>`__
-   `#9619 <https://pagure.io/freeipa/issue/9619>`__
+   `#9619 <https://codeberg.org/freeipa/freeipa/issues/9619>`__
 -  ipa-migrate - remove -V option
    `commit <https://codeberg.org/freeipa/freeipa/commit/efa57193630f244185b3f295ed0de17c6d08f75a>`__
-   `#9620 <https://pagure.io/freeipa/issue/9620>`__
+   `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__
 
 .. _mohammad_rizwan_2:
 
@@ -345,10 +345,10 @@ Mohammad Rizwan (2)
 -  ipatests: Verify that SIDgen task continue even if it fails to assign
    sid
    `commit <https://codeberg.org/freeipa/freeipa/commit/ee96c129a6034d02245a41c58fa3398c12c9ee75>`__
-   `#9618 <https://pagure.io/freeipa/issue/9618>`__
+   `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__
 -  ipatests: tests related to --token-password-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/4ea1ad6acae910574a524403bc82c80d24b525d6>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 
 .. _rob_crittenden_14:
 
@@ -357,46 +357,46 @@ Rob Crittenden (14)
 
 -  Fix some resource leaks identified by a static analyzer
    `commit <https://codeberg.org/freeipa/freeipa/commit/21c6ccc982b54e13b8058f9af130ce64426bd4bb>`__
-   `#9367 <https://pagure.io/freeipa/issue/9367>`__
+   `#9367 <https://codeberg.org/freeipa/freeipa/issues/9367>`__
 -  Ignore TripleDES python-cryptography import warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0684a7ecf474fcaf468816f4d9892ea5f2dc897>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  Correct usage of public_key_algorithm_oid in ipalib/x509
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cc7941f30f14964abe14f7907e480e91a612ba2>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  Log errors reported by adtrustinstance.check_inst() using logger
    `commit <https://codeberg.org/freeipa/freeipa/commit/e83d949c7f1734dff70379e360e9bbf626149c61>`__
-   `#9637 <https://pagure.io/freeipa/issue/9637>`__
+   `#9637 <https://codeberg.org/freeipa/freeipa/issues/9637>`__
 -  Force a logout in KerberosSession if a login is needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffba69648aa6b20cdc3d8950a982b49fd8004aa2>`__
-   `#9624 <https://pagure.io/freeipa/issue/9624>`__
+   `#9624 <https://codeberg.org/freeipa/freeipa/issues/9624>`__
 -  Run HSM validation as pkiuser to verify token permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/38b83c2b9329b8b16096d63e83f186c91d578ce8>`__
-   `#9626 <https://pagure.io/freeipa/issue/9626>`__
+   `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
 -  ipatests: Fix usage of token_password_file
    `commit <https://codeberg.org/freeipa/freeipa/commit/f03a96a7b914eb5130552cea626fd28e26b2108d>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Fix a copy/paste issue when detecting the HSM SELinux subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/fdd471d55c73503456683b1dea55769700730b16>`__
-   `#9636 <https://pagure.io/freeipa/issue/9636>`__
+   `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__
 -  Include token password options in ipa-kra-install man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/6c53a22a2cacf7807df11e51492d1a2c42aeeda1>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Re-organize HSM validation to be more consistent/less duplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ab1bcb2d364c26024db4ec99c707ebefffcd3e7>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Fix syntax error in the selinux-luna %postun script
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b278de4ab9c5e00fb48dc2de1ea31d9bdfc94bc>`__
-   `#9629 <https://pagure.io/freeipa/issue/9629>`__
+   `#9629 <https://codeberg.org/freeipa/freeipa/issues/9629>`__
 -  Clean up more files and directories created by the installer(s)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9e364910f537413cfce2b6ee2434579a5acf5c16>`__
-   `#8080 <https://pagure.io/freeipa/issue/8080>`__
+   `#8080 <https://codeberg.org/freeipa/freeipa/issues/8080>`__
 -  Add iparepltopoconf objectclass to topology permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebccaac3cf8a5688739d76426924469d5b4df6b1>`__
-   `#9594 <https://pagure.io/freeipa/issue/9594>`__
+   `#9594 <https://codeberg.org/freeipa/freeipa/issues/9594>`__
 -  Use a unique task name for each backend in ipa-backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/584d0cecbcb99a09b09d5698fc906b4849a7234c>`__
-   `#9584 <https://pagure.io/freeipa/issue/9584>`__
+   `#9584 <https://codeberg.org/freeipa/freeipa/issues/9584>`__
 
 .. _sudhir_menon_4:
 
@@ -406,7 +406,7 @@ Sudhir Menon (4)
 -  ipatests: Replace 'usermod -r' command with 'gpasswd -d' in
    test_hsm.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed813fe6f0716906c8b9cd09c27e3acfb8b21e43>`__
-   `#9626 <https://pagure.io/freeipa/issue/9626>`__
+   `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
 -  ipatests: ipa-migrate tool with -Z option (CACERTFILE)
    `commit <https://codeberg.org/freeipa/freeipa/commit/8046023fc46c628c099d84b026ab866f7c6e16d6>`__
 -  Added new testsuite(ipa_ipa_migration) in prci definitions
@@ -421,4 +421,4 @@ Thomas Woerner (1)
 
 -  ipa_sidgen: Allow sidgen_task to continue after finding issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/a8e75bbb77e15e3a42adb2d30933cf9e1edd2f0b>`__
-   `#9618 <https://pagure.io/freeipa/issue/9618>`__
+   `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__

--- a/src/release-notes/4-12-4.rst
+++ b/src/release-notes/4-12-4.rst
@@ -34,7 +34,7 @@ always have the canonical Kerberos principal name also set as an alias
 for the same account.
 
 However, as a part of the change in
-https://pagure.io/freeipa/issue/8326, there was no additional
+https://codeberg.org/freeipa/freeipa/issues/8326, there was no additional
 enforcement of the canonical Kerberos principal name for a pre-defined
 'admin' account. This allowed another authenticated Kerberos principal
 with privileges to add Kerberos principal aliases to create a canonical
@@ -92,7 +92,7 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#9777 <https://pagure.io/freeipa/issue/9777>`__ kdb:
+-  `#9777 <https://codeberg.org/freeipa/freeipa/issues/9777>`__ kdb:
    ipadb_get_connection() succeeds but returns null LDAP context
 
 .. _detailed_changelog_since_4.12.3:
@@ -116,7 +116,7 @@ Julien Rische (1)
 -  kdb: keep ipadb_get_connection() from succeeding with null LDAP
    context
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ae52a2fb451bbe57a4f0c584e14bca0274b85e8>`__
-   `#9777 <https://pagure.io/freeipa/issue/9777>`__
+   `#9777 <https://codeberg.org/freeipa/freeipa/issues/9777>`__
 
 .. _rob_crittenden_1:
 

--- a/src/release-notes/4-13-0.rst
+++ b/src/release-notes/4-13-0.rst
@@ -138,17 +138,17 @@ Highlights in 4.13.0
 Enhancements
 ~~~~~~~~~~~~
 
--  `#9674 <https://pagure.io/freeipa/issue/9674>`__ Handle PKI 11.6.0
+-  `#9674 <https://codeberg.org/freeipa/freeipa/issues/9674>`__ Handle PKI 11.6.0
    uninstallation
 
 --------------
 
--  `#9675 <https://pagure.io/freeipa/issue/9675>`__ Support GSSAPI in
+-  `#9675 <https://codeberg.org/freeipa/freeipa/issues/9675>`__ Support GSSAPI in
    Cockpit on IPA servers
 
 --------------
 
--  `#9757 <https://pagure.io/freeipa/issue/9757>`__ Support full 32-bit
+-  `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__ Support full 32-bit
    ID range space
 
 --------------
@@ -183,385 +183,385 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#8924 <https://pagure.io/freeipa/issue/8924>`__ ipa-client-install
+-  `#8924 <https://codeberg.org/freeipa/freeipa/issues/8924>`__ ipa-client-install
    fails to install on Ubuntu 20.04 LTS due to incorrect cert name
--  `#9002 <https://pagure.io/freeipa/issue/9002>`__ Nightly failure in
+-  `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__ Nightly failure in
    test_fips.py::TestInstallFIPS::test_basic::setup
--  `#9135 <https://pagure.io/freeipa/issue/9135>`__ Nightly test failure
+-  `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__ Nightly test failure
    (f37+): reverse zone not created
--  `#9202 <https://pagure.io/freeipa/issue/9202>`__ Generated QR codes
+-  `#9202 <https://codeberg.org/freeipa/freeipa/issues/9202>`__ Generated QR codes
    not being read by Android authentication apps
--  `#9363 <https://pagure.io/freeipa/issue/9363>`__ Set compat tree and
+-  `#9363 <https://codeberg.org/freeipa/freeipa/issues/9363>`__ Set compat tree and
    NIS configuration disabled by default when deploying FreeIPA
--  `#9365 <https://pagure.io/freeipa/issue/9365>`__ Covscan issues:
+-  `#9365 <https://codeberg.org/freeipa/freeipa/issues/9365>`__ Covscan issues:
    usage of free() instead of krb5_free_enctypes()
--  `#9367 <https://pagure.io/freeipa/issue/9367>`__ Covscan issues:
+-  `#9367 <https://codeberg.org/freeipa/freeipa/issues/9367>`__ Covscan issues:
    Resource Leak
--  `#9370 <https://pagure.io/freeipa/issue/9370>`__ kdb: support storing
+-  `#9370 <https://codeberg.org/freeipa/freeipa/issues/9370>`__ kdb: support storing
    and retrieving multiple master keys
--  `#9387 <https://pagure.io/freeipa/issue/9387>`__ FreeIPA OTP Allows
+-  `#9387 <https://codeberg.org/freeipa/freeipa/issues/9387>`__ FreeIPA OTP Allows
    Users with Expired Tokens to Authenticate
--  `#9450 <https://pagure.io/freeipa/issue/9450>`__ Find and replace del
+-  `#9450 <https://codeberg.org/freeipa/freeipa/issues/9450>`__ Find and replace del
    os.environ['foo'] with os.environ.pop('foo', None)
--  `#9468 <https://pagure.io/freeipa/issue/9468>`__ Covscan issues in
+-  `#9468 <https://codeberg.org/freeipa/freeipa/issues/9468>`__ Covscan issues in
    ipa-4.11
--  `#9471 <https://pagure.io/freeipa/issue/9471>`__ Pre-authentication
+-  `#9471 <https://codeberg.org/freeipa/freeipa/issues/9471>`__ Pre-authentication
    with trusted domain object over IPA to IPA trust fails due to wrong
    canonical name choice
--  `#9488 <https://pagure.io/freeipa/issue/9488>`__ Nightly test failure
+-  `#9488 <https://codeberg.org/freeipa/freeipa/issues/9488>`__ Nightly test failure
    in test_trust.py::TestTrust::test_server_option_with_unreachable_ad
--  `#9571 <https://pagure.io/freeipa/issue/9571>`__ Pytest 8
+-  `#9571 <https://codeberg.org/freeipa/freeipa/issues/9571>`__ Pytest 8
    compatibility
--  `#9577 <https://pagure.io/freeipa/issue/9577>`__ Replica installation
+-  `#9577 <https://codeberg.org/freeipa/freeipa/issues/9577>`__ Replica installation
    fails in FIPS mode in fedora 39+
--  `#9584 <https://pagure.io/freeipa/issue/9584>`__ Race condition in
+-  `#9584 <https://codeberg.org/freeipa/freeipa/issues/9584>`__ Race condition in
    ipa-backup
--  `#9603 <https://pagure.io/freeipa/issue/9603>`__ ipa-server-install:
+-  `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__ ipa-server-install:
    token_password_file read in kra.install_check after calling
    hsm_validator in ca.install_check
--  `#9605 <https://pagure.io/freeipa/issue/9605>`__ Add support for
+-  `#9605 <https://codeberg.org/freeipa/freeipa/issues/9605>`__ Add support for
    DoT/DoH for Zero-Trust
--  `#9606 <https://pagure.io/freeipa/issue/9606>`__ Nightly test failure
+-  `#9606 <https://codeberg.org/freeipa/freeipa/issues/9606>`__ Nightly test failure
    (f40+) in
    test_cert.py::TestCAShowErrorHandling::test_ca_show_error_handling
--  `#9607 <https://pagure.io/freeipa/issue/9607>`__ Nightly test failure
+-  `#9607 <https://codeberg.org/freeipa/freeipa/issues/9607>`__ Nightly test failure
    (f40+) in test_commands.py::TestIPACommand::test_ssh_key_connection
--  `#9609 <https://pagure.io/freeipa/issue/9609>`__ ipa-otptoken-import
+-  `#9609 <https://codeberg.org/freeipa/freeipa/issues/9609>`__ ipa-otptoken-import
    fails to import encrypted file
--  `#9610 <https://pagure.io/freeipa/issue/9610>`__ ipa-client rpm post
+-  `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__ ipa-client rpm post
    script creates always ssh_config.orig even if nothing needs to be
    changed
--  `#9611 <https://pagure.io/freeipa/issue/9611>`__ kdc.crt certificate
+-  `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__ kdc.crt certificate
    not getting automatically renewed by certmonger in IPA Hidden replica
--  `#9612 <https://pagure.io/freeipa/issue/9612>`__ RFE: add a tool to
+-  `#9612 <https://codeberg.org/freeipa/freeipa/issues/9612>`__ RFE: add a tool to
    quickly detect and fix issues with IPA ID ranges
--  `#9613 <https://pagure.io/freeipa/issue/9613>`__ After backup/restore
+-  `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__ After backup/restore
    of dnssec master, zones are not signed
--  `#9615 <https://pagure.io/freeipa/issue/9615>`__ Nightly test failure
+-  `#9615 <https://codeberg.org/freeipa/freeipa/issues/9615>`__ Nightly test failure
    (f40+) in test_sssd.py::TestNestedMembers::test_nested_group_members
--  `#9616 <https://pagure.io/freeipa/issue/9616>`__ Nightly test failure
+-  `#9616 <https://codeberg.org/freeipa/freeipa/issues/9616>`__ Nightly test failure
    in test_backup_and_restore_TestReplicaInstallAfterRestore
--  `#9617 <https://pagure.io/freeipa/issue/9617>`__ The ipa-advise,
+-  `#9617 <https://codeberg.org/freeipa/freeipa/issues/9617>`__ The ipa-advise,
    ipa-backup, and ipa-restore manuals incorrectly show the --v option.
--  `#9618 <https://pagure.io/freeipa/issue/9618>`__ Allow IPA SIDgen
+-  `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__ Allow IPA SIDgen
    task to continue if it finds an entity that SID can't be assigned to
--  `#9619 <https://pagure.io/freeipa/issue/9619>`__ ipa-migrate starttls
+-  `#9619 <https://codeberg.org/freeipa/freeipa/issues/9619>`__ ipa-migrate starttls
    does not work
--  `#9620 <https://pagure.io/freeipa/issue/9620>`__ ipa-migrate remove
+-  `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__ ipa-migrate remove
    -V option
--  `#9621 <https://pagure.io/freeipa/issue/9621>`__ ipa-migrate should
+-  `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__ ipa-migrate should
    not update mapped attributes in managed entries
--  `#9624 <https://pagure.io/freeipa/issue/9624>`__ A missing cccache
+-  `#9624 <https://codeberg.org/freeipa/freeipa/issues/9624>`__ A missing cccache
    prevents Kerberos SSO
--  `#9625 <https://pagure.io/freeipa/issue/9625>`__ Executing the -d
+-  `#9625 <https://codeberg.org/freeipa/freeipa/issues/9625>`__ Executing the -d
    option results in an error.
--  `#9626 <https://pagure.io/freeipa/issue/9626>`__
+-  `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
    ipa-replica/server-install with softhsm needs to check
    permission/ownership of /var/lib/softhsm/tokens to avoid install
    failure.
--  `#9629 <https://pagure.io/freeipa/issue/9629>`__ Syntax error
+-  `#9629 <https://codeberg.org/freeipa/freeipa/issues/9629>`__ Syntax error
    uninstalling the selinux-luna subpackage
--  `#9632 <https://pagure.io/freeipa/issue/9632>`__ Unconditionally add
+-  `#9632 <https://codeberg.org/freeipa/freeipa/issues/9632>`__ Unconditionally add
    MS-PAC to global config
--  `#9633 <https://pagure.io/freeipa/issue/9633>`__ Remove RC4 and 3DES
+-  `#9633 <https://codeberg.org/freeipa/freeipa/issues/9633>`__ Remove RC4 and 3DES
    default encryption types on update
--  `#9635 <https://pagure.io/freeipa/issue/9635>`__ Ignore time skew
+-  `#9635 <https://codeberg.org/freeipa/freeipa/issues/9635>`__ Ignore time skew
    during CA replica installation
--  `#9636 <https://pagure.io/freeipa/issue/9636>`__ misleading warning
+-  `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__ misleading warning
    for missing ipa-selinux-nfast package on luna hsm
--  `#9637 <https://pagure.io/freeipa/issue/9637>`__ adtrustinstance only
+-  `#9637 <https://codeberg.org/freeipa/freeipa/issues/9637>`__ adtrustinstance only
    prints issues in check_inst() and does not log them
--  `#9640 <https://pagure.io/freeipa/issue/9640>`__ ipa-migrate - fix
+-  `#9640 <https://codeberg.org/freeipa/freeipa/issues/9640>`__ ipa-migrate - fix
    migration issues with entries using ipaUniqueId in the RDN
--  `#9641 <https://pagure.io/freeipa/issue/9641>`__ support for python
+-  `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__ support for python
    cryptography 43.0.0
--  `#9642 <https://pagure.io/freeipa/issue/9642>`__ ipa-migrate -
+-  `#9642 <https://codeberg.org/freeipa/freeipa/issues/9642>`__ ipa-migrate -
    properly handle invalid certificates
--  `#9643 <https://pagure.io/freeipa/issue/9643>`__ freeipa fails to
+-  `#9643 <https://codeberg.org/freeipa/freeipa/issues/9643>`__ freeipa fails to
    build with nodejs22 on f39 and f40
--  `#9644 <https://pagure.io/freeipa/issue/9644>`__ Fedora 40 pylint
+-  `#9644 <https://codeberg.org/freeipa/freeipa/issues/9644>`__ Fedora 40 pylint
    issues with PY2/PY3 compatibility
--  `#9645 <https://pagure.io/freeipa/issue/9645>`__ support for python
+-  `#9645 <https://codeberg.org/freeipa/freeipa/issues/9645>`__ support for python
    module netaddr 1.3.0
--  `#9648 <https://pagure.io/freeipa/issue/9648>`__ Nightly test
+-  `#9648 <https://codeberg.org/freeipa/freeipa/issues/9648>`__ Nightly test
    failures in test_hsm_TestHSMNegative
--  `#9649 <https://pagure.io/freeipa/issue/9649>`__ Also enable SSSD's
+-  `#9649 <https://codeberg.org/freeipa/freeipa/issues/9649>`__ Also enable SSSD's
    ssh service when enabling sss_ssh_knownhosts
--  `#9652 <https://pagure.io/freeipa/issue/9652>`__ IPA requires unique
+-  `#9652 <https://codeberg.org/freeipa/freeipa/issues/9652>`__ IPA requires unique
    CA certificate subject names
--  `#9654 <https://pagure.io/freeipa/issue/9654>`__ Update SELinux
+-  `#9654 <https://codeberg.org/freeipa/freeipa/issues/9654>`__ Update SELinux
    policy to mark IPA log files as ipa_log_t file context
--  `#9655 <https://pagure.io/freeipa/issue/9655>`__
+-  `#9655 <https://codeberg.org/freeipa/freeipa/issues/9655>`__
    upstream-adtrust-install: SSSD offline causing test-adtrust-install
    failure
--  `#9656 <https://pagure.io/freeipa/issue/9656>`__ Nightly test failure
+-  `#9656 <https://codeberg.org/freeipa/freeipa/issues/9656>`__ Nightly test failure
    in
    test_ipa_idrange_fix.py::TestIpaIdrangeFix::test_idrange_no_rid_bases_reversed
--  `#9657 <https://pagure.io/freeipa/issue/9657>`__ Prepare ipatests
+-  `#9657 <https://codeberg.org/freeipa/freeipa/issues/9657>`__ Prepare ipatests
    environment to test multidomain ipa server
--  `#9658 <https://pagure.io/freeipa/issue/9658>`__ Nightly test failure
+-  `#9658 <https://codeberg.org/freeipa/freeipa/issues/9658>`__ Nightly test failure
    in test_ipa_ipa_migration.py
--  `#9661 <https://pagure.io/freeipa/issue/9661>`__ Change the default
+-  `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__ Change the default
    CA serial number algorithm to random serial numbers
--  `#9665 <https://pagure.io/freeipa/issue/9665>`__ Sentences truncated
+-  `#9665 <https://codeberg.org/freeipa/freeipa/issues/9665>`__ Sentences truncated
    in man pages
--  `#9666 <https://pagure.io/freeipa/issue/9666>`__ Nightly test failure
+-  `#9666 <https://codeberg.org/freeipa/freeipa/issues/9666>`__ Nightly test failure
    (f42) in test_adtrust_install
--  `#9667 <https://pagure.io/freeipa/issue/9667>`__ Nightly test failure
+-  `#9667 <https://codeberg.org/freeipa/freeipa/issues/9667>`__ Nightly test failure
    (f42) in test_trust
--  `#9668 <https://pagure.io/freeipa/issue/9668>`__ Nightly test failure
+-  `#9668 <https://codeberg.org/freeipa/freeipa/issues/9668>`__ Nightly test failure
    (@pki/master) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_source_pki_server_clones_connectivity_and_data
--  `#9673 <https://pagure.io/freeipa/issue/9673>`__ Uninstall ACME
+-  `#9673 <https://codeberg.org/freeipa/freeipa/issues/9673>`__ Uninstall ACME
    separately during PKI uninstallation
--  `#9674 <https://pagure.io/freeipa/issue/9674>`__ Handle PKI 11.6.0
+-  `#9674 <https://codeberg.org/freeipa/freeipa/issues/9674>`__ Handle PKI 11.6.0
    uninstallation
--  `#9675 <https://pagure.io/freeipa/issue/9675>`__ Support GSSAPI in
+-  `#9675 <https://codeberg.org/freeipa/freeipa/issues/9675>`__ Support GSSAPI in
    Cockpit on IPA servers
--  `#9676 <https://pagure.io/freeipa/issue/9676>`__ move away from
+-  `#9676 <https://codeberg.org/freeipa/freeipa/issues/9676>`__ move away from
    setuptools and pkg_resources
--  `#9680 <https://pagure.io/freeipa/issue/9680>`__ config-mod accepting
+-  `#9680 <https://codeberg.org/freeipa/freeipa/issues/9680>`__ config-mod accepting
    invalid e-mail addresses for "Default e-mail domain"
--  `#9681 <https://pagure.io/freeipa/issue/9681>`__ Man page for
+-  `#9681 <https://codeberg.org/freeipa/freeipa/issues/9681>`__ Man page for
    ipa-migrate refers to non-existing option --hostname
--  `#9682 <https://pagure.io/freeipa/issue/9682>`__ ipa-migrate in stage
+-  `#9682 <https://codeberg.org/freeipa/freeipa/issues/9682>`__ ipa-migrate in stage
    mode fails with TypeError: 'NoneType' object is not iterable
--  `#9686 <https://pagure.io/freeipa/issue/9686>`__ ipa-migrate should
+-  `#9686 <https://codeberg.org/freeipa/freeipa/issues/9686>`__ ipa-migrate should
    also migrate DNS forward zones
--  `#9687 <https://pagure.io/freeipa/issue/9687>`__ 'Organization'
+-  `#9687 <https://codeberg.org/freeipa/freeipa/issues/9687>`__ 'Organization'
    should not be required for Okta provider type
--  `#9689 <https://pagure.io/freeipa/issue/9689>`__ vault-add fails in
+-  `#9689 <https://codeberg.org/freeipa/freeipa/issues/9689>`__ vault-add fails in
    FIPS mode
--  `#9691 <https://pagure.io/freeipa/issue/9691>`__ pki.client:
+-  `#9691 <https://codeberg.org/freeipa/freeipa/issues/9691>`__ pki.client:
    /usr/libexec/ipa/ipa-pki-wait-running:61: The subsystem in
    PKIConnection.\__init\_\_() has been deprecated
    (https://github.com/dogtagpki/pki/wiki/PKI-10.8-Python-Changes)
--  `#9692 <https://pagure.io/freeipa/issue/9692>`__ ipa-kra-install
+-  `#9692 <https://codeberg.org/freeipa/freeipa/issues/9692>`__ ipa-kra-install
    fails - Unable to add KRA connector for URL KRA connector already
    exists
--  `#9696 <https://pagure.io/freeipa/issue/9696>`__ Support OpenSSL
+-  `#9696 <https://codeberg.org/freeipa/freeipa/issues/9696>`__ Support OpenSSL
    provider API
--  `#9697 <https://pagure.io/freeipa/issue/9697>`__ IPA-to-IPA migration
+-  `#9697 <https://codeberg.org/freeipa/freeipa/issues/9697>`__ IPA-to-IPA migration
    tests should install destination server with --allow-zone-overlap
--  `#9698 <https://pagure.io/freeipa/issue/9698>`__ Static code analysis
+-  `#9698 <https://codeberg.org/freeipa/freeipa/issues/9698>`__ Static code analysis
    defects
--  `#9699 <https://pagure.io/freeipa/issue/9699>`__ EnforceLDAPOTP
+-  `#9699 <https://codeberg.org/freeipa/freeipa/issues/9699>`__ EnforceLDAPOTP
    ldap-bind with sysaccount no longer possible
--  `#9702 <https://pagure.io/freeipa/issue/9702>`__ ipa trust-add fails
+-  `#9702 <https://codeberg.org/freeipa/freeipa/issues/9702>`__ ipa trust-add fails
    in FIPS mode with an internal error has occurred
--  `#9705 <https://pagure.io/freeipa/issue/9705>`__ In FIPS mode + HSM,
+-  `#9705 <https://codeberg.org/freeipa/freeipa/issues/9705>`__ In FIPS mode + HSM,
    renewal of auditSigningCert cert-pki-kra prevents PKI restart
--  `#9706 <https://pagure.io/freeipa/issue/9706>`__ Nightly test failure
+-  `#9706 <https://codeberg.org/freeipa/freeipa/issues/9706>`__ Nightly test failure
    in test_acme.py::TestACMEPrune::test_enable_pruning
--  `#9707 <https://pagure.io/freeipa/issue/9707>`__ Nightly test failure
+-  `#9707 <https://codeberg.org/freeipa/freeipa/issues/9707>`__ Nightly test failure
    in test_webui/test_cert.py
--  `#9708 <https://pagure.io/freeipa/issue/9708>`__ add support for
+-  `#9708 <https://codeberg.org/freeipa/freeipa/issues/9708>`__ add support for
    python cryptography 44.0.0
--  `#9709 <https://pagure.io/freeipa/issue/9709>`__ All user groups are
+-  `#9709 <https://codeberg.org/freeipa/freeipa/issues/9709>`__ All user groups are
    not being included during HSM token validation
--  `#9711 <https://pagure.io/freeipa/issue/9711>`__ Regression: LDAP
+-  `#9711 <https://codeberg.org/freeipa/freeipa/issues/9711>`__ Regression: LDAP
    bind is allowed without OTP in 4.12
--  `#9712 <https://pagure.io/freeipa/issue/9712>`__ [ipa-4-9]
+-  `#9712 <https://codeberg.org/freeipa/freeipa/issues/9712>`__ [ipa-4-9]
    ipa-server-upgrade fails after established trust with ad
--  `#9715 <https://pagure.io/freeipa/issue/9715>`__ [testday] Fix typo
+-  `#9715 <https://codeberg.org/freeipa/freeipa/issues/9715>`__ [testday] Fix typo
    in ipa-migrate log file i.e 'Privledges' to 'Privileges'
--  `#9720 <https://pagure.io/freeipa/issue/9720>`__ Workshop Vagrant
+-  `#9720 <https://codeberg.org/freeipa/freeipa/issues/9720>`__ Workshop Vagrant
    OOMs During Setup
--  `#9721 <https://pagure.io/freeipa/issue/9721>`__ Nightly test failure
+-  `#9721 <https://codeberg.org/freeipa/freeipa/issues/9721>`__ Nightly test failure
    in test_webui/test_host.py::test_host::test_search
--  `#9723 <https://pagure.io/freeipa/issue/9723>`__ Nightly test failure
+-  `#9723 <https://codeberg.org/freeipa/freeipa/issues/9723>`__ Nightly test failure
    after pkg uninstall/install
--  `#9724 <https://pagure.io/freeipa/issue/9724>`__ Nightly test failure
+-  `#9724 <https://codeberg.org/freeipa/freeipa/issues/9724>`__ Nightly test failure
    (rawhide) in
    test_integration/test_acme.py::TestACME::test_certbot_dns
--  `#9725 <https://pagure.io/freeipa/issue/9725>`__ A slow HSM can cause
+-  `#9725 <https://codeberg.org/freeipa/freeipa/issues/9725>`__ A slow HSM can cause
    IPA server installation to fail setting up certificate tracking
--  `#9730 <https://pagure.io/freeipa/issue/9730>`__ [tests]
+-  `#9730 <https://codeberg.org/freeipa/freeipa/issues/9730>`__ [tests]
    test_ipahealthcheck_ds_configcheck fails against 389-ds-base 2.5.3
--  `#9734 <https://pagure.io/freeipa/issue/9734>`__ crash in ipa-otpd
+-  `#9734 <https://codeberg.org/freeipa/freeipa/issues/9734>`__ crash in ipa-otpd
    with --client-secret-stdin use
--  `#9735 <https://pagure.io/freeipa/issue/9735>`__ Installing IPA with
+-  `#9735 <https://codeberg.org/freeipa/freeipa/issues/9735>`__ Installing IPA with
    KRA creates invalid ca_admin.cert format
--  `#9737 <https://pagure.io/freeipa/issue/9737>`__ ipa-migrate should
+-  `#9737 <https://codeberg.org/freeipa/freeipa/issues/9737>`__ ipa-migrate should
    skip tombstone entries
--  `#9738 <https://pagure.io/freeipa/issue/9738>`__ During server
+-  `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__ During server
    installation don't use the PKI API directly to issue certificates
--  `#9739 <https://pagure.io/freeipa/issue/9739>`__ Remove migration
+-  `#9739 <https://codeberg.org/freeipa/freeipa/issues/9739>`__ Remove migration
    support from mod_nss
--  `#9740 <https://pagure.io/freeipa/issue/9740>`__ Suppress meaningless
+-  `#9740 <https://codeberg.org/freeipa/freeipa/issues/9740>`__ Suppress meaningless
    errors when uninstalling the PKI ACME service
--  `#9741 <https://pagure.io/freeipa/issue/9741>`__ Add message to end
+-  `#9741 <https://codeberg.org/freeipa/freeipa/issues/9741>`__ Add message to end
    of server install that service restart is happening
--  `#9742 <https://pagure.io/freeipa/issue/9742>`__ Log then a user
+-  `#9742 <https://codeberg.org/freeipa/freeipa/issues/9742>`__ Log then a user
    attempts to authenticate using LDAP but is locked out due to policy
--  `#9743 <https://pagure.io/freeipa/issue/9743>`__ The pki-tomcatd
+-  `#9743 <https://codeberg.org/freeipa/freeipa/issues/9743>`__ The pki-tomcatd
    service can time out starting with a slow HSM
--  `#9748 <https://pagure.io/freeipa/issue/9748>`__ Server installation:
+-  `#9748 <https://codeberg.org/freeipa/freeipa/issues/9748>`__ Server installation:
    dot-forwarder not added as a forwarder
--  `#9750 <https://pagure.io/freeipa/issue/9750>`__ Remove
+-  `#9750 <https://codeberg.org/freeipa/freeipa/issues/9750>`__ Remove
    fips-mode-setup
--  `#9751 <https://pagure.io/freeipa/issue/9751>`__ Nightly test failure
+-  `#9751 <https://codeberg.org/freeipa/freeipa/issues/9751>`__ Nightly test failure
    (rawhide) in
    test_trust.py::TestTrust::test_server_option_with_unreachable_ad
--  `#9752 <https://pagure.io/freeipa/issue/9752>`__ ipatests: use "sos
+-  `#9752 <https://codeberg.org/freeipa/freeipa/issues/9752>`__ ipatests: use "sos
    report" instead of "sosreport" command
--  `#9753 <https://pagure.io/freeipa/issue/9753>`__ Allow customizing
+-  `#9753 <https://codeberg.org/freeipa/freeipa/issues/9753>`__ Allow customizing
    'nobody' group per platform
--  `#9754 <https://pagure.io/freeipa/issue/9754>`__ ipa vault-del
+-  `#9754 <https://codeberg.org/freeipa/freeipa/issues/9754>`__ ipa vault-del
    triggers a deprecation warning
--  `#9756 <https://pagure.io/freeipa/issue/9756>`__ ipa dnsrecord-\*
+-  `#9756 <https://codeberg.org/freeipa/freeipa/issues/9756>`__ ipa dnsrecord-\*
    --raw --structured throws internal error
--  `#9757 <https://pagure.io/freeipa/issue/9757>`__ Support full 32-bit
+-  `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__ Support full 32-bit
    ID range space
--  `#9758 <https://pagure.io/freeipa/issue/9758>`__ Search size limit
+-  `#9758 <https://codeberg.org/freeipa/freeipa/issues/9758>`__ Search size limit
    tooltip has Search time limit tooltip text
--  `#9760 <https://pagure.io/freeipa/issue/9760>`__ ipa-cert-fix
+-  `#9760 <https://codeberg.org/freeipa/freeipa/issues/9760>`__ ipa-cert-fix
    proceeds with the externally signed CA signing cert being expired
--  `#9762 <https://pagure.io/freeipa/issue/9762>`__ The test
+-  `#9762 <https://codeberg.org/freeipa/freeipa/issues/9762>`__ The test
    test_ca_show_error_handling should wait for replication
--  `#9764 <https://pagure.io/freeipa/issue/9764>`__ Protect \*all\* IPA
+-  `#9764 <https://codeberg.org/freeipa/freeipa/issues/9764>`__ Protect \*all\* IPA
    service principals
--  `#9765 <https://pagure.io/freeipa/issue/9765>`__ Regression in ipa
+-  `#9765 <https://codeberg.org/freeipa/freeipa/issues/9765>`__ Regression in ipa
    trust-add
--  `#9768 <https://pagure.io/freeipa/issue/9768>`__ Disable --raw and
+-  `#9768 <https://codeberg.org/freeipa/freeipa/issues/9768>`__ Disable --raw and
    --structured tests are skipped
--  `#9769 <https://pagure.io/freeipa/issue/9769>`__ Test failure on f42
+-  `#9769 <https://codeberg.org/freeipa/freeipa/issues/9769>`__ Test failure on f42
    in test_integration/test_idp.py::TestIDPKeycloak::test_auth_sudo_idp
--  `#9771 <https://pagure.io/freeipa/issue/9771>`__ Fix deprecation
+-  `#9771 <https://codeberg.org/freeipa/freeipa/issues/9771>`__ Fix deprecation
    warning in ipa-replica-manage
--  `#9772 <https://pagure.io/freeipa/issue/9772>`__ ipa-sidgen:
+-  `#9772 <https://codeberg.org/freeipa/freeipa/issues/9772>`__ ipa-sidgen:
    important memory leak
--  `#9776 <https://pagure.io/freeipa/issue/9776>`__ ipa-migrate does not
+-  `#9776 <https://codeberg.org/freeipa/freeipa/issues/9776>`__ ipa-migrate does not
    handle replication state data
--  `#9777 <https://pagure.io/freeipa/issue/9777>`__ kdb:
+-  `#9777 <https://codeberg.org/freeipa/freeipa/issues/9777>`__ kdb:
    ipadb_get_connection() succeeds but returns null LDAP context
--  `#9779 <https://pagure.io/freeipa/issue/9779>`__ When creating an ID
+-  `#9779 <https://codeberg.org/freeipa/freeipa/issues/9779>`__ When creating an ID
    range, should require a RID
--  `#9780 <https://pagure.io/freeipa/issue/9780>`__ [RFE]
+-  `#9780 <https://codeberg.org/freeipa/freeipa/issues/9780>`__ [RFE]
    ipa-client-automount should have an option to include domain of the
    machine.
--  `#9781 <https://pagure.io/freeipa/issue/9781>`__ Give warning when
+-  `#9781 <https://codeberg.org/freeipa/freeipa/issues/9781>`__ Give warning when
    adding user with UID out of any ID range
--  `#9782 <https://pagure.io/freeipa/issue/9782>`__ selinux avc when
+-  `#9782 <https://codeberg.org/freeipa/freeipa/issues/9782>`__ selinux avc when
    installing dns server in selinux enforcing mode
--  `#9784 <https://pagure.io/freeipa/issue/9784>`__ ipa-migrate
+-  `#9784 <https://codeberg.org/freeipa/freeipa/issues/9784>`__ ipa-migrate
    --migrate-dns fails to update the DNS record
--  `#9787 <https://pagure.io/freeipa/issue/9787>`__ Rawhide: test
+-  `#9787 <https://codeberg.org/freeipa/freeipa/issues/9787>`__ Rawhide: test
    failure when installing a replica in CA less mode
--  `#9788 <https://pagure.io/freeipa/issue/9788>`__ ipatests: Fix
+-  `#9788 <https://codeberg.org/freeipa/freeipa/issues/9788>`__ ipatests: Fix
    test_integration/test_uninstallation.py::TestUninstallCleanup::test_clean_uninstall
--  `#9790 <https://pagure.io/freeipa/issue/9790>`__ ipatests:
+-  `#9790 <https://codeberg.org/freeipa/freeipa/issues/9790>`__ ipatests:
    test_manual_renewal_master_transfer should wait for replication
--  `#9791 <https://pagure.io/freeipa/issue/9791>`__
+-  `#9791 <https://codeberg.org/freeipa/freeipa/issues/9791>`__
    test_ipa_healthcheck_fips_enabled xfail annotation is incorrect
--  `#9794 <https://pagure.io/freeipa/issue/9794>`__ Unable to modify IPA
+-  `#9794 <https://codeberg.org/freeipa/freeipa/issues/9794>`__ Unable to modify IPA
    config; --ipaconfigstring="" causes internal error
--  `#9799 <https://pagure.io/freeipa/issue/9799>`__ edns is not
+-  `#9799 <https://codeberg.org/freeipa/freeipa/issues/9799>`__ edns is not
    available for older fedora
--  `#9801 <https://pagure.io/freeipa/issue/9801>`__ Nightly failure in
+-  `#9801 <https://codeberg.org/freeipa/freeipa/issues/9801>`__ Nightly failure in
    test_integration/test_ipa_idrange_fix.py::TestIpaIdrangeFix::test_idrange_no_rid_bases
    and test_idrange_no_rid_bases_reversed
--  `#9804 <https://pagure.io/freeipa/issue/9804>`__ Description for
+-  `#9804 <https://codeberg.org/freeipa/freeipa/issues/9804>`__ Description for
    --dot-forwarder in man pages for ipa-server-install and
    ipa-dns-install inconsistent
--  `#9805 <https://pagure.io/freeipa/issue/9805>`__ client: DNSSEC
+-  `#9805 <https://codeberg.org/freeipa/freeipa/issues/9805>`__ client: DNSSEC
    validation turned on for unbound by default
--  `#9806 <https://pagure.io/freeipa/issue/9806>`__ ipa-client-install:
+-  `#9806 <https://codeberg.org/freeipa/freeipa/issues/9806>`__ ipa-client-install:
    nsupdate issues when dns_over_tls is enabled
--  `#9808 <https://pagure.io/freeipa/issue/9808>`__ Replica: Request
+-  `#9808 <https://codeberg.org/freeipa/freeipa/issues/9808>`__ Replica: Request
    cert for DoT fails after setting up bind
--  `#9809 <https://pagure.io/freeipa/issue/9809>`__ ipa-idrange-fix
+-  `#9809 <https://codeberg.org/freeipa/freeipa/issues/9809>`__ ipa-idrange-fix
    should check if the server is configured
--  `#9810 <https://pagure.io/freeipa/issue/9810>`__ Nightly test failure
+-  `#9810 <https://codeberg.org/freeipa/freeipa/issues/9810>`__ Nightly test failure
    in test_integration/test_fips.py - sed couldn't open temporary file
--  `#9811 <https://pagure.io/freeipa/issue/9811>`__ Incorrect use of
+-  `#9811 <https://codeberg.org/freeipa/freeipa/issues/9811>`__ Incorrect use of
    GitHub and GitLab trademarks
--  `#9812 <https://pagure.io/freeipa/issue/9812>`__ Test failure in
+-  `#9812 <https://codeberg.org/freeipa/freeipa/issues/9812>`__ Test failure in
    test_adtrust_install_with_non_ipa_user
--  `#9813 <https://pagure.io/freeipa/issue/9813>`__ When using
+-  `#9813 <https://codeberg.org/freeipa/freeipa/issues/9813>`__ When using
    --dns-over-tls in read-only container, ipa-server-install fails due
    to /etc/resolv.conf operation
--  `#9814 <https://pagure.io/freeipa/issue/9814>`__ eDNS: Conflict
+-  `#9814 <https://codeberg.org/freeipa/freeipa/issues/9814>`__ eDNS: Conflict
    between dnsconfd and IPA installer
--  `#9824 <https://pagure.io/freeipa/issue/9824>`__ Error when sizing
+-  `#9824 <https://codeberg.org/freeipa/freeipa/issues/9824>`__ Error when sizing
    output for a terminal
--  `#9826 <https://pagure.io/freeipa/issue/9826>`__ With
+-  `#9826 <https://codeberg.org/freeipa/freeipa/issues/9826>`__ With
    rpm-5.99.91-1.fc43.x86_64, dnf installation of
    freeipa-server-trust-ad-4.12.2-14.fc43.x86_64 now fails
--  `#9831 <https://pagure.io/freeipa/issue/9831>`__ hsm validation fails
+-  `#9831 <https://codeberg.org/freeipa/freeipa/issues/9831>`__ hsm validation fails
    on systems with private tmp
--  `#9836 <https://pagure.io/freeipa/issue/9836>`__ Fails to build on
+-  `#9836 <https://codeberg.org/freeipa/freeipa/issues/9836>`__ Fails to build on
    fedora42+ with nodejs24
--  `#9838 <https://pagure.io/freeipa/issue/9838>`__ Nightly test failure
+-  `#9838 <https://codeberg.org/freeipa/freeipa/issues/9838>`__ Nightly test failure
    (rawhide) in
    test_edns.py::TestDNSOverTLS::test_install_dnsovertls_master
--  `#9843 <https://pagure.io/freeipa/issue/9843>`__ Bump samba version
+-  `#9843 <https://codeberg.org/freeipa/freeipa/issues/9843>`__ Bump samba version
    for rawhide
--  `#9848 <https://pagure.io/freeipa/issue/9848>`__ Test failure in
+-  `#9848 <https://codeberg.org/freeipa/freeipa/issues/9848>`__ Test failure in
    test_certmonger_ipa_responder_jsonrpc
--  `#9849 <https://pagure.io/freeipa/issue/9849>`__ Random test failure
+-  `#9849 <https://codeberg.org/freeipa/freeipa/issues/9849>`__ Random test failure
    in test_otp
--  `#9850 <https://pagure.io/freeipa/issue/9850>`__ Test failure in
+-  `#9850 <https://codeberg.org/freeipa/freeipa/issues/9850>`__ Test failure in
    test_xmlrpc/test_automember_plugin.py/TestAutomemberFindOrphans
--  `#5614 <https://pagure.io/freeipa/issue/5614>`__
+-  `#5614 <https://codeberg.org/freeipa/freeipa/issues/5614>`__
    (`rhbz#1310834 <https://bugzilla.redhat.com/show_bug.cgi?id=1310834>`__)
    [tracker] mod_auth_gssapi additional NTLM auth request from Chrome
--  `#5913 <https://pagure.io/freeipa/issue/5913>`__ Use augeas for
+-  `#5913 <https://codeberg.org/freeipa/freeipa/issues/5913>`__ Use augeas for
    configuring krb5
--  `#2496 <https://pagure.io/freeipa/issue/2496>`__
+-  `#2496 <https://codeberg.org/freeipa/freeipa/issues/2496>`__
    (`rhbz#797333 <https://bugzilla.redhat.com/show_bug.cgi?id=797333>`__)
    krbpasswordexpiration field in LDAP can not have value >=
    20380119031408Z
--  `#9744 <https://pagure.io/freeipa/issue/9744>`__ [RFE] Allow ipa tool
+-  `#9744 <https://codeberg.org/freeipa/freeipa/issues/9744>`__ [RFE] Allow ipa tool
    to force running on specific server
--  `#9763 <https://pagure.io/freeipa/issue/9763>`__ KRA install failure
+-  `#9763 <https://codeberg.org/freeipa/freeipa/issues/9763>`__ KRA install failure
    if /root/.dogtag/pki-tomcat/ca_admin.cert is expired
--  `#9785 <https://pagure.io/freeipa/issue/9785>`__ IPA fails to sign
+-  `#9785 <https://codeberg.org/freeipa/freeipa/issues/9785>`__ IPA fails to sign
    zone in FIPS mode
--  `#9833 <https://pagure.io/freeipa/issue/9833>`__ Nightly test failure
+-  `#9833 <https://codeberg.org/freeipa/freeipa/issues/9833>`__ Nightly test failure
    (f43+) in test_idp.py::TestIDPKeycloak::test_auth_keycloak_idp
--  `#9835 <https://pagure.io/freeipa/issue/9835>`__ RFE: Add support for
+-  `#9835 <https://codeberg.org/freeipa/freeipa/issues/9835>`__ RFE: Add support for
    libpwquality credit counting
--  `#9842 <https://pagure.io/freeipa/issue/9842>`__ Add ability to
+-  `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__ Add ability to
    configure external password reset agents with ipa_pwd_extop
--  `#9845 <https://pagure.io/freeipa/issue/9845>`__ ipatests: Port
+-  `#9845 <https://codeberg.org/freeipa/freeipa/issues/9845>`__ ipatests: Port
    downstream ipa-trust-functional test suite.
--  `#9852 <https://pagure.io/freeipa/issue/9852>`__ Nightly tests
+-  `#9852 <https://codeberg.org/freeipa/freeipa/issues/9852>`__ Nightly tests
    failure (rawhide): ipactl restart fails to restart winbindd
--  `#9854 <https://pagure.io/freeipa/issue/9854>`__ Erroneous
+-  `#9854 <https://codeberg.org/freeipa/freeipa/issues/9854>`__ Erroneous
    case-sensitivity in offline DSE lookup
--  `#9857 <https://pagure.io/freeipa/issue/9857>`__ Nightly failure in
+-  `#9857 <https://codeberg.org/freeipa/freeipa/issues/9857>`__ Nightly failure in
    test_commands.py::TestIPACommand::test_cacert_manage
--  `#9858 <https://pagure.io/freeipa/issue/9858>`__
+-  `#9858 <https://codeberg.org/freeipa/freeipa/issues/9858>`__
    TestIPAMigratewithBackupRestore fails in IdM CI environment
--  `#9859 <https://pagure.io/freeipa/issue/9859>`__ Encrypted DNS:
+-  `#9859 <https://codeberg.org/freeipa/freeipa/issues/9859>`__ Encrypted DNS:
    disable dnsconfd prior to configuring Unbound
--  `#9862 <https://pagure.io/freeipa/issue/9862>`__ Update breaks
+-  `#9862 <https://codeberg.org/freeipa/freeipa/issues/9862>`__ Update breaks
    krb5.conf if modified
--  `#9865 <https://pagure.io/freeipa/issue/9865>`__ Support storing LWCA
+-  `#9865 <https://codeberg.org/freeipa/freeipa/issues/9865>`__ Support storing LWCA
    private keys on an HSM
--  `#9866 <https://pagure.io/freeipa/issue/9866>`__ [BUG]
+-  `#9866 <https://codeberg.org/freeipa/freeipa/issues/9866>`__ [BUG]
    ATTR_NAME_BY_OID is missing OID 2.5.4.97, organizationIdentifier
--  `#9867 <https://pagure.io/freeipa/issue/9867>`__ IPA Modrdn plugin
+-  `#9867 <https://codeberg.org/freeipa/freeipa/issues/9867>`__ IPA Modrdn plugin
    performs duplicate replication changes
--  `#9870 <https://pagure.io/freeipa/issue/9870>`__ backup-restore does
+-  `#9870 <https://codeberg.org/freeipa/freeipa/issues/9870>`__ backup-restore does
    not restore /etc/krb5.conf.d/freeipa-realm
--  `#9871 <https://pagure.io/freeipa/issue/9871>`__
+-  `#9871 <https://codeberg.org/freeipa/freeipa/issues/9871>`__
    test_http_kdc_proxy.py::TestHttpKdcProxy failure during its setup
--  `#9874 <https://pagure.io/freeipa/issue/9874>`__ Nightly test failure
+-  `#9874 <https://codeberg.org/freeipa/freeipa/issues/9874>`__ Nightly test failure
    in
    test_sudo.py::TestSudo_Functional::test_007_sudorule_offline_caching_option_command
--  `#9875 <https://pagure.io/freeipa/issue/9875>`__ The permission with
+-  `#9875 <https://codeberg.org/freeipa/freeipa/issues/9875>`__ The permission with
    'System: Modify System Accounts' fails to modify the description.
--  `#9878 <https://pagure.io/freeipa/issue/9878>`__ ipa-server-install
+-  `#9878 <https://codeberg.org/freeipa/freeipa/issues/9878>`__ ipa-server-install
    fails in FIPS mode
--  `#9879 <https://pagure.io/freeipa/issue/9879>`__ ipa-pkinit-manage
+-  `#9879 <https://codeberg.org/freeipa/freeipa/issues/9879>`__ ipa-pkinit-manage
    enable fails on replica without CA instance
--  `#9881 <https://pagure.io/freeipa/issue/9881>`__ Test failure in
+-  `#9881 <https://codeberg.org/freeipa/freeipa/issues/9881>`__ Test failure in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ipahealthcheck_dogtag_ca_connectivity_check
--  `#9885 <https://pagure.io/freeipa/issue/9885>`__ Minor typo in
+-  `#9885 <https://codeberg.org/freeipa/freeipa/issues/9885>`__ Minor typo in
    ipa_idrange_fix.py
--  `#9888 <https://pagure.io/freeipa/issue/9888>`__ Nightly test failure
+-  `#9888 <https://codeberg.org/freeipa/freeipa/issues/9888>`__ Nightly test failure
    in
    test_integration/test_ipa_cert_fix.py::TestIpaCertFix::test_expired_CA_cert::teardown
 
@@ -578,21 +578,21 @@ Alexander Bokovoy (60)
 -  sysaccounts: extend permissions to include description and account
    lock
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec22295fede3f1c71b6111e4d36a7386080cf39e>`__
-   `#9875 <https://pagure.io/freeipa/issue/9875>`__
+   `#9875 <https://codeberg.org/freeipa/freeipa/issues/9875>`__
 -  sysaccount: make sure nsaccountlock is always present
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2fc104f067221f7621537a2daa40c13239522e3>`__
-   `#9842 <https://pagure.io/freeipa/issue/9842>`__
+   `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__
 -  freeipa.spec: use proper package name when installing Web UI license
    `commit <https://codeberg.org/freeipa/freeipa/commit/d4c3b150fb4494313ef4b0e3324cc9e48efa87a2>`__
 -  sysaccounts: add integration test
    `commit <https://codeberg.org/freeipa/freeipa/commit/8c7427a2bae5f88e1ef3aa1fd267b7dddbe09605>`__
-   `#9842 <https://pagure.io/freeipa/issue/9842>`__
+   `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__
 -  Add system accounts (sysaccounts)
    `commit <https://codeberg.org/freeipa/freeipa/commit/24e4fd5c0c346b316845e3eea2ff437222fe0823>`__
-   `#9842 <https://pagure.io/freeipa/issue/9842>`__
+   `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__
 -  ipa-pwd-extop: add SysAcctManagersDNs support
    `commit <https://codeberg.org/freeipa/freeipa/commit/f17fba0adc91f9ecacfdb4cd975dc20ce051b80f>`__
-   `#9842 <https://pagure.io/freeipa/issue/9842>`__
+   `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__
 -  Require krb5.conf.d because we install snippets there
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a6391f245257e53ec1d648e2186c9ece069e901>`__
 -  krb5.conf templates: move IPA domain configuration into a separate
@@ -610,27 +610,27 @@ Alexander Bokovoy (60)
    `commit <https://codeberg.org/freeipa/freeipa/commit/2b2cd1eade1d03296727cb88a08cc919003f5e0f>`__
 -  GetEntryFromLDIF: handle DNs case-insensitive
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f3c035e2b8a8ac70b98264d17e84201578f2871>`__
-   `#9854 <https://pagure.io/freeipa/issue/9854>`__
+   `#9854 <https://codeberg.org/freeipa/freeipa/issues/9854>`__
 -  ipasam: define prototypes
    `commit <https://codeberg.org/freeipa/freeipa/commit/516ad5a82147ccd1cbec1fdddfb36b2d0a90fb40>`__
 -  ipasam: address signedness warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c3a094500f2e89fe759e5580d2d96b08857cf1c>`__
 -  ipasam: simplify error handling in fill_pdb_trusted_domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/6594c9d5e3fa89cde013c55d94d64caff70c1731>`__
-   `#9852 <https://pagure.io/freeipa/issue/9852>`__
+   `#9852 <https://codeberg.org/freeipa/freeipa/issues/9852>`__
 -  dcerpc: Support Samba 4.23
    `commit <https://codeberg.org/freeipa/freeipa/commit/ae8e850708b118b3da9c9ebc2d5cf8b085d845df>`__
-   `#9852 <https://pagure.io/freeipa/issue/9852>`__
+   `#9852 <https://codeberg.org/freeipa/freeipa/issues/9852>`__
 -  dcerpc: make sure forest trust info structure version is 1
    `commit <https://codeberg.org/freeipa/freeipa/commit/96c3d2d1ad6c947678a15928de258f462c3ea4ed>`__
-   `#9852 <https://pagure.io/freeipa/issue/9852>`__
+   `#9852 <https://codeberg.org/freeipa/freeipa/issues/9852>`__
 -  kdb: prevent double crash in RBCD ACL free
    `commit <https://codeberg.org/freeipa/freeipa/commit/a53b2a374da3683ae303896996737b98d0f57b1d>`__
-   `#9367 <https://pagure.io/freeipa/issue/9367>`__
+   `#9367 <https://codeberg.org/freeipa/freeipa/issues/9367>`__
 -  freeipa.spec.in: protect scriptlets in environment where dbus or
    systemd do not run
    `commit <https://codeberg.org/freeipa/freeipa/commit/eada98e48d4307b2b85d33c14c59b4be73127e0c>`__
-   `#9826 <https://pagure.io/freeipa/issue/9826>`__
+   `#9826 <https://codeberg.org/freeipa/freeipa/issues/9826>`__
 -  test_schema: do not fool pytest with a non-test class name
    `commit <https://codeberg.org/freeipa/freeipa/commit/e7095dce69d6f811b7420148f3c017869d10d70c>`__
 -  Azure CI: do not run test_ipaserver/test_migratepw
@@ -649,89 +649,89 @@ Alexander Bokovoy (60)
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7b454e1593ad65d8addc8389325bfa095f9138d>`__
 -  freeipa.spec.in: update BIND-related dependencies
    `commit <https://codeberg.org/freeipa/freeipa/commit/c9f7cf11241ed83409439c737442ac22fc355eed>`__
-   `#9696 <https://pagure.io/freeipa/issue/9696>`__
+   `#9696 <https://codeberg.org/freeipa/freeipa/issues/9696>`__
 -  ipa-dnskeysyncd: use systemd-tmpfiles to handle tokens
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9579fe08c83593b01b8f1781250617a5aef5975>`__
-   `#9696 <https://pagure.io/freeipa/issue/9696>`__
+   `#9696 <https://codeberg.org/freeipa/freeipa/issues/9696>`__
 -  DNS: detect when OpenSSL engine should be removed on upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1e22146d2a4463ed09e63d2f78d618c1b9e7137>`__
-   `#9696 <https://pagure.io/freeipa/issue/9696>`__
+   `#9696 <https://codeberg.org/freeipa/freeipa/issues/9696>`__
 -  Use OpenSSL provider with BIND for Fedora 42+ and RHEL10+
    `commit <https://codeberg.org/freeipa/freeipa/commit/1311df2e0e7343632e25f2d0adfbbbd79adfda51>`__
-   `#9696 <https://pagure.io/freeipa/issue/9696>`__
+   `#9696 <https://codeberg.org/freeipa/freeipa/issues/9696>`__
 -  Revert "add sourcery.ai github action"
    `commit <https://codeberg.org/freeipa/freeipa/commit/f9eb1154d089383bb2c6beb4dcb60908d7b81680>`__
 -  add sourcery.ai github action
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3f991948a439bd6d84f22263c98a13f9b47d2a0>`__
 -  ipatests: add a test to use full 32-bit ID range space
    `commit <https://codeberg.org/freeipa/freeipa/commit/5a398d270f5987a9c1ac54d8d7107bae724f6757>`__
-   `#9757 <https://pagure.io/freeipa/issue/9757>`__
+   `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__
 -  baseuser: allow uidNumber and gidNumber of 32-bit range
    `commit <https://codeberg.org/freeipa/freeipa/commit/99decb113145c39206a71676f8f589ce675af79d>`__
-   `#9757 <https://pagure.io/freeipa/issue/9757>`__
+   `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__
 -  update_dna_shared_config: do not fail when config is not found
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdafe1d3e4bc297f93d94fdcf3a3b3bd4ef4d2c8>`__
-   `#9757 <https://pagure.io/freeipa/issue/9757>`__
+   `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__
 -  config-mod: allow disabling subordinate ID integration
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc763d78cc9d4f3fb858b9c5771cf9f6b5317990>`__
-   `#9757 <https://pagure.io/freeipa/issue/9757>`__
+   `#9757 <https://codeberg.org/freeipa/freeipa/issues/9757>`__
 -  Reintroduce test_idp to gating tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/92ca7c63322f2a8f496cd6b2faf322e7cbc9b4cf>`__
-   `#9734 <https://pagure.io/freeipa/issue/9734>`__
+   `#9734 <https://codeberg.org/freeipa/freeipa/issues/9734>`__
 -  Migrate Keycloak tests to JDK 21 and Keycloak 26
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e43dd7cd30042588a2264fca98b6e6b9d4d25bb>`__
 -  ipa-otpd: do not pass OIDC client secret if there is none to pass
    `commit <https://codeberg.org/freeipa/freeipa/commit/f12c4ed600e9b35c930d386b37e36064fbf83968>`__
-   `#9734 <https://pagure.io/freeipa/issue/9734>`__
+   `#9734 <https://codeberg.org/freeipa/freeipa/issues/9734>`__
 -  ipa tools: remove sensitive material from the commandline
    `commit <https://codeberg.org/freeipa/freeipa/commit/0591de367f6999df955f30a4b42ff98df45f9487>`__
 -  Unify use of option parsers
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba720b921d9813e0ed1f9a6010ee195bd77e59f1>`__
 -  ipa-pwd-extop: clarify OTP use over LDAP binds
    `commit <https://codeberg.org/freeipa/freeipa/commit/60f9bd043075ad9efce4cd908b23781b81065ca4>`__
-   `#9699 <https://pagure.io/freeipa/issue/9699>`__,
-   `#9711 <https://pagure.io/freeipa/issue/9711>`__
+   `#9699 <https://codeberg.org/freeipa/freeipa/issues/9699>`__,
+   `#9711 <https://codeberg.org/freeipa/freeipa/issues/9711>`__
 -  ipalib/x509: support PyCA 44.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/a47475f3794533b207cd763b407a0f414c33b459>`__
-   `#9708 <https://pagure.io/freeipa/issue/9708>`__
+   `#9708 <https://codeberg.org/freeipa/freeipa/issues/9708>`__
 -  Revert "readthedocs: install crypto 43.0.0"
    `commit <https://codeberg.org/freeipa/freeipa/commit/8a8b8a76acb1290bc62cceec9d153e28e88f73b3>`__
 -  ipaserver/dcerpc: support Samba 4.21
    `commit <https://codeberg.org/freeipa/freeipa/commit/aa81bd25f1442b408f4788d7082b42c3536b39bd>`__
-   `#9702 <https://pagure.io/freeipa/issue/9702>`__
+   `#9702 <https://codeberg.org/freeipa/freeipa/issues/9702>`__
 -  vault: handle pyca InternalError exception for PKCS#1 v1.5 padding
    `commit <https://codeberg.org/freeipa/freeipa/commit/c100b1a294f399e23ee6b0c9a68d4d26d50f2d5f>`__
-   `#9689 <https://pagure.io/freeipa/issue/9689>`__
+   `#9689 <https://codeberg.org/freeipa/freeipa/issues/9689>`__
 -  web ui: Add explicit white border for QR code widget
    `commit <https://codeberg.org/freeipa/freeipa/commit/67441226125da127c01a12397a1940cc635d911f>`__
-   `#9202 <https://pagure.io/freeipa/issue/9202>`__
+   `#9202 <https://codeberg.org/freeipa/freeipa/issues/9202>`__
 -  Extend nightly tests with Cockpit test
    `commit <https://codeberg.org/freeipa/freeipa/commit/c4f3d9034ddfcddcb13e75d1c149d38da34dea08>`__
-   `#9675 <https://pagure.io/freeipa/issue/9675>`__
+   `#9675 <https://codeberg.org/freeipa/freeipa/issues/9675>`__
 -  Minimal test for Cockpit integration on IPA master
    `commit <https://codeberg.org/freeipa/freeipa/commit/4519c2fde183d8b8c4f49da37fed68a41a220d72>`__
-   `#9675 <https://pagure.io/freeipa/issue/9675>`__
+   `#9675 <https://codeberg.org/freeipa/freeipa/issues/9675>`__
 -  selinux: allow Cockpit to use HTTP keytab on IPA servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/c775de3c2bf05b447bfd17646306f62406ffc6dc>`__
-   `#9675 <https://pagure.io/freeipa/issue/9675>`__
+   `#9675 <https://codeberg.org/freeipa/freeipa/issues/9675>`__
 -  selinux: add all IPA log files to ipa_log_t file context
    `commit <https://codeberg.org/freeipa/freeipa/commit/2959c989942a96ef93bffd5b308c36d3fec5542f>`__
-   `#9654 <https://pagure.io/freeipa/issue/9654>`__
+   `#9654 <https://codeberg.org/freeipa/freeipa/issues/9654>`__
 -  Remove NIS server support
    `commit <https://codeberg.org/freeipa/freeipa/commit/e98a80827bcc42dc16b516355077fed844220107>`__
-   `#9363 <https://pagure.io/freeipa/issue/9363>`__
+   `#9363 <https://codeberg.org/freeipa/freeipa/issues/9363>`__
 -  Get rid of unicode and long helpers in ipa-otptoken-import
    `commit <https://codeberg.org/freeipa/freeipa/commit/af316dd6f99c4ffad82e0c8002356c77197bdeff>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  ipalib/constants.py: factor out TripleDES use
    `commit <https://codeberg.org/freeipa/freeipa/commit/cb008bc9dc3bfff966f480a329b17544c4614f49>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  ipalib/x509.py: get rid of unicode helper
    `commit <https://codeberg.org/freeipa/freeipa/commit/fc5728804b720207a60d68f4b92ccced8de00325>`__
-   `#9644 <https://pagure.io/freeipa/issue/9644>`__
+   `#9644 <https://codeberg.org/freeipa/freeipa/issues/9644>`__
 -  ipalib/x509.py: support Cryptography 43
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b9ac93f5bc0481998468992adc39a7edc60692e>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 
 .. _anuja_more_5:
 
@@ -740,22 +740,22 @@ Anuja More (7)
 
 -  ipatests: Refactor and port trust functional SUDO tests.
    `commit <https://codeberg.org/freeipa/freeipa/commit/f395e162e1da4d58482b0520fcfc4068f5792f17>`__
-   `#9845 <https://pagure.io/freeipa/issue/9845>`__
+   `#9845 <https://codeberg.org/freeipa/freeipa/issues/9845>`__
 -  Revert "Temp commit"
    `commit <https://codeberg.org/freeipa/freeipa/commit/b38b681480f6e9f19ec2d7be0e86a97d4f772c19>`__
 -  ipatests: Refactor and port trust functional HBAC tests.
    `commit <https://codeberg.org/freeipa/freeipa/commit/14d7a5b3b6a4eae8df838e737ed23515b017dec3>`__
-   `#9845 <https://pagure.io/freeipa/issue/9845>`__
+   `#9845 <https://codeberg.org/freeipa/freeipa/issues/9845>`__
 -  ipatests: Add comprehensive tests for ipa-client-automount --domain
    option
    `commit <https://codeberg.org/freeipa/freeipa/commit/76727f970c1c810b5cfd182734a4db260bb192bd>`__
-   `#9780 <https://pagure.io/freeipa/issue/9780>`__
+   `#9780 <https://codeberg.org/freeipa/freeipa/issues/9780>`__
 -  ipatests: Remove xfail from test_installation::test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8017371d3752a42c53577264aab0184756c804a>`__
-   `#9135 <https://pagure.io/freeipa/issue/9135>`__
+   `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__
 -  ipatests: Update ipatests to test topology with multiple domain.
    `commit <https://codeberg.org/freeipa/freeipa/commit/817d8849b4c9ad14dc068882244bc5046c0afed5>`__
-   `#9657 <https://pagure.io/freeipa/issue/9657>`__
+   `#9657 <https://codeberg.org/freeipa/freeipa/issues/9657>`__
 -  Added template for ad_master_1replica_1client
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5f40a304c6d1732dc980ac1f4eae1bdc98ca709>`__
 
@@ -778,19 +778,19 @@ Antonio Torres (11)
 
 -  eDNS: disable dnsconfd before configuring Unbound
    `commit <https://codeberg.org/freeipa/freeipa/commit/68cc47a3e430fd4717aa60934677898afb95a961>`__
-   `#9859 <https://pagure.io/freeipa/issue/9859>`__
+   `#9859 <https://codeberg.org/freeipa/freeipa/issues/9859>`__
 -  dns: disable all previous Unbound configuration before deploying ours
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6445b88ab56c664376c3cafce9b69a602be6624>`__
-   `#9814 <https://pagure.io/freeipa/issue/9814>`__
+   `#9814 <https://codeberg.org/freeipa/freeipa/issues/9814>`__
 -  dns: only overwrite resolv.conf during eDNS setup when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/76b3a342d523be8574d6b8a6c0c75849418a9ea6>`__
-   `#9813 <https://pagure.io/freeipa/issue/9813>`__
+   `#9813 <https://codeberg.org/freeipa/freeipa/issues/9813>`__
 -  Fix inconsistency in manpage for DoT forwarder option
    `commit <https://codeberg.org/freeipa/freeipa/commit/34ed47f820b2c44ee9981367d5ea5c9e3427460c>`__
-   `#9804 <https://pagure.io/freeipa/issue/9804>`__
+   `#9804 <https://codeberg.org/freeipa/freeipa/issues/9804>`__
 -  dns: don't populate forwarders with DoT forwarders
    `commit <https://codeberg.org/freeipa/freeipa/commit/f1c30c5f6b587cb6ad31c0c5563ead05e8d55c51>`__
-   `#9748 <https://pagure.io/freeipa/issue/9748>`__
+   `#9748 <https://codeberg.org/freeipa/freeipa/issues/9748>`__
 -  dns: only disable unbound when DoT is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/91353b10748f1153540c6f5447a80864dee59d7f>`__
 -  spec: add unbound requirement and template file
@@ -822,23 +822,23 @@ Aleksandr Sharov (6)
 -  Correctly recognize OID 2.5.4.97, organizationIdentifier as a
    subject/issuer DN of the CA certificate
    `commit <https://codeberg.org/freeipa/freeipa/commit/e0b9ad0ae00ea478b6603fb56c9b369afd957d34>`__
-   `#9866 <https://pagure.io/freeipa/issue/9866>`__
+   `#9866 <https://codeberg.org/freeipa/freeipa/issues/9866>`__
 -  Allow ipa tool to force specific server
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9a2a6abcdaa66f4e2053c6cbf303c959d8be4f4>`__
-   `#9744 <https://pagure.io/freeipa/issue/9744>`__
+   `#9744 <https://codeberg.org/freeipa/freeipa/issues/9744>`__
 -  Test fix for the update
    `commit <https://codeberg.org/freeipa/freeipa/commit/23bfcdd4e22013552e8d95ed5d150c580201bdc9>`__
-   `#9760 <https://pagure.io/freeipa/issue/9760>`__
+   `#9760 <https://codeberg.org/freeipa/freeipa/issues/9760>`__
 -  Add a check into ipa-cert-fix tool to avoid updating certs if CA is
    close to being expired.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac6eee670d8a753e66ba69a65eff55447fff2822>`__
-   `#9760 <https://pagure.io/freeipa/issue/9760>`__
+   `#9760 <https://codeberg.org/freeipa/freeipa/issues/9760>`__
 -  Add PR-CI definitions
    `commit <https://codeberg.org/freeipa/freeipa/commit/90297c4c1a2b9b8e09275550f055bdf9d02942a6>`__
-   `#9612 <https://pagure.io/freeipa/issue/9612>`__
+   `#9612 <https://codeberg.org/freeipa/freeipa/issues/9612>`__
 -  Add ipa-idrange-fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/01d90b4a53c6810499bfdb6495559e52b9f9001f>`__
-   `#9612 <https://pagure.io/freeipa/issue/9612>`__
+   `#9612 <https://codeberg.org/freeipa/freeipa/issues/9612>`__
 
 .. _carla_martinez_1:
 
@@ -849,7 +849,7 @@ Carla Martinez (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c03fe90186c47645093f65854c0a922af7fba5d5>`__
 -  Fix: 'Organization' field in Okta not required
    `commit <https://codeberg.org/freeipa/freeipa/commit/13281e785a74b01fda5368a645477f3a7ed3675f>`__
-   `#9687 <https://pagure.io/freeipa/issue/9687>`__
+   `#9687 <https://codeberg.org/freeipa/freeipa/issues/9687>`__
 
 .. _david_hanina_8:
 
@@ -864,28 +864,28 @@ David Hanina (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b7fc311d3fa83ff146d83f665ab6aee846e0a4a>`__
 -  Fix terminal height for Rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/4484ad72905d12741b2dd0f29484480fa0566587>`__
-   `#9824 <https://pagure.io/freeipa/issue/9824>`__
+   `#9824 <https://codeberg.org/freeipa/freeipa/issues/9824>`__
 -  Warn when UID is out of local ID ranges
    `commit <https://codeberg.org/freeipa/freeipa/commit/b36c163fe8c225e12737d0e25092bb1a7fc9fd5c>`__
-   `#9781 <https://pagure.io/freeipa/issue/9781>`__
+   `#9781 <https://codeberg.org/freeipa/freeipa/issues/9781>`__
 -  Require baserid and secondarybaserid
    `commit <https://codeberg.org/freeipa/freeipa/commit/247adf43133222745c78d53624ca921e43e42f7b>`__
-   `#9779 <https://pagure.io/freeipa/issue/9779>`__
+   `#9779 <https://codeberg.org/freeipa/freeipa/issues/9779>`__
 -  Correct dnsrecord\_\* tests for --raw --structured
    `commit <https://codeberg.org/freeipa/freeipa/commit/ea374e83460a35cfca1caed7357fe1b70ffd7fab>`__
-   `#9768 <https://pagure.io/freeipa/issue/9768>`__
+   `#9768 <https://codeberg.org/freeipa/freeipa/issues/9768>`__
 -  Disallow removal of dogtag and ipa-dnskeysyncd services on IPA
    servers
    `commit <https://codeberg.org/freeipa/freeipa/commit/14196891138e2f88b57d23120a4471496a3cccb6>`__
-   `#9764 <https://pagure.io/freeipa/issue/9764>`__
+   `#9764 <https://codeberg.org/freeipa/freeipa/issues/9764>`__
 -  Disable --raw and --structured together
    `commit <https://codeberg.org/freeipa/freeipa/commit/b917b320a856bcedd313721e85c962a885095dfd>`__
-   `#9756 <https://pagure.io/freeipa/issue/9756>`__
+   `#9756 <https://codeberg.org/freeipa/freeipa/issues/9756>`__
 -  Skip for unpatched freeipa-healthcheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/90d70b5dd019f4f0d81b4c3a2096c4b64a736849>`__
 -  Replace fips-mode-setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/3c50bc23897abb74a414ed1d6986023674dd8ac2>`__
-   `#9750 <https://pagure.io/freeipa/issue/9750>`__
+   `#9750 <https://codeberg.org/freeipa/freeipa/issues/9750>`__
 
 .. _erik_belko_2:
 
@@ -896,7 +896,7 @@ Erik Belko (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/a542a9185a127ac0202ac0c0b0bc255d11aaf355>`__
 -  ipatests: Update ipa-adtrust-install test
    `commit <https://codeberg.org/freeipa/freeipa/commit/d87dc8296039ef093198e0cb4d648d52ba953ed2>`__
-   `#9655 <https://pagure.io/freeipa/issue/9655>`__
+   `#9655 <https://codeberg.org/freeipa/freeipa/issues/9655>`__
 
 .. _emilio_herrera_1:
 
@@ -913,7 +913,7 @@ Finn Krein-Schuch (1)
 
 -  Use mod_auth_gssapi option GssapiNegotiateOnce
    `commit <https://codeberg.org/freeipa/freeipa/commit/2dcc943e6bb9915494dcca3fecb35956943e1709>`__
-   `#5614 <https://pagure.io/freeipa/issue/5614>`__
+   `#5614 <https://codeberg.org/freeipa/freeipa/issues/5614>`__
 
 .. _florence_blanc_renaud_84:
 
@@ -922,32 +922,32 @@ Florence Blanc-Renaud (112)
 
 -  ipatests: fix teardown of TestIpaCertFix
    `commit <https://codeberg.org/freeipa/freeipa/commit/443aff6a0ae4bc35ceb7a4adc06c9b7bb2704743>`__
-   `#9888 <https://pagure.io/freeipa/issue/9888>`__
+   `#9888 <https://codeberg.org/freeipa/freeipa/issues/9888>`__
 -  test_ipahealthcheck_dogtag_ca_connectivity_check: update expected msg
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b9c71475b6a8d009335738108050c86213b0251>`__
-   `#9881 <https://pagure.io/freeipa/issue/9881>`__
+   `#9881 <https://codeberg.org/freeipa/freeipa/issues/9881>`__
 -  temp_commit: revert to the version pre 0b521f7
    `commit <https://codeberg.org/freeipa/freeipa/commit/bcbc88dc4a77d159ffcfa8ca4d2d98ef90f089d6>`__
 -  ipatests: mark test_dnssec as xfail in fips mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca5510a08dd5e8bdad617589a3acf1aee427373a>`__
-   `#9785 <https://pagure.io/freeipa/issue/9785>`__
+   `#9785 <https://codeberg.org/freeipa/freeipa/issues/9785>`__
 -  FIPS mode: openssl pkcs12 command needs -nomacver option
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e6b5b954b355df3f4f0859961f1a5ae151d72f5>`__
-   `#9878 <https://pagure.io/freeipa/issue/9878>`__
+   `#9878 <https://codeberg.org/freeipa/freeipa/issues/9878>`__
 -  test_sudo: do not clean the cache for offline cache tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/d3909d8601e0bdb6c78dcdf2507e7bf71f656e8f>`__
-   `#9874 <https://pagure.io/freeipa/issue/9874>`__
+   `#9874 <https://codeberg.org/freeipa/freeipa/issues/9874>`__
 -  test_idp: use more recent keycloak server
    `commit <https://codeberg.org/freeipa/freeipa/commit/54f9e0f3e69dde43082889afe101d01edfe93fdd>`__
-   `#9833 <https://pagure.io/freeipa/issue/9833>`__
+   `#9833 <https://codeberg.org/freeipa/freeipa/issues/9833>`__
 -  PRCI: switch testing from f41 and f42 to f42 and f43
    `commit <https://codeberg.org/freeipa/freeipa/commit/ec308a0358f109bd9acb1cdb189a4019fb7c53f1>`__
 -  Backup-restore: backup krb5.conf.d snippet files
    `commit <https://codeberg.org/freeipa/freeipa/commit/bd8288476fa0be98458cb18a92e1ffb9811e568e>`__
-   `#9870 <https://pagure.io/freeipa/issue/9870>`__
+   `#9870 <https://codeberg.org/freeipa/freeipa/issues/9870>`__
 -  TestHttpKdcProxy: use the snippet file for krb5 config
    `commit <https://codeberg.org/freeipa/freeipa/commit/0ff5d6a388912bc0a3645de4a57b5ab228652ff4>`__
-   `#9871 <https://pagure.io/freeipa/issue/9871>`__
+   `#9871 <https://codeberg.org/freeipa/freeipa/issues/9871>`__
 -  Localization: remove zh_Hant file
    `commit <https://codeberg.org/freeipa/freeipa/commit/1550fedee1131c5432f4b1bba5625f472d8a7599>`__
 -  Modern webui: refresh to the tip of main branch
@@ -978,69 +978,69 @@ Florence Blanc-Renaud (112)
    `commit <https://codeberg.org/freeipa/freeipa/commit/96a5e706d16724b805d31478eb3f6e9ed2882309>`__
 -  ipatests: fix TestIPAMigratewithBackupRestore setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b796ce7623d420786e3968697ab8569ed97ae3c>`__
-   `#9858 <https://pagure.io/freeipa/issue/9858>`__
+   `#9858 <https://codeberg.org/freeipa/freeipa/issues/9858>`__
 -  ipatests: add xfail for TestKRAinstallAfterCertRenew
    `commit <https://codeberg.org/freeipa/freeipa/commit/92f992a6ec5806676d086c889bc6eca923237a79>`__
-   `#9763 <https://pagure.io/freeipa/issue/9763>`__
+   `#9763 <https://codeberg.org/freeipa/freeipa/issues/9763>`__
 -  ipatests: exclude TomcatFileCheck when RSN are enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/0d0a558b79f45dc162b2b60eba0bc305db594673>`__
 -  ipatests: update the Let's Encrypt cert chain
    `commit <https://codeberg.org/freeipa/freeipa/commit/b73d8f18a65a7615e1052aae8c53d58ca67de8fa>`__
-   `#9857 <https://pagure.io/freeipa/issue/9857>`__
+   `#9857 <https://codeberg.org/freeipa/freeipa/issues/9857>`__
 -  azure webui tests: force chromium version
    `commit <https://codeberg.org/freeipa/freeipa/commit/70518cec0d3149e85a1f9dfda49ece36d665affa>`__
 -  ipatests: fix test_otp
    `commit <https://codeberg.org/freeipa/freeipa/commit/b0e4cdbf9dcaf8d46002f7b89a714b561ab97e03>`__
-   `#9849 <https://pagure.io/freeipa/issue/9849>`__
+   `#9849 <https://codeberg.org/freeipa/freeipa/issues/9849>`__
 -  xmlrpc test: fix test_find_orphan_automember_rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/ca29a5a43e1d66f6e25a59009592e58c0f59c393>`__
-   `#9850 <https://pagure.io/freeipa/issue/9850>`__
+   `#9850 <https://codeberg.org/freeipa/freeipa/issues/9850>`__
 -  ipatests: remove xfail for PKI 11.7
    `commit <https://codeberg.org/freeipa/freeipa/commit/81aadac8c0cae29a322b4e9df99eb275db36d692>`__
-   `#9606 <https://pagure.io/freeipa/issue/9606>`__
+   `#9606 <https://codeberg.org/freeipa/freeipa/issues/9606>`__
 -  ipatests: fix test_certmonger_ipa_responder_jsonrpc
    `commit <https://codeberg.org/freeipa/freeipa/commit/40b24b24c77d54750cda2a090c063f55d961b716>`__
-   `#9848 <https://pagure.io/freeipa/issue/9848>`__
+   `#9848 <https://codeberg.org/freeipa/freeipa/issues/9848>`__
 -  DNS over TLS: use system trust store
    `commit <https://codeberg.org/freeipa/freeipa/commit/c0994948b55da24eb946550bade3a33efe8801e6>`__
-   `#9838 <https://pagure.io/freeipa/issue/9838>`__
+   `#9838 <https://codeberg.org/freeipa/freeipa/issues/9838>`__
 -  Spec file: bump samba version to 4.23.0 in f43 and above
    `commit <https://codeberg.org/freeipa/freeipa/commit/6069147e3bea92059849e0a8c1948a0f1c3c8425>`__
-   `#9843 <https://pagure.io/freeipa/issue/9843>`__
+   `#9843 <https://codeberg.org/freeipa/freeipa/issues/9843>`__
 -  Spec file: use nodejs22 on fedora 41+
    `commit <https://codeberg.org/freeipa/freeipa/commit/52024ed7f394ac5eefebff60b53a2cd938ed7628>`__
-   `#9836 <https://pagure.io/freeipa/issue/9836>`__
+   `#9836 <https://codeberg.org/freeipa/freeipa/issues/9836>`__
 -  ipatests: fix test_adtrust_install_with_non_ipa_user
    `commit <https://codeberg.org/freeipa/freeipa/commit/2eaba8497a5095b23dac39b759dbf632fa422529>`__
-   `#9812 <https://pagure.io/freeipa/issue/9812>`__
+   `#9812 <https://codeberg.org/freeipa/freeipa/issues/9812>`__
 -  ipa-idrange-fix: check that IPA server is installed
    `commit <https://codeberg.org/freeipa/freeipa/commit/5323b7701386eb524eb51a9ce62ce151c13b9d58>`__
-   `#9809 <https://pagure.io/freeipa/issue/9809>`__
+   `#9809 <https://codeberg.org/freeipa/freeipa/issues/9809>`__
 -  ipatests: fix invalid range creation in test_ipa_idrange_fix.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/3e15108f456768d5ca4cf2ffbbfe090c57d0f988>`__
-   `#9801 <https://pagure.io/freeipa/issue/9801>`__
+   `#9801 <https://codeberg.org/freeipa/freeipa/issues/9801>`__
 -  ipatests: fix xfail annotation for test_ipa_healthcheck_fips_enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/982569fcb3d23d6e6578e5efbaafb99c32542a8d>`__
-   `#9791 <https://pagure.io/freeipa/issue/9791>`__
+   `#9791 <https://codeberg.org/freeipa/freeipa/issues/9791>`__
 -  ipatests: skip encrypted dns tests on fedora 41
    `commit <https://codeberg.org/freeipa/freeipa/commit/78abf1ffa1316585e658baf309d0ea0699858260>`__
-   `#9799 <https://pagure.io/freeipa/issue/9799>`__
+   `#9799 <https://codeberg.org/freeipa/freeipa/issues/9799>`__
 -  ipa config-mod: fix internalerror when setting an empty
    ipaconfigstring
    `commit <https://codeberg.org/freeipa/freeipa/commit/e4a3d46e89a49e18fa437723370988b165ded4b5>`__
-   `#9794 <https://pagure.io/freeipa/issue/9794>`__
+   `#9794 <https://codeberg.org/freeipa/freeipa/issues/9794>`__
 -  ipatests: test_manual_renewal_master_transfer must wait for
    replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/089e813bf4a981be1e6660c8db9bec6c1a67a777>`__
-   `#9790 <https://pagure.io/freeipa/issue/9790>`__
+   `#9790 <https://codeberg.org/freeipa/freeipa/issues/9790>`__
 -  azure pipeline: disable InstallDNSSECFirst
    `commit <https://codeberg.org/freeipa/freeipa/commit/6329c3703a3d878fa4cf7a9646746d4ee19fabe6>`__
 -  ipatests: add extensions to server certificates for CAless mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/d1abdca13f26cf3c50c7898eb7d034c7dfc6d392>`__
-   `#9787 <https://pagure.io/freeipa/issue/9787>`__
+   `#9787 <https://codeberg.org/freeipa/freeipa/issues/9787>`__
 -  dns install: fix selinux avc relabelto
    `commit <https://codeberg.org/freeipa/freeipa/commit/c2aae876f04c127b7b2eb6dad8677a3ae8ceefb8>`__
-   `#9782 <https://pagure.io/freeipa/issue/9782>`__
+   `#9782 <https://codeberg.org/freeipa/freeipa/issues/9782>`__
 -  PRCI tests: update vagrant image with latest bind package
    `commit <https://codeberg.org/freeipa/freeipa/commit/e3425d0649d10b72e8e5d521296165932967419d>`__
 -  Azure CI: use podman instead of docker through emulation
@@ -1051,7 +1051,7 @@ Florence Blanc-Renaud (112)
    `commit <https://codeberg.org/freeipa/freeipa/commit/26c80e8476b288ae3775716d52ff32b0958422fb>`__
 -  ipatests: fix test_idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/e964b7de94e1616558ca5c2471667c10ab2db5ec>`__
-   `#9769 <https://pagure.io/freeipa/issue/9769>`__
+   `#9769 <https://codeberg.org/freeipa/freeipa/issues/9769>`__
 -  PRCI: switch testing from f40 and f41 to f41 and f42
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5084adb6dde67fa7eb8dc58cc3dfa5a0a9bdaa3>`__
 -  PRCI definitions: update vagrant box version for rawhide
@@ -1063,160 +1063,160 @@ Florence Blanc-Renaud (112)
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed8b4bc3631ae00a9ee687797767fbdb9d02f7ea>`__
 -  idrange: use minvalue=0 for baserid and secondarybaserid
    `commit <https://codeberg.org/freeipa/freeipa/commit/140c3b54771fbc636286a70354e7bcd180bb9709>`__
-   `#9765 <https://pagure.io/freeipa/issue/9765>`__
+   `#9765 <https://codeberg.org/freeipa/freeipa/issues/9765>`__
 -  ipatest: make test_cert more robust to replication delays
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6060fe5e781fb87bce380763e4417380be365f3>`__
-   `#9762 <https://pagure.io/freeipa/issue/9762>`__
+   `#9762 <https://codeberg.org/freeipa/freeipa/issues/9762>`__
 -  Leapp upgrade: skip systemctl calls
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a7a11c196da4660286a8c499bc9381ca3deab05>`__
 -  ipatests: adapt error code and message for samba 4.22
    `commit <https://codeberg.org/freeipa/freeipa/commit/cd3b7b9bd506c48714f171490735ecf564ad6b69>`__
-   `#9751 <https://pagure.io/freeipa/issue/9751>`__
+   `#9751 <https://codeberg.org/freeipa/freeipa/issues/9751>`__
 -  WebUI: fix the tooltip for Search Size limit
    `commit <https://codeberg.org/freeipa/freeipa/commit/69ca3e477b2390f1f19ac14452bdca2a55fcea56>`__
-   `#9758 <https://pagure.io/freeipa/issue/9758>`__
+   `#9758 <https://codeberg.org/freeipa/freeipa/issues/9758>`__
 -  vault: remove PKIConnection deprecation warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/cbe863bf15ed3c0091256f86e9da3fe382b658f1>`__
-   `#9754 <https://pagure.io/freeipa/issue/9754>`__
+   `#9754 <https://codeberg.org/freeipa/freeipa/issues/9754>`__
 -  ipatests: use "sos report" instead of "sosreport" command
    `commit <https://codeberg.org/freeipa/freeipa/commit/d2b5a9b93c3cf95b14dde888605f404edabd3fe9>`__
-   `#9752 <https://pagure.io/freeipa/issue/9752>`__
+   `#9752 <https://codeberg.org/freeipa/freeipa/issues/9752>`__
 -  ipatests: simulate FIPS mode and install replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/50e8c4a1273dc5ba9dace14df8743821127b37fd>`__
-   `#9002 <https://pagure.io/freeipa/issue/9002>`__
+   `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__
 -  ipatests: on rhel10 do not install firefox
    `commit <https://codeberg.org/freeipa/freeipa/commit/d9bf35dcc0367b522ba986cc4f0e37a6ffc9c8cc>`__
 -  ipatests: restart dirsrv after time jumps
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f475294e0868b0b7bf6143260c9b30e00e25efd>`__
 -  ipatests: skip test_ipahealthcheck_ds_configcheck for recent versions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d93e48644960231d72b2c75f7f847a31a62f84f>`__
-   `#9730 <https://pagure.io/freeipa/issue/9730>`__
+   `#9730 <https://codeberg.org/freeipa/freeipa/issues/9730>`__
 -  Nightly tests: add test_ipahelthcheck to 389ds pipeline
    `commit <https://codeberg.org/freeipa/freeipa/commit/3863043fd1a0cccd964daedc3d12928c236d8b4b>`__
 -  ipatests: force the version for uninstall/reinstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e26b060871cf7763cca0fd798119b658f4f93df>`__
-   `#9723 <https://pagure.io/freeipa/issue/9723>`__
+   `#9723 <https://codeberg.org/freeipa/freeipa/issues/9723>`__
 -  Fix pylint issue in ipatests/i18n.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/31338fea70aae3fdfa0c6117d7652816d03a6f74>`__
 -  ipatests: certbot removed the --manual-public-ip-logging-ok parameter
    `commit <https://codeberg.org/freeipa/freeipa/commit/e13be8a7c535a9d2131ccd1f58bf7e564dc02e7e>`__
-   `#9724 <https://pagure.io/freeipa/issue/9724>`__
+   `#9724 <https://codeberg.org/freeipa/freeipa/issues/9724>`__
 -  Temp commit: move to fedora 41
    `commit <https://codeberg.org/freeipa/freeipa/commit/4146d77d2547160df2df31665dc201a7d3118173>`__
 -  Cert renewal: update the trust flags for audit cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/7ec0cb4ced0fe5118077a4804a70b928b2a9f442>`__
-   `#9705 <https://pagure.io/freeipa/issue/9705>`__
+   `#9705 <https://codeberg.org/freeipa/freeipa/issues/9705>`__
 -  Dogtag instance: add method to create temp password file
    `commit <https://codeberg.org/freeipa/freeipa/commit/1e5eb442adb9b6630b95eaf118e65f110d2087ac>`__
-   `#9705 <https://pagure.io/freeipa/issue/9705>`__
+   `#9705 <https://codeberg.org/freeipa/freeipa/issues/9705>`__
 -  KRA cert renewal: update ca.connector.KRA.transportCert
    `commit <https://codeberg.org/freeipa/freeipa/commit/10c3464e55eaafff728042bc878938c380c4f9d5>`__
-   `#9692 <https://pagure.io/freeipa/issue/9692>`__
+   `#9692 <https://codeberg.org/freeipa/freeipa/issues/9692>`__
 -  Installation test: KRA on replica after cert renewal
    `commit <https://codeberg.org/freeipa/freeipa/commit/76dfadd95fe23fde4af19249191c285dede4120e>`__
-   `#9692 <https://pagure.io/freeipa/issue/9692>`__
+   `#9692 <https://codeberg.org/freeipa/freeipa/issues/9692>`__
 -  Fix copr build
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9d7137d8aed514c48e9bf3e55b450860276a29b>`__
 -  readthedocs: install crypto 43.0.0
    `commit <https://codeberg.org/freeipa/freeipa/commit/b20c3fb60558b538ef13e0e0fe89ae361d529553>`__
 -  webuitests: adapt to Random Serial Numbers
    `commit <https://codeberg.org/freeipa/freeipa/commit/c8befc9f46b43aec748ede33236ca4f77b2356c6>`__
-   `#9707 <https://pagure.io/freeipa/issue/9707>`__
+   `#9707 <https://codeberg.org/freeipa/freeipa/issues/9707>`__
 -  ipatests: pruning is enabled by default with LMDB
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd222273a544f9e8c7a1749ff797880db7edbf25>`__
-   `#9706 <https://pagure.io/freeipa/issue/9706>`__
+   `#9706 <https://codeberg.org/freeipa/freeipa/issues/9706>`__
 -  ipatests: install master with allow-zone-overlap
    `commit <https://codeberg.org/freeipa/freeipa/commit/411b29db8f2bf9b8390dd021cf464d5cac013e3b>`__
-   `#9697 <https://pagure.io/freeipa/issue/9697>`__
+   `#9697 <https://codeberg.org/freeipa/freeipa/issues/9697>`__
 -  Nightly test def: fix topology for test_IPAMigrateADTrust
    `commit <https://codeberg.org/freeipa/freeipa/commit/2f1ca6db12897c2c89bd64f7353268f45b8468a0>`__
 -  Tests: migrate to f40/f41
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a47d3a9066ecad4466f8fd4d919b035f1c13f27>`__
 -  ipa-migrate man page: fix typos and errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/35fc1470cd0295d8b387e034b7b30f6088eb49b8>`__
-   `#9681 <https://pagure.io/freeipa/issue/9681>`__
+   `#9681 <https://codeberg.org/freeipa/freeipa/issues/9681>`__
 -  test_ipahealthcheck: skip connectivity_and_data check
    `commit <https://codeberg.org/freeipa/freeipa/commit/929dc568808f12917a738b51def45c31fb351ddc>`__
-   `#9668 <https://pagure.io/freeipa/issue/9668>`__
+   `#9668 <https://codeberg.org/freeipa/freeipa/issues/9668>`__
 -  Nightly test definition: use master_1repl topology for idrange_fix
    `commit <https://codeberg.org/freeipa/freeipa/commit/df8cdb06f3d5b7ce0b7a91586cdd1f1951c229ab>`__
 -  test_adtrust_install: add --use-krb5-ccache to smbclient command
    `commit <https://codeberg.org/freeipa/freeipa/commit/c33e92d8954dd1578c89693e10d59d2bd4f31940>`__
-   `#9666 <https://pagure.io/freeipa/issue/9666>`__
+   `#9666 <https://codeberg.org/freeipa/freeipa/issues/9666>`__
 -  ipatests: provide a ccache to rpcclient deletetrustdom
    `commit <https://codeberg.org/freeipa/freeipa/commit/3203afcc11487730aceb222a54cbdbaaaf371d15>`__
-   `#9667 <https://pagure.io/freeipa/issue/9667>`__
+   `#9667 <https://codeberg.org/freeipa/freeipa/issues/9667>`__
 -  azure pipeline: use latest version of DownloadPipelineArtifact task
    `commit <https://codeberg.org/freeipa/freeipa/commit/97718f688c73265c0240fbe6380cf0476e873395>`__
 -  UnsafeIPAddress: pass flag=0 to IPNetwork
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4a0a142058a45ab2bf614c14c1b037b674cccc9>`__
-   `#9645 <https://pagure.io/freeipa/issue/9645>`__
+   `#9645 <https://codeberg.org/freeipa/freeipa/issues/9645>`__
 -  azure tests: move to fedora 40
    `commit <https://codeberg.org/freeipa/freeipa/commit/19651f8ecc1aba69f96817e676e1dd953bc640ec>`__
 -  Custodia: in fips mode add -nomac or -nomacver to openssl pkcs12
    `commit <https://codeberg.org/freeipa/freeipa/commit/ce673216639f4516367952609191e87b1b05e0fa>`__
-   `#9577 <https://pagure.io/freeipa/issue/9577>`__
+   `#9577 <https://codeberg.org/freeipa/freeipa/issues/9577>`__
 -  ipatests: Add missing comma in test_idrange_no_rid_bases_reversed
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9fc303e61e0b073649810a768d8ad5062d81426>`__
-   `#9656 <https://pagure.io/freeipa/issue/9656>`__
+   `#9656 <https://codeberg.org/freeipa/freeipa/issues/9656>`__
 -  HSM: fix the module name
    `commit <https://codeberg.org/freeipa/freeipa/commit/995c4f3597ccd754c5c329eb190691947808faca>`__
-   `#9636 <https://pagure.io/freeipa/issue/9636>`__
+   `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__
 -  trust-add: handle unavailable domain
    `commit <https://codeberg.org/freeipa/freeipa/commit/88123ad2b32fbdd6206028215e4a58575a37dd9e>`__
-   `#9488 <https://pagure.io/freeipa/issue/9488>`__
+   `#9488 <https://codeberg.org/freeipa/freeipa/issues/9488>`__
 -  ipatests: skip HSM test if pki < 11.5.9
    `commit <https://codeberg.org/freeipa/freeipa/commit/bbc232e4898673f3cab9f6b12fac0f04292326c6>`__
-   `#9648 <https://pagure.io/freeipa/issue/9648>`__
+   `#9648 <https://codeberg.org/freeipa/freeipa/issues/9648>`__
 -  ipatests: increase the timeout for test_hsm.py::TestHSMInstall
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfefe5313f31760072f4a4b06ac493ee124e646f>`__
 -  Replica CA installation: ignore time skew during initial replication
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b21e191a9ff43bb293bc075a4a26b07375485cc>`__
-   `#9635 <https://pagure.io/freeipa/issue/9635>`__
+   `#9635 <https://codeberg.org/freeipa/freeipa/issues/9635>`__
 -  spec file: do not use nodejs-22 on f39 and f40
    `commit <https://codeberg.org/freeipa/freeipa/commit/acb87a8b220ad2fd9f61b98e7eadce48051f0803>`__
-   `#9643 <https://pagure.io/freeipa/issue/9643>`__
+   `#9643 <https://codeberg.org/freeipa/freeipa/issues/9643>`__
 -  ipatests: remove xfail for test_ipa_migrate_stage_mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/cf3a46cc00b237d3845481ee1a4737a92aa94636>`__
-   `#9621 <https://pagure.io/freeipa/issue/9621>`__
+   `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__
 -  ipatests: remove xfail for test_ipa_migrate_version_option
    `commit <https://codeberg.org/freeipa/freeipa/commit/5cfc4b404e27d20b786aac8b22e320c510862c52>`__
-   `#9620 <https://pagure.io/freeipa/issue/9620>`__
+   `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__
 -  test_replica_install_after_restore: kinit after restore
    `commit <https://codeberg.org/freeipa/freeipa/commit/0be8d040a7e385c17c8ff98fdee805ccab142ca4>`__
-   `#9613 <https://pagure.io/freeipa/issue/9613>`__
+   `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__
 -  Uninstall: stop sssd-kcm before removing KCM ccaches database
    `commit <https://codeberg.org/freeipa/freeipa/commit/88a392cf840a0ca8eae527863e925ca0b4167513>`__
-   `#9616 <https://pagure.io/freeipa/issue/9616>`__
+   `#9616 <https://codeberg.org/freeipa/freeipa/issues/9616>`__
 -  ipa-ods-enforcer: stop must also stop the socket
    `commit <https://codeberg.org/freeipa/freeipa/commit/9110050517b6f1059a29ad578963f0f53c58dbd3>`__
-   `#9613 <https://pagure.io/freeipa/issue/9613>`__
+   `#9613 <https://codeberg.org/freeipa/freeipa/issues/9613>`__
 -  ipatests: fix / permissions for test_nested_group_members
    `commit <https://codeberg.org/freeipa/freeipa/commit/58003600089f1262971c392ca43a9d0767e57c8c>`__
-   `#9615 <https://pagure.io/freeipa/issue/9615>`__
+   `#9615 <https://codeberg.org/freeipa/freeipa/issues/9615>`__
 -  ipatests: fix / permissions to allow ssh with private key
    `commit <https://codeberg.org/freeipa/freeipa/commit/7513575c441ea6d625963f67917ad4879144bc11>`__
-   `#9607 <https://pagure.io/freeipa/issue/9607>`__
+   `#9607 <https://codeberg.org/freeipa/freeipa/issues/9607>`__
 -  ipatests: mark test_ca_show_error_handling as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a83d833e9f252208e9922f061a25d2bd0d0ebc0>`__
-   `#9606 <https://pagure.io/freeipa/issue/9606>`__
+   `#9606 <https://codeberg.org/freeipa/freeipa/issues/9606>`__
 -  Gating and nightly tests: move to f39/f40
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd93a3b81686f9d8a5cb926541401232049ccb19>`__
 -  ipatests: add test for PKINIT renewal on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/70cd9dd161af558b08c3a76403641e8c8995fffc>`__
-   `#9611 <https://pagure.io/freeipa/issue/9611>`__
+   `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__
 -  PKINIT certificate: fix renewal on hidden replica
    `commit <https://codeberg.org/freeipa/freeipa/commit/20df6090765f63a280c8cd5d50a997efdf2d46d3>`__
-   `#9611 <https://pagure.io/freeipa/issue/9611>`__
+   `#9611 <https://codeberg.org/freeipa/freeipa/issues/9611>`__
 -  ipatests: add test for ticket 9610
    `commit <https://codeberg.org/freeipa/freeipa/commit/78e96707091e42e0b3e96cf04ac15ff3a93cca5b>`__
-   `#9610 <https://pagure.io/freeipa/issue/9610>`__
+   `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__
 -  spec file: do not create /etc/ssh/ssh_config.orig if unchanged
    `commit <https://codeberg.org/freeipa/freeipa/commit/8075512338836c82132ee51cb931611d84c9841d>`__
-   `#9610 <https://pagure.io/freeipa/issue/9610>`__
+   `#9610 <https://codeberg.org/freeipa/freeipa/issues/9610>`__
 -  ipa-otptoken-import: open the key file in binary mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/3249b1247f148f648d8b9696e9e80a8237b4d14c>`__
-   `#9609 <https://pagure.io/freeipa/issue/9609>`__
+   `#9609 <https://codeberg.org/freeipa/freeipa/issues/9609>`__
 
 .. _frederik_himpe_2:
 
@@ -1228,7 +1228,7 @@ Frederik Himpe (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/c7b6f4d00ef380a2835c00ec00ef69d3b928ea3b>`__
 -  Make name of nobody group configurable and use nogroup on Debian
    `commit <https://codeberg.org/freeipa/freeipa/commit/1937189e605f4301a25c1f0b4a78b300a4fd76e3>`__
-   `#9753 <https://pagure.io/freeipa/issue/9753>`__
+   `#9753 <https://codeberg.org/freeipa/freeipa/issues/9753>`__
 
 .. _fco._javier_f._serrador_2:
 
@@ -1248,10 +1248,10 @@ Francisco Trivino (2)
 
 -  doc/designs: add encrypted DNS design documents
    `commit <https://codeberg.org/freeipa/freeipa/commit/79c704fb9d8deef822b341b0beab412f9031793d>`__
-   `#9605 <https://pagure.io/freeipa/issue/9605>`__
+   `#9605 <https://codeberg.org/freeipa/freeipa/issues/9605>`__
 -  ipatests: increase delays for WebUI host test
    `commit <https://codeberg.org/freeipa/freeipa/commit/3cd3d175c17a3f581184d52ea0d25368afef075a>`__
-   `#9721 <https://pagure.io/freeipa/issue/9721>`__
+   `#9721 <https://codeberg.org/freeipa/freeipa/issues/9721>`__
 
 .. _fraser_tweedale_1:
 
@@ -1260,7 +1260,7 @@ Fraser Tweedale (1)
 
 -  Refactor installer cert issuance to use pki python lib
    `commit <https://codeberg.org/freeipa/freeipa/commit/8aea0fd90018c5f55c9b2ed1a6ef055205752789>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 
 .. _dmytro_markevych_1:
 
@@ -1277,7 +1277,7 @@ Ian Brown (1)
 
 -  Replace instances of del os.environ with os.environ.pop
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3ec6ae8d000add0d2af648645d22191012541a4>`__
-   `#9450 <https://pagure.io/freeipa/issue/9450>`__
+   `#9450 <https://codeberg.org/freeipa/freeipa/issues/9450>`__
 
 .. _julien_rische_9:
 
@@ -1294,20 +1294,20 @@ Julien Rische (11)
    `commit <https://codeberg.org/freeipa/freeipa/commit/fb12d9e14eafeaf036951e98e0d291db892afe2d>`__
 -  ipa-kdb: support storing multiple KVNO for the same principal
    `commit <https://codeberg.org/freeipa/freeipa/commit/43b1fd77f10cf2752a44b4b5c219660872e5b1de>`__
-   `#9370 <https://pagure.io/freeipa/issue/9370>`__
+   `#9370 <https://codeberg.org/freeipa/freeipa/issues/9370>`__
 -  kdb: keep ipadb_get_connection() from succeeding with null LDAP
    context
    `commit <https://codeberg.org/freeipa/freeipa/commit/56261bbba4355c33a002df98566b290ef9681c0c>`__
-   `#9777 <https://pagure.io/freeipa/issue/9777>`__
+   `#9777 <https://codeberg.org/freeipa/freeipa/issues/9777>`__
 -  ipa-sidgen: fix memory leak in ipa_sidgen_add_post_op
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b938b511c6c9e58ca0cd86888d61cfde99c41d3>`__
-   `#9772 <https://pagure.io/freeipa/issue/9772>`__
+   `#9772 <https://codeberg.org/freeipa/freeipa/issues/9772>`__
 -  Remove RC4 and 3DES default encryption types on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c566104d661679f9babfac12afc9e44a28d5246>`__
-   `#9633 <https://pagure.io/freeipa/issue/9633>`__
+   `#9633 <https://codeberg.org/freeipa/freeipa/issues/9633>`__
 -  Unconditionally add MS-PAC to global config on update
    `commit <https://codeberg.org/freeipa/freeipa/commit/0c79ecb163dac9b7a07c2ab48982eb4823cfde0d>`__
-   `#9632 <https://pagure.io/freeipa/issue/9632>`__
+   `#9632 <https://codeberg.org/freeipa/freeipa/issues/9632>`__
 -  kdb: apply combinatorial logic for ticket flags
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfd4492efd47d45bcac4ee1d32d21cae91142df8>`__
 -  kdb: fix vulnerability in GCD rules handling
@@ -1320,7 +1320,7 @@ Jonathan Steffan (1)
 
 -  workshop: Increase RAM for VMs to Avoid OOM
    `commit <https://codeberg.org/freeipa/freeipa/commit/ab82b3d8cfb049c4b7f571c7d99770629b69b349>`__
-   `#9720 <https://pagure.io/freeipa/issue/9720>`__
+   `#9720 <https://codeberg.org/freeipa/freeipa/issues/9720>`__
 
 .. _léane_grasser_1:
 
@@ -1337,7 +1337,7 @@ TAKAHASHI Masatsuna (1)
 
 -  ipa-advise ipa-backup ipa-restore: Fix --v option of the manual.
    `commit <https://codeberg.org/freeipa/freeipa/commit/224c4517c5ca18bba52fd066c7acc19c55bd7f0a>`__
-   `#9617 <https://pagure.io/freeipa/issue/9617>`__
+   `#9617 <https://codeberg.org/freeipa/freeipa/issues/9617>`__
 
 .. _shunsuke_matsumoto_1:
 
@@ -1346,7 +1346,7 @@ Shunsuke matsumoto (1)
 
 -  The -d option of the ipa-advise command was able to used.
    `commit <https://codeberg.org/freeipa/freeipa/commit/09aecbc775adbb460218c806578358cfca619843>`__
-   `#9625 <https://pagure.io/freeipa/issue/9625>`__
+   `#9625 <https://codeberg.org/freeipa/freeipa/issues/9625>`__
 
 .. _miro_hrončok_1:
 
@@ -1355,7 +1355,7 @@ Miro Hrončok (1)
 
 -  Stop using deprecated pkg_resources
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac791f7372d32d25c75eb61f949f1db38fe2f0d6>`__
-   `#9676 <https://pagure.io/freeipa/issue/9676>`__
+   `#9676 <https://codeberg.org/freeipa/freeipa/issues/9676>`__
 
 .. _michal_polovka_1:
 
@@ -1364,7 +1364,7 @@ Michal Polovka (1)
 
 -  ipatests: test_fips: Remove obsolete patch
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8378a0d779be56cea08d0e57ede2b69cb17c5f1>`__
-   `#9810 <https://pagure.io/freeipa/issue/9810>`__
+   `#9810 <https://codeberg.org/freeipa/freeipa/issues/9810>`__
 
 .. _mark_reynolds_14:
 
@@ -1373,50 +1373,50 @@ Mark Reynolds (14)
 
 -  ipa-migrate - only remove repl state attribute options
    `commit <https://codeberg.org/freeipa/freeipa/commit/878b800e879c460038ab0d3f6aff96a89a22961e>`__
-   `#9784 <https://pagure.io/freeipa/issue/9784>`__
+   `#9784 <https://codeberg.org/freeipa/freeipa/issues/9784>`__
 -  ipa-migrate - improve suffix replacement
    `commit <https://codeberg.org/freeipa/freeipa/commit/6cdabdacc950e4c334eb4a3e1666b19178072e36>`__
-   `#9776 <https://pagure.io/freeipa/issue/9776>`__
+   `#9776 <https://codeberg.org/freeipa/freeipa/issues/9776>`__
 -  ipa-migrate - do not process AD entgries in staging mode
    `commit <https://codeberg.org/freeipa/freeipa/commit/1fb3e7fedce745cc1f175d86ca3e9ed6145edad3>`__
-   `#9776 <https://pagure.io/freeipa/issue/9776>`__
+   `#9776 <https://codeberg.org/freeipa/freeipa/issues/9776>`__
 -  ipa-migrate - remove replication state information
    `commit <https://codeberg.org/freeipa/freeipa/commit/4e06a4179e3a1c5732add61a31ea2404844feda3>`__
-   `#9776 <https://pagure.io/freeipa/issue/9776>`__
+   `#9776 <https://codeberg.org/freeipa/freeipa/issues/9776>`__
 -  ipa-migrate - do not migrate tombstone entries, ignore
    MidairCollisions, and krbpwdpolicyreference
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b7235c8b307264d56ac3a3bcdbe85966aad8d8e>`__
-   `#9737 <https://pagure.io/freeipa/issue/9737>`__
+   `#9737 <https://codeberg.org/freeipa/freeipa/issues/9737>`__
 -  ipa-migrate should migrate dns forward zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/0abfb20c34ade85d5c10a358a73ba33626b2f1ef>`__
-   `#9686 <https://pagure.io/freeipa/issue/9686>`__
+   `#9686 <https://codeberg.org/freeipa/freeipa/issues/9686>`__
 -  ipa-migrate - dryrun write updates crashes when removing values
    `commit <https://codeberg.org/freeipa/freeipa/commit/1f5954260859b8b891065c023316bd326f2a7680>`__
-   `#9682 <https://pagure.io/freeipa/issue/9682>`__
+   `#9682 <https://codeberg.org/freeipa/freeipa/issues/9682>`__
 -  Do not let user with an expired OTP token to log in if only OTP is
    allowed
    `commit <https://codeberg.org/freeipa/freeipa/commit/9ab6601c3103cee1341fb3674a62180ebc482789>`__
-   `#9387 <https://pagure.io/freeipa/issue/9387>`__
+   `#9387 <https://codeberg.org/freeipa/freeipa/issues/9387>`__
 -  ipa-migrate - fix alternate entry search filter
    `commit <https://codeberg.org/freeipa/freeipa/commit/b98b4a886ee0a75c7cf2c1650e4a0c8a699ac808>`__
-   `#9658 <https://pagure.io/freeipa/issue/9658>`__
+   `#9658 <https://codeberg.org/freeipa/freeipa/issues/9658>`__
 -  ipa-migrate - fix migration issues with entries using ipaUniqueId in
    the RDN
    `commit <https://codeberg.org/freeipa/freeipa/commit/7808fc8398b54a9008872c3d5cb13ccde4ec10bc>`__
-   `#9640 <https://pagure.io/freeipa/issue/9640>`__
+   `#9640 <https://codeberg.org/freeipa/freeipa/issues/9640>`__
 -  ipa-migrate - properly handle invalid certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d075fdd2aa55730dd54bb46eb3477c06eea626e>`__
-   `#9642 <https://pagure.io/freeipa/issue/9642>`__
+   `#9642 <https://codeberg.org/freeipa/freeipa/issues/9642>`__
 -  Issue 9621 - ipa-migrate - should not update mapped attributes in
    managed entries
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d2bf9068ca8f81debdca8cb710602055e1f630c>`__
-   `#9621 <https://pagure.io/freeipa/issue/9621>`__
+   `#9621 <https://codeberg.org/freeipa/freeipa/issues/9621>`__
 -  ipa-migrate - starttls does not work
    `commit <https://codeberg.org/freeipa/freeipa/commit/31645c414d639f17f7f391fc7a8888c9d5809f3f>`__
-   `#9619 <https://pagure.io/freeipa/issue/9619>`__
+   `#9619 <https://codeberg.org/freeipa/freeipa/issues/9619>`__
 -  ipa-migrate - remove -V option
    `commit <https://codeberg.org/freeipa/freeipa/commit/024d41ebeaa875d500050aad39220d68eb70a709>`__
-   `#9620 <https://pagure.io/freeipa/issue/9620>`__
+   `#9620 <https://codeberg.org/freeipa/freeipa/issues/9620>`__
 
 .. _madhuri_upadhye_1:
 
@@ -1436,10 +1436,10 @@ Mohammad Rizwan (3)
 -  ipatests: Verify that SIDgen task continue even if it fails to assign
    sid
    `commit <https://codeberg.org/freeipa/freeipa/commit/dd1bcd178b388e086dc02541b1b960b2788ce2de>`__
-   `#9618 <https://pagure.io/freeipa/issue/9618>`__
+   `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__
 -  ipatests: tests related to --token-password-file
    `commit <https://codeberg.org/freeipa/freeipa/commit/a11c843adcd5947ef124fc418bfb3e0ac0750ae4>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 
 .. _n_m_1:
 
@@ -1509,7 +1509,7 @@ PRANAV THUBE (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/89fb6ad49a4a1a32bf37adac960d87117e562fc1>`__
 -  ipatests: Ignore /run/log/journal in test_uninstallation.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/397a85cd29eaf30dfa6c41e8277f1d7e38c21aef>`__
-   `#9788 <https://pagure.io/freeipa/issue/9788>`__
+   `#9788 <https://codeberg.org/freeipa/freeipa/issues/9788>`__
 
 .. _rafael_fontenelle_1:
 
@@ -1526,90 +1526,90 @@ Rob Crittenden (73)
 
 -  Don't assume the server has a CA service when issuing certificates
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffb8fe35414bd6d24f56be841e44364b14efad31>`__
-   `#9879 <https://pagure.io/freeipa/issue/9879>`__
+   `#9879 <https://codeberg.org/freeipa/freeipa/issues/9879>`__
 -  Revert "Temp commit"
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7c66bf23b214e12161b70f235999f792d0f202d>`__
 -  PR-CI: Run test_installation_TestInstallKeySizes in the nightlies
    `commit <https://codeberg.org/freeipa/freeipa/commit/0b521f7d19cb1682b67287a7c9f754f5b92b8868>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Move some functions to installutils to be more independent
    `commit <https://codeberg.org/freeipa/freeipa/commit/d424dc6dd2b23b485f15c7159090fda391ad78fc>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Detect the highest API version the remote server supports
    `commit <https://codeberg.org/freeipa/freeipa/commit/d322bbfb3fd745733ae3ecf245f099f1c3ede9a7>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Refine restricting CA profiles to known subjects
    `commit <https://codeberg.org/freeipa/freeipa/commit/f74ff2136488be7fae4c3f99c5f25e0ccd18a3b8>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Sort when comparing tuples in the xmlrpc tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/56620f400adb183ebd9c37ee69876bc108913f30>`__
 -  Set minimum version of certmonger and PKI for PKI-API
    `commit <https://codeberg.org/freeipa/freeipa/commit/372468511d18e8b609d7724670713373f01defa1>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Reduce the log level before calling PKI functions
    `commit <https://codeberg.org/freeipa/freeipa/commit/1729aa4e66fbd2ec38e51a90699f1d481cb55995>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Retrieve all cert profiles from the CA with --all
    `commit <https://codeberg.org/freeipa/freeipa/commit/1c107542cf1113079c5562b490c2520663153f0f>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Configure renewals to use the IPA JSON API
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8425bd88dfe10e0cb4901ac93b87a3110247097>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Use PKIClient instead of deprecated PKIConnection
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a33bccabd11875d5da16680c1f4213c2c12af13>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Remove the RestClient class
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5fc5e0fdf87c7b8e23e0289f0b6d810d9335aad>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Use the APIClient instead of direct REST calls for ACME
    `commit <https://codeberg.org/freeipa/freeipa/commit/191aec5a5278368a4af1836178442f08dfc791b2>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Replace REST with PKI python API for cert and LWCA
    `commit <https://codeberg.org/freeipa/freeipa/commit/43f0284080b9ed51d929ce41bc3bc2e891ffecb5>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Add config option for RSA key size for HTTP, DS, PKINIT, RA certs
    `commit <https://codeberg.org/freeipa/freeipa/commit/5d55b4efb24f042142b4c25e72b7c5f6ed1fe305>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Use the pki tool to bootstrap certificates during installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/cdc8054453cb83c9b7fa9628c86f4566a91815f8>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Temp commit
    `commit <https://codeberg.org/freeipa/freeipa/commit/b94848ccff807951bacfa42886ec91342094e85e>`__
 -  Include the HSM token name when creating LWCAs
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b5caf9dbd31117a88421c639c325f58bee5c93c>`__
-   `#9865 <https://pagure.io/freeipa/issue/9865>`__
+   `#9865 <https://codeberg.org/freeipa/freeipa/issues/9865>`__
 -  Use Augeas when updating dbmodules in krb5.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/9605ea9a0b1f190f931e0b491b8ccb9146fa409d>`__
-   `#5913 <https://pagure.io/freeipa/issue/5913>`__,
-   `#9862 <https://pagure.io/freeipa/issue/9862>`__
+   `#5913 <https://codeberg.org/freeipa/freeipa/issues/5913>`__,
+   `#9862 <https://codeberg.org/freeipa/freeipa/issues/9862>`__
 -  Add support for libpwpolicy credit to password policy
    `commit <https://codeberg.org/freeipa/freeipa/commit/892fea881a6ceef80affd6d6a3fb9b5afafa969b>`__
-   `#9835 <https://pagure.io/freeipa/issue/9835>`__
+   `#9835 <https://codeberg.org/freeipa/freeipa/issues/9835>`__
 -  Enforce uniqueness across krbprincipalname and krbcanonicalname
    `commit <https://codeberg.org/freeipa/freeipa/commit/b866ec296b1425d9dba8ab27de78c8519ae24428>`__
 -  Catch decoding errors in CertificateSigningRequest parameters
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc459c8c66349a5fecb2e1060f1fd7b98634bc7e>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Don't let lack of subca in PKI prevent LDAP deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/46b7c16be13c755ccbf87ab4252fe511f68dfd3a>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Test that password expiration date past 2038 works
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2a8f5cc9f6ff8f1d6af59f3a384fda3ca8aa93a>`__
-   `#2496 <https://pagure.io/freeipa/issue/2496>`__
+   `#2496 <https://codeberg.org/freeipa/freeipa/issues/2496>`__
 -  Test that certificates beyond 2038 can be parsed
    `commit <https://codeberg.org/freeipa/freeipa/commit/9f49a8daa6d5a2af247efb81e6cddbf9a777a17f>`__
-   `#2496 <https://pagure.io/freeipa/issue/2496>`__
+   `#2496 <https://codeberg.org/freeipa/freeipa/issues/2496>`__
 -  Add token options to immutables for pki override
    `commit <https://codeberg.org/freeipa/freeipa/commit/6346ca71d7e4ebbd5737a91372849f2c00b3d293>`__
 -  Set krbCanonicalName=admin@REALM on the admin user
    `commit <https://codeberg.org/freeipa/freeipa/commit/6b9400c135ed16b10057b350cc9ce42aa0e862d4>`__
 -  Fix some issues identified by a static analyzer
    `commit <https://codeberg.org/freeipa/freeipa/commit/111e0f04bbcffc6b9fcd3c9e15aa56963b6ea42a>`__
-   `#9365 <https://pagure.io/freeipa/issue/9365>`__,
-   `#9468 <https://pagure.io/freeipa/issue/9468>`__
+   `#9365 <https://codeberg.org/freeipa/freeipa/issues/9365>`__,
+   `#9468 <https://codeberg.org/freeipa/freeipa/issues/9468>`__
 -  Add --domain option to ipa-client-automount for DNS discovery
    `commit <https://codeberg.org/freeipa/freeipa/commit/a58479b0b9d8003b9dd77ef05732edffdd34a7e4>`__
-   `#9780 <https://pagure.io/freeipa/issue/9780>`__
+   `#9780 <https://codeberg.org/freeipa/freeipa/issues/9780>`__
 -  Test: dnf5 handles updating itself differently than dnf4
    `commit <https://codeberg.org/freeipa/freeipa/commit/b7c17c70a18382aa156327618f5c961eb16fc595>`__
 -  Make the Azure template work with both dnf4 and dnf5
@@ -1618,123 +1618,123 @@ Rob Crittenden (73)
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e254aee3dd2ba0018346821fc79bf2e3ff7ec83>`__
 -  Address deprecation warning in ipa-replica-manage
    `commit <https://codeberg.org/freeipa/freeipa/commit/9743fb96f26bd1c216ba81d3689b2718fb081f3a>`__
-   `#9771 <https://pagure.io/freeipa/issue/9771>`__
+   `#9771 <https://codeberg.org/freeipa/freeipa/issues/9771>`__
 -  Don't require certificates to have unique ipaCertSubject
    `commit <https://codeberg.org/freeipa/freeipa/commit/f91b677ada376034b25d50e78475237c5976770e>`__
-   `#9652 <https://pagure.io/freeipa/issue/9652>`__
+   `#9652 <https://codeberg.org/freeipa/freeipa/issues/9652>`__
 -  Drop python 2 support in ipaserver/install/ca.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d7f51c115e255873f09fc73d5246b2745016a76>`__
 -  Drop python 2 support in installutils.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a9c1dde579bb048e3d90cfafa93dfd8eef359c2>`__
 -  Drop python v2 in ipaserver/install/certs.py for lint errors
    `commit <https://codeberg.org/freeipa/freeipa/commit/56be7b460e7fc070847e589435c951dfba84c13d>`__
-   `#9738 <https://pagure.io/freeipa/issue/9738>`__
+   `#9738 <https://codeberg.org/freeipa/freeipa/issues/9738>`__
 -  Log failed auth attempts over LDAP when a user is locked
    `commit <https://codeberg.org/freeipa/freeipa/commit/dfcc25525ac8f2be4a5ecd8b7bcac8f282b9c4cd>`__
-   `#9742 <https://pagure.io/freeipa/issue/9742>`__
+   `#9742 <https://codeberg.org/freeipa/freeipa/issues/9742>`__
 -  Remove the migration of the RA cert from mod_nss to mod_ssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/42a94e9998804de7470eaf943b03297b06110f75>`__
-   `#9739 <https://pagure.io/freeipa/issue/9739>`__
+   `#9739 <https://codeberg.org/freeipa/freeipa/issues/9739>`__
 -  Remove migration from mod_nss to mod_ssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/2085b61cf66d55fe34a66c80af3cefd199624c65>`__
-   `#9739 <https://pagure.io/freeipa/issue/9739>`__
+   `#9739 <https://codeberg.org/freeipa/freeipa/issues/9739>`__
 -  Fix some memory errors identified by a static analyzer
    `commit <https://codeberg.org/freeipa/freeipa/commit/0dee69d771025f9e2780a592f3a3b82bb75032be>`__
-   `#9698 <https://pagure.io/freeipa/issue/9698>`__
+   `#9698 <https://codeberg.org/freeipa/freeipa/issues/9698>`__
 -  Use new(er) PKI connection API in ipa-pki-wait-running
    `commit <https://codeberg.org/freeipa/freeipa/commit/8fda2e0dc7c9a029ef365fb0b954dbe88e6931c5>`__
-   `#9691 <https://pagure.io/freeipa/issue/9691>`__
+   `#9691 <https://codeberg.org/freeipa/freeipa/issues/9691>`__
 -  Validate the default e-mail domain in the config plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/018b3d3dc6d26ec50f73aaea675ecfb8813aaea1>`__
-   `#9680 <https://pagure.io/freeipa/issue/9680>`__
+   `#9680 <https://codeberg.org/freeipa/freeipa/issues/9680>`__
 -  Align startup_timeout with the systemd default and document it
    `commit <https://codeberg.org/freeipa/freeipa/commit/4952dff42df78ed57ac397dd8026c191ae3c9453>`__
-   `#9743 <https://pagure.io/freeipa/issue/9743>`__
+   `#9743 <https://codeberg.org/freeipa/freeipa/issues/9743>`__
 -  Configure the pki-tomcatd service systemd timeout
    `commit <https://codeberg.org/freeipa/freeipa/commit/11b4ef749c709738454f7fd72083b430808b93dd>`__
-   `#9743 <https://pagure.io/freeipa/issue/9743>`__
+   `#9743 <https://codeberg.org/freeipa/freeipa/issues/9743>`__
 -  Suppress spurious failure messages when uninstalling ACME
    `commit <https://codeberg.org/freeipa/freeipa/commit/18c4a2f9e32728765af3044b2c88fec033c43921>`__
-   `#9740 <https://pagure.io/freeipa/issue/9740>`__
+   `#9740 <https://codeberg.org/freeipa/freeipa/issues/9740>`__
 -  Add a message where the ipa service restarted at end of install
    `commit <https://codeberg.org/freeipa/freeipa/commit/ac931764341a4832ec0245a7bb01ca53cd777cd0>`__
-   `#9741 <https://pagure.io/freeipa/issue/9741>`__
+   `#9741 <https://codeberg.org/freeipa/freeipa/issues/9741>`__
 -  Write out the PKI admin certificate as a PEM file
    `commit <https://codeberg.org/freeipa/freeipa/commit/66335486954137aa998d5e2ba939e67a5d82f464>`__
-   `#9735 <https://pagure.io/freeipa/issue/9735>`__
+   `#9735 <https://codeberg.org/freeipa/freeipa/issues/9735>`__
 -  Apply certmonger_timeout to start_tracking and request_cert
    `commit <https://codeberg.org/freeipa/freeipa/commit/c5300a312775676ce64a3aac3cde2d83ae5f2fde>`__
-   `#9725 <https://pagure.io/freeipa/issue/9725>`__
+   `#9725 <https://codeberg.org/freeipa/freeipa/issues/9725>`__
 -  Add 30-second timeout for certmonger request/start tracking
    `commit <https://codeberg.org/freeipa/freeipa/commit/4776a8babdd25b8fa1afa7e826fd8d153b90f31e>`__
-   `#9725 <https://pagure.io/freeipa/issue/9725>`__
+   `#9725 <https://codeberg.org/freeipa/freeipa/issues/9725>`__
 -  Pass all pkiuser groups as suplementary when validating an HSM
    `commit <https://codeberg.org/freeipa/freeipa/commit/efadc564eb4ff52375d2c80580f4bc82d5cb11df>`__
-   `#9709 <https://pagure.io/freeipa/issue/9709>`__
+   `#9709 <https://codeberg.org/freeipa/freeipa/issues/9709>`__
 -  Allow looking up constants.Group by gid in addition to name
    `commit <https://codeberg.org/freeipa/freeipa/commit/65ed1aa1ff093de5dc49c5e7e2ee7cf0f71b225a>`__
-   `#9709 <https://pagure.io/freeipa/issue/9709>`__
+   `#9709 <https://codeberg.org/freeipa/freeipa/issues/9709>`__
 -  Don't drop certificates in cert-find if the LWCA was removed
    `commit <https://codeberg.org/freeipa/freeipa/commit/0eafb03110b6ae4c80680e5c451661e1cf41db77>`__
-   `#9661 <https://pagure.io/freeipa/issue/9661>`__
+   `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__
 -  Enable pruning when Random Serial Numbers are enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f304bac61eadbacf4f176421c6927b92b74685e>`__
-   `#9661 <https://pagure.io/freeipa/issue/9661>`__
+   `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__
 -  Set required version of 389-ds for VLV fix on F40/41
    `commit <https://codeberg.org/freeipa/freeipa/commit/2cd2b8fe43036a97f1051c5aa76fd5ed28e7ed6c>`__
 -  Add RSN-by-default test to nightly builds
    `commit <https://codeberg.org/freeipa/freeipa/commit/9248e2df86c3a12c277bd783cd8c9ca7e9603286>`__
-   `#9661 <https://pagure.io/freeipa/issue/9661>`__
+   `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__
 -  ipatests: Test that when lmdb is available, enable RSN
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed70380cbb97a355a4d84ca61fd27120cda902b9>`__
-   `#9661 <https://pagure.io/freeipa/issue/9661>`__
+   `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__
 -  Change default to RSN when 389-ds uses the mdb backend
    `commit <https://codeberg.org/freeipa/freeipa/commit/3777d2b06299454766ab70ee479a829d5f6b7fc0>`__
-   `#9661 <https://pagure.io/freeipa/issue/9661>`__
+   `#9661 <https://codeberg.org/freeipa/freeipa/issues/9661>`__
 -  Small fixup to determine which ACME uninstaller to use
    `commit <https://codeberg.org/freeipa/freeipa/commit/48479d40b24ac532453ff49d4eb9003c73b9b403>`__
-   `#9673 <https://pagure.io/freeipa/issue/9673>`__,
-   `#9674 <https://pagure.io/freeipa/issue/9674>`__
+   `#9673 <https://codeberg.org/freeipa/freeipa/issues/9673>`__,
+   `#9674 <https://codeberg.org/freeipa/freeipa/issues/9674>`__
 -  Don't rely on removing the CA to uninstall the ACME depoyment
    `commit <https://codeberg.org/freeipa/freeipa/commit/273f68b77b75845cc7194187405d8c8c8203b834>`__
-   `#9673 <https://pagure.io/freeipa/issue/9673>`__,
-   `#9674 <https://pagure.io/freeipa/issue/9674>`__
+   `#9673 <https://codeberg.org/freeipa/freeipa/issues/9673>`__,
+   `#9674 <https://codeberg.org/freeipa/freeipa/issues/9674>`__
 -  Fix some resource leaks identified by a static analyzer
    `commit <https://codeberg.org/freeipa/freeipa/commit/15de71ae61b0f97689bc8cf38256446f3e7922c1>`__
-   `#9367 <https://pagure.io/freeipa/issue/9367>`__
+   `#9367 <https://codeberg.org/freeipa/freeipa/issues/9367>`__
 -  Ignore TripleDES python-cryptography import warnings
    `commit <https://codeberg.org/freeipa/freeipa/commit/2aa49424ff46a1e388514e8f91dca3b6b7b8b6fe>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  Correct usage of public_key_algorithm_oid in ipalib/x509
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ef3396647bd0049cbee2dcbe91cd3c536dccc78>`__
-   `#9641 <https://pagure.io/freeipa/issue/9641>`__
+   `#9641 <https://codeberg.org/freeipa/freeipa/issues/9641>`__
 -  Force a logout in KerberosSession if a login is needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/64937571fdf3534b89d8db9ccb8b5ac1abfb5a6d>`__
-   `#9624 <https://pagure.io/freeipa/issue/9624>`__
+   `#9624 <https://codeberg.org/freeipa/freeipa/issues/9624>`__
 -  Log errors reported by adtrustinstance.check_inst() using logger
    `commit <https://codeberg.org/freeipa/freeipa/commit/1dc84ba7ebf1bb3b2734a9ea0dd1a4ba6660c93b>`__
-   `#9637 <https://pagure.io/freeipa/issue/9637>`__
+   `#9637 <https://codeberg.org/freeipa/freeipa/issues/9637>`__
 -  ipatests: Fix usage of token_password_file
    `commit <https://codeberg.org/freeipa/freeipa/commit/fd5ce0caf5741aaba1f15296f2b077043a290883>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Run HSM validation as pkiuser to verify token permissions
    `commit <https://codeberg.org/freeipa/freeipa/commit/202de166c6057cdfd9bd024069c8e9e6a87c34d0>`__
-   `#9626 <https://pagure.io/freeipa/issue/9626>`__
+   `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
 -  Fix a copy/paste issue when detecting the HSM SELinux subpackage
    `commit <https://codeberg.org/freeipa/freeipa/commit/c40ce0e1ff01cbecf2d83377f48c0ace55fd1ed9>`__
-   `#9636 <https://pagure.io/freeipa/issue/9636>`__
+   `#9636 <https://codeberg.org/freeipa/freeipa/issues/9636>`__
 -  Include token password options in ipa-kra-install man page
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d5461bea785c43a14725a2fb8f5f705758c54ed>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Re-organize HSM validation to be more consistent/less duplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/23de845987c0776f77d8b8caeabf51f312bca5a6>`__
-   `#9603 <https://pagure.io/freeipa/issue/9603>`__
+   `#9603 <https://codeberg.org/freeipa/freeipa/issues/9603>`__
 -  Fix syntax error in the selinux-luna %postun script
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0f15a6d01a592c9f8ecc9a904691fab80ba284b>`__
-   `#9629 <https://pagure.io/freeipa/issue/9629>`__
+   `#9629 <https://codeberg.org/freeipa/freeipa/issues/9629>`__
 -  Use a unique task name for each backend in ipa-backup
    `commit <https://codeberg.org/freeipa/freeipa/commit/65bea69358b07fdd54d4f890a3752548200dd5bd>`__
-   `#9584 <https://pagure.io/freeipa/issue/9584>`__
+   `#9584 <https://codeberg.org/freeipa/freeipa/issues/9584>`__
 
 .. _ricky_tigg_3:
 
@@ -1755,10 +1755,10 @@ Rafael Guterres Jeffman (2)
 
 -  ipa-idrange-fix: Fix typo when ID under 1000 is present.
    `commit <https://codeberg.org/freeipa/freeipa/commit/c98d1b819e1fc3f4a63a2e61823b69be996e95ed>`__
-   `#9885 <https://pagure.io/freeipa/issue/9885>`__
+   `#9885 <https://codeberg.org/freeipa/freeipa/issues/9885>`__
 -  Use correct capitalization for GitHub and GitLab
    `commit <https://codeberg.org/freeipa/freeipa/commit/9d7689f95913bff472661b5f9e4ad11c07cd405d>`__
-   `#9811 <https://pagure.io/freeipa/issue/9811>`__
+   `#9811 <https://codeberg.org/freeipa/freeipa/issues/9811>`__
 
 .. _sam_morris_2:
 
@@ -1768,11 +1768,11 @@ Sam Morris (2)
 -  Fix ipa-client-install failure when a trusted CA's distinguished name
    contains slash characters
    `commit <https://codeberg.org/freeipa/freeipa/commit/64809910912237ff40a18eeda9ed1c9e2e21dfaa>`__
-   `#8924 <https://pagure.io/freeipa/issue/8924>`__
+   `#8924 <https://codeberg.org/freeipa/freeipa/issues/8924>`__
 -  Fix a couple of instances of the "no-break control character" being
    used inadvertently
    `commit <https://codeberg.org/freeipa/freeipa/commit/2df2066a4ea5113187039371adc25fcd1d4ab7b5>`__
-   `#9665 <https://pagure.io/freeipa/issue/9665>`__
+   `#9665 <https://codeberg.org/freeipa/freeipa/issues/9665>`__
 
 .. _sumit_bose_1:
 
@@ -1799,17 +1799,17 @@ Stanislav Levin (4)
 
 -  install: make use of shared temp directory for hsm validation
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e436ff6fe3c78f605cd63e98bd560cfefb5a293>`__
-   `#9831 <https://pagure.io/freeipa/issue/9831>`__
+   `#9831 <https://codeberg.org/freeipa/freeipa/issues/9831>`__
 -  adtrust: add missing ipaAllowedOperations objectclass
    `commit <https://codeberg.org/freeipa/freeipa/commit/e184864a3025a6ccd522556fffa4014e6ae7bbc1>`__
-   `#9471 <https://pagure.io/freeipa/issue/9471>`__,
-   `#9712 <https://pagure.io/freeipa/issue/9712>`__
+   `#9471 <https://codeberg.org/freeipa/freeipa/issues/9471>`__,
+   `#9712 <https://codeberg.org/freeipa/freeipa/issues/9712>`__
 -  pyca: adapt import paths for TripleDES cipher
    `commit <https://codeberg.org/freeipa/freeipa/commit/bc31c2700c3779cfad688eb098042060bf09df3c>`__
-   `#9708 <https://pagure.io/freeipa/issue/9708>`__
+   `#9708 <https://codeberg.org/freeipa/freeipa/issues/9708>`__
 -  ipatests: make TestDuplicates teardowns order agnostic
    `commit <https://codeberg.org/freeipa/freeipa/commit/18d550a3367710618675b87f0157685165bfe444>`__
-   `#9571 <https://pagure.io/freeipa/issue/9571>`__
+   `#9571 <https://codeberg.org/freeipa/freeipa/issues/9571>`__
 
 .. _sumedh_sidhaye_2:
 
@@ -1832,7 +1832,7 @@ Sudhir Menon (22)
    `commit <https://codeberg.org/freeipa/freeipa/commit/15d5093f6d0856fcd6ad76e03ad78bedfecad972>`__
 -  ipatests: Tests for ipa-migrate tool with ldif file
    `commit <https://codeberg.org/freeipa/freeipa/commit/82fa9f1e887d6b3a83fb4f1edc0a520d7dcfbc2d>`__
-   `#9776 <https://pagure.io/freeipa/issue/9776>`__
+   `#9776 <https://codeberg.org/freeipa/freeipa/issues/9776>`__
 -  ipatests: prci nightly definitions for 32BitIdranges
    `commit <https://codeberg.org/freeipa/freeipa/commit/43033b0c01234564a826b60f0a00943b92a5ef06>`__
 -  ipatests: Tests for 32BitIdranges.
@@ -1852,31 +1852,31 @@ Sudhir Menon (22)
    `commit <https://codeberg.org/freeipa/freeipa/commit/08450eefe6ef671a11dcc9572cdcec20819c2dd8>`__
 -  Fix the typo in ipa_migrate_constants.
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a9ee0d85b1d8b05dcb88e965a003fff466ffdd0>`__
-   `#9715 <https://pagure.io/freeipa/issue/9715>`__
+   `#9715 <https://codeberg.org/freeipa/freeipa/issues/9715>`__
 -  ipatests: Updated nightly definitions for ipa-ipa-migration
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8ed1d70f7080700726b66c67181574972bcfcb7>`__
 -  ipatests: Tests for ipa-migrate tool
    `commit <https://codeberg.org/freeipa/freeipa/commit/07f33365d8868bf9c62fe1617f97b6073419a14b>`__
 -  ipatests: Test for ipa hbac rule duplication
    `commit <https://codeberg.org/freeipa/freeipa/commit/e1f96ffc2070ba7036c1108c6621450ab8f3f1f5>`__
-   `#9640 <https://pagure.io/freeipa/issue/9640>`__
+   `#9640 <https://codeberg.org/freeipa/freeipa/issues/9640>`__
 -  ipatests: Activate ssh in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/c37f4d09e2c97ee90a0acebf2c3bc30fed4e85ad>`__
-   `#9649 <https://pagure.io/freeipa/issue/9649>`__
+   `#9649 <https://codeberg.org/freeipa/freeipa/issues/9649>`__
 -  ipatests: Fixes for ipa-idrange-fix testsuite
    `commit <https://codeberg.org/freeipa/freeipa/commit/26af2164a464f4df544d6850eb1ba21b14df45a6>`__
 -  ipatests: Check Default PAC type is added to config
    `commit <https://codeberg.org/freeipa/freeipa/commit/b07f1d970b2ca4877daa6232acd6786bcebeb5a7>`__
-   `#9632 <https://pagure.io/freeipa/issue/9632>`__
+   `#9632 <https://codeberg.org/freeipa/freeipa/issues/9632>`__
 -  ipatests: Test to check that the configured value for
    "nsslapd-ignore-time-skew" remains on even after a "force-sync" is
    done
    `commit <https://codeberg.org/freeipa/freeipa/commit/b56d434953b93a0cecd2ee57194862e36b2ae3b2>`__
-   `#9635 <https://pagure.io/freeipa/issue/9635>`__
+   `#9635 <https://codeberg.org/freeipa/freeipa/issues/9635>`__
 -  ipatests: Replace 'usermod -r' command with 'gpasswd -d' in
    test_hsm.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/58c1fdd41681c15f39b59bbb5e39b2e1cf245c6c>`__
-   `#9626 <https://pagure.io/freeipa/issue/9626>`__
+   `#9626 <https://codeberg.org/freeipa/freeipa/issues/9626>`__
 -  ipatests: ipa-migrate tool with -Z option (CACERTFILE)
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8189933c72ee0b312a91ec5d63179e6e75661a5>`__
 -  Added new testsuite(ipa_ipa_migration) in prci definitions
@@ -1907,20 +1907,20 @@ Thomas Woerner (5)
 
 -  Replica: Request cert for DoT before setting up bind
    `commit <https://codeberg.org/freeipa/freeipa/commit/47626a950f343c3ae7c49bc99f4c25d976c0bdb6>`__
-   `#9808 <https://pagure.io/freeipa/issue/9808>`__
+   `#9808 <https://codeberg.org/freeipa/freeipa/issues/9808>`__
 -  ipaserver/install/dns.py: Allow to Turn off DNSSEC validation for
    unbound
    `commit <https://codeberg.org/freeipa/freeipa/commit/0bc089681c77c7c65412ca8f02b724ff9088e0f7>`__
-   `#9805 <https://pagure.io/freeipa/issue/9805>`__
+   `#9805 <https://codeberg.org/freeipa/freeipa/issues/9805>`__
 -  ipa-client-install: New --no-dnssec-validation option
    `commit <https://codeberg.org/freeipa/freeipa/commit/4b877c7ccd68a829b3d05aa3b5de01df5730a4dd>`__
-   `#9805 <https://pagure.io/freeipa/issue/9805>`__
+   `#9805 <https://codeberg.org/freeipa/freeipa/issues/9805>`__
 -  ipa-client-install: Fix nsupdate issues when dns_over_tls is enabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/974a507ee0105fc05e455df6e5316e0e84f3f181>`__
-   `#9806 <https://pagure.io/freeipa/issue/9806>`__
+   `#9806 <https://codeberg.org/freeipa/freeipa/issues/9806>`__
 -  ipa_sidgen: Allow sidgen_task to continue after finding issues
    `commit <https://codeberg.org/freeipa/freeipa/commit/faa0aa5de1b4618bc0f1fcee98f136983e21e735>`__
-   `#9618 <https://pagure.io/freeipa/issue/9618>`__
+   `#9618 <https://codeberg.org/freeipa/freeipa/issues/9618>`__
 
 .. _vectinx_1:
 
@@ -1929,7 +1929,7 @@ vectinx (1)
 
 -  slapi-plugins: Add replication checking to the Modrdn plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/a4a218b4ebe490a1d55132e5a19202ca675d393a>`__
-   `#9867 <https://pagure.io/freeipa/issue/9867>`__
+   `#9867 <https://codeberg.org/freeipa/freeipa/issues/9867>`__
 
 .. _vasily_parfenov_1:
 

--- a/src/release-notes/4-13-1.rst
+++ b/src/release-notes/4-13-1.rst
@@ -68,30 +68,30 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#9839 <https://pagure.io/freeipa/issue/9839>`__ [RFE] Allow
+-  `#9839 <https://codeberg.org/freeipa/freeipa/issues/9839>`__ [RFE] Allow
    ipa-certupdate to force specific server to get updates from
--  `#9842 <https://pagure.io/freeipa/issue/9842>`__ Add ability to
+-  `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__ Add ability to
    configure external password reset agents with ipa_pwd_extop
--  `#9876 <https://pagure.io/freeipa/issue/9876>`__ Incorrect exception
+-  `#9876 <https://codeberg.org/freeipa/freeipa/issues/9876>`__ Incorrect exception
    type in remove_edge()
--  `#9884 <https://pagure.io/freeipa/issue/9884>`__
+-  `#9884 <https://codeberg.org/freeipa/freeipa/issues/9884>`__
    test_integration/test_ipa_ipa_migration.py::TestIPAMigrationProdMode
    fails in local setup
--  `#9891 <https://pagure.io/freeipa/issue/9891>`__ Incorrect error type
+-  `#9891 <https://codeberg.org/freeipa/freeipa/issues/9891>`__ Incorrect error type
    when user logs in multiple times with wrong password
--  `#9892 <https://pagure.io/freeipa/issue/9892>`__ After upgrade from
+-  `#9892 <https://codeberg.org/freeipa/freeipa/issues/9892>`__ After upgrade from
    9.7 to 9.8 ipactl restart fails to restart winbind service
--  `#9895 <https://pagure.io/freeipa/issue/9895>`__ Memory leaks in IPA
+-  `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__ Memory leaks in IPA
    plugins
--  `#9902 <https://pagure.io/freeipa/issue/9902>`__ Nightly test failure
+-  `#9902 <https://codeberg.org/freeipa/freeipa/issues/9902>`__ Nightly test failure
    in test_installation.py::TestInstallWithCA_DNS4::test_number_of_zones
--  `#9910 <https://pagure.io/freeipa/issue/9910>`__ Test failure in
+-  `#9910 <https://codeberg.org/freeipa/freeipa/issues/9910>`__ Test failure in
    TestIPAMigratewithBackupRestore::test_ipa_migrate_stage_mode
--  `#9913 <https://pagure.io/freeipa/issue/9913>`__ Upgrade from RHEL
+-  `#9913 <https://codeberg.org/freeipa/freeipa/issues/9913>`__ Upgrade from RHEL
    9.4 to 9.6+ breaks ipa-dnskeysyncd
--  `#9914 <https://pagure.io/freeipa/issue/9914>`__ AddressSanitizer:
+-  `#9914 <https://codeberg.org/freeipa/freeipa/issues/9914>`__ AddressSanitizer:
    SEGV ipa-pwd-extop/common.c:584 in ipapwd_gen_checks
--  `#9915 <https://pagure.io/freeipa/issue/9915>`__ Support replaceable
+-  `#9915 <https://codeberg.org/freeipa/freeipa/issues/9915>`__ Support replaceable
    artwork for modern-ui
 
 .. _detailed_changelog_since_4.13.0:
@@ -106,7 +106,7 @@ MOHAMMAD SAMI (1)
 
 -  Fix incorrect error handling in ipapython/graph.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/f094818347d48606e186e8ad9c6d05ce74c04560>`__
-   `#9876 <https://pagure.io/freeipa/issue/9876>`__
+   `#9876 <https://codeberg.org/freeipa/freeipa/issues/9876>`__
 
 .. _anuja_more_2:
 
@@ -115,7 +115,7 @@ Anuja More (2)
 
 -  ipatests: sysaccounts: add missing integration/webui/xmlrpc tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/386e9f37af484fc018b174ffcbe5f2e59a783cb4>`__
-   `#9842 <https://pagure.io/freeipa/issue/9842>`__
+   `#9842 <https://codeberg.org/freeipa/freeipa/issues/9842>`__
 -  sysaccount_mod: Use object.\__setattr\_\_ to set allow_empty_update
    in exception handler
    `commit <https://codeberg.org/freeipa/freeipa/commit/f580f12e5bcace2dbbee493f093bd62937cc2e3a>`__
@@ -136,7 +136,7 @@ Aleksandr Sharov (1)
 -  Adding option --force-server to specify a server to ipa-certupdate
    tool.
    `commit <https://codeberg.org/freeipa/freeipa/commit/573c9194d9894eb2bea6db77e142cdd899e78bd6>`__
-   `#9839 <https://pagure.io/freeipa/issue/9839>`__
+   `#9839 <https://codeberg.org/freeipa/freeipa/issues/9839>`__
 
 .. _carla_martinez_1:
 
@@ -145,7 +145,7 @@ Carla Martinez (1)
 
 -  Fix: Incorrect auth error message
    `commit <https://codeberg.org/freeipa/freeipa/commit/f39acce91176c043dd531646a2acd0b7678779e2>`__
-   `#9891 <https://pagure.io/freeipa/issue/9891>`__
+   `#9891 <https://codeberg.org/freeipa/freeipa/issues/9891>`__
 
 .. _david_hanina_2:
 
@@ -156,7 +156,7 @@ David Hanina (2)
    `commit <https://codeberg.org/freeipa/freeipa/commit/250ab5412cc51ed20b9bbd647bb4e8c6c8ed927f>`__
 -  Delete modern-ui images for RHEL
    `commit <https://codeberg.org/freeipa/freeipa/commit/ffde59d26020381ffe61da30d20af3d20f7550d3>`__
-   `#9915 <https://pagure.io/freeipa/issue/9915>`__
+   `#9915 <https://codeberg.org/freeipa/freeipa/issues/9915>`__
 
 .. _florence_blanc_renaud_6:
 
@@ -165,19 +165,19 @@ Florence Blanc-Renaud (6)
 
 -  ipa-migrate: avoid KeyError before attributes are normalized
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b09e9b7240ccedca60e812ed1b2337ed476e471>`__
-   `#9910 <https://pagure.io/freeipa/issue/9910>`__
+   `#9910 <https://codeberg.org/freeipa/freeipa/issues/9910>`__
 -  Upgrade: use openssl_engine on rhel9
    `commit <https://codeberg.org/freeipa/freeipa/commit/6ddd9d978ac1d70acf688667515f916ee4373c42>`__
-   `#9913 <https://pagure.io/freeipa/issue/9913>`__
+   `#9913 <https://codeberg.org/freeipa/freeipa/issues/9913>`__
 -  ipatests: do not allow zone overlap for TestInstallWithCA_DNS4
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5458214311abc3ee1fae7133487fb1ad6977011>`__
-   `#9902 <https://pagure.io/freeipa/issue/9902>`__
+   `#9902 <https://codeberg.org/freeipa/freeipa/issues/9902>`__
 -  ipatest: add an integration test for samba upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/c03f7eb2b9a0ee36d0ad396f3e4e4e8a6e40ecd2>`__
-   `#9892 <https://pagure.io/freeipa/issue/9892>`__
+   `#9892 <https://codeberg.org/freeipa/freeipa/issues/9892>`__
 -  Trust: fix tdo with WITH_FOREST
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f0cd075e5a588628a98d3b4a95e755af59845d7>`__
-   `#9892 <https://pagure.io/freeipa/issue/9892>`__
+   `#9892 <https://codeberg.org/freeipa/freeipa/issues/9892>`__
 -  Nightly test definitions: configure 4.13 branch
    `commit <https://codeberg.org/freeipa/freeipa/commit/b575e3dc39b84af69fd71ddb77c01fe4b24a2d66>`__
 
@@ -206,10 +206,10 @@ Rob Crittenden (2)
 
 -  ipa-pwd-extop: Don't manipulate the config if not retrieved
    `commit <https://codeberg.org/freeipa/freeipa/commit/d6f7c0b14c7211b603b47e8fe3851ba0197ed38c>`__
-   `#9914 <https://pagure.io/freeipa/issue/9914>`__
+   `#9914 <https://codeberg.org/freeipa/freeipa/issues/9914>`__
 -  ipatests: Add the remote IP before running ipa-migrate
    `commit <https://codeberg.org/freeipa/freeipa/commit/f28c8a2bc39e44b1ec5883fe828625e5a5575adb>`__
-   `#9884 <https://pagure.io/freeipa/issue/9884>`__
+   `#9884 <https://codeberg.org/freeipa/freeipa/issues/9884>`__
 
 .. _viktor_ashirov_17:
 
@@ -218,52 +218,52 @@ Viktor Ashirov (17)
 
 -  ipa-pwd-extop: fix valueset memory leak in \`ipapwd_get_cur_kvno()\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/edc00aae575399a6c11f7b9d1ca5bbd833459274>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix memory leaks in \`ipapwd_gen_hashes()\` error path
    `commit <https://codeberg.org/freeipa/freeipa/commit/614b3cdc872427e632870413b8f44d6ba1373cc8>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix password history values memory leak
    `commit <https://codeberg.org/freeipa/freeipa/commit/370cdf03572463688445cece88bacbc8b797cc5d>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix NT hash string memory leak
    `commit <https://codeberg.org/freeipa/freeipa/commit/f5e47c974b4e5fa32e9a00db89df16bee2fd3f84>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix bind DN memory leaks in pre-op handlers
    `commit <https://codeberg.org/freeipa/freeipa/commit/1545c3fd7dc9c5765dcdf83bbb591c46eb489de3>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix memory leaks in \`ipapwd_pre_add()\`
    `commit <https://codeberg.org/freeipa/freeipa/commit/28979893e620a033878405b9edeaa4bca730f9fc>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix memory leaks of bind DN
    `commit <https://codeberg.org/freeipa/freeipa/commit/1a7819b2c6145f8686771cf305a43589b5028c51>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/8eeccb6dba8861731a786dd1b115a1eac6c1d98d>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: free krbcfg in all exit paths
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba9074c9605bed6466580c10657fc7b1341aacbf>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  topology: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/61bc55c9c3951f7653b6d63be512c654650ffd77>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-enrollment: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/bfc9552d565dc2bb452ae79e2bc972b419e81cad>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-extdom-extop: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/4a62d6141af54b77408628877a1027c3ea5a106f>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-range-check: fix memory leak
    `commit <https://codeberg.org/freeipa/freeipa/commit/0e409d1955d4e2248b05310962671e1f9c8a069e>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-sidgen: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/67ea4467eca5fdb6df9b267445cee41dc5d8691e>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-pwd-extop: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/29699af133ce7c9e1570376c978d4ecce217825f>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-lockout: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/819fddc3d201e5764538878c78ddf3da7c8c0326>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__
 -  ipa-graceperiod: fix memory leaks
    `commit <https://codeberg.org/freeipa/freeipa/commit/c173a70c8581bf25e063766039f0ea875c8f5691>`__
-   `#9895 <https://pagure.io/freeipa/issue/9895>`__
+   `#9895 <https://codeberg.org/freeipa/freeipa/issues/9895>`__

--- a/src/release-notes/4-9-12.rst
+++ b/src/release-notes/4-9-12.rst
@@ -67,82 +67,82 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#5130 <https://pagure.io/freeipa/issue/5130>`__
+-  `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
    (`rhbz#1243261 <https://bugzilla.redhat.com/show_bug.cgi?id=1243261>`__)
    non-admin users cannot search hbac rules
--  `#6044 <https://pagure.io/freeipa/issue/6044>`__
+-  `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
    (`rhbz#1353899 <https://bugzilla.redhat.com/show_bug.cgi?id=1353899>`__)
    ipa-advise: object of type 'type' has no len()
--  `#9195 <https://pagure.io/freeipa/issue/9195>`__
+-  `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
    (`rhbz#2158775 <https://bugzilla.redhat.com/show_bug.cgi?id=2158775>`__)
    Hiding a server does not completely clean up DNS records
--  `#9226 <https://pagure.io/freeipa/issue/9226>`__
+-  `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
    (`rhbz#2124547 <https://bugzilla.redhat.com/show_bug.cgi?id=2124547>`__)
    Infinite redirect loop in the WebUI for user root
--  `#9238 <https://pagure.io/freeipa/issue/9238>`__ Nightly test failure
+-  `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__ Nightly test failure
    (rawhide) in
    test_ipahealthcheck.py::TestIpaHealthCheck::test_ds_configcheck_passwordstorage
--  `#9279 <https://pagure.io/freeipa/issue/9279>`__ ipa-otpd@.service:
+-  `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__ ipa-otpd@.service:
    deprecated syslog setting
--  `#9282 <https://pagure.io/freeipa/issue/9282>`__ Nightly test failure
+-  `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__ Nightly test failure
    in
    test_webui/test_subid.py/test_subid/test_subid_range_deletion_not_allowed
--  `#9285 <https://pagure.io/freeipa/issue/9285>`__ ipa-certupdate
+-  `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__ ipa-certupdate
    restarts HTTPd too early
--  `#9286 <https://pagure.io/freeipa/issue/9286>`__
+-  `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
    (`rhbz#2056009 <https://bugzilla.redhat.com/show_bug.cgi?id=2056009>`__)
    memberManager ACIs aren't allowing group-based manager access due to
    missing upgrade code
--  `#9287 <https://pagure.io/freeipa/issue/9287>`__ [RFE] makeapi should
+-  `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__ [RFE] makeapi should
    validate the generated API doc vs stored doc
--  `#9290 <https://pagure.io/freeipa/issue/9290>`__
+-  `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
    (`rhbz#2149889 <https://bugzilla.redhat.com/show_bug.cgi?id=2149889>`__)
    idm:client is missing dependency on krb5-pkinit.
--  `#9291 <https://pagure.io/freeipa/issue/9291>`__ Nightly test failure
+-  `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__ Nightly test failure
    (rawhide) in test_ipa_dns_systemrecords_check
--  `#9306 <https://pagure.io/freeipa/issue/9306>`__
+-  `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
    (`rhbz#2160389 <https://bugzilla.redhat.com/show_bug.cgi?id=2160389>`__)
    'ERROR Could not remove /tmp/tmpbkw6hawo.ipabkp' can be seen prior to
    'ipa-client-install' command was successful.
--  `#9310 <https://pagure.io/freeipa/issue/9310>`__
+-  `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
    (`rhbz#2162335 <https://bugzilla.redhat.com/show_bug.cgi?id=2162335>`__)
    ipa-trust-add with --range-type=ipa-ad-trust-posix fails while
    creating an ID range
--  `#9314 <https://pagure.io/freeipa/issue/9314>`__ Redundant build
+-  `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__ Redundant build
    dependency on python3-paste (if with lint)
--  `#9315 <https://pagure.io/freeipa/issue/9315>`__ [tests]
+-  `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__ [tests]
    test_ipa_healthcheck_fips_enabled fails on system without
    fips-mode-setup
--  `#9316 <https://pagure.io/freeipa/issue/9316>`__
+-  `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
    (`rhbz#2166324 <https://bugzilla.redhat.com/show_bug.cgi?id=2166324>`__)
    Passwordless (GSSAPI) SSH login with AD user
--  `#9318 <https://pagure.io/freeipa/issue/9318>`__ Incomplete fast
+-  `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__ Incomplete fast
    lint/codestyle check if both Python template files and Python modules
    were changed
--  `#9319 <https://pagure.io/freeipa/issue/9319>`__ [tests]
+-  `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__ [tests]
    TestDNSResolver failures on systems without or empty /etc/resolv.conf
--  `#9320 <https://pagure.io/freeipa/issue/9320>`__
+-  `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
    (`rhbz#2018198 <https://bugzilla.redhat.com/show_bug.cgi?id=2018198>`__)
    RFE - Add a warning note about possible performance impact of the
    Auto Member rebuild task.
--  `#9324 <https://pagure.io/freeipa/issue/9324>`__ ipatests: Frequent
+-  `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__ ipatests: Frequent
    timeout of test_acme
--  `#9326 <https://pagure.io/freeipa/issue/9326>`__ ipatests: timeout of
+-  `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__ ipatests: timeout of
    test_trust
--  `#9329 <https://pagure.io/freeipa/issue/9329>`__ Azure test:
+-  `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__ Azure test:
    WebUI_Unit_Tests are failing
--  `#9333 <https://pagure.io/freeipa/issue/9333>`__ ipa-client-install
+-  `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__ ipa-client-install
    --pkinit-identity can block in unattended mode
--  `#9338 <https://pagure.io/freeipa/issue/9338>`__ Update 'Auth
+-  `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__ Update 'Auth
    indicators' doc string to show 'ipd' usage
--  `#9339 <https://pagure.io/freeipa/issue/9339>`__ Broken support for
+-  `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__ Broken support for
    dnspython < 2
--  `#9349 <https://pagure.io/freeipa/issue/9349>`__
+-  `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
    (`rhbz#2180914 <https://bugzilla.redhat.com/show_bug.cgi?id=2180914>`__)
    Sequence processing failures for group_add using server context
--  `#9355 <https://pagure.io/freeipa/issue/9355>`__ support python
+-  `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__ support python
    cryptography 40.0
--  `#9358 <https://pagure.io/freeipa/issue/9358>`__
+-  `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
    update_dna_shared_config sometimes blocks installation for 2 minutes
 
 .. _detailed_changelog_since_4.9.11:
@@ -158,24 +158,24 @@ Alexander Bokovoy (6)
 -  ipalib/x509: Implement abstract method
    Certificate.verify_directly_issued_by
    `commit <https://codeberg.org/freeipa/freeipa/commit/e43b10858a8014b2b1b6e555bff48ab172f14a9b>`__
-   `#9355 <https://pagure.io/freeipa/issue/9355>`__
+   `#9355 <https://codeberg.org/freeipa/freeipa/issues/9355>`__
 -  Fix tox in Azure CI
    `commit <https://codeberg.org/freeipa/freeipa/commit/53ac81765aaad71ef18e720017454c33df0ab27c>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Use system-wide chromium for webui tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/3593a798cc6a6bc3130c59ec7acf3f534b69158f>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  Don't fail if optional RPM macros file is missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/801308af209167ef84351987cd894c5721e3d853>`__
-   `#9347 <https://pagure.io/freeipa/issue/9347>`__
+   `#9347 <https://codeberg.org/freeipa/freeipa/issues/9347>`__
 -  ipa-kdb: PAC consistency checker needs to handle child domains as
    well
    `commit <https://codeberg.org/freeipa/freeipa/commit/2d7cc19d238e0a20a44bb5422fd369d1e5cf764f>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 -  updates: fix memberManager ACI to allow managers from a specified
    group
    `commit <https://codeberg.org/freeipa/freeipa/commit/651e28c1fb6b86ad1fbd4ea98644e00b7042499c>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -184,16 +184,16 @@ Anuja More (4)
 
 -  ipatests: Test that non admin user can search hbac rule.
    `commit <https://codeberg.org/freeipa/freeipa/commit/3599a4a7e35baa8b936b2c00abe4827be5473212>`__
-   `#5130 <https://pagure.io/freeipa/issue/5130>`__
+   `#5130 <https://codeberg.org/freeipa/freeipa/issues/5130>`__
 -  ipatests: Test ipa-advise is not failing with error.
    `commit <https://codeberg.org/freeipa/freeipa/commit/b2f197d3100d7ca95ead6180fa6b196f1aa77f74>`__
-   `#6044 <https://pagure.io/freeipa/issue/6044>`__
+   `#6044 <https://codeberg.org/freeipa/freeipa/issues/6044>`__
 -  PRCI: update test_trust.py for nightly pipelines.
    `commit <https://codeberg.org/freeipa/freeipa/commit/9577e0b1f5cc4b3569a71eea1657981355eb80f3>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  Add test for SSH with GSSAPI auth.
    `commit <https://codeberg.org/freeipa/freeipa/commit/ed1959dc0cf8823a0ce60e32ce0de7a389ecb942>`__
-   `#9316 <https://pagure.io/freeipa/issue/9316>`__
+   `#9316 <https://codeberg.org/freeipa/freeipa/issues/9316>`__
 
 
 
@@ -206,14 +206,14 @@ Antonio Torres (8)
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2bb386b44ef96a1e90d30ea4d3d37799fd01388>`__
 -  ipaserver: deepcopy objectclasses list from IPA config
    `commit <https://codeberg.org/freeipa/freeipa/commit/62fe608390c41115edf4e356a6cff2ab1a6d0daf>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  API doc: add usage guides for groups, HBAC and sudo rules
    `commit <https://codeberg.org/freeipa/freeipa/commit/e96d91c104b616c175a8c66a6e93a60d5a06e7ab>`__
 -  API doc: add note about ipa show-mappings to usage guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/a6592c6a79f15b0e6eef02a3f3545b9b72bc1705>`__
 -  API doc: validate generated reference
    `commit <https://codeberg.org/freeipa/freeipa/commit/34a06d7f06f35b9aad034f7a4ff99753a0426275>`__
-   `#9287 <https://pagure.io/freeipa/issue/9287>`__
+   `#9287 <https://codeberg.org/freeipa/freeipa/issues/9287>`__
 -  API doc: add basic user management guide
    `commit <https://codeberg.org/freeipa/freeipa/commit/84c4449e93d57f5236f978388cf6561a4866686a>`__
 -  Back to git snapshots
@@ -226,7 +226,7 @@ Carla Martinez (1)
 
 -  Update 'Auth indicators' doc string
    `commit <https://codeberg.org/freeipa/freeipa/commit/42744ebbcab7ef0a6bf5f16d6fca513c323d2fa9>`__
-   `#9338 <https://pagure.io/freeipa/issue/9338>`__
+   `#9338 <https://codeberg.org/freeipa/freeipa/issues/9338>`__
 
 
 
@@ -235,13 +235,13 @@ Christian Heimes (3)
 
 -  Speed up installer by restarting DS after DNA plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/27e9181bdc684915a7f9f15631f4c3dd6ac5f884>`__
-   `#9358 <https://pagure.io/freeipa/issue/9358>`__
+   `#9358 <https://codeberg.org/freeipa/freeipa/issues/9358>`__
 -  Don't block when kinit_pkinit() fails
    `commit <https://codeberg.org/freeipa/freeipa/commit/03f544e83c1f775786bcda211a35f15a0b2a582f>`__
-   `#9333 <https://pagure.io/freeipa/issue/9333>`__
+   `#9333 <https://codeberg.org/freeipa/freeipa/issues/9333>`__
 -  ipa-certupdate: Update client certs before KDC/HTTPd restart
    `commit <https://codeberg.org/freeipa/freeipa/commit/f3052c17599c7318c385b27795678b368906fd26>`__
-   `#9285 <https://pagure.io/freeipa/issue/9285>`__
+   `#9285 <https://codeberg.org/freeipa/freeipa/issues/9285>`__
 
 
 
@@ -269,7 +269,7 @@ Erik Belko (1)
 -  ipatests: Test MemberManager ACI to allow managers from a specified
    group after upgrade scenario
    `commit <https://codeberg.org/freeipa/freeipa/commit/2fb6f0216e7433e0e6459678863edb2a31c90cde>`__
-   `#9286 <https://pagure.io/freeipa/issue/9286>`__
+   `#9286 <https://codeberg.org/freeipa/freeipa/issues/9286>`__
 
 
 
@@ -278,31 +278,31 @@ Florence Blanc-Renaud (16)
 
 -  ipatests: increase timeout for test_trust
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7147fa4c67ee5bdfa6f6020fdfb6278131f79d4>`__
-   `#9326 <https://pagure.io/freeipa/issue/9326>`__
+   `#9326 <https://codeberg.org/freeipa/freeipa/issues/9326>`__
 -  ipatests: remove wrong job definition TestACMEPrune
    `commit <https://codeberg.org/freeipa/freeipa/commit/bdd115239adeae9f84b016207552b60985d65854>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  ipatests: increase timeout for test_acme
    `commit <https://codeberg.org/freeipa/freeipa/commit/67131ae7f93e6ceab9be06d29151c37d74024699>`__
-   `#9324 <https://pagure.io/freeipa/issue/9324>`__
+   `#9324 <https://codeberg.org/freeipa/freeipa/issues/9324>`__
 -  automember-rebuild: add a notice about high CPU usage
    `commit <https://codeberg.org/freeipa/freeipa/commit/2deaaa788cbdde22d5b15566599fdcf7a10f02c6>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  trust-add: handle missing msSFU30MaxGidNumber
    `commit <https://codeberg.org/freeipa/freeipa/commit/703ab8c4dfb7f8fd1540c3849ad469d39695a26f>`__
-   `#9310 <https://pagure.io/freeipa/issue/9310>`__
+   `#9310 <https://codeberg.org/freeipa/freeipa/issues/9310>`__
 -  Tests: force key type in ACME tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/16c37cf26c8bf3a032a2d6845b3ff406002590be>`__
-   `#9298 <https://pagure.io/freeipa/issue/9298>`__
+   `#9298 <https://codeberg.org/freeipa/freeipa/issues/9298>`__
 -  server install: remove error log about missing bkup file
    `commit <https://codeberg.org/freeipa/freeipa/commit/6f50b00953c0000d6da8db0f5e8974ae33d7b5d5>`__
-   `#9306 <https://pagure.io/freeipa/issue/9306>`__
+   `#9306 <https://codeberg.org/freeipa/freeipa/issues/9306>`__
 -  ipatests: mark test_smb as xfail
    `commit <https://codeberg.org/freeipa/freeipa/commit/1bdd8147e7fa1032025dc6f6868e26f285744ee1>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  ipatests: update the xfail annotation for test_number_of_zones
    `commit <https://codeberg.org/freeipa/freeipa/commit/cc9e568e5c769754a5882a52e2a32d6e1c3a64bc>`__
-   `#9135 <https://pagure.io/freeipa/issue/9135>`__
+   `#9135 <https://codeberg.org/freeipa/freeipa/issues/9135>`__
 -  Spec file: bump krb5_kdb_version on rawhide
    `commit <https://codeberg.org/freeipa/freeipa/commit/f2b4d019881232833e915fedba48537548d2ef60>`__
 -  FIPS setup: fix typo filtering camellia encryption
@@ -311,13 +311,13 @@ Florence Blanc-Renaud (16)
    `commit <https://codeberg.org/freeipa/freeipa/commit/42381ebd036feee63fab2bbf8579b7a385624bf7>`__
 -  ipatests: update the fake fips mode expected message
    `commit <https://codeberg.org/freeipa/freeipa/commit/1d01692cf241645ca59b7f3d3e2096ce738d6a05>`__
-   `#9002 <https://pagure.io/freeipa/issue/9002>`__
+   `#9002 <https://codeberg.org/freeipa/freeipa/issues/9002>`__
 -  Spec file: ipa-client depends on krb5-pkinit-openssl
    `commit <https://codeberg.org/freeipa/freeipa/commit/d7c5fe5f1cc3b68492da27cf4ea25b611412c834>`__
-   `#9290 <https://pagure.io/freeipa/issue/9290>`__
+   `#9290 <https://codeberg.org/freeipa/freeipa/issues/9290>`__
 -  webui tests: fix assertion in test_subid.py
    `commit <https://codeberg.org/freeipa/freeipa/commit/3801d0c1c8a3dbec54dead29666137de2649e109>`__
-   `#9282 <https://pagure.io/freeipa/issue/9282>`__
+   `#9282 <https://codeberg.org/freeipa/freeipa/issues/9282>`__
 -  PRCI: update memory reqs for each topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/4f69f4cff32c0b5f8d4a36484a541a4b96c07e9d>`__
 
@@ -328,16 +328,16 @@ mbhalodi (4)
 
 -  ipatests: Test for sequence processing failures with server context
    `commit <https://codeberg.org/freeipa/freeipa/commit/6e5c6b1a138c3ead57cb42483f45f364894342e3>`__
-   `#9349 <https://pagure.io/freeipa/issue/9349>`__
+   `#9349 <https://codeberg.org/freeipa/freeipa/issues/9349>`__
 -  ipatests: add missing automember-cli tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/34c1574bed9fe6d35ea6a9e04f4e2e148fec9788>`__
-   `#9332 <https://pagure.io/freeipa/issue/9332>`__
+   `#9332 <https://codeberg.org/freeipa/freeipa/issues/9332>`__
 -  ipatests: WebUI - ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/ff50fe5f038be52207bb770179becc31fbc74e17>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 -  ipatests: ensure that ipa automember-rebuild prints a warning
    `commit <https://codeberg.org/freeipa/freeipa/commit/d035dc78cc7a1c88fc443719793a7c619af86fde>`__
-   `#9320 <https://pagure.io/freeipa/issue/9320>`__
+   `#9320 <https://codeberg.org/freeipa/freeipa/issues/9320>`__
 
 
 
@@ -346,7 +346,7 @@ Michal Polovka (1)
 
 -  ipatest: loginscreen: do not use hardcoded password
    `commit <https://codeberg.org/freeipa/freeipa/commit/2eca13e9660b3394fdd0a793142428dfe9d9ffa6>`__
-   `#9226 <https://pagure.io/freeipa/issue/9226>`__
+   `#9226 <https://codeberg.org/freeipa/freeipa/issues/9226>`__
 
 
 
@@ -355,13 +355,13 @@ Rob Crittenden (3)
 
 -  Wipe the ipa-ca DNS record when updating system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/b9387280543b86444cf4c258a7b720f492357baf>`__
-   `#9195 <https://pagure.io/freeipa/issue/9195>`__
+   `#9195 <https://codeberg.org/freeipa/freeipa/issues/9195>`__
 -  tests: Add new ipa-ca error messages to IPADNSSystemRecordsCheck
    `commit <https://codeberg.org/freeipa/freeipa/commit/f28cb79ffaf18b190642a8b07e8fc4ea00fa4c58>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 -  tests: Add ipa_ca_name checking to DNS system records
    `commit <https://codeberg.org/freeipa/freeipa/commit/0231ea8cd7895da6bc2bbc155f2d94b551ebac5c>`__
-   `#9291 <https://pagure.io/freeipa/issue/9291>`__
+   `#9291 <https://codeberg.org/freeipa/freeipa/issues/9291>`__
 
 
 
@@ -370,31 +370,31 @@ Stanislav Levin (9)
 
 -  fastlint: Correct concatenation of file lists
    `commit <https://codeberg.org/freeipa/freeipa/commit/d8418ce63de206967bea5918615ee4471183cd06>`__
-   `#9318 <https://pagure.io/freeipa/issue/9318>`__
+   `#9318 <https://codeberg.org/freeipa/freeipa/issues/9318>`__
 -  dns: Fix support for dnspython 1.1x
    `commit <https://codeberg.org/freeipa/freeipa/commit/c57507f3a4ed1f3314d0f57ad4f3469220b2cb6b>`__
-   `#9339 <https://pagure.io/freeipa/issue/9339>`__
+   `#9339 <https://codeberg.org/freeipa/freeipa/issues/9339>`__
 -  tests: webui: Update vendored qunit
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b15dca6095a44589c55aa6f8ef8c7646341d4d8>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  AP: webui: List installed nodejs packages
    `commit <https://codeberg.org/freeipa/freeipa/commit/1ec521d9aea95fa212f3a8acf966a9eca32c257f>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Load qunit only once
    `commit <https://codeberg.org/freeipa/freeipa/commit/958a3958b4835fc2454e8bd71797638dcef9c460>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: webui: Allow file access from files in tests
    `commit <https://codeberg.org/freeipa/freeipa/commit/a9f29047ab352757ddfeb5cda9701fee0a06032a>`__
-   `#9329 <https://pagure.io/freeipa/issue/9329>`__
+   `#9329 <https://codeberg.org/freeipa/freeipa/issues/9329>`__
 -  tests: Configure DNSResolver as platform agnostic resolver
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6f1b363c40f6e04d7ce6eeb80597e89c5684875>`__
-   `#9319 <https://pagure.io/freeipa/issue/9319>`__
+   `#9319 <https://codeberg.org/freeipa/freeipa/issues/9319>`__
 -  spec: Drop no longer used build dependency on paste
    `commit <https://codeberg.org/freeipa/freeipa/commit/ebd4096f039964cfd1d95467630c10559d051e13>`__
-   `#9314 <https://pagure.io/freeipa/issue/9314>`__
+   `#9314 <https://codeberg.org/freeipa/freeipa/issues/9314>`__
 -  ipatests: healthcheck: Handle missing fips-mode-setup
    `commit <https://codeberg.org/freeipa/freeipa/commit/8d2c8fcf0ca498e9fc431cf3e531bbd39cb1d9a2>`__
-   `#9315 <https://pagure.io/freeipa/issue/9315>`__
+   `#9315 <https://codeberg.org/freeipa/freeipa/issues/9315>`__
 
 
 
@@ -404,7 +404,7 @@ Sumedh Sidhaye (1)
 -  With the commit #99a74d7, 389-ds changed the message returned in
    ipa-healthcheck.
    `commit <https://codeberg.org/freeipa/freeipa/commit/e8ef2c2f226704ce510525f07675107179124a95>`__
-   `#9238 <https://pagure.io/freeipa/issue/9238>`__
+   `#9238 <https://codeberg.org/freeipa/freeipa/issues/9238>`__
 
 
 
@@ -413,7 +413,7 @@ Sudhir Menon (1)
 
 -  Fixes: ipa-otpd@.service: deprecated syslog setting
    `commit <https://codeberg.org/freeipa/freeipa/commit/05bba992a6f8ba9f3c4383d023f5977dff457382>`__
-   `#9279 <https://pagure.io/freeipa/issue/9279>`__
+   `#9279 <https://codeberg.org/freeipa/freeipa/issues/9279>`__
 
 
 

--- a/src/release-notes/4-9-13.rst
+++ b/src/release-notes/4-9-13.rst
@@ -117,96 +117,96 @@ or #freeipa channel on libera.chat.
 Resolved tickets
 ----------------
 
--  `#8878 <https://pagure.io/freeipa/issue/8878>`__
+-  `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
    (`rhbz#1821181 <https://bugzilla.redhat.com/show_bug.cgi?id=1821181>`__,
    `rhbz#2229712 <https://bugzilla.redhat.com/show_bug.cgi?id=2229712>`__)
    Prevent deletion of 'admin' account with web UI
--  `#8941 <https://pagure.io/freeipa/issue/8941>`__ Usage of
+-  `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__ Usage of
    \`/usr/bin/env\` in Python scripts
--  `#8990 <https://pagure.io/freeipa/issue/8990>`__ ipa group-mod should
+-  `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__ ipa group-mod should
    fail properly with --posix and --external options
--  `#9003 <https://pagure.io/freeipa/issue/9003>`__ ipa-server-install
+-  `#9003 <https://codeberg.org/freeipa/freeipa/issues/9003>`__ ipa-server-install
    not validating hostname != domain
--  `#9086 <https://pagure.io/freeipa/issue/9086>`__ Have
+-  `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__ Have
    ipa-client-install additionally disable the unscd service if using
    SSSD
--  `#9124 <https://pagure.io/freeipa/issue/9124>`__ Nightly test failure
+-  `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__ Nightly test failure
    in test_smb.py::TestSMB::test_smb_service_s4u2self
--  `#9267 <https://pagure.io/freeipa/issue/9267>`__
+-  `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
    (`rhbz#2188567 <https://bugzilla.redhat.com/show_bug.cgi?id=2188567>`__)
    Unconditionally adding 'includedir
    /var/lib/sss/pubconf/krb5.include.d' to /etc/krb5.conf break Java's
    ability to parse krb5.conf
--  `#9289 <https://pagure.io/freeipa/issue/9289>`__
+-  `#9289 <https://codeberg.org/freeipa/freeipa/issues/9289>`__
    (`rhbz#2149344 <https://bugzilla.redhat.com/show_bug.cgi?id=2149344>`__)
    Configure server affinity during replica installation
--  `#9297 <https://pagure.io/freeipa/issue/9297>`__ Minimum length
+-  `#9297 <https://codeberg.org/freeipa/freeipa/issues/9297>`__ Minimum length
    parameter in pwpolicy cannot be removed with empty string.
--  `#9317 <https://pagure.io/freeipa/issue/9317>`__ Distinguish between
+-  `#9317 <https://codeberg.org/freeipa/freeipa/issues/9317>`__ Distinguish between
    different location meaning
--  `#9331 <https://pagure.io/freeipa/issue/9331>`__
+-  `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
    (`rhbz#2164349 <https://bugzilla.redhat.com/show_bug.cgi?id=2164349>`__)
    Better handling of the command line and web UI cert search and/or
    list features
--  `#9378 <https://pagure.io/freeipa/issue/9378>`__
+-  `#9378 <https://codeberg.org/freeipa/freeipa/issues/9378>`__
    (`rhbz#2150217 <https://bugzilla.redhat.com/show_bug.cgi?id=2150217>`__)
    [RFE] Descriptive error message in ipa user-add
--  `#9379 <https://pagure.io/freeipa/issue/9379>`__ Test failure in
+-  `#9379 <https://codeberg.org/freeipa/freeipa/issues/9379>`__ Test failure in
    test_ipa_cert_fix.py::TestCertFixReplica::test_renew_expired_cert_replica
--  `#9381 <https://pagure.io/freeipa/issue/9381>`__
+-  `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
    (`rhbz#2215336 <https://bugzilla.redhat.com/show_bug.cgi?id=2215336>`__)
    Race condition in ipa-server-upgrade where pki-tomcat needs dirsrv
    while it's stopped
--  `#9383 <https://pagure.io/freeipa/issue/9383>`__ Random nightly test
+-  `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__ Random nightly test
    failure in test_acme.py::TestACMEPrune::test_prune_cert_manual
--  `#9385 <https://pagure.io/freeipa/issue/9385>`__
+-  `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
    (`rhbz#2216549 <https://bugzilla.redhat.com/show_bug.cgi?id=2216549>`__)
    Upgrade to 4.9.10-6.0.1 fails: attributes are managed by topology
    plugin
--  `#9389 <https://pagure.io/freeipa/issue/9389>`__ Nightly test failure
+-  `#9389 <https://codeberg.org/freeipa/freeipa/issues/9389>`__ Nightly test failure
    in test_webui_service
--  `#9395 <https://pagure.io/freeipa/issue/9395>`__ Search for user by
+-  `#9395 <https://codeberg.org/freeipa/freeipa/issues/9395>`__ Search for user by
    krbPrincipalExpiration not returning results
--  `#9396 <https://pagure.io/freeipa/issue/9396>`__ Renaming user or
+-  `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__ Renaming user or
    group with --setattr does not check supported formats
--  `#9397 <https://pagure.io/freeipa/issue/9397>`__
+-  `#9397 <https://codeberg.org/freeipa/freeipa/issues/9397>`__
    automountlocation-tofiles is not working after removing indirect
    automount map.
--  `#9402 <https://pagure.io/freeipa/issue/9402>`__
+-  `#9402 <https://codeberg.org/freeipa/freeipa/issues/9402>`__
    (`rhbz#2216872 <https://bugzilla.redhat.com/show_bug.cgi?id=2216872>`__)
    OTP authentication failure on s390x
--  `#9403 <https://pagure.io/freeipa/issue/9403>`__
+-  `#9403 <https://codeberg.org/freeipa/freeipa/issues/9403>`__
    (`rhbz#2209636 <https://bugzilla.redhat.com/show_bug.cgi?id=2209636>`__)
    libipa_otp_lasttoken plugin memory leak
--  `#9415 <https://pagure.io/freeipa/issue/9415>`__ Nightly test failure
+-  `#9415 <https://codeberg.org/freeipa/freeipa/issues/9415>`__ Nightly test failure
    in
    test_integration/test_installation.py::TestInstallMaster::test_ipactl_scenario_check
--  `#9416 <https://pagure.io/freeipa/issue/9416>`__
+-  `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
    (`rhbz#2224570 <https://bugzilla.redhat.com/show_bug.cgi?id=2224570>`__)
    Better error description when managing a user with '--idp'
--  `#9418 <https://pagure.io/freeipa/issue/9418>`__ Typo in "Subordinate
+-  `#9418 <https://codeberg.org/freeipa/freeipa/issues/9418>`__ Typo in "Subordinate
    ID Selfservice User" role
--  `#9422 <https://pagure.io/freeipa/issue/9422>`__
+-  `#9422 <https://codeberg.org/freeipa/freeipa/issues/9422>`__
    (`rhbz#2214638 <https://bugzilla.redhat.com/show_bug.cgi?id=2214638>`__,
    `rhbz#2227831 <https://bugzilla.redhat.com/show_bug.cgi?id=2227831>`__,
    `rhbz#2227832 <https://bugzilla.redhat.com/show_bug.cgi?id=2227832>`__)
    Interrupt request processing in ipadb_fill_info3() if connection to
    389ds is lost
--  `#9427 <https://pagure.io/freeipa/issue/9427>`__
+-  `#9427 <https://codeberg.org/freeipa/freeipa/issues/9427>`__
    (`rhbz#2216532 <https://bugzilla.redhat.com/show_bug.cgi?id=2216532>`__)
    RHEL 8.8 & 9.2 fails to create AD trust with STIG applied
--  `#9431 <https://pagure.io/freeipa/issue/9431>`__ Covscan issues:
+-  `#9431 <https://codeberg.org/freeipa/freeipa/issues/9431>`__ Covscan issues:
    deadcode and Use after free
--  `#9433 <https://pagure.io/freeipa/issue/9433>`__
+-  `#9433 <https://codeberg.org/freeipa/freeipa/issues/9433>`__
    (`rhbz#2234480 <https://bugzilla.redhat.com/show_bug.cgi?id=2234480>`__)
    ipa user-mod --idp-user-id fails with: attribute "ipaIdpSub" not
    allowed
--  `#9446 <https://pagure.io/freeipa/issue/9446>`__
+-  `#9446 <https://codeberg.org/freeipa/freeipa/issues/9446>`__
    (`rhbz#2149344 <https://bugzilla.redhat.com/show_bug.cgi?id=2149344>`__)
    Nightly test failure for replica installation with --setup-ca
--  `#9448 <https://pagure.io/freeipa/issue/9448>`__ FreeIPA 4.9 KDB
+-  `#9448 <https://codeberg.org/freeipa/freeipa/issues/9448>`__ FreeIPA 4.9 KDB
    rejects FreeIPA 4.10 KDB-issued evidence ticket in S4U processing
--  `#9449 <https://pagure.io/freeipa/issue/9449>`__ Squished FreeIPA
+-  `#9449 <https://codeberg.org/freeipa/freeipa/issues/9449>`__ Squished FreeIPA
    favicon
 
 .. _detailed_changelog_since_4.9.12:
@@ -225,7 +225,7 @@ Alexander Bokovoy (4)
    `commit <https://codeberg.org/freeipa/freeipa/commit/274ecc1be6c5a4c447874256acd0345ceca9b174>`__
 -  support more DateTime attributes in LDAP searches in IPA API
    `commit <https://codeberg.org/freeipa/freeipa/commit/3498ac88e71a6367294761510c937d225dec1140>`__
-   `#9395 <https://pagure.io/freeipa/issue/9395>`__
+   `#9395 <https://codeberg.org/freeipa/freeipa/issues/9395>`__
 -  ipalib/x509.py: Add signature_algorithm_parameters
    `commit <https://codeberg.org/freeipa/freeipa/commit/6a109d91a9256e2d0257d62fb5b555c163642de6>`__
 
@@ -245,7 +245,7 @@ Anuja More (1)
 -  ipatests: Check that SSSD_PUBCONF_KRB5_INCLUDE_D_DIR is not included
    in krb5.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/1b51fa4cb07380d1102891233e85a7940f804c72>`__
-   `#9267 <https://pagure.io/freeipa/issue/9267>`__
+   `#9267 <https://codeberg.org/freeipa/freeipa/issues/9267>`__
 
 .. _antonio_torres_1:
 
@@ -262,7 +262,7 @@ Erik Belko (1)
 
 -  test: add tests for descriptive error message in ipa user-add
    `commit <https://codeberg.org/freeipa/freeipa/commit/4d55ee3033641c772c2a8cc8625f7b133ab8416b>`__
-   `#9378 <https://pagure.io/freeipa/issue/9378>`__
+   `#9378 <https://codeberg.org/freeipa/freeipa/issues/9378>`__
 
 .. _florence_blanc_renaud_19:
 
@@ -271,57 +271,57 @@ Florence Blanc-Renaud (19)
 
 -  ipatests: fix test_ipactl_scenario_check
    `commit <https://codeberg.org/freeipa/freeipa/commit/9b41de8f4bf8689d7aa9c46cec6371a333958846>`__
-   `#9415 <https://pagure.io/freeipa/issue/9415>`__
+   `#9415 <https://codeberg.org/freeipa/freeipa/issues/9415>`__
 -  Covscan issues: Use after free
    `commit <https://codeberg.org/freeipa/freeipa/commit/6d0c1a2f3e692d355c858551709985c5dbb50731>`__
-   `#9431 <https://pagure.io/freeipa/issue/9431>`__
+   `#9431 <https://codeberg.org/freeipa/freeipa/issues/9431>`__
 -  idp: add the ipaidpuser objectclass when needed
    `commit <https://codeberg.org/freeipa/freeipa/commit/7e5740f534893487f5a61907ebd6e3677f0beecc>`__
-   `#9433 <https://pagure.io/freeipa/issue/9433>`__
+   `#9433 <https://codeberg.org/freeipa/freeipa/issues/9433>`__
 -  Installer: activate nss and pam services in sssd.conf
    `commit <https://codeberg.org/freeipa/freeipa/commit/f38eefd9f7e54470de7c707782114b17aac8762a>`__
-   `#9427 <https://pagure.io/freeipa/issue/9427>`__
+   `#9427 <https://codeberg.org/freeipa/freeipa/issues/9427>`__
 -  ipatests: fix test_topology
    `commit <https://codeberg.org/freeipa/freeipa/commit/fdaad3a45f5674876fd3f6cc7ad1e916ebfc7080>`__
 -  ipatests: update expected webui msg for admin deletion
    `commit <https://codeberg.org/freeipa/freeipa/commit/7d62d84bdd3c2acd2f4bf70bb5fabf14c72e8ee7>`__
-   `#8878 <https://pagure.io/freeipa/issue/8878>`__
+   `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
 -  xmlrpc tests: add a test for user plugin with non-existing idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/dbcbe9a39c99008c6858bab53e2807b7bf01ba65>`__
-   `#9416 <https://pagure.io/freeipa/issue/9416>`__
+   `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
 -  User plugin: improve error related to non existing idp
    `commit <https://codeberg.org/freeipa/freeipa/commit/99aa03413421cf2839e89e10ca279ec19233dd01>`__
-   `#9416 <https://pagure.io/freeipa/issue/9416>`__
+   `#9416 <https://codeberg.org/freeipa/freeipa/issues/9416>`__
 -  OTP: fix data type to avoid endianness issue
    `commit <https://codeberg.org/freeipa/freeipa/commit/a7e167154b889f75463ccc9cd91a75c1afb22da9>`__
-   `#9402 <https://pagure.io/freeipa/issue/9402>`__
+   `#9402 <https://codeberg.org/freeipa/freeipa/issues/9402>`__
 -  Integration tests: add a test to ipa-server-upgrade
    `commit <https://codeberg.org/freeipa/freeipa/commit/93d97b59600c15e5028ee39b0e98450544165158>`__
-   `#9385 <https://pagure.io/freeipa/issue/9385>`__
+   `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
 -  Upgrade: fix replica agreement
    `commit <https://codeberg.org/freeipa/freeipa/commit/d29b47512a39ada02fb371521994576cd9815a6c>`__
-   `#9385 <https://pagure.io/freeipa/issue/9385>`__
+   `#9385 <https://codeberg.org/freeipa/freeipa/issues/9385>`__
 -  Integration test: add a test for upgrade and PKI drop-in file
    `commit <https://codeberg.org/freeipa/freeipa/commit/356ec5cbfe0876686239f938bdf54892dc30571e>`__
-   `#9381 <https://pagure.io/freeipa/issue/9381>`__
+   `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
 -  Upgrade: add PKI drop-in file if missing
    `commit <https://codeberg.org/freeipa/freeipa/commit/86c1426b2d376a390e87b074d3e10d85fa124abf>`__
-   `#9381 <https://pagure.io/freeipa/issue/9381>`__
+   `#9381 <https://codeberg.org/freeipa/freeipa/issues/9381>`__
 -  xmlrpc tests: add test renaming user or group with setattr
    `commit <https://codeberg.org/freeipa/freeipa/commit/a5a4800cbe3e45907f39f78a3da3ded504712982>`__
-   `#9396 <https://pagure.io/freeipa/issue/9396>`__
+   `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__
 -  User and groups: rename with --setattr must check format
    `commit <https://codeberg.org/freeipa/freeipa/commit/ba30addb05d47c36e2857c76ae2aff42d6f3fbb3>`__
-   `#9396 <https://pagure.io/freeipa/issue/9396>`__
+   `#9396 <https://codeberg.org/freeipa/freeipa/issues/9396>`__
 -  webuitests: close notification which hides Add button
    `commit <https://codeberg.org/freeipa/freeipa/commit/f599e2d67bad5945e4dcf99fdd584f01f1e20d1e>`__
-   `#9389 <https://pagure.io/freeipa/issue/9389>`__
+   `#9389 <https://codeberg.org/freeipa/freeipa/issues/9389>`__
 -  ipatest: remove xfail from test_smb
    `commit <https://codeberg.org/freeipa/freeipa/commit/998bafee86a870ad1ea4d6bccf12f0fae64c398c>`__
-   `#9124 <https://pagure.io/freeipa/issue/9124>`__
+   `#9124 <https://codeberg.org/freeipa/freeipa/issues/9124>`__
 -  ACME tests: fix issue_and_expire_acme_cert method
    `commit <https://codeberg.org/freeipa/freeipa/commit/7a94acca6a9efb546f1cf59f63fcb89f98944ea5>`__
-   `#9383 <https://pagure.io/freeipa/issue/9383>`__
+   `#9383 <https://codeberg.org/freeipa/freeipa/issues/9383>`__
 -  user or group name: explain the supported format
    `commit <https://codeberg.org/freeipa/freeipa/commit/f42a106e84c1fd609350da2540289ce945a7ecbd>`__
 
@@ -340,10 +340,10 @@ Julien Rische (2)
 
 -  ipa-kdb: Make AD-SIGNEDPATH optional with krb5 DAL 8 and older
    `commit <https://codeberg.org/freeipa/freeipa/commit/d394afc1210a21378c018d0ff93d400a57324289>`__
-   `#9448 <https://pagure.io/freeipa/issue/9448>`__
+   `#9448 <https://codeberg.org/freeipa/freeipa/issues/9448>`__
 -  ipa-kdb: fix error handling of is_master_host()
    `commit <https://codeberg.org/freeipa/freeipa/commit/b5793c854035a122ed4c66f917cc427e5024e46a>`__
-   `#9422 <https://pagure.io/freeipa/issue/9422>`__
+   `#9422 <https://codeberg.org/freeipa/freeipa/issues/9422>`__
 
 .. _mohammad_rizwan_2:
 
@@ -352,7 +352,7 @@ Mohammad Rizwan (2)
 
 -  ipatests: restart ipa services after moving date
    `commit <https://codeberg.org/freeipa/freeipa/commit/4fc28edbe6c9fee1e16d4057f4d83b7910264fdd>`__
-   `#9379 <https://pagure.io/freeipa/issue/9379>`__
+   `#9379 <https://codeberg.org/freeipa/freeipa/issues/9379>`__
 -  ipatests: enable firewall rule for http service on acme client
    `commit <https://codeberg.org/freeipa/freeipa/commit/f68468718c1e01df4a9180e17d7e24d961850e19>`__
 
@@ -363,46 +363,46 @@ Rob Crittenden (14)
 
 -  Allow password policy minlength to be removed like other values
    `commit <https://codeberg.org/freeipa/freeipa/commit/d0348612f96e320594f3b9b167ff5aef890a93e1>`__
-   `#9297 <https://pagure.io/freeipa/issue/9297>`__
+   `#9297 <https://codeberg.org/freeipa/freeipa/issues/9297>`__
 -  Don't assume KRB5CCNAME is in the environment in replica install
    `commit <https://codeberg.org/freeipa/freeipa/commit/0cf6292f9c5d0cb31d57439e234a4e8640edc64f>`__
-   `#9446 <https://pagure.io/freeipa/issue/9446>`__
+   `#9446 <https://codeberg.org/freeipa/freeipa/issues/9446>`__
 -  Configure affinity during server installation
    `commit <https://codeberg.org/freeipa/freeipa/commit/3af7747364d184c8ef5bad8ea1654b12c529727b>`__
-   `#9289 <https://pagure.io/freeipa/issue/9289>`__
+   `#9289 <https://codeberg.org/freeipa/freeipa/issues/9289>`__
 -  Remove all references to deleted indirect map from parent map
    `commit <https://codeberg.org/freeipa/freeipa/commit/2c402c46c2652b54adec5e8554ca7dfa00f2d37b>`__
-   `#9397 <https://pagure.io/freeipa/issue/9397>`__
+   `#9397 <https://codeberg.org/freeipa/freeipa/issues/9397>`__
 -  Prevent the admin user from being deleted
    `commit <https://codeberg.org/freeipa/freeipa/commit/f215d3f45396fa29bdd69f56096b50842df14908>`__
-   `#8878 <https://pagure.io/freeipa/issue/8878>`__
+   `#8878 <https://codeberg.org/freeipa/freeipa/issues/8878>`__
 -  Fix memory leak in the OTP last token plugin
    `commit <https://codeberg.org/freeipa/freeipa/commit/9438ce9207445e4ad4a9c7bdf0c9e569cabac571>`__
-   `#9403 <https://pagure.io/freeipa/issue/9403>`__
+   `#9403 <https://codeberg.org/freeipa/freeipa/issues/9403>`__
 -  Differentiate location meaning between host and server
    `commit <https://codeberg.org/freeipa/freeipa/commit/af9c89e789e30e12aaeed1d607c2647861ecb3cc>`__
-   `#9317 <https://pagure.io/freeipa/issue/9317>`__
+   `#9317 <https://codeberg.org/freeipa/freeipa/issues/9317>`__
 -  Use the python-cryptography parser directly in cert-find
    `commit <https://codeberg.org/freeipa/freeipa/commit/d00fd3398c32beb2c3e72f4878c87f9d2c0e833d>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Revert "cert_find: fix call with --all"
    `commit <https://codeberg.org/freeipa/freeipa/commit/3b1dbcdba2994bf57908f530913998e9ab888e4c>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Revert "Use the OpenSSL certificate parser in cert-find"
    `commit <https://codeberg.org/freeipa/freeipa/commit/9fe30f21c987bdccf80ef5f6d645fdc59b393bdb>`__
-   `#9331 <https://pagure.io/freeipa/issue/9331>`__
+   `#9331 <https://codeberg.org/freeipa/freeipa/issues/9331>`__
 -  Don't allow the FQDN to match the domain on server installs
    `commit <https://codeberg.org/freeipa/freeipa/commit/00e8ccda83bffbb571a127d7a8a194496b9a53bd>`__
-   `#9003 <https://pagure.io/freeipa/issue/9003>`__
+   `#9003 <https://codeberg.org/freeipa/freeipa/issues/9003>`__
 -  Don't allow a group to be converted to POSIX and external
    `commit <https://codeberg.org/freeipa/freeipa/commit/fa321b2cca07dc2bd27ab6fa868e05ddf69637df>`__
-   `#8990 <https://pagure.io/freeipa/issue/8990>`__
+   `#8990 <https://codeberg.org/freeipa/freeipa/issues/8990>`__
 -  Replace usage of #!/usr/bin/env python3 with #!/usr/bin/python3
    `commit <https://codeberg.org/freeipa/freeipa/commit/e6f4478b87e441d9e9ad6fdc358f942981996c5a>`__
-   `#8941 <https://pagure.io/freeipa/issue/8941>`__
+   `#8941 <https://codeberg.org/freeipa/freeipa/issues/8941>`__
 -  Mention in ipa-client-install that nscd is disabled
    `commit <https://codeberg.org/freeipa/freeipa/commit/e859b82677f13149de708006ab4f39b1b45ff66c>`__
-   `#9086 <https://pagure.io/freeipa/issue/9086>`__
+   `#9086 <https://codeberg.org/freeipa/freeipa/issues/9086>`__
 
 .. _rafael_guterres_jeffman_1:
 
@@ -411,7 +411,7 @@ Rafael Guterres Jeffman (1)
 
 -  Fix typo in "Subordinate ID Selfservice User" role
    `commit <https://codeberg.org/freeipa/freeipa/commit/22db4497512a0fb62920648a732348ee9e8473fd>`__
-   `#9418 <https://pagure.io/freeipa/issue/9418>`__
+   `#9418 <https://codeberg.org/freeipa/freeipa/issues/9418>`__
 
 .. _sudhir_menon_1:
 
@@ -428,4 +428,4 @@ Viktor Ashirov (1)
 
 -  WebUI: update favicon.ico
    `commit <https://codeberg.org/freeipa/freeipa/commit/af4fb52bf140c69fb3d52d662aee48d37059721b>`__
-   `#9449 <https://pagure.io/freeipa/issue/9449>`__
+   `#9449 <https://codeberg.org/freeipa/freeipa/issues/9449>`__


### PR DESCRIPTION
Since FreeIPA repo is moving to Codeberg, fix all references to issues hosted on Pagure.